### PR TITLE
fix: org trainings editing, lesson URLs, and Lessons.track

### DIFF
--- a/app/frontend/app/app.js
+++ b/app/frontend/app/app.js
@@ -530,9 +530,10 @@ LingoLinq.avatarUrls = [
 ];
 LingoLinq.Lessons = {
   track: function(url) {
-    return new RSVP.Promise(function(resolve, reject) {
+    return new RSVP.Promise(function(resolve) {
       var lesson = LingoLinq.Lessons.assert_lesson();
       lesson.restart(url);
+      resolve(lesson);
     });
   },
   assert_lesson: function() {
@@ -541,6 +542,7 @@ LingoLinq.Lessons = {
         this.set('state', null);
       }
     }).create();
+    return LingoLinq.Lessons.lesson;
   }
 };
 LingoLinq.Videos = {

--- a/app/frontend/app/app.js
+++ b/app/frontend/app/app.js
@@ -537,11 +537,14 @@ LingoLinq.Lessons = {
     });
   },
   assert_lesson: function() {
-    LingoLinq.Lessons.lesson = LingoLinq.Lessons.lesson || EmberObject.extend({
-      restart: function(url) {
-        this.set('state', null);
-      }
-    }).create();
+    var existing = LingoLinq.Lessons.lesson;
+    if (!existing || typeof existing.restart !== 'function') {
+      LingoLinq.Lessons.lesson = EmberObject.extend({
+        restart: function(url) {
+          this.set('state', null);
+        }
+      }).create();
+    }
     return LingoLinq.Lessons.lesson;
   }
 };

