### PR TITLE
Fix HubSpot ENV var and add error handling

### DIFF
--- a/lib/external_tracker.rb
+++ b/lib/external_tracker.rb
@@ -13,7 +13,7 @@ module ExternalTracker
     user = User.find_by_path(user_id)
     return false unless user && user.external_email_allowed? && user.supporter_registration?
     return false if user.cookies_opted_out?
-    return false unless ENV['HUBSPOT_TOKEN']
+    return false unless ENV['HUBSPOT_ACCESS_TOKEN']
     return false unless user.settings && user.settings['email']
 
     d = user.devices[0]
@@ -25,6 +25,7 @@ module ExternalTracker
         res = Typhoeus.get(url, timeout: 5)
         location = JSON.parse(res.body)
       rescue => e
+        Rails.logger.warn("ExternalTracker: iplocate lookup failed for user #{user.global_id}: #{e.class}: #{e.message}")
       end
     end
     email = user.settings['email']
@@ -81,13 +82,18 @@ module ExternalTracker
     end
   
     url = "https://api.hubapi.com/contacts/v1/contact/"
-    res = Typhoeus.post(url, {body: json.to_json, headers: {
-      'Content-Type' => 'application/json',
-      'Authorization' => "Bearer #{ENV['HUBSPOT_TOKEN']}"
-      }})
-    # if res.code > 299
-    #   puts res.body
-    # end
+    begin
+      res = Typhoeus.post(url, {body: json.to_json, headers: {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{ENV['HUBSPOT_ACCESS_TOKEN']}"
+        }})
+    rescue => e
+      Rails.logger.error("ExternalTracker: HubSpot POST raised for user #{user.global_id}: #{e.class}: #{e.message}")
+      return nil
+    end
+    if res.code.to_i >= 300
+      Rails.logger.error("ExternalTracker: HubSpot contact sync failed for user #{user.global_id}: status=#{res.code} body=#{res.body.to_s[0, 500]}")
+    end
     res.code
   end
 end

--- a/spec/lib/external_tracker_spec.rb
+++ b/spec/lib/external_tracker_spec.rb
@@ -68,9 +68,9 @@ describe ExternalTracker do
     end
 
     it "should not call HubSpot when user opted out of cookies (GDPR)" do
-      original_token = ENV['HUBSPOT_TOKEN']
+      original_token = ENV['HUBSPOT_ACCESS_TOKEN']
       begin
-        ENV['HUBSPOT_TOKEN'] = 'hubby'
+        ENV['HUBSPOT_ACCESS_TOKEN'] = 'hubby'
         u = User.create
         u.settings['preferences'] ||= {}
         u.settings['preferences']['registration_type'] = 'therapist'
@@ -80,14 +80,14 @@ describe ExternalTracker do
         expect(Typhoeus).not_to receive(:post)
         expect(ExternalTracker.persist_new_user(u.global_id)).to eq(false)
       ensure
-        ENV['HUBSPOT_TOKEN'] = original_token
+        ENV['HUBSPOT_ACCESS_TOKEN'] = original_token
       end
     end
 
     it "should not call HubSpot when cookies preference is legacy string false" do
-      original_token = ENV['HUBSPOT_TOKEN']
+      original_token = ENV['HUBSPOT_ACCESS_TOKEN']
       begin
-        ENV['HUBSPOT_TOKEN'] = 'hubby'
+        ENV['HUBSPOT_ACCESS_TOKEN'] = 'hubby'
         u = User.create
         u.settings['preferences'] ||= {}
         u.settings['preferences']['registration_type'] = 'therapist'
@@ -97,29 +97,17 @@ describe ExternalTracker do
         expect(Typhoeus).not_to receive(:post)
         expect(ExternalTracker.persist_new_user(u.global_id)).to eq(false)
       ensure
-        ENV['HUBSPOT_TOKEN'] = original_token
+        ENV['HUBSPOT_ACCESS_TOKEN'] = original_token
       end
     end
 
