### PR TITLE
Refactor button settings and new board modal functionality

### DIFF
--- a/app/frontend/app/components/button-settings.js
+++ b/app/frontend/app/components/button-settings.js
@@ -894,23 +894,18 @@ export default Component.extend({
       if(new_button_id) {
         new_button_id = emberGet(new_button_id, 'id') || new_button_id;
         var modalService = _this.get('modal');
-        _this.get('contentGrabbers').save_pending().then(function() {
+        var openNextButtonSettings = function() {
+          if (_this.isDestroyed || _this.isDestroying) { return; }
           modalService.close();
           runLater(function() {
+            if (_this.isDestroyed || _this.isDestroying) { return; }
             var button = editManager.find_button(new_button_id);
             if(!button) { return; }
             button.state = 'general';
             modalService.open('button-settings', {button: button, board: board});
           }, 100);
-        }, function() {
-          modalService.close();
-          runLater(function() {
-            var button = editManager.find_button(new_button_id);
-            if(!button) { return; }
-            button.state = 'general';
-            modalService.open('button-settings', {button: button, board: board});
-          }, 100);
-        });
+        };
+        _this.get('contentGrabbers').save_pending().then(openNextButtonSettings, openNextButtonSettings);
       }
     },
     setState: function(state) {

--- a/app/frontend/app/controllers/new-board.js
+++ b/app/frontend/app/controllers/new-board.js
@@ -12,8 +12,15 @@ import { computed } from '@ember/object';
 
 export default modal.ModalController.extend({
   uncloseable: true,
+  unprotected_vocabulary: computed('model.locale', function() {
+    var locale = this.get('model.locale');
+    if(locale) {
+      return i18n.get('unprotected_vocabulary')[locale];
+    }
+    return null;
+  }),
   opening: function() {
-    this.set('model', LingoLinq.store.createRecord('board', {public: false, license: {type: 'private'}, grid: {rows: 2, columns: 4}}));
+    this.set('model', LingoLinq.store.createRecord('board', {public: false, visibility: 'private', license: {type: 'private'}, grid: {rows: 2, columns: 4}}));
     if(window.webkitSpeechRecognition) {
       var speech = new window.webkitSpeechRecognition();
       if(speech) {
@@ -290,6 +297,13 @@ export default modal.ModalController.extend({
             cats.push(cat.id);
           }
         });
+        this.set('model.categories', cats);
+      }
+      if(this.get('model.visibility') == 'private') {
+        var cats = this.get('model.categories') || [];
+        if(cats.indexOf('protected_vocabulary') == -1) {
+          cats.push('unprotected_vocabulary');
+        }
         this.set('model.categories', cats);
       }
       this.get('model').save().then(function(board) {

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1858,6 +1858,8 @@ class Board < ActiveRecord::Base
       # Normalize hidden/link_disabled so string "false" from params is not treated as truthy
       button['hidden'] = (button['hidden'] == true || button['hidden'].to_s == 'true')
       button['link_disabled'] = (button['link_disabled'] == true || button['link_disabled'].to_s == 'true')
+      button['hide_label'] = (button['hide_label'] == true || button['hide_label'].to_s == 'true')
+      button['text_only'] = (button['text_only'] == true || button['text_only'].to_s == 'true')
       button.delete('level_modifications') if button['level_modifications'] && !button['level_modifications'].is_a?(Hash)
       button.delete('ref_id') if button['ref_id'].blank?
       button.delete('rules') if button['rules'].blank?


### PR DESCRIPTION
- Simplified the button settings modal opening logic by consolidating the success and error handling into a single function.
- Updated the new board modal to include a visibility property and adjusted category handling based on the board's visibility.
- Enhanced the board model to handle additional button properties: `hide_label` and `text_only`.