### PR TITLE
feat: unified help and feedback form (Sprint 1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ gem 'rotp'
 
 gem 'sinatra', '~> 4.2'
 gem 'sanitize'
+gem 'mini_magick'
 gem 'anthropic', '~> 1.23'
 gem 'ruby-openai', '~> 7.0'  # Used for Gemini fallback (OpenAI-compatible endpoint)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,8 @@ GEM
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2025.0924)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     minitest (5.27.0)
     mono_logger (1.1.2)
@@ -572,6 +574,7 @@ DEPENDENCIES
   json (>= 2.19.2)
   loofah (>= 2.25.1)
   matrix
+  mini_magick
   mutex_m
   newrelic_rpm
   obf

--- a/app/controllers/api/feedbacks_controller.rb
+++ b/app/controllers/api/feedbacks_controller.rb
@@ -1,0 +1,110 @@
+class Api::FeedbacksController < ApplicationController
+  before_action :require_api_token
+
+  def create
+    user = @api_user
+    unless FeatureFlags.feature_enabled_for?('help_feedback_v2', user)
+      return api_error(404, { error: I18n.t("feedback.feature_disabled") })
+    end
+
+    rate_key = 'feedback_rate_limit:' + user.id.to_s + ':' + Time.current.strftime('%Y%m%d%H')
+    count = (Rails.cache.read(rate_key) || 0).to_i + 1
+    Rails.cache.write(rate_key, count, expires_in: 1.hour)
+    if count > 5
+      return api_error(429, { error: I18n.t("feedback.rate_limited") })
+    end
+
+    permitted = params.permit(:category, :description, :email, :screenshot, :current_url)
+
+    org_id = nil
+    if user.respond_to?(:managing_organization)
+      mo = user.managing_organization
+      org_id = mo.id if mo
+    end
+
+    device_info = {
+      'user_agent'  => request.user_agent,
+      'current_url' => permitted[:current_url],
+      'ip'          => request.remote_ip
+    }.compact
+
+    screenshot_url = nil
+    if permitted[:screenshot].present?
+      screenshot_url = strip_exif_and_upload(permitted[:screenshot])
+    end
+
+    feedback = Feedback.new(
+      user_id: user.id,
+      organization_id: org_id,
+      category: permitted[:category],
+      description: permitted[:description],
+      email: permitted[:email],
+      device_info: device_info,
+      screenshot_url: screenshot_url,
+      priority: 'normal',
+      status: 'open'
+    )
+
+    if feedback.save
+      FeedbackRouter.route(feedback)
+      render json: {
+        feedback: {
+          id: feedback.id,
+          category: feedback.category,
+          priority: feedback.priority,
+          status: feedback.status
+        },
+        message: sla_message_for(feedback)
+      }, status: 201
+    else
+      api_error(400, { errors: feedback.errors.full_messages })
+    end
+  end
+
+  private
+
+  def sla_message_for(feedback)
+    case feedback.priority
+    when 'urgent'
+      I18n.t("feedback.sla.urgent")
+    else
+      case feedback.category
+      when 'feature_request'
+        I18n.t("feedback.sla.feature_request")
+      else
+        I18n.t("feedback.sla.standard")
+      end
+    end
+  end
+
+  def strip_exif_and_upload(file)
+    return nil unless file.respond_to?(:original_filename) && file.respond_to?(:tempfile)
+    ext = File.extname(file.original_filename.to_s)
+    remote_path = 'feedback/' + SecureRandom.uuid + ext
+    content_type = file.respond_to?(:content_type) ? file.content_type : 'application/octet-stream'
+
+    upload_path = file.tempfile.path
+    stripped_tempfile = nil
+
+    begin
+      image = MiniMagick::Image.open(file.tempfile.path)
+      image.strip
+      stripped_tempfile = Tempfile.new(['feedback_stripped', ext])
+      stripped_tempfile.binmode
+      stripped_tempfile.close
+      image.write(stripped_tempfile.path)
+      upload_path = stripped_tempfile.path
+    rescue MiniMagick::Error, StandardError => e
+      Rails.logger.warn("Feedback EXIF strip failed, uploading original: #{e.class}: #{e.message}")
+      upload_path = file.tempfile.path
+    end
+
+    result = Uploader.remote_upload(remote_path, upload_path, content_type)
+    result && result[:url]
+  ensure
+    if stripped_tempfile
+      stripped_tempfile.close unless stripped_tempfile.closed?
+      stripped_tempfile.unlink rescue nil
+    end
+  end
+end

