### PR TITLE
fix(uploader): default S3 region to us-west-2

### DIFF
--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -6,7 +6,7 @@ module Uploader
   CONTENT_LENGTH_RANGE=200.megabytes.to_i
 
   def self.s3_region
-    ENV['AWS_REGION'].presence || 'us-east-1'
+    ENV['AWS_REGION'].presence || 'us-west-2'
   end
 
   def self.s3_client(config)


### PR DESCRIPTION
## Summary

- Changes `Uploader.s3_region` default from `us-east-1` to `us-west-2`.
- All LingoLinq S3 buckets (`lingolinq-uploads`, `lingolinq-dev-uploads`, `lingolinq-dev-static`) live in us-west-2.
- `ENV['AWS_REGION']` is still read first; this only kicks in when the env var is missing.

## Why

PR #191 replaced the unmaintained `s3` gem with `aws-sdk-s3`. The old gem hit the global S3 endpoint with v2 signatures, so it didn't care about region config. The new SDK uses SigV4, which is region-strict — signing for the wrong region returns `400 BadRequest`.

`AWS_REGION` was not set on `lingolinq-staging`, so after #191 merged the new client defaulted to `us-east-1` and every `check_existing_upload` HEAD on the staging uploads bucket failed with BadRequest. This manifested as slow/unreliable board copy and print (each cache lookup double-round-tripped: failed HEAD -> fallback proxy fetch).

Staging was already patched by setting `AWS_REGION=us-west-2` on the affected Render services. Logs confirmed the BadRequest burst stopped immediately on redeploy.

This PR removes the footgun: if the env var ever goes missing again (e.g., during a partial 1Password sync), the uploader still works.

## Test plan

- [x] Verified locally: with `AWS_REGION` unset, `Aws::S3::Client` with `region: us-west-2` produces `Forbidden` (reaches auth) instead of `BadRequest` (region-mismatch) against the real bucket.
- [x] Confirmed staging errors cleared after setting the env var (instance `srv-d510c13e5dus73c8lg10-xl2qr` post-redeploy shows zero `Aws::S3::Errors` in the minutes after going live).
- [ ] Run uploader specs in CI.

## Related

Root-caused in handoff: `/home/scotw/handoff-worker-oom.md`.
Triggered by: #191.