### PR TITLE
Refactor: Extract button-list into reusable component

### DIFF
--- a/app/frontend/app/components/button-list.js
+++ b/app/frontend/app/components/button-list.js
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  // Classic Ember component for rendering a list of buttons
+  // Usage: {{button-list buttonList=button_list}}
+});
+

--- a/app/frontend/app/templates/application.hbs
+++ b/app/frontend/app/templates/application.hbs
@@ -99,37 +99,7 @@
           {{/if}}
         {{/unless}}
         {{#with app_state.button_list as |button_list|}}
-          {{#each button_list as |button|}}
-            {{#unless button.ghost}}
-              {{#if button.insert_before}}
-                <div class='utterance_cursor history_button'><div class='left'>&nbsp;</div><div class='right'>&nbsp;</div></div>
-              {{/if}}
-            {{/unless}}
-            <div class={{if button.ghost "history_button ghosted" "history_button"}}>
-              <span style={{if button.history_clearable "opacity: 0.6;"}}>
-                {{#if button.modeling}}
-                  <div class='modeling'>
-                    <span class='glyphicon glyphicon-hand-up'></span>
-                  </div>
-                {{/if}}
-                {{#if button.image}}
-                  <img src={{button.image}} onerror="button_broken_image(this);"  draggable="false">
-                {{else}}
-                  <img src="https://opensymbols.s3.amazonaws.com/libraries/mulberry/paper.svg" onerror="button_broken_image(this);" draggable="false">
-                {{/if}}
-                {{#if button.sound}}
-                  <!--audio style="display: none;" preload="auto" src={{button.sound}}></audio-->
-                {{/if}}
-                <div class={{if button.modeling "text modeled" "text"}}>{{ button.label }} </div>
-              </span>
-            </div>
-            {{#unless button.ghost}}
-              {{#if button.insert_after}}
-                <div class='utterance_cursor history_button'><div class='left'>&nbsp;</div><div class='right'>&nbsp;</div></div>
-              {{/if}}
-            {{/unless}}
-          {{/each}}
-          <div style="clear: left;"></div>
+          {{button-list buttonList=button_list}}
         {{/with}}
       </a>
       {{#unless app_state.button_list}}

--- a/app/frontend/app/templates/brief.hbs
+++ b/app/frontend/app/templates/brief.hbs
@@ -15,37 +15,7 @@
       {{/unless}}
       <a href='#' tabindex="0" id="button_list" class={{button_list_class}} {{ action "vocalize" on="select"}} data-placement="bottom" data-trigger="manual">
         {{#with app_state.button_list as |button_list|}}
-          {{#each button_list as |button|}}
-            {{#unless button.ghost}}
-              {{#if button.insert_before}}
-                <div class='utterance_cursor history_button'><div class='left'>&nbsp;</div><div class='right'>&nbsp;</div></div>
-              {{/if}}
-            {{/unless}}
-            <div class={{if button.ghost "history_button ghosted" "history_button"}}>
-              <span style={{if button.history_clearable "opacity: 0.6;"}}>
-                {{#if button.modeling}}
-                  <div class='modeling'>
-                    <span class='glyphicon glyphicon-hand-up'></span>
-                  </div>
-                {{/if}}
-                {{#if button.image}}
-                  <img src={{button.image}} onerror="button_broken_image(this);"  draggable="false">
-                {{else}}
-                  <img src="https://opensymbols.s3.amazonaws.com/libraries/mulberry/paper.svg" onerror="button_broken_image(this);" draggable="false">
-                {{/if}}
-                {{#if button.sound}}
-                  <!--audio style="display: none;" preload="auto" src={{button.sound}}></audio-->
-                {{/if}}
-                <div class={{if button.modeling "text modeled" "text"}}>{{ button.label }} </div>
-              </span>
-            </div>
-            {{#unless button.ghost}}
-              {{#if button.insert_after}}
-                <div class='utterance_cursor history_button'><div class='left'>&nbsp;</div><div class='right'>&nbsp;</div></div>
-              {{/if}}
-            {{/unless}}
-          {{/each}}
-          <div style="clear: left;"></div>
+          {{button-list buttonList=button_list}}
         {{/with}}
       </a>
       <button class="btn btn-default" {{action "speakOptions"}} id="speak_options"><span class="sr-only">{{t "speak options" key="speak_options"}}</span><span class="glyphicon glyphicon-chevron-down"></span></button>

--- a/app/frontend/app/templates/components/button-list.hbs
+++ b/app/frontend/app/templates/components/button-list.hbs
@@ -1,4 +1,4 @@
-{{#each button_list as |button|}}
+{{#each buttonList as |button|}}
   {{#unless button.ghost}}
     {{#if button.insert_before}}
       <div class='utterance_cursor history_button'><div class='left'>&nbsp;</div><div class='right'>&nbsp;</div></div>
@@ -29,3 +29,4 @@
   {{/unless}}
 {{/each}}
 <div style="clear: left;"></div>
+

--- a/app/frontend/app/templates/utterance.hbs
+++ b/app/frontend/app/templates/utterance.hbs
@@ -30,37 +30,7 @@
       {{else}}
         <div id="utterance" class="button_list" {{ action "vocalize"}}>
           {{#with model.button_list as |button_list|}}
-            {{#each button_list as |button|}}
-              {{#unless button.ghost}}
-                {{#if button.insert_before}}
-                  <div class='utterance_cursor history_button'><div class='left'>&nbsp;</div><div class='right'>&nbsp;</div></div>
-                {{/if}}
-              {{/unless}}
-              <div class={{if button.ghost "history_button ghosted" "history_button"}}>
-                <span style={{if button.history_clearable "opacity: 0.6;"}}>
-                  {{#if button.modeling}}
-                    <div class='modeling'>
-                      <span class='glyphicon glyphicon-hand-up'></span>
-                    </div>
-                  {{/if}}
-                  {{#if button.image}}
-                    <img src={{button.image}} onerror="button_broken_image(this);"  draggable="false">
-                  {{else}}
-                    <img src="https://opensymbols.s3.amazonaws.com/libraries/mulberry/paper.svg" onerror="button_broken_image(this);" draggable="false">
-                  {{/if}}
-                  {{#if button.sound}}
-                    <!--audio style="display: none;" preload="auto" src={{button.sound}}></audio-->
-                  {{/if}}
-                  <div class={{if button.modeling "text modeled" "text"}}>{{ button.label }} </div>
-                </span>
-              </div>
-              {{#unless button.ghost}}
-                {{#if button.insert_after}}
-                  <div class='utterance_cursor history_button'><div class='left'>&nbsp;</div><div class='right'>&nbsp;</div></div>
-                {{/if}}
-              {{/unless}}
-            {{/each}}
-            <div style="clear: left;"></div>
+            {{button-list buttonList=button_list}}
           {{/with}}
         </div>
       {{/if}}

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -10,7 +10,7 @@ port        ENV['PORT']     || 3000
 # bind "tcp://0.0.0.0:3000"
 environment ENV['RACK_ENV'] || 'development'
 
-before_worker_boot do
+on_worker_boot do
   # Worker specific setup for Rails 4.1+
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
   defined?(ActiveRecord::Base) and


### PR DESCRIPTION
- Create button-list component to eliminate code duplication
- Replace duplicated button list markup in application.hbs, brief.hbs, and utterance.hbs
- Move button-list template to components directory
- Fix puma.rb: Change before_worker_boot to on_worker_boot (correct Puma DSL method)

This refactoring improves maintainability and follows Ember best practices by using a reusable component instead of duplicated template code.

Preparation for Ember 3.28 upgrade.