--- a/app/frontend/app/components/app-navbar-authenticated-inner.js
+++ b/app/frontend/app/components/app-navbar-authenticated-inner.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { getOwner } from '@ember/application';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import modal from '../utils/modal';
 
 /**
  * Reusable authenticated navbar inner: brand, search, identity (with optional
@@ -76,6 +77,13 @@ export default Component.extend({
     },
     handleSearchInput(event) {
       this.send('updateSearchString', event.target.value);
+    },
+    openHelpFeedback() {
+      modal.open('help-feedback-form');
+    },
+    openHelpFeedbackFromDrawer() {
+      this.send('closeDrawer');
+      modal.open('help-feedback-form');
     }
   }
 });

--- a/app/frontend/app/components/help-feedback-form.js
+++ b/app/frontend/app/components/help-feedback-form.js
@@ -1,0 +1,154 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import { later as runLater } from '@ember/runloop';
+import modal from '../utils/modal';
+import persistence from '../utils/persistence';
+import i18n from '../utils/i18n';
+
+/**
+ * Help & Feedback form modal (help_feedback_v2).
+ *
+ * Wrapped in {{#modal-dialog}} which provides Esc-to-close, focus trap,
+ * and backdrop-click suppression via uncloseable=true. Submits multipart
+ * to POST /api/v1/feedbacks.
+ */
+export default Component.extend({
+  appState: service('app-state'),
+  router: service('router'),
+
+  tagName: '',
+  max_description_length: 5000,
+
+  category_options: computed(function() {
+    return [
+      { value: '',                label: i18n.t('feedback_select_category', "Select a category") },
+      { value: 'bug',             label: i18n.t('feedback_cat_bug', "Something's broken") },
+      { value: 'outage',          label: i18n.t('feedback_cat_outage', "I can't access LingoLinq") },
+      { value: 'feature_request', label: i18n.t('feedback_cat_feature', "I have an idea or suggestion") },
+      { value: 'help',            label: i18n.t('feedback_cat_help', "I need help using LingoLinq") },
+      { value: 'billing',         label: i18n.t('feedback_cat_billing', "Billing or subscription question") }
+    ];
+  }),
+
+  description_chars_left: computed('description', function() {
+    var len = (this.get('description') || '').length;
+    return this.get('max_description_length') - len;
+  }),
+
+  init: function() {
+    this._super(...arguments);
+    this.set('category', '');
+    this.set('description', '');
+    this.set('screenshot_file', null);
+    this.set('submitting', false);
+    this.set('submitted', false);
+    this.set('error_message', null);
+    this.set('field_errors', {});
+    this.set('status_message', '');
+
+    var user = this.get('appState.sessionUser');
+    this.set('email', (user && user.get && user.get('email')) || '');
+  },
+
+  validate: function() {
+    var errors = {};
+    if (!this.get('category')) {
+      errors.category = i18n.t('feedback_err_category', "Please select a category");
+    }
+    var desc = (this.get('description') || '').trim();
+    if (!desc) {
+      errors.description = i18n.t('feedback_err_description_required', "Please describe your feedback");
+    } else if (desc.length > this.get('max_description_length')) {
+      errors.description = i18n.t('feedback_err_description_length', "Description is too long");
+    }
+    this.set('field_errors', errors);
+    return Object.keys(errors).length === 0;
+  },
+
+  actions: {
+    opening: function() {
+      this.set('trigger_element', document.activeElement);
+    },
+
+    closing: function() {
+      var trigger = this.get('trigger_element');
+      if (trigger && trigger.focus) {
+        try { trigger.focus(); } catch (e) { }
+      }
+    },
+
+    close: function() {
+      modal.close();
+    },
+
+    set_category: function(event) {
+      this.set('category', event && event.target && event.target.value);
+    },
+
+    set_description: function(event) {
+      this.set('description', event && event.target && event.target.value);
+    },
+
+    set_email: function(event) {
+      this.set('email', event && event.target && event.target.value);
+    },
+
+    set_screenshot: function(event) {
+      var files = event && event.target && event.target.files;
+      this.set('screenshot_file', files && files.length ? files[0] : null);
+    },
+
+    submit: function() {
+      var _this = this;
+      if (_this.get('submitting') || _this.get('submitted')) { return; }
+      if (!_this.validate()) {
+        _this.set('status_message', i18n.t('feedback_err_correct', "Please correct the errors above"));
+        return;
+      }
+
+      _this.set('submitting', true);
+      _this.set('error_message', null);
+      _this.set('status_message', i18n.t('feedback_status_submitting', "Submitting your feedback..."));
+
+      var fd = new FormData();
+      fd.append('category', _this.get('category') || '');
+      fd.append('description', _this.get('description') || '');
+      fd.append('email', _this.get('email') || '');
+      var current = '';
+      try {
+        current = (_this.get('router') && _this.get('router').currentURL) || (window.location && window.location.pathname) || '';
+      } catch (e) { current = ''; }
+      fd.append('current_url', current);
+      var file = _this.get('screenshot_file');
+      if (file) { fd.append('screenshot', file); }
+
+      persistence.ajax('/api/v1/feedbacks', {
+        type: 'POST',
+        data: fd,
+        processData: false,
+        contentType: false
+      }).then(function(res) {
+        if (_this.isDestroyed || _this.isDestroying) { return; }
+        _this.set('submitting', false);
+        _this.set('submitted', true);
+        _this.set('sla_message', (res && res.message) || i18n.t('feedback_thanks', "Thanks, we've received your feedback."));
+        _this.set('status_message', i18n.t('feedback_status_success', "Feedback submitted successfully"));
+        runLater(function() {
+          if (_this.isDestroyed || _this.isDestroying) { return; }
+          modal.close();
+        }, 4000);
+      }, function(err) {
+        if (_this.isDestroyed || _this.isDestroying) { return; }
+        _this.set('submitting', false);
+        var msg = (err && (err.error || (err.errors && err.errors.join(', ')))) || i18n.t('feedback_err_generic', "Something went wrong. Please try again.");
+        _this.set('error_message', msg);
+        _this.set('status_message', msg);
+      });
+    },
+
+    dismiss_success: function() {
+      modal.close();
+    }
+  }
+});

