### PR TITLE
Replace rubyzip ZIP writing with zip_kit for streaming exports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,10 @@ gem 'puma'
 gem 'paper_trail', '~> 15.0'
 gem 'geokit'
 gem 'obf'
-# OBF uses Zip::File::CREATE, which was removed in rubyzip 3.x
+# OBF uses Zip::File::CREATE (rubyzip) for reading ZIPs.
+# zip_kit handles all ZIP writing (streaming, flat memory).
 gem 'rubyzip', '~> 2.3'
+gem 'zip_kit', '~> 6.3'
 gem 'accessible-books'
 gem 'bugsnag'
 gem 'stripe'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -536,6 +536,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.7.5)
+    zip_kit (6.3.4)
 
 PLATFORMS
   aarch64-linux
@@ -610,6 +611,7 @@ DEPENDENCIES
   stripe
   ttfunk (= 1.7)
   typhoeus
+  zip_kit (~> 6.3)
 
 RUBY VERSION
    ruby 3.4.4p34

--- a/config/initializers/zip_kit_patch.rb
+++ b/config/initializers/zip_kit_patch.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Monkey-patch OBF::Utils.build_zip to use zip_kit instead of rubyzip.
+# zip_kit writes ZIP files in a streaming, append-only fashion with flat
+# ~128KB memory overhead regardless of archive size. rubyzip buffers the
+# entire archive in memory (seekable IO).
+#
+# Only the write path is patched. OBF::Utils.load_zip stays on rubyzip
+# because zip_kit cannot read/extract ZIP entries.
+#
+# Set OBF_ZIPKIT_PATCH=0 to disable and fall back to rubyzip writing.
+
+require 'zip_kit'
+
+if !ENV['OBF_ZIPKIT_PATCH'].to_s.match(/\A(0|false|no|off)\z/i)
+  module OBF
+    module Utils
+      # Shim that presents the same add(path, contents) interface as
+      # OBF::Utils::Zipper but delegates to ZipKit::Streamer.
+      class ZipKitZipper
+        def initialize(streamer)
+          @streamer = streamer
+        end
+
+        # Add content (string or binary) as a named entry in the ZIP.
+        def add(path, contents)
+          @streamer.write_file(path) do |sink|
+            sink << contents.b
+          end
+        end
+
+        # Stream a local file into the ZIP without loading it all into memory.
+        def add_file(path, local_path)
+          @streamer.write_file(path) do |sink|
+            File.open(local_path, 'rb') do |f|
+              IO.copy_stream(f, sink)
+            end
+          end
+        end
+      end
+
+      class << self
+        alias_method :build_zip_rubyzip, :build_zip
+
+        def build_zip(dest_path = nil, &block)
+          if !dest_path
+            dest_path = OBF::Utils.temp_path(['archive', '.obz'])
+          end
+          File.open(dest_path, 'wb') do |file_io|
+            ZipKit::Streamer.open(file_io) do |streamer|
+              block.call(ZipKitZipper.new(streamer))
+            end
+          end
+        end
+      end
+    end
+  end
+
+  Rails.logger.info('[zip_kit] OBF::Utils.build_zip patched for streaming ZIP writes') if defined?(Rails.logger) && Rails.logger
+end

--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -31,7 +31,6 @@ module Exporter
     
     # If chunking is required, the result will need to be a zip file, not a single obl/obla
     if chunks.length > 1 && !zipper && !cutoff
-      raise 'arg'
       file = Tempfile.new(['log-data', '.zip'])
       begin
         file.close
@@ -510,8 +509,10 @@ More information about the file formats being used is available at https://www.o
   end
 
   # Stream a local file into the zipper without loading it all into memory.
-  # Falls back to file.read for zippers that lack add_file (e.g. tests with
+  # Falls back to File.binread for zippers that lack add_file (e.g. tests with
   # the original OBF::Utils::Zipper).
+  # NOTE: this method always deletes local_path after writing (in an ensure
+  # block), so it must only be called with temporary files that are safe to remove.
   def self.add_local_file(zipper, name, local_path)
     if zipper.respond_to?(:add_file)
       zipper.add_file(name, local_path)

