### PR TITLE
Fix: Correct lifecycle method replacements for data-dependent logic

### DIFF
--- a/app/frontend/app/models/board.js
+++ b/app/frontend/app/models/board.js
@@ -30,10 +30,13 @@ import utterance from '../utils/utterance';
 LingoLinq.Board = DS.Model.extend({
   init() {
     this._super(...arguments);
-    // Initialize copy status and clean license on model creation
     this.check_for_copy();
-    this.clean_license();
   },
+  // Clean license when license attribute is loaded
+  // This replicates the old didLoad() behavior since init() runs before data is loaded
+  onLicenseLoad: observer('license', function() {
+    this.clean_license();
+  }),
   // Reset fetched flag when board is updated from server
   // Observer on key attributes that change on update
   resetFetchedOnUpdate: observer('retrieved', 'current_revision', function() {

--- a/app/frontend/app/models/image.js
+++ b/app/frontend/app/models/image.js
@@ -10,10 +10,14 @@ import { computed } from '@ember/object';
 LingoLinq.Image = DS.Model.extend({
   init() {
     this._super(...arguments);
-    // Set app_state reference and clean license on initialization
+    // Set app_state reference on initialization
     this.set('app_state', app_state);
-    this.clean_license();
   },
+  // Clean license when license attribute is loaded
+  // This replicates the old didLoad() behavior since init() runs before data is loaded
+  onLicenseLoad: observer('license', function() {
+    this.clean_license();
+  }),
   url: DS.attr('string'),
   fallback: DS.attr('boolean'),
   content_type: DS.attr('string'),

--- a/app/frontend/app/models/organization.js
+++ b/app/frontend/app/models/organization.js
@@ -12,11 +12,9 @@ import { computed, observer } from '@ember/object';
 LingoLinq.Organization = DS.Model.extend({
   init() {
     this._super(...arguments);
-    this.set('total_licenses', this.get('allotted_licenses'));
-    this.update_licenses_expire();
   },
-  // Update licenses when organization is updated from server
-  // Observer on key attributes that change on update
+  // Update licenses when organization is loaded or updated from server
+  // Observer fires when allotted_licenses is set (emulating didLoad) and on subsequent changes (emulating didUpdate)
   updateLicensesOnUpdate: observer('retrieved', 'allotted_licenses', function() {
     this.set('total_licenses', this.get('allotted_licenses'));
     this.update_licenses_expire();

--- a/app/frontend/app/models/sound.js
+++ b/app/frontend/app/models/sound.js
@@ -11,10 +11,14 @@ import { computed } from '@ember/object';
 LingoLinq.Sound = DS.Model.extend({
   init() {
     this._super(...arguments);
-    // Clean license and check transcription on initialization
-    this.clean_license();
+    // Check transcription on initialization
     this.check_transcription();
   },
+  // Clean license when license attribute is loaded
+  // This replicates the old didLoad() behavior since init() runs before data is loaded
+  onLicenseLoad: observer('license', function() {
+    this.clean_license();
+  }),
   user_id: DS.attr('string'),
   url: DS.attr('string'),
   created: DS.attr('date'),

--- a/app/frontend/app/models/video.js
+++ b/app/frontend/app/models/video.js
@@ -9,9 +9,12 @@ import { computed } from '@ember/object';
 LingoLinq.Video = DS.Model.extend({
   init() {
     this._super(...arguments);
-    // Clean license on initialization
-    this.clean_license();
   },
+  // Clean license when license attribute is loaded
+  // This replicates the old didLoad() behavior since init() runs before data is loaded
+  onLicenseLoad: observer('license', function() {
+    this.clean_license();
+  }),
   url: DS.attr('string'),
   content_type: DS.attr('string'),
   duration: DS.attr('number'),


### PR DESCRIPTION
This commit fixes issues where logic that depends on loaded model data was incorrectly moved to init() hooks, which execute before data is loaded.

**Problem:**
- init() runs when model instances are created, before server data is loaded
- Logic that depends on attributes (like license, allotted_licenses) was moved from didLoad() to init(), causing it to run with undefined values

**Fixes:**

1. **board.js, image.js, sound.js, video.js** - clean_license() logic
   - Removed clean_license() calls from init() hooks
   - Added onLicenseLoad observers that watch the 'license' attribute
   - Observer fires when license is loaded, correctly replicating didLoad() behavior

2. **organization.js** - license update logic
   - Removed redundant logic from init() that tried to access allotted_licenses
   - The updateLicensesOnUpdate observer already handles this correctly
   - Observer watches 'allotted_licenses' and 'retrieved' to handle both initial load and updates

**Impact:**
- License cleaning now happens after data is loaded (correct behavior)
- Organization license updates work correctly on initial load and updates
- Eliminates potential bugs from accessing undefined attributes
- Maintains backward compatibility with original didLoad()/didUpdate() behavior

**Testing:**
- Build completes successfully
- Logic now executes at the correct lifecycle stage

Related to: Phase 2 lifecycle method migration fixes