### PR TITLE
Fix sync script: match Render's RAILS_SERVE_STATIC_FILES value

### DIFF
--- a/scripts/sync-render-env.js
+++ b/scripts/sync-render-env.js
@@ -118,7 +118,7 @@ const KEY_MANIFEST = {
   // -- Performance (shared, hardcoded) --
   LD_PRELOAD:            { defaultValue: '/usr/lib/x86_64-linux-gnu/libjemalloc.so.2' },
   MALLOC_CONF:           { defaultValue: 'background_thread:true,narenas:2,dirty_decay_ms:1000' },
-  RAILS_SERVE_STATIC_FILES: { defaultValue: 'true' },
+  RAILS_SERVE_STATIC_FILES: { defaultValue: 'enabled' },
 
   // -- Auto-managed by Render (DO NOT sync) --
   // DATABASE_URL:  set by Render


### PR DESCRIPTION
Small fix: the sync-render-env.js script had defaultValue 'true' but Render has 'enabled', causing a false diff on every sync run.