### PR TITLE
fix: hide Tarheel Reader behind feature flag (off by default)

### DIFF
--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -11,7 +11,8 @@ module FeatureFlags
               'auto_inflections', 'remote_modeling', 'focus_word_highlighting', 'profiles',
               'skin_tones', 'lessons', 'other_menu', 'shallow_clones', 'ai_board_generation',
               'ai_word_prediction', 'ai_board_suggestions', 'ai_symbol_search',
-              'ai_compliance_logging', 'supervisor_consent_flow']
+              'ai_compliance_logging', 'supervisor_consent_flow',
+              'tarheel_reader']
   ENABLED_FRONTEND_FEATURES = ['subscriptions', 'assessments', 'custom_sidebar', 'snapshots',
               'video_recording', 'goals', 'modeling', 'geo_sidebar', 'edit_before_copying',
               'core_reports', 'lessonpix', 'translation', 'fast_render',
@@ -42,7 +43,8 @@ module FeatureFlags
     'ai_board_suggestions' => 'Feb 21, 2026',
     'ai_symbol_search' => 'Feb 21, 2026',
     'ai_compliance_logging' => 'Feb 21, 2026',
-    'supervisor_consent_flow' => 'Mar 22, 2026'
+    'supervisor_consent_flow' => 'Mar 22, 2026',
+    'tarheel_reader' => 'Apr 14, 2026'
   }
   AI_FEATURES = %w[ai_board_generation ai_word_prediction ai_board_suggestions
                    ai_symbol_search ai_compliance_logging].freeze

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -697,6 +697,14 @@ module Uploader
   end
   
   def self.find_resources(query, source, user)
+    if (source == 'tarheel' || source == 'tarheel_book') && !FeatureFlags.feature_enabled_for?('tarheel_reader', user)
+      # Tarheel Reader was acquired by Building Wings and moved to Monarch Reader
+      # (Sept 2024). The tarheelreader.org JSON endpoints now 301-redirect to a
+      # closed SPA, so live calls return HTML that fails to parse. Gated behind
+      # the 'tarheel_reader' feature flag (off by default) until a partnership
+      # or alternate book source is in place.
+      return []
+    end
     tarheel_prefix = "https://tarheelreader.org" #ENV['TARHEEL_PROXY'] || "https://images.weserv.nl/?url=tarheelreader.org"
     if source == 'tarheel'
       url = "https://tarheelreader.org/find/?search=#{CGI.escape(query)}&category=&reviewed=R&audience=E&language=en&page=1&json=1"

--- a/spec/lib/uploader_spec.rb
+++ b/spec/lib/uploader_spec.rb
@@ -1604,8 +1604,16 @@ describe Uploader do
       expect(Uploader.find_resources('bacon', 'whatever', nil)).to eq([])
       expect(Uploader.find_resources('bacon', nil, nil)).to eq([])
     end
-    
+
+    it 'should return [] for tarheel sources when tarheel_reader flag is off' do
+      allow(FeatureFlags).to receive(:feature_enabled_for?).with('tarheel_reader', nil).and_return(false)
+      expect(Typhoeus).not_to receive(:get)
+      expect(Uploader.find_resources('bacon', 'tarheel', nil)).to eq([])
+      expect(Uploader.find_resources('bacon-1', 'tarheel_book', nil)).to eq([])
+    end
+
     it 'should search for tarheel results' do
+      allow(FeatureFlags).to receive(:feature_enabled_for?).with('tarheel_reader', nil).and_return(true)
       expect(Typhoeus).to receive(:get).with("https://tarheelreader.org/find/?search=bacon&category=&reviewed=R&audience=E&language=en&page=1&json=1", {timeout: 5}).and_return(OpenStruct.new(body: {
         books: [
           {
@@ -1651,6 +1659,7 @@ describe Uploader do
     end
     
     it 'should return tarheel book pages' do
+      allow(FeatureFlags).to receive(:feature_enabled_for?).with('tarheel_reader', nil).and_return(true)
       expect(Typhoeus).to receive(:get).with("https://tarheelreader.org/book-as-json/?slug=bacon-1", {:followlocation=>true}).and_return(OpenStruct.new(headers: {}, body: {
         'slug' => 'bacon-1',
         'ID' => '12345',
@@ -1702,6 +1711,7 @@ describe Uploader do
     end
 
     it "should return custom book pages" do
+      allow(FeatureFlags).to receive(:feature_enabled_for?).with('tarheel_reader', nil).and_return(true)
       expect(Typhoeus).to receive(:get).with("http://www.example.com/book.json", {:followlocation=>true}).and_return(OpenStruct.new(headers: {}, body: {
         "book_url": "http://github.com/whitmer",
         "author": "Brian",


### PR DESCRIPTION
## Summary
- Tarheel Reader was acquired by Building Wings in Sept 2024 and moved to Monarch Reader. The old `tarheelreader.org` JSON endpoints now 301-redirect to a closed Vue SPA, returning HTML instead of JSON.
- `Uploader.find_resources` was calling those endpoints and `JSON.parse`-ing the HTML response, surfacing a broken experience to users.
- Added a `tarheel_reader` feature flag (in `AVAILABLE_FRONTEND_FEATURES` but NOT `ENABLED_FRONTEND_FEATURES`) and guarded the `source=tarheel` / `source=tarheel_book` paths so they return `[]` by default.
- Users still see the Tarheel Reader category UI in `focus-words.js` but tapping through returns an empty result set instead of a broken error.

## Why not remove entirely?
- Individual users can still be opted in via `settings['feature_flags']['tarheel_reader'] = true` for testing when we negotiate Monarch Reader partner access or wire up an alternate book source (Unite for Literacy, Bookshare, etc.).
- Full UI removal is a larger, multi-file change; this is the minimum safe fix to stop silent prod errors.

## Test plan
- [ ] Confirm local rspec for `Uploader.find_resources` passes (existing specs stub Typhoeus; should be unaffected)
- [ ] Manually verify in dev: navigate to Tarheel Reader category in focus-words, tap a book, see empty result instead of JSON parse error
- [ ] Opt a single test user into `tarheel_reader` flag and confirm the old (broken) behavior still reaches tarheelreader.org (we want to keep this path wired so we can re-enable it the moment there is an API to call)
- [ ] Check Sentry for any existing Tarheel-related exceptions stopping after deploy

## Context
- Research finding: [Building Wings acquisition announcement](https://www.buildingwings.com/blog/tar-heel-reader-joins-building-wings-as-monarch-reader/)
- Monarch Reader has a Directus backend that returns 403 on all public probes. No public API exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)