### PR TITLE
debug: log SECRET_KEY_BASE presence in prod build env

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -36,6 +36,7 @@ bundle exec rake extras:assert_js
 # SKIP_OFFLINE_MANIFEST: routes.rb loads Rack::Offline which calls asset_path;
 # assets don't exist until after precompile, so skip it during build tasks.
 export SKIP_OFFLINE_MANIFEST=1
+echo "DEBUG: SECRET_KEY_BASE length=${#SECRET_KEY_BASE} | LEADER_POSTGRES_URL set=${LEADER_POSTGRES_URL:+yes} | RAILS_ENV=${RAILS_ENV} | COOKIE_KEY length=${#COOKIE_KEY}"
 bundle exec rake extras:copy_terms
 
 echo "=== Building Frontend (Ember) ==="


### PR DESCRIPTION
## Summary
Temporary diagnostic commit to unblock failing prod deploys.

Prod builds have been failing with \`Missing secret_key_base for 'production' environment\` at \`config/environments/production.rb:13\`, even though \`SECRET_KEY_BASE\` is visibly set in the Render dashboard. Need to confirm whether the var is actually reaching the build environment.

Adds a one-line \`echo\` in \`bin/render-build.sh\` right before \`rake extras:copy_terms\` that prints:
- \`SECRET_KEY_BASE\` length (not value)
- Whether \`LEADER_POSTGRES_URL\` is set
- \`RAILS_ENV\`
- \`COOKIE_KEY\` length (fallback)

No secrets are logged.

## Test plan
- [ ] Merge to main
- [ ] Watch lingolinq-prod auto-deploy
- [ ] Check build logs for the DEBUG line
- [ ] Based on output: if length=0, Render isn't injecting it into build; if length>0, boot order / initializer issue
- [ ] Revert this commit once root cause is identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)