--- a/app/frontend/app/services/app-state.js
+++ b/app/frontend/app/services/app-state.js
@@ -63,7 +63,11 @@ export default Service.extend({
     // Expose globally for utilities
     window.appState = this;
     if (typeof window !== 'undefined') {
-      window.LingoLinq = window.LingoLinq || {};
+      // Never assign `{}` here: it is truthy and would replace the real namespace
+      // (including `Lessons`) if something created an empty `window.LingoLinq` early.
+      if (!window.LingoLinq || !window.LingoLinq.Lessons) {
+        window.LingoLinq = LingoLinq;
+      }
       window.LingoLinq.appState = this;
     }
     // Also assign to buttonTracker as it's used in raw_events

--- a/app/frontend/app/services/session.js
+++ b/app/frontend/app/services/session.js
@@ -19,7 +19,9 @@ export default Service.extend({
     this._super(...arguments);
     LingoLinq.session = this;
     if (typeof window !== 'undefined') {
-      window.LingoLinq = window.LingoLinq || {};
+      if (!window.LingoLinq || !window.LingoLinq.Lessons) {
+        window.LingoLinq = LingoLinq;
+      }
       window.LingoLinq.session = this;
     }
   },

--- a/app/frontend/app/templates/lesson.hbs
+++ b/app/frontend/app/templates/lesson.hbs
@@ -34,7 +34,7 @@
       <button {{action "new_window"}} class='btn btn-default' style='background: #444; color: #fff; border-color: #aaa;'>{{t "Open in New Window" key="open_in_new_window"}}</button>
     </div>
   </div>
-  <iframe id='lesson_embed' src={{this.model.url}} frameborder='0' style='position: fixed; width: 100%; height: calc(100% - 70px); top: 70px; bottom: 0; right: 0; lefT: 0; background: #fff;' title="Lesson content"></iframe>
+  <iframe id='lesson_embed' src={{this.model.url}} frameborder='0' style='position: fixed; width: 100%; height: calc(100% - 70px); top: 70px; bottom: 0; right: 0; left: 0; background: #fff;' title="Lesson content"></iframe>
   {{#if this.show_description}}
     <div {{action "toggle_description" on="click"}} style='position: fixed; left: 10px; top: 70px; background: #fff; min-height: 50px; width: 300px; border: 1px solid #000; border-top-width: 0; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px; padding: 10px 10px 5px 10px; box-shadow: inset 0 7px 9px -7px #888, 3px 3px 15px #000;'>
       {{#if this.model.time_estimate}}

--- a/app/frontend/app/templates/organization/lessons.hbs
+++ b/app/frontend/app/templates/organization/lessons.hbs
@@ -160,9 +160,12 @@
           <td>{{lesson.target_types_list}}</td>
           <td style='text-align: right;'>
             {{#if lesson.editable}}
-              <a href='#' {{action "edit" lesson}}><span class='glyphicon glyphicon-pencil'></span></a>&nbsp;&nbsp;&nbsp;&nbsp;
+              <button type="button" class="btn btn-default btn-sm" {{action "edit" lesson}}>
+                <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+                {{t "Edit" key="edit"}}
+              </button>
             {{/if}}
-            <a href='#' {{action "delete" lesson}}><span class='glyphicon glyphicon-remove'></span></a>
+            <a href='#' style='margin-left: 0.5rem;' {{action "delete" lesson}} aria-label="{{t "Remove Training" key='remove_training'}}"><span class='glyphicon glyphicon-remove' aria-hidden="true"></span></a>
           </td>
         </tr>
       {{/each}}

--- a/app/frontend/app/templates/organization/lessons.hbs
+++ b/app/frontend/app/templates/organization/lessons.hbs
@@ -165,7 +165,7 @@
                 {{t "Edit" key="edit"}}
               </button>
             {{/if}}
-            <a href='#' style='margin-left: 0.5rem;' {{action "delete" lesson}} aria-label="{{t "Remove Training" key='remove_training'}}"><span class='glyphicon glyphicon-remove' aria-hidden="true"></span></a>
+            <a href='#' style='margin-left: 0.5rem;' {{action "delete" lesson}} aria-label='{{t "Remove Training" key="remove_training"}}'><span class='glyphicon glyphicon-remove' aria-hidden="true"></span></a>
           </td>
         </tr>
       {{/each}}

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -45,7 +45,32 @@ class Lesson < ApplicationRecord
     end
     res
   }
+  # Lessons assigned to an org/unit may still be stored with user_id only; org/unit managers
+  # need edit so they can update links and settings from the organization trainings UI.
+  add_permissions('view', 'view_ratings', 'edit') {|user|
+    (self.settings['usages'] || []).any? do |use|
+      record_code = use['obj']
+      next false unless record_code
+      rec = Webhook.find_record(record_code)
+      !!(rec && (
+        (rec.is_a?(Organization) && rec.allows?(user, 'edit')) ||
+        (rec.is_a?(OrganizationUnit) && rec.allows?(user, 'edit'))
+      ))
+    end
+  }
   cache_permissions
+
+  # Bare hostnames (e.g. "google.com") are invalid in iframe src without a scheme — browsers
+  # resolve them as paths relative to the current URL. Prepend https:// when appropriate.
+  def self.normalize_lesson_embed_url(url)
+    return nil if url.blank?
+    url = url.to_s.strip
+    return nil if url.empty?
+    return url if url.match?(/\A[a-z][a-z0-9+.-]*:/i)
+    return url if url.start_with?('//')
+    return url if url.start_with?('/')
+    "https://#{url}"
+  end
 
   def generate_defaults
     self.settings ||= {}
@@ -109,13 +134,15 @@ class Lesson < ApplicationRecord
   end
 
   def check_url(frd=false)
-    return if !self.settings['url'] || (self.settings['checked_url'] && self.settings['checked_url']['url'] = self.settings['url'])
+    return if !self.settings['url']
+    normalized = Lesson.normalize_lesson_embed_url(self.settings['url'])
+    return if self.settings['checked_url'] && self.settings['checked_url']['url'] == normalized
     if !frd
       self.schedule(:check_url, true)
       return
     end
-    res = Typhoeus.head(self.settings['url'], followlocation: true)
-    self.settings['checked_url'] = {'url' => self.settings['url'], 'ts' => Time.now.to_i}
+    res = Typhoeus.head(normalized, followlocation: true)
+    self.settings['checked_url'] = {'url' => normalized, 'ts' => Time.now.to_i}
     if res.code < 300 && res.code > 199
       if ['deny', 'sameorigin'].include?((res.headers['X-Frame-Options'] || '').downcase)
         self.settings['checked_url']['noframe'] = true
@@ -338,7 +365,9 @@ class Lesson < ApplicationRecord
     self.settings['author_id'] ||= non_user_params['author'].global_id
     self.settings['title'] = process_string(params['title']) if params['title']
     self.settings['description'] = process_string(params['description']) if params['description']
-    self.settings['url'] = process_string(params['url']) if params['url']
+    if params['url']
+      self.settings['url'] = Lesson.normalize_lesson_embed_url(process_string(params['url']))
+    end
     self.settings['required'] = process_boolean(params['required']) if params['required']
     if params.key?('due_at')
       self.settings['due_at'] = params['due_at'].present? ? Time.parse(params['due_at'].to_s).iso8601 : nil
@@ -355,7 +384,7 @@ class Lesson < ApplicationRecord
   end
 
   def launch_url
-    self.settings['url']
+    Lesson.normalize_lesson_embed_url(self.settings['url'])
   end
   
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -66,9 +66,10 @@ class Lesson < ApplicationRecord
     return nil if url.blank?
     url = url.to_s.strip
     return nil if url.empty?
-    return url if url.match?(/\A[a-z][a-z0-9+.-]*:/i)
-    return url if url.start_with?('//')
     return url if url.start_with?('/')
+    return url if url.start_with?('//')
+    return url if url.match?(/\Ahttps?:\/\//i)
+    return nil if url.match?(/\A[a-z][a-z0-9+.-]*:/i)
     "https://#{url}"
   end
 
@@ -136,6 +137,7 @@ class Lesson < ApplicationRecord
   def check_url(frd=false)
     return if !self.settings['url']
     normalized = Lesson.normalize_lesson_embed_url(self.settings['url'])
+    return if !normalized
     return if self.settings['checked_url'] && self.settings['checked_url']['url'] == normalized
     if !frd
       self.schedule(:check_url, true)

--- a/lib/json_api/lesson.rb
+++ b/lib/json_api/lesson.rb
@@ -10,8 +10,9 @@ module JsonApi::Lesson
     
     json['id'] = lesson.global_id
     json['title'] = lesson.settings['title']
-    json['url'] = lesson.settings['url']
-    json['original_url'] = lesson.settings['url']
+    stored_url = lesson.settings['url']
+    json['original_url'] = stored_url
+    json['url'] = ::Lesson.normalize_lesson_embed_url(stored_url)
     json['required'] = !!lesson.settings['required']
     json['lesson_code'] = lesson.nonce
     json['due_at'] = lesson.settings['due_at']
@@ -45,12 +46,18 @@ module JsonApi::Lesson
         json['editable'] = true if lesson.user_id == args[:obj].id
         json['completed_users'][args[:obj].global_id] = comps[args[:obj].global_id] if comps[args[:obj].global_id]
       elsif args[:obj].is_a?(Organization)
-        json['editable'] = true if lesson.organization_id == args[:obj].id
-        ids = args[:obj].attached_users('all').map(&:global_id)
+        org = args[:obj]
+        owned_by_org = lesson.organization_id == org.id
+        assigned_to_org = (lesson.settings['usages'] || []).any? { |u| u['obj'] == Webhook.get_record_code(org) }
+        json['editable'] = true if owned_by_org || assigned_to_org
+        ids = org.attached_users('all').map(&:global_id)
         ids.each{|user_id| json['completed_users'][user_id] = comps[user_id] if comps[user_id] }
       elsif args[:obj].is_a?(OrganizationUnit)
-        json['editable'] = true if lesson.organization_unit_id == args[:obj].id
-        ids = args[:obj].all_user_ids
+        unit = args[:obj]
+        owned_by_unit = lesson.organization_unit_id == unit.id
+        assigned_to_unit = (lesson.settings['usages'] || []).any? { |u| u['obj'] == Webhook.get_record_code(unit) }
+        json['editable'] = true if owned_by_unit || assigned_to_unit
+        ids = unit.all_user_ids
         ids.each{|user_id| json['completed_users'][user_id] = comps[user_id] if comps[user_id] }
       end
     end

--- a/spec/lib/json_api/lesson_spec.rb
+++ b/spec/lib/json_api/lesson_spec.rb
@@ -17,6 +17,23 @@ describe JsonApi::Lesson do
       expect(json['lesson_code']).to eq(l.nonce)
     end
 
+    it "should normalize schemaless lesson URLs for iframe embedding" do
+      l = Lesson.create(settings: {'url' => 'google.com', 'title' => 'Test'})
+      json = JsonApi::Lesson.build_json(l)
+      expect(json['original_url']).to eq('google.com')
+      expect(json['url']).to eq('https://google.com')
+    end
+
+    it "marks lessons editable for org admins when the training is assigned to the org" do
+      o = Organization.create
+      author = User.create
+      l = Lesson.create(user_id: author.id)
+      l.settings['usages'] = [{'obj' => Webhook.get_record_code(o)}]
+      l.save!
+      json = JsonApi::Lesson.build_json(l, {obj: o})
+      expect(json['editable']).to eq(true)
+    end
+
     it "should include target preferences if specified" do
       o = Organization.create
       o2 = Organization.create

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -23,13 +23,13 @@ describe Lesson, :type => :model do
       expect(l.permissions_for(u)).to eq({'user_id' => u.global_id, 'view' => true, 'edit' => true, 'view_ratings' => true})
     end
 
-    it "should let all usages view" do
+    it "should let organization managers view and edit lessons assigned to their org" do
       l = Lesson.create
       u = User.create
       o = Organization.create
       o.add_manager(u.user_name, true)
       l.settings['usages'] = [{'obj' => Webhook.get_record_code(o)}]
-      expect(l.permissions_for(u)).to eq({'user_id' => u.global_id, 'view' => true, 'view_ratings' => true})
+      expect(l.permissions_for(u)).to eq({'user_id' => u.global_id, 'view' => true, 'view_ratings' => true, 'edit' => true})
     end
   end
 
@@ -125,60 +125,75 @@ describe Lesson, :type => :model do
     end
   end
 
+  describe "normalize_lesson_embed_url" do
+    it "prepends https for hostnames without a scheme" do
+      expect(Lesson.normalize_lesson_embed_url('google.com')).to eq('https://google.com')
+      expect(Lesson.normalize_lesson_embed_url('  www.example.org/path  ')).to eq('https://www.example.org/path')
+    end
+
+    it "leaves absolute URLs and paths unchanged" do
+      expect(Lesson.normalize_lesson_embed_url('http://example.com/x')).to eq('http://example.com/x')
+      expect(Lesson.normalize_lesson_embed_url('https://example.com/x')).to eq('https://example.com/x')
+      expect(Lesson.normalize_lesson_embed_url('//example.com/x')).to eq('//example.com/x')
+      expect(Lesson.normalize_lesson_embed_url('/internal/lesson')).to eq('/internal/lesson')
+      expect(Lesson.normalize_lesson_embed_url('mailto:a@b.co')).to eq('mailto:a@b.co')
+    end
+  end
+
   describe "check_url" do
     it "should skip if already checked" do
       l = Lesson.create
       expect(l.check_url).to eq(nil)
-      l.settings['url'] = 'asdf'
-      l.settings['checked_url'] = {'url' => 'asdf'}
+      l.settings['url'] = 'http://example.com/lesson'
+      l.settings['checked_url'] = {'url' => 'http://example.com/lesson'}
       expect(l.check_url).to eq(nil)
     end
 
     it "should schedule a check if not checked and not frd" do
       l = Lesson.create
-      l.settings['url'] = 'asdf'
+      l.settings['url'] = 'http://example.com/lesson'
       expect(l).to receive(:schedule).with(:check_url, true)
       expect(l.check_url).to eq(nil)
     end
 
     it "should make a remote call if frd" do
       l = Lesson.create
-      l.settings['url'] = 'asdf'
+      l.settings['url'] = 'http://example.com/lesson'
       o = OpenStruct.new(code: 200, headers: {})
-      expect(Typhoeus).to receive(:head).with('asdf', followlocation: true).and_return(o)
+      expect(Typhoeus).to receive(:head).with('http://example.com/lesson', followlocation: true).and_return(o)
       expect(l.check_url(true)).to eq(true)
       l.reload
-      expect(l.settings['checked_url'].except('ts')).to eq({'url' => 'asdf'})
+      expect(l.settings['checked_url'].except('ts')).to eq({'url' => 'http://example.com/lesson'})
     end
 
     it "should mark deny or sameorigin responses as problematic" do
       l = Lesson.create
-      l.settings['url'] = 'asdf'
+      l.settings['url'] = 'http://example.com/lesson'
       o = OpenStruct.new(code: 200, headers: {'X-Frame-Options' => 'deny'})
-      expect(Typhoeus).to receive(:head).with('asdf', followlocation: true).and_return(o)
+      expect(Typhoeus).to receive(:head).with('http://example.com/lesson', followlocation: true).and_return(o)
       expect(l.check_url(true)).to eq(true)
       l.reload
-      expect(l.settings['checked_url'].except('ts')).to eq({'url' => 'asdf', 'noframe' => true})
+      expect(l.settings['checked_url'].except('ts')).to eq({'url' => 'http://example.com/lesson', 'noframe' => true})
     end
 
     it "should mark csp issues as problematic" do
       l = Lesson.create
-      l.settings['url'] = 'asdf'
+      l.settings['url'] = 'http://example.com/lesson'
       o = OpenStruct.new(code: 200, headers: {'Content-Security-Policy' => 'a;b;  frame-ancestors: asdf'})
-      expect(Typhoeus).to receive(:head).with('asdf', followlocation: true).and_return(o)
+      expect(Typhoeus).to receive(:head).with('http://example.com/lesson', followlocation: true).and_return(o)
       expect(l.check_url(true)).to eq(true)
       l.reload
-      expect(l.settings['checked_url'].except('ts')).to eq({'url' => 'asdf', 'noframe' => true})
+      expect(l.settings['checked_url'].except('ts')).to eq({'url' => 'http://example.com/lesson', 'noframe' => true})
     end
 
     it "should remember checked_url" do
       l = Lesson.create
-      l.settings['url'] = 'asdf'
+      l.settings['url'] = 'http://example.com/lesson'
       o = OpenStruct.new(code: 200, headers: {})
-      expect(Typhoeus).to receive(:head).with('asdf', followlocation: true).and_return(o)
+      expect(Typhoeus).to receive(:head).with('http://example.com/lesson', followlocation: true).and_return(o)
       expect(l.check_url(true)).to eq(true)
       l.reload
-      expect(l.settings['checked_url'].except('ts')).to eq({'url' => 'asdf'})
+      expect(l.settings['checked_url'].except('ts')).to eq({'url' => 'http://example.com/lesson'})
     end
   end
 

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -136,7 +136,12 @@ describe Lesson, :type => :model do
       expect(Lesson.normalize_lesson_embed_url('https://example.com/x')).to eq('https://example.com/x')
       expect(Lesson.normalize_lesson_embed_url('//example.com/x')).to eq('//example.com/x')
       expect(Lesson.normalize_lesson_embed_url('/internal/lesson')).to eq('/internal/lesson')
-      expect(Lesson.normalize_lesson_embed_url('mailto:a@b.co')).to eq('mailto:a@b.co')
+    end
+
+    it "rejects non-http(s) schemes used for iframe src" do
+      expect(Lesson.normalize_lesson_embed_url('mailto:a@b.co')).to eq(nil)
+      expect(Lesson.normalize_lesson_embed_url('javascript:alert(1)')).to eq(nil)
+      expect(Lesson.normalize_lesson_embed_url('data:text/html,<script>1</script>')).to eq(nil)
     end
   end
 


### PR DESCRIPTION
Normalize schemaless lesson URLs for iframe/embed; grant org/unit managers edit on assigned trainings and show Edit in org UI; fix assert_lesson return and resolve Lessons.track promise; correct lesson iframe CSS typo.

Made-with: Cursor