### PR TITLE
fix: disable SassC CSS compressor for modern CSS compat

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,9 +25,10 @@ Rails.application.configure do
   # (they don't have nginx in front like traditional deployments)
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present? || ENV['RENDER'].present?
 
-  # Compress JavaScripts and CSS.
-  # uglifier is deprecated, JavaScript compression handled by ember-cli-terser in frontend
-  config.assets.css_compressor = :sass
+  # CSS compression disabled: SassC cannot handle modern CSS functions
+  # (clamp, calc with mixed units like px + vw). Ember frontend already
+  # outputs minified CSS, so no additional compression is needed.
+  config.assets.css_compressor = nil
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
## Summary
- Sets `config.assets.css_compressor = nil` in production.rb
- SassC was evaluating math inside `clamp()` and `calc()` during asset compression, causing `Incompatible units: px and vw` build failures on Render
- Ember frontend already outputs minified CSS, so SassC compression is unnecessary
- This is the root cause behind the 3 consecutive failed staging deploys (PRs #126, #127, #128)

## Test plan
- [ ] Verify Render staging build succeeds after merge
- [ ] Confirm CSS loads correctly on lingolinq-staging.onrender.com
- [ ] Check page weight hasn't increased significantly (Ember CSS is already minified)