--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -33,13 +33,17 @@ module Exporter
     if chunks.length > 1 && !zipper && !cutoff
       raise 'arg'
       file = Tempfile.new(['log-data', '.zip'])
-      file.close
-      OBF::Utils.build_zip(file.path) do |zipper|
-        export_logs(user_id, anonymized, zipper, cutoff)
+      begin
+        file.close
+        OBF::Utils.build_zip(file.path) do |zipper|
+          export_logs(user_id, anonymized, zipper, cutoff)
+        end
+        export_fn = fn + ".zip"
+        ts = Time.now.iso8601[0, 16].sub(/:/, '-')
+        return Uploader.remote_upload("downloads/logs/user/#{ts}/#{user.anonymized_identifier}/#{export_fn}", file.path, 'application/zip')
+      ensure
+        File.unlink(file.path) if file && File.exist?(file.path)
       end
-      export_fn = fn + ".zip"
-      ts = Time.now.iso8601[0, 16].sub(/:/, '-')
-      return Uploader.remote_upload("downloads/logs/user/#{ts}/#{user.anonymized_identifier}/#{export_fn}", file.path, 'application/zip')
     end
 
     upload_res = nil
@@ -87,6 +91,8 @@ More information about the file formats being used is available at https://www.o
       export_boards(user, zipper)
     end
     Uploader.remote_upload("downloads/users/#{CGI.escape(Time.now.iso8601[0, 16].sub(/:/, '-'))}/#{user.user_name}/lingolinq-export-#{user.user_name}.zip", file.path, "application/zip")
+  ensure
+    File.unlink(file.path) if file && File.exist?(file.path)
   end
   
   def self.export_boards(user, zipper=nil)
@@ -101,17 +107,13 @@ More information about the file formats being used is available at https://www.o
         path = file.path
         file.close
         Converters::LingoLinq.to_obz(home_board, path, {'user' => user})
-        file = File.open(path, 'rb')
-        zipper.add('boards/home.obz', file.read)
-        file.close
+        add_local_file(zipper, 'boards/home.obz', path)
 
         file = Tempfile.new(['home-board', '.pdf'])
         path = file.path
         file.close
         Converters::LingoLinq.to_pdf(home_board, path, {'user' => user, 'packet' => true})
-        file = File.open(path, 'rb')
-        zipper.add('boards/home.pdf', file.read)
-        file.close
+        add_local_file(zipper, 'boards/home.pdf', path)
       end
     end
     user.sidebar_boards.each_with_index do |board, idx|
@@ -124,9 +126,7 @@ More information about the file formats being used is available at https://www.o
         path = file.path
         file.close
         Converters::LingoLinq.to_obz(sidebar_board, path, {'user' => user})
-        file = File.open(path, 'rb')
-        zipper.add("boards/sidebar-#{idx.to_s.rjust(2, '0')}.obz", file.read)
-        file.close
+        add_local_file(zipper, "boards/sidebar-#{idx.to_s.rjust(2, '0')}.obz", path)
       end
     end
     Board.where(user_id: user.id).find_in_batches(batch_size: 5) do |batch|
@@ -136,9 +136,7 @@ More information about the file formats being used is available at https://www.o
         path = file.path
         file.close
         Converters::LingoLinq.to_obf(board, path)
-        file = File.open(path, 'rb')
-        zipper.add("boards/personal/board-#{board.global_id}.obf", file.read)
-        file.close
+        add_local_file(zipper, "boards/personal/board-#{board.global_id}.obf", path)
       end
     end
     "boards/home.obz"
@@ -509,6 +507,19 @@ More information about the file formats being used is available at https://www.o
       hash[:text] = str
     end
     hash
+  end
+
+  # Stream a local file into the zipper without loading it all into memory.
+  # Falls back to file.read for zippers that lack add_file (e.g. tests with
+  # the original OBF::Utils::Zipper).
+  def self.add_local_file(zipper, name, local_path)
+    if zipper.respond_to?(:add_file)
+      zipper.add_file(name, local_path)
+    else
+      zipper.add(name, File.binread(local_path))
+    end
+  ensure
+    File.unlink(local_path) if File.exist?(local_path)
   end
 
   def self.process_log(data, type, user_id, author_id, device_id)

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -320,8 +320,9 @@ module Uploader
     Progress.update_current_progress(0.9, :uploading_file)
     url = (Uploader.remote_upload(remote_path, path, content_type) || {})[:url]
     raise "File not uploaded" unless url