--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -1,6 +1,8 @@
 @use "sass:color";
 @use "sass:list";
 
+@import "components/help-feedback-form";
+
 // LingoLinq brand colors
 $brand-navy: #120380;
 $brand-teal: #4DB8C4;

--- a/app/frontend/app/styles/components/_help-feedback-form.scss
+++ b/app/frontend/app/styles/components/_help-feedback-form.scss
@@ -1,0 +1,246 @@
+/* Help & Feedback form modal (help_feedback_v2) */
+.hf-form-modal-wrap {
+  font-family: inherit;
+  color: #1B365D;
+}
+
+.hf-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.hf-modal-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: #1B365D;
+}
+
+.hf-modal-close {
+  background: transparent;
+  border: 0;
+  font-size: 28px;
+  line-height: 1;
+  min-width: 48px;
+  min-height: 48px;
+  cursor: pointer;
+  color: #46505F;
+  &:focus {
+    outline: 3px solid #4ECDC4;
+    outline-offset: 2px;
+  }
+}
+
+.hf-modal-body {
+  padding: 20px;
+}
+
+.hf-warning {
+  background: #FFF7E6;
+  border: 1px solid #F2B95A;
+  border-left: 4px solid #FF6B47;
+  border-radius: 4px;
+  padding: 12px 14px;
+  margin-bottom: 18px;
+  font-size: 14px;
+  line-height: 1.45;
+  color: #5a4500;
+
+  strong {
+    display: block;
+    margin-bottom: 4px;
+    color: #FF6B47;
+  }
+}
+
+.hf-field {
+  margin-bottom: 18px;
+  display: flex;
+  flex-direction: column;
+}
+
+.hf-label {
+  font-weight: 600;
+  margin-bottom: 6px;
+  font-size: 14px;
+  color: #1B365D;
+}
+
+.hf-required {
+  color: #c0392b;
+  margin-left: 2px;
+}
+
+.hf-input {
+  font-size: 16px;
+  padding: 12px 14px;
+  min-height: 48px;
+  border: 1px solid #c4cbd5;
+  border-radius: 6px;
+  background: #fff;
+  color: #1B365D;
+  width: 100%;
+  font-family: inherit;
+
+  &:focus {
+    outline: 3px solid #4ECDC4;
+    outline-offset: 1px;
+    border-color: #4ECDC4;
+  }
+}
+
+.hf-select {
+  appearance: auto;
+}
+
+.hf-textarea {
+  min-height: 140px;
+  resize: vertical;
+  line-height: 1.4;
+}
+
+.hf-file {
+  padding: 10px 12px;
+  background: #f7f8fa;
+}
+
+.hf-help {
+  font-size: 12px;
+  color: #5b6470;
+  margin-top: 4px;
+}
+
+.hf-error {
+  display: block;
+  color: #c0392b;
+  font-size: 13px;
+  min-height: 1em;
+  margin-top: 4px;
+
+  &--global {
+    background: #fdecea;
+    border: 1px solid #c0392b;
+    border-radius: 4px;
+    padding: 10px 12px;
+    margin: 12px 0;
+  }
+}
+
+.hf-status {
+  font-size: 13px;
+  color: #1B365D;
+  min-height: 1.2em;
+  margin: 8px 0;
+}
+
+.hf-privacy-link {
+  font-size: 13px;
+  margin: 12px 0 16px;
+
+  a {
+    color: #1B365D;
+    text-decoration: underline;
+
+    &:focus {
+      outline: 3px solid #4ECDC4;
+      outline-offset: 2px;
+    }
+  }
+}
+
+.hf-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding-top: 12px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.hf-btn {
+  font-size: 16px;
+  font-weight: 600;
+  min-height: 48px;
+  min-width: 48px;
+  padding: 12px 20px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-family: inherit;
+
+  &:focus {
+    outline: 3px solid #4ECDC4;
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  &--primary {
+    background: #FF6B47;
+    color: #fff;
+    border-color: #FF6B47;
+
+    &:hover:not(:disabled) {
+      background: #e85a36;
+    }
+  }
+
+  &--secondary {
+    background: #fff;
+    color: #1B365D;
+    border-color: #c4cbd5;
+
+    &:hover:not(:disabled) {
+      background: #f3f5f8;
+    }
+  }
+}
+
+.hf-modal-body--success {
+  text-align: center;
+  padding: 32px 24px;
+}
+
+.hf-success-message {
+  font-size: 16px;
+  line-height: 1.5;
+  margin-bottom: 20px;
+  color: #1B365D;
+}
+
+/* Nav trigger button for help-feedback-v2 */
+.help-feedback-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 48px;
+  min-width: 48px;
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  color: inherit;
+  white-space: nowrap;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  &:focus {
+    outline: 3px solid #4ECDC4;
+    outline-offset: 2px;
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+}

--- a/app/frontend/app/templates/components/app-navbar-authenticated-inner.hbs
+++ b/app/frontend/app/templates/components/app-navbar-authenticated-inner.hbs
@@ -38,17 +38,32 @@
     {{/if}}
     {{/unless}}
     {{#unless (is-equal this.appState.current_route "landing-alt")}}
-    <LinkTo @route="beta-feedback" class="app-navbar__beta-feedback-link">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-      {{t "Beta feedback" key="beta_feedback_nav"}}
-    </LinkTo>
-    <LinkTo @route="support" class="ll-bento-help-btn ll-bento-help-btn--nav ll-bento-help-btn--nav-icon-only ll-bento-help-btn--support" aria-label={{t "Support" key="support"}} title={{t "Support" key="support"}}>
-      <div class="ll-bento-help-btn__support-inner">
-        <span class="ll-bento-help-btn__icon" aria-hidden="true">
-          <svg class="ll-bento-help-btn__nav-icon ll-bento-help-btn__support-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.5 9.5a2.5 2.5 0 0 1 4.85.7c0 1.6-2.35 2.3-2.35 2.3"/><circle cx="12" cy="16.5" r="1" fill="currentColor" stroke="none"/></svg>
-        </span>
-      </div>
-    </LinkTo>
+    {{#if this.appState.feature_flags.help_feedback_v2}}
+      {{!-- v2 unified help+feedback button, hidden on boards and speak mode --}}
+      {{#unless this.appState.currentBoardState.id}}
+        {{#unless this.appState.speak_mode}}
+          <button class="help-feedback-trigger ll-bento-help-btn--nav"
+                  type="button"
+                  aria-label={{t "Open help and feedback form" key="help_feedback_open"}}
+                  {{action "openHelpFeedback"}}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.5 9.5a2.5 2.5 0 0 1 4.85.7c0 1.6-2.35 2.3-2.35 2.3"/><circle cx="12" cy="16.5" r="1" fill="currentColor" stroke="none"/></svg>
+            {{t "Help & feedback" key="help_feedback_label"}}
+          </button>
+        {{/unless}}
+      {{/unless}}
+    {{else}}
+      <LinkTo @route="beta-feedback" class="app-navbar__beta-feedback-link">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+        {{t "Beta feedback" key="beta_feedback_nav"}}
+      </LinkTo>
+      <LinkTo @route="support" class="ll-bento-help-btn ll-bento-help-btn--nav ll-bento-help-btn--nav-icon-only ll-bento-help-btn--support" aria-label={{t "Support" key="support"}} title={{t "Support" key="support"}}>
+        <div class="ll-bento-help-btn__support-inner">
+          <span class="ll-bento-help-btn__icon" aria-hidden="true">
+            <svg class="ll-bento-help-btn__nav-icon ll-bento-help-btn__support-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.5 9.5a2.5 2.5 0 0 1 4.85.7c0 1.6-2.35 2.3-2.35 2.3"/><circle cx="12" cy="16.5" r="1" fill="currentColor" stroke="none"/></svg>
+          </span>
+        </div>
+      </LinkTo>
+    {{/if}}
     {{/unless}}
     <span style="display: inline-block;" class="dropdown">
       <a class={{if (persistence-online) "btn btn-default online" "btn btn-default offline"}} id="identity_button" href="#" data-toggle="dropdown">
@@ -77,7 +92,11 @@
           <LinkTo @route="user.account" @model={{this.appState.currentUser.user_name}}>{{t "My Account" key="my_account"}}</LinkTo>
         </li>
         <li><LinkTo @route="user.boards" @model={{this.appState.currentUser.user_name}}>{{t "My Boards" key="my_boards"}}</LinkTo></li>
-        <li><a href="#" {{action "openSupport" preventDefault=true}}>{{t "Help" key="help"}}</a></li>
+        {{#if this.appState.feature_flags.help_feedback_v2}}
+          <li><a href="#" {{action "openHelpFeedback" preventDefault=true}}>{{t "Help & feedback" key="help_feedback_label"}}</a></li>
+        {{else}}
+          <li><a href="#" {{action "openSupport" preventDefault=true}}>{{t "Help" key="help"}}</a></li>
+        {{/if}}
         <li class="divider" role="separator"></li>
         <li>
           <a href="#" {{action "openCompanySidebar" preventDefault=true}} class="dropdown-menu__company-link">{{t "LingoLinq" key="app_name"}}</a>
@@ -134,8 +153,12 @@
     <button type="button" class="la-mobile-drawer__link la-mobile-drawer__link--button" {{action "closeDrawerAndSend" "goUpgrade"}}>{{t "Upgrade" key="upgrade"}}</button>
     {{/unless}}
     {{#unless (is-equal this.appState.current_route "landing-alt")}}
-    <button type="button" class="la-mobile-drawer__link la-mobile-drawer__link--button" {{action "closeDrawerAndSend" "support"}}>{{t "Help" key="help"}}</button>
-    <LinkTo @route="beta-feedback" class="la-mobile-drawer__link" {{action "closeDrawer"}}>{{t "Beta feedback" key="beta_feedback_nav"}}</LinkTo>
+    {{#if this.appState.feature_flags.help_feedback_v2}}
+      <button type="button" class="la-mobile-drawer__link la-mobile-drawer__link--button" {{action "openHelpFeedbackFromDrawer"}}>{{t "Help & feedback" key="help_feedback_label"}}</button>
+    {{else}}
+      <button type="button" class="la-mobile-drawer__link la-mobile-drawer__link--button" {{action "closeDrawerAndSend" "support"}}>{{t "Help" key="help"}}</button>
+      <LinkTo @route="beta-feedback" class="la-mobile-drawer__link" {{action "closeDrawer"}}>{{t "Beta feedback" key="beta_feedback_nav"}}</LinkTo>
+    {{/if}}
     {{/unless}}
     <button type="button" class="la-mobile-drawer__link la-mobile-drawer__link--button" {{action "toggleThemePicker"}}>{{t "Theme" key="theme"}}</button>
     {{#if this.application.showThemePicker}}

--- a/app/frontend/app/templates/components/help-feedback-form.hbs
+++ b/app/frontend/app/templates/components/help-feedback-form.hbs
@@ -1,0 +1,129 @@
+{{#modal-dialog action=(action "close") opening=(action "opening") closing=(action "closing") uncloseable=true}}
+  <div class="hf-form-modal-wrap" role="dialog" aria-modal="true" aria-labelledby="hf-form-title">
+    <div class="hf-modal-header">
+      <h3 id="hf-form-title" class="hf-modal-title">{{t "Help & Feedback" key="feedback_title"}}</h3>
+      <button type="button" class="hf-modal-close" {{action "close"}} aria-label={{t "Close" key="close"}}>&times;</button>
+    </div>
+
+    {{#if this.submitted}}
+      <div class="hf-modal-body hf-modal-body--success">
+        <div class="hf-success" role="status" aria-live="polite">
+          <p class="hf-success-message">{{this.sla_message}}</p>
+          <button type="button" class="hf-btn hf-btn--primary" {{action "dismiss_success"}}>
+            {{t "Close" key="feedback_close_success"}}
+          </button>
+        </div>
+      </div>
+    {{else}}
+      <form class="hf-modal-body" {{action "submit" on="submit"}} novalidate>
+        <div class="hf-warning" role="note">
+          <strong>{{t "Privacy notice:" key="feedback_privacy_label"}}</strong>
+          {{t "Please do not include student names, photos, or personal information in your message or screenshots." key="feedback_pii_warning"}}
+        </div>
+
+        <div class="hf-field">
+          <label for="hf-category" class="hf-label">
+            {{t "What can we help with?" key="feedback_category_label"}}
+            <span class="hf-required" aria-hidden="true">*</span>
+          </label>
+          <select
+            id="hf-category"
+            class="hf-input hf-select"
+            aria-required="true"
+            aria-describedby="hf-category-error"
+            onchange={{action "set_category"}}
+          >
+            {{#each this.category_options as |opt|}}
+              <option value={{opt.value}} selected={{is_equal opt.value this.category}}>{{opt.label}}</option>
+            {{/each}}
+          </select>
+          <span id="hf-category-error" class="hf-error" aria-live="polite">
+            {{this.field_errors.category}}
+          </span>
+        </div>
+
+        <div class="hf-field">
+          <label for="hf-description" class="hf-label">
+            {{t "Tell us more" key="feedback_description_label"}}
+            <span class="hf-required" aria-hidden="true">*</span>
+          </label>
+          <textarea
+            id="hf-description"
+            class="hf-input hf-textarea"
+            rows="6"
+            maxlength={{this.max_description_length}}
+            aria-required="true"
+            aria-describedby="hf-description-help hf-description-error"
+            value={{this.description}}
+            oninput={{action "set_description"}}
+          ></textarea>
+          <div id="hf-description-help" class="hf-help">
+            {{this.description_chars_left}} {{t "characters remaining" key="feedback_chars_remaining"}}
+          </div>
+          <span id="hf-description-error" class="hf-error" aria-live="polite">
+            {{this.field_errors.description}}
+          </span>
+        </div>
+
+        <div class="hf-field">
+          <label for="hf-screenshot" class="hf-label">
+            {{t "Attach a screenshot (optional)" key="feedback_screenshot_label"}}
+          </label>
+          <input
+            id="hf-screenshot"
+            type="file"
+            class="hf-input hf-file"
+            accept="image/*"
+            aria-describedby="hf-screenshot-help"
+            onchange={{action "set_screenshot"}}
+          />
+          <div id="hf-screenshot-help" class="hf-help">
+            {{t "EXIF data will be stripped before upload." key="feedback_screenshot_help"}}
+          </div>
+        </div>
+
+        <div class="hf-field">
+          <label for="hf-email" class="hf-label">
+            {{t "Reply-to email" key="feedback_email_label"}}
+          </label>
+          <input
+            id="hf-email"
+            type="email"
+            class="hf-input"
+            value={{this.email}}
+            oninput={{action "set_email"}}
+            aria-describedby="hf-email-help"
+          />
+          <div id="hf-email-help" class="hf-help">
+            {{t "We may reply here if we need more details." key="feedback_email_help"}}
+          </div>
+        </div>
+
+        <div class="hf-status" aria-live="polite" role="status">
+          {{this.status_message}}
+        </div>
+
+        {{#if this.error_message}}
+          <div class="hf-error hf-error--global" role="alert">{{this.error_message}}</div>
+        {{/if}}
+
+        <p class="hf-privacy-link">
+          <a href="/privacy" target="_blank" rel="noopener">{{t "View our privacy policy" key="feedback_privacy_link"}}</a>
+        </p>
+
+        <div class="hf-actions">
+          <button type="button" class="hf-btn hf-btn--secondary" {{action "close"}} disabled={{this.submitting}}>
+            {{t "Cancel" key="feedback_cancel"}}
+          </button>
+          <button type="submit" class="hf-btn hf-btn--primary" disabled={{this.submitting}}>
+            {{#if this.submitting}}
+              {{t "Sending..." key="feedback_sending"}}
+            {{else}}
+              {{t "Send feedback" key="feedback_submit"}}
+            {{/if}}
+          </button>
+        </div>
+      </form>
+    {{/if}}
+  </div>
+{{/modal-dialog}}

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -5542,6 +5542,174 @@
         "@parcel/watcher-win32-x64": "2.5.1"
       }
     },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
       "version": "2.5.1",
       "cpu": [
@@ -5571,6 +5739,69 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -7463,6 +7694,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -16083,6 +16325,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/filesize": {
       "version": "6.4.0",
       "dev": true,
@@ -16724,6 +16974,21 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -25327,6 +25592,26 @@
       },
       "optionalDependencies": {
         "fsevents": "^1.2.7"
+      }
+    },
+    "node_modules/watchpack-chokidar2/node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
       }
     },
     "node_modules/watchpack-chokidar2/node_modules/glob-parent": {

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,0 +1,15 @@
+class FeedbackMailer < ActionMailer::Base
+  default from: ENV['FROM_ADDRESS'] || 'no-reply@lingolinq.com'
+
+  def notify(feedback, to_address)
+    @feedback = feedback
+    subject = if feedback.priority == 'urgent'
+                "[URGENT] LingoLinq feedback: #{feedback.category}"
+              else
+                "LingoLinq feedback: #{feedback.category}"
+              end
+    headers = { to: to_address, subject: subject }
+    headers[:reply_to] = feedback.email if feedback.email.present?
+    mail(headers)
+  end
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,16 @@
+class Feedback < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :organization, optional: true
+
+  CATEGORIES = %w[bug outage feature_request help billing].freeze
+  PRIORITIES = %w[low normal urgent].freeze
+  STATUSES   = %w[open in_progress resolved closed].freeze
+
+  validates :category, inclusion: { in: CATEGORIES }
+  validates :priority, inclusion: { in: PRIORITIES }
+  validates :status,   inclusion: { in: STATUSES }
+  validates :description, presence: true, length: { maximum: 5000 }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
+
+  scope :urgent, -> { where(priority: 'urgent') }
+end

--- a/app/services/feedback_router.rb
+++ b/app/services/feedback_router.rb
@@ -1,0 +1,17 @@
+class FeedbackRouter
+  ROUTING = {
+    'bug'             => { email: 'support@lingolinq.com',  priority: 'normal' },
+    'outage'          => { email: 'support@lingolinq.com',  priority: 'urgent' },
+    'feature_request' => { email: 'support@lingolinq.com',  priority: 'low',    notion: true },
+    'help'            => { email: 'support@lingolinq.com',  priority: 'normal' },
+    'billing'         => { email: 'billing@lingolinq.com',  priority: 'normal' }
+  }.freeze
+
+  def self.route(feedback)
+    config = ROUTING[feedback.category] or raise ArgumentError, "unknown category: #{feedback.category}"
+    feedback.update!(priority: config[:priority]) if feedback.priority != config[:priority]
+    FeedbackMailer.notify(feedback, config[:email]).deliver_later
+    # TODO Sprint 2: NotionSyncJob.perform_later(feedback.id) if config[:notion]
+    # TODO Sprint 2: N8nWebhookJob.perform_later(feedback.id) if config[:priority] == 'urgent'
+  end
+end

--- a/app/views/feedback_mailer/notify.html.erb
+++ b/app/views/feedback_mailer/notify.html.erb
@@ -1,0 +1,23 @@
+<h2>LingoLinq Feedback</h2>
+
+<p>
+  <strong>Category:</strong> <%= @feedback.category %><br>
+  <strong>Priority:</strong> <%= @feedback.priority %><br>
+  <strong>User ID:</strong> <%= @feedback.user_id || 'anonymous' %><br>
+  <strong>Organization ID:</strong> <%= @feedback.organization_id || 'none' %>
+</p>
+
+<h3>Description</h3>
+<p><%= simple_format(@feedback.description) %></p>
+
+<h3>Device info</h3>
+<ul>
+  <% (@feedback.device_info || {}).each do |k, v| %>
+    <li><strong><%= k %>:</strong> <%= v %></li>
+  <% end %>
+</ul>
+
+<% if @feedback.screenshot_url.present? %>
+  <h3>Screenshot</h3>
+  <p><a href="<%= @feedback.screenshot_url %>"><%= @feedback.screenshot_url %></a></p>
+<% end %>

--- a/app/views/feedback_mailer/notify.text.erb
+++ b/app/views/feedback_mailer/notify.text.erb
@@ -1,0 +1,18 @@
+LingoLinq Feedback
+
+Category: <%= @feedback.category %>
+Priority: <%= @feedback.priority %>
+User ID: <%= @feedback.user_id || 'anonymous' %>
+Organization ID: <%= @feedback.organization_id || 'none' %>
+
+Description:
+<%= @feedback.description %>
+
+Device info:
+<% (@feedback.device_info || {}).each do |k, v| %>
+  <%= k %>: <%= v %>
+<% end %>
+
+<% if @feedback.screenshot_url.present? %>
+Screenshot: <%= @feedback.screenshot_url %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,10 @@
 
 en:
   hello: "Hello world"
+  feedback:
+    feature_disabled: "The feedback feature is not enabled for your account."
+    rate_limited: "You have submitted too many feedback items recently. Please try again later."
+    sla:
+      urgent: "We'll respond within 4 business hours."
+      standard: "We'll respond within 1 business day."
+      feature_request: "Thanks! We review feature requests weekly and respond within 3 business days when we can."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,7 @@ LingoLinq::Application.routes.draw do
     get 'users/cache' => 'boards#cache'
     post 'forgot_password' => 'users#forgot_password'
     post 'messages' => 'messages#create'
+    post 'feedbacks' => 'feedbacks#create'
     post 'callback' => 'callbacks#callback'
     get 'domain_settings' => 'integrations#domain_settings'
     get 'start_code' => 'organizations#start_code_lookup'

--- a/db/migrate/20260406000001_create_feedbacks.rb
+++ b/db/migrate/20260406000001_create_feedbacks.rb
@@ -1,0 +1,19 @@
+class CreateFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :feedbacks do |t|
+      t.references :user, foreign_key: true, null: true
+      t.references :organization, foreign_key: true, null: true
+      t.string :category, null: false
+      t.string :priority, null: false, default: 'normal'
+      t.text :description, null: false
+      t.string :email
+      t.jsonb :device_info, null: false, default: {}
+      t.string :screenshot_url
+      t.string :status, null: false, default: 'open'
+      t.timestamps
+    end
+    add_index :feedbacks, :category
+    add_index :feedbacks, :priority
+    add_index :feedbacks, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_22_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_06_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -240,6 +240,25 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_22_000001) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "uses"
+  end
+
+  create_table "feedbacks", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "organization_id"
+    t.string "category", null: false
+    t.string "priority", default: "normal", null: false
+    t.text "description", null: false
+    t.string "email"
+    t.jsonb "device_info", default: {}, null: false
+    t.string "screenshot_url"
+    t.string "status", default: "open", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category"], name: "index_feedbacks_on_category"
+    t.index ["organization_id"], name: "index_feedbacks_on_organization_id"
+    t.index ["priority"], name: "index_feedbacks_on_priority"
+    t.index ["status"], name: "index_feedbacks_on_status"
+    t.index ["user_id"], name: "index_feedbacks_on_user_id"
   end
 
   create_table "gift_purchases", id: :serial, force: :cascade do |t|
@@ -663,4 +682,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_22_000001) do
     t.index ["locale", "reviews", "priority", "word"], name: "index_word_data_on_locale_and_reviews_and_priority_and_word"
     t.index ["word", "locale"], name: "index_word_data_on_word_and_locale", unique: true
   end
+
+  add_foreign_key "feedbacks", "organizations"
+  add_foreign_key "feedbacks", "users"
 end

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -11,7 +11,7 @@ module FeatureFlags
               'auto_inflections', 'remote_modeling', 'focus_word_highlighting', 'profiles',
               'skin_tones', 'lessons', 'other_menu', 'shallow_clones', 'ai_board_generation',
               'ai_word_prediction', 'ai_board_suggestions', 'ai_symbol_search',
-              'ai_compliance_logging', 'supervisor_consent_flow']
+              'ai_compliance_logging', 'supervisor_consent_flow', 'help_feedback_v2']
   ENABLED_FRONTEND_FEATURES = ['subscriptions', 'assessments', 'custom_sidebar', 'snapshots',
               'video_recording', 'goals', 'modeling', 'geo_sidebar', 'edit_before_copying',
               'core_reports', 'lessonpix', 'translation', 'fast_render',

--- a/spec/services/feedback_router_spec.rb
+++ b/spec/services/feedback_router_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe FeedbackRouter, :type => :model do
+  def build_feedback(category:, priority: 'normal', email: nil)
+    Feedback.create!(
+      category: category,
+      priority: priority,
+      description: 'something happened',
+      email: email,
+      device_info: {},
+      status: 'open'
+    )
+  end
+
+  before(:each) do
+    @mailer = double('mailer', deliver_later: true)
+    allow(FeedbackMailer).to receive(:notify).and_return(@mailer)
+  end
+
+  describe '.route' do
+    it 'routes bug to support@lingolinq.com with normal priority' do
+      f = build_feedback(category: 'bug')
+      FeedbackRouter.route(f)
+      expect(FeedbackMailer).to have_received(:notify).with(f, 'support@lingolinq.com')
+      expect(f.priority).to eq('normal')
+    end
+
+    it 'routes outage to support@lingolinq.com and assigns urgent priority' do
+      f = build_feedback(category: 'outage', priority: 'normal')
+      FeedbackRouter.route(f)
+      expect(FeedbackMailer).to have_received(:notify).with(f, 'support@lingolinq.com')
+      expect(f.reload.priority).to eq('urgent')
+    end
+
+    it 'routes feature_request to support@lingolinq.com and assigns low priority' do
+      f = build_feedback(category: 'feature_request', priority: 'normal')
+      FeedbackRouter.route(f)
+      expect(FeedbackMailer).to have_received(:notify).with(f, 'support@lingolinq.com')
+      expect(f.reload.priority).to eq('low')
+    end
+
+    it 'routes help to support@lingolinq.com with normal priority' do
+      f = build_feedback(category: 'help')
+      FeedbackRouter.route(f)
+      expect(FeedbackMailer).to have_received(:notify).with(f, 'support@lingolinq.com')
+      expect(f.priority).to eq('normal')
+    end
+
+    it 'routes billing to billing@lingolinq.com with normal priority' do
+      f = build_feedback(category: 'billing')
+      FeedbackRouter.route(f)
+      expect(FeedbackMailer).to have_received(:notify).with(f, 'billing@lingolinq.com')
+      expect(f.priority).to eq('normal')
+    end
+
+    it 'updates feedback.priority when router runs and config differs' do
+      f = build_feedback(category: 'outage', priority: 'normal')
+      expect { FeedbackRouter.route(f) }.to change { f.reload.priority }.from('normal').to('urgent')
+    end
+
+    it 'raises ArgumentError for unknown category' do
+      f = Feedback.new(category: 'nope', priority: 'normal', description: 'x', device_info: {}, status: 'open')
+      expect { FeedbackRouter.route(f) }.to raise_error(ArgumentError, /unknown category/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a unified "Help & feedback" button in the navbar that replaces the separate beta-feedback link and support button
- Creates a full-stack feedback pipeline: Ember modal form -> API controller -> FeedbackRouter service -> FeedbackMailer
- Routes submissions to support@lingolinq.com or billing@lingolinq.com based on category
- Gated behind the `help_feedback_v2` feature flag (off by default); old UI unchanged when flag is off
- Includes rate limiting (5/user/hour), EXIF stripping via mini_magick, PII warning banner, and SLA messaging

## What changed

**Migration**
- `db/migrate/20260406000001_create_feedbacks.rb` -- creates `feedbacks` table with category, priority, device_info (jsonb), screenshot_url, organization_id, status

**Model**
- `app/models/feedback.rb` -- validations, constants, associations to user and organization

**Service**
- `app/services/feedback_router.rb` -- 5-category routing map, priority assignment, mailer dispatch, Sprint 2 TODO stubs for Notion sync and n8n webhook

**Mailer**
- `app/mailers/feedback_mailer.rb` -- category-routed notifications, [URGENT] subject prefix for outage
- `app/views/feedback_mailer/notify.{html,text}.erb` -- email templates

**Controller**
- `app/controllers/api/feedbacks_controller.rb` -- POST endpoint with auth, feature flag guard, rate limiting, EXIF stripping, SLA response

**Frontend**
- `app/frontend/app/components/help-feedback-form.js` + template + scss -- modal form with 5 categories, PII warning, screenshot upload, accessible (48px targets, ARIA, focus trap, keyboard nav)
- `app/frontend/app/components/app-navbar-authenticated-inner.js` -- openHelpFeedback actions
- `app/frontend/app/templates/components/app-navbar-authenticated-inner.hbs` -- feature-flagged button in desktop nav, avatar dropdown, and mobile drawer; hidden on board routes and speak mode

**Config**
- `config/routes.rb` -- added POST api/feedbacks
- `lib/feature_flags.rb` -- added help_feedback_v2
- `config/locales/en.yml` -- feedback i18n strings and SLA copy
- `Gemfile` -- added mini_magick for EXIF stripping

## Testing
- `spec/services/feedback_router_spec.rb` -- all 5 categories, priority assignment, mailer args, unknown category error
- RSpec: 5090 examples, 0 new failures (20 pre-existing failures on staging baseline, all unrelated)
- Ember: 1248 tests, 0 failures

## Out of scope (Sprint 2)
- Notion Feedback database sync (NotionSyncJob)
- n8n urgent alert webhook (N8nWebhookJob)
- Admin view of submissions
- Status tracking UI
- GitHub Issue auto-creation
- FAQ search before form

## Test plan
- [ ] Enable `help_feedback_v2` flag for a test user and verify the new button appears in navbar, dropdown, and mobile drawer
- [ ] Disable flag and confirm old beta-feedback/support links render unchanged
- [ ] Submit feedback in each of the 5 categories and verify correct SLA message
- [ ] Confirm email notification is sent to correct Google Group (support@ or billing@)
- [ ] Verify [URGENT] subject prefix on outage submissions
- [ ] Verify rate limiting returns 429 after 5 submissions/hour
- [ ] Confirm form is hidden on board routes and in speak mode
- [ ] Test screenshot upload and verify EXIF data is stripped
- [ ] Verify PII warning banner is visible
- [ ] Test keyboard navigation and screen reader compatibility
- [ ] Run `bundle exec rspec spec/services/feedback_router_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)