-    it "should return false if not configured" do
-      u = User.create
-      ENV['HUBSPOT_KEY'] = nil
-      expect(ExternalTracker.persist_new_user(u.global_id)).to eq(false)
-    end
-    
-    it "should return false if no email provided" do
-      u = User.create
-      ENV['HUBSPOT_KEY'] = 'hubby'
-      expect(ExternalTracker.persist_new_user(u.global_id)).to eq(false)
-    end
-    
     it "should return non-false on success" do
       u = User.create
       u.settings['email'] = 'testing@example.com'
       u.settings['preferences'] ||= {}
       u.settings['preferences']['registration_type'] = 'therapist'
       u.save
-      ENV['HUBSPOT_TOKEN'] = 'hubby'
+      ENV['HUBSPOT_ACCESS_TOKEN'] = 'hubby'
 #       geo = {
 #         'country_code' => 'US',
 #         'city' => 'Sandy',
@@ -153,7 +141,7 @@ describe ExternalTracker do
       d = Device.create(:user => u)
       d.settings['ip_address'] = '1.2.3.4'
       d.save
-      ENV['HUBSPOT_TOKEN'] = 'hubby'
+      ENV['HUBSPOT_ACCESS_TOKEN'] = 'hubby'
       geo = {
         'country_code' => 'US',
         'city' => 'Sandy',
@@ -187,7 +175,7 @@ describe ExternalTracker do
       d = Device.create(:user => u)
       d.settings['ip_address'] = '1.2.3.4'
       d.save
-      ENV['HUBSPOT_TOKEN'] = 'hubby'
+      ENV['HUBSPOT_ACCESS_TOKEN'] = 'hubby'
       geo = {
         'country_code' => 'US',
         'city' => 'Sandy',


### PR DESCRIPTION
## Summary
- Rename `ENV['HUBSPOT_TOKEN']` to `ENV['HUBSPOT_ACCESS_TOKEN']` in `lib/external_tracker.rb` to match the actual env var name in master config and Render. HubSpot contact sync was silently non-functional because the old name never resolved.
- Add real error handling: log iplocate lookup failures at WARN level, wrap HubSpot POST in begin/rescue with ERROR-level logging for both HTTP failures (status >= 300) and exceptions. Return nil on exception so the background worker fails gracefully without blocking user registration.
- Remove 2 dead spec tests that referenced the non-existent `HUBSPOT_KEY` env var (never wired to anything).
- Rename all `HUBSPOT_TOKEN` references in spec to `HUBSPOT_ACCESS_TOKEN` (8 occurrences).
- Preserve all existing FERPA/COPPA/GDPR consent gates (supporter_registration?, cookies_opted_out?, external_email_allowed?) without modification.

## Phase 1 context (Stripe + HubSpot integration)
This is the HubSpot fix portion of Phase 1. Remaining Phase 1 items tracked separately:
- Stripe products/prices creation in test dashboard (manual, awaiting IDs)
- STRIPE_PUBLIC_KEY added to master config (done, not in this PR)
- 1Password service account needs rebuild (blocker for sync-render-env.js and GitHub Actions secrets sync)
- n8n HubSpot credential creation (deferred to Phase 2)

## Test plan
- [x] `bundle exec rspec spec/lib/external_tracker_spec.rb` -- 11 examples, 0 failures
- [x] Grep confirms zero remaining `HUBSPOT_TOKEN` or `HUBSPOT_KEY` references in codebase
- [x] PiiScrubber compliance review: no new PII leaves the app, no data shape changes, consent gates preserved
- [x] n8n credential check: Stripe credential exists, HubSpot deferred to Phase 2
- [ ] CI passes on PR
- [ ] Manual HubSpot contact creation test via rails console (dev only, post-merge)

## Discovered issues (not addressed in this PR)
- 1Password service account is deleted (403 Forbidden). Blocks sync-render-env.js, GitHub Actions secrets sync, and any op CLI usage. Needs rebuild as separate infra task.
- n8n has no HubSpot credential configured. Needed for Phase 3 bidirectional sync workflows.

Generated with Claude Code

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>