### PR TITLE
Fix vocab ngram crash and button image persistence

### DIFF
--- a/app/frontend/app/services/content-grabbers.js
+++ b/app/frontend/app/services/content-grabbers.js
@@ -1284,6 +1284,13 @@ var pictureGrabber = EmberObject.extend({
         _this.controller.set('model.image', image);
       }
       _this.clear();
+      // Synchronously mirror the image onto board.buttons so persistence (which may
+      // serialize before afterRender fires) sees the updated image_id immediately.
+      var syncServerId = (image.get && image.get('id')) || image.id;
+      editManager.change_button(button_id, {
+        'image': image,
+        'image_id': syncServerId
+      });
       // Defer to afterRender so Ember Data has finished processing the save response.
       // This ensures we use the server-assigned id (not the client id) when the server
       // returns a different id (e.g. due to RecordIdentifier handling).

--- a/app/frontend/app/utils/edit_manager.js
+++ b/app/frontend/app/utils/edit_manager.js
@@ -1387,7 +1387,7 @@ var editManager = EmberObject.extend({
           return typeof v.get !== 'function'; // exclude Ember models
         };
         for(var bi = 0; bi < boardButtons.length; bi++) {
-          if(boardButtons[bi] && boardButtons[bi].id == id) {
+          if(boardButtons[bi] && String(boardButtons[bi].id) === String(id)) {
             for(var key in options) {
               if(rawAttrs.indexOf(key) >= 0 && isSerializable(options[key])) {
                 boardButtons[bi][key] = options[key];

--- a/app/frontend/app/utils/word_suggestions.js
+++ b/app/frontend/app/utils/word_suggestions.js
@@ -165,6 +165,7 @@ var word_suggestions = EmberObject.extend({
       var res = RSVP.all(promises).then(function() {
         _this.loading = false;
         _this.ngrams = ngrams;
+        _this.ngrams[''] = _this.ngrams[''] || [];
         if(_this.watchers) {
           _this.watchers.forEach(function(d) {
             d.resolve();
@@ -327,7 +328,7 @@ var word_suggestions = EmberObject.extend({
         // find the most common next-words
         find_lookups(_this.ngrams[last_finished_word]);
         // if not enough found, add in the most common starting words
-        if(result.length < max_results) { find_lookups(_this.ngrams['']); }
+        if(result.length < max_results && _this.ngrams[''] && _this.ngrams[''].length) { find_lookups(_this.ngrams['']); }
         // if still not enough found, find the closest spelling
         if(result.length < max_results) {
           var edits = [];
@@ -337,7 +338,7 @@ var word_suggestions = EmberObject.extend({
             min = word_in_progress.length - 5;
             max = word_in_progress.length + 5; 
           }
-          _this.ngrams[''].forEach(function(str) {
+          (_this.ngrams[''] || []).forEach(function(str) {
             if(str[0] && (str[0].length > min && str[0].length < max)) {
               if(!_this.filtered_words[str[0].toLowerCase()]) {
                 var dist = _this.edit_distance(word_in_progress, str[0]);


### PR DESCRIPTION
## Summary
- **Bug 2 (vocab ngrams):** guard `word_suggestions.js` against missing `ngrams['']` bucket so a failed/empty ngram fetch no longer crashes with `Cannot read properties of undefined (reading 'word')`.
- **Bug 4 (button image "Use this"):** mirror the new `image_id` into `board.buttons` synchronously in `content-grabbers.js` (not only in `afterRender`) and use a `String===String` id compare in `edit_manager.js` so image changes actually persist on the next board save.

Also (infra, already done): copied `language/` static files from `lingolinq-prod-static` into `lingolinq-dev-static` and `lingolinq-staging-static`. The "CORS blocked" browser error was actually a 404; S3 CORS was already correct.

Replaces #165 (which was accidentally based on an older branch point and showed hundreds of unrelated files).

## Test plan
- [ ] Staging: load a board, confirm `ngrams.arpa.trimmed.10.json` returns 200 in Network tab
- [ ] Staging: no `Cannot read properties of undefined (reading 'word')` in console
- [ ] Staging: edit a button, image search, "Use this", save board, reload, confirm new image persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)