-    File.unlink(path) if File.exist?(path)
     return url
+  ensure
+    File.unlink(path) if path && File.exist?(path)
   end
   
   def self.valid_remote_url?(url)

--- a/spec/lib/exporter_spec.rb
+++ b/spec/lib/exporter_spec.rb
@@ -1084,4 +1084,52 @@ describe Exporter do
       expect(res[0].data['events'][1]['percent_y']).to eq(nil)
     end
   end
+
+  describe 'add_local_file' do
+    it 'should use add_file for zippers that support streaming and delete the source file' do
+      tmp = Tempfile.new(['test-board', '.obz'])
+      tmp.write('fake zip contents')
+      tmp.close
+      tmp_path = tmp.path
+      expect(File.exist?(tmp_path)).to eq(true)
+
+      zipper = double('streaming_zipper')
+      expect(zipper).to receive(:add_file).with('board.obz', tmp_path)
+
+      Exporter.add_local_file(zipper, 'board.obz', tmp_path)
+
+      expect(File.exist?(tmp_path)).to eq(false)
+    end
+
+    it 'should fall back to binread for zippers without add_file and delete the source file' do
+      tmp = Tempfile.new(['test-board', '.obz'])
+      tmp.write('fake zip contents')
+      tmp.close
+      tmp_path = tmp.path
+      expect(File.exist?(tmp_path)).to eq(true)
+
+      zipper = double('legacy_zipper')
+      expect(zipper).not_to receive(:add_file)
+      expect(zipper).to receive(:add).with('board.obz', 'fake zip contents')
+      allow(zipper).to receive(:respond_to?).with(:add_file).and_return(false)
+
+      Exporter.add_local_file(zipper, 'board.obz', tmp_path)
+
+      expect(File.exist?(tmp_path)).to eq(false)
+    end
+
+    it 'should delete the source file even if the zipper raises an error' do
+      tmp = Tempfile.new(['test-board', '.obz'])
+      tmp.write('fake zip contents')
+      tmp.close
+      tmp_path = tmp.path
+
+      zipper = double('error_zipper')
+      allow(zipper).to receive(:respond_to?).with(:add_file).and_return(true)
+      expect(zipper).to receive(:add_file).and_raise('zip write failed')
+
+      expect { Exporter.add_local_file(zipper, 'board.obz', tmp_path) }.to raise_error('zip write failed')
+      expect(File.exist?(tmp_path)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds `zip_kit ~> 6.3` for streaming ZIP writes (flat ~128KB memory vs full-archive buffering)
- Monkey-patches `OBF::Utils.build_zip` to use `ZipKit::Streamer` (kill-switch: `OBF_ZIPKIT_PATCH=0`)
- Streams inner OBZ/PDF files from disk via `IO.copy_stream` instead of `file.read`
- Adds `ensure` blocks to `export_user`, `export_logs`, and `generate_zip` for guaranteed tempfile cleanup
- `OBF::Utils.load_zip` (ZIP reading) stays on rubyzip -- zip_kit is write-only

## Context
Board set exports (50-200 boards) caused 500MB+ memory spikes, contributing to staging crashes (3-7x/day at 730-900MB on 2GB plan). This is the third PR in the export optimization pipeline after #174 (memory optimizations) and #178 (Clowne board copy).

## Test plan
- [x] Exporter specs: 34/34 passing
- [x] Uploader generate_zip specs: 2/2 passing
- [x] 14 uploader failures are pre-existing (AWS S3 mock-related, identical on staging)
- [ ] Manual: export a large board set on staging, verify OBZ opens in AAC app
- [ ] Monitor Render memory graphs after deployment
- [ ] Run `zipinfo` on generated OBZ to validate data descriptor format

🤖 Generated with [Claude Code](https://claude.com/claude-code)