### PR TITLE
Fix org rename 400 and board copy 400

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -437,12 +437,18 @@ class Api::BoardsController < ApplicationController
     processed_params = params
     # Necessary because by default Rails is stripping out nil references in an array, which
     # messes up grid.order
-    if request.content_type == 'application/json'
-      processed_params = JSON.parse(request.body.read)
+    is_json_request = request.media_type == 'application/json'
+    if is_json_request
+      begin
+        processed_params = JSON.parse(request.raw_post)
+      rescue JSON::ParserError
+        processed_params = params
+        is_json_request = false
+      end
     end
     # Use a single source for board params: parsed JSON body for JSON requests, params otherwise.
     # JSON-parsed params are plain hashes; Rails params need permit! since models do their own filtering.
-    board_params = if request.content_type == 'application/json'
+    board_params = if is_json_request
       processed_params['board'] || {}
     else
       raw_board = params['board']

--- a/app/controllers/api/organizations_controller.rb
+++ b/app/controllers/api/organizations_controller.rb
@@ -807,7 +807,7 @@ class Api::OrganizationsController < ApplicationController
     if org.process(org_data, {'updater' => @api_user})
       render json: JsonApi::Organization.as_json(org, :wrapper => true, :permissions => @api_user).to_json
     else
-      api_error(400, {error: "organization update failed", errors: org.processing_errors})
+      api_error(400, {error: "organization update failed", errors: (Array(org.processing_errors) + Array(org.errors.full_messages)).uniq})
     end
   end
   

--- a/app/frontend/app/controllers/organization/settings.js
+++ b/app/frontend/app/controllers/organization/settings.js
@@ -108,8 +108,9 @@ export default Controller.extend({
         _this.set('model.saml_metadata_url', null);
         _this.set('model.saml_sso_url', null);
       }
-      if(_this.get('home_board_key_lines.length') > 0) {
-        _this.set('model.home_board_keys', _this.get('home_board_key_lines').split(/\n/));
+      var home_board_key_lines = _this.get('home_board_key_lines');
+      if(home_board_key_lines && home_board_key_lines.replace(/\s/g, '').length > 0) {
+        _this.set('model.home_board_keys', home_board_key_lines.split(/\n/).map(function(s) { return s.trim(); }).filter(function(s) { return s.length > 0; }));
       }
       _this.set('model.support_target', null);
       if(_this.get('allow_support_target') && _this.get('support_email')) {


### PR DESCRIPTION
## Summary
- Bug 1: Organization rename PUT no longer 400s when the home board keys textarea is empty. The Ember settings controller now guards the split, trims entries, and filters empties so we never send `['']`. The Rails update action also surfaces `org.errors.full_messages` alongside `processing_errors` so future failures show the real validation error.
- Bug 3: Board copy POST no longer 400s when the client sends `application/json; charset=utf-8`. Switched from `request.content_type` strict equality to `request.media_type`, read the body via `request.raw_post`, and rescue `JSON::ParserError` back to `params`.
- Protected-copy permission widening intentionally not included; tracked as a follow-up.

## Test plan
- [ ] Rename an organization from the settings page with the home boards textarea empty and confirm a 200
- [ ] Rename an organization with one and multiple home board keys (including blank lines) and confirm only non-empty trimmed keys are saved
- [ ] Trigger a real org validation failure and confirm the error message now reflects the underlying ActiveModel error
- [ ] Copy a public board via the page set copy flow and confirm a 200 with both `application/json` and `application/json; charset=utf-8` content types
- [ ] Send a malformed JSON body to POST /api/v1/boards and confirm graceful fallback (no 500)