### PR TITLE
fix(pdf): cap ImageMagick per-process memory to prevent OOM kills

### DIFF
--- a/config/initializers/imagemagick_limits.rb
+++ b/config/initializers/imagemagick_limits.rb
@@ -1,0 +1,18 @@
+# Cap per-process ImageMagick resource use to prevent OOM kills.
+#
+# The obf gem's PDF board export fans out up to 20 concurrent `convert`
+# child processes per board (lib/obf/pdf.rb#317). At density 300, a single
+# SVG rasterization can briefly allocate hundreds of MB. With 20 in flight,
+# total memory spikes past the cgroup limit and Render kills the entire
+# worker container with no Ruby-level error captured.
+#
+# ImageMagick reads MAGICK_*_LIMIT from its process environment, so spawned
+# `convert` children inherit these limits automatically. No gem patching
+# required and any Render override (set explicitly on a service) wins.
+#
+# Defaults sized for the 2 GB worker plan: 64MiB x 20 concurrent ~ 1.3 GB,
+# leaving headroom for the Ruby/Rails baseline (~600 MB) and Prawn buffers.
+ENV['MAGICK_MEMORY_LIMIT'] ||= '64MiB'
+ENV['MAGICK_MAP_LIMIT']    ||= '128MiB'
+ENV['MAGICK_DISK_LIMIT']   ||= '2GiB'
+ENV['MAGICK_THREAD_LIMIT'] ||= '1'


### PR DESCRIPTION
## Summary

- Adds `config/initializers/imagemagick_limits.rb` that sets four `MAGICK_*_LIMIT` env vars at Rails boot.
- Caps each `convert` child process at 64 MiB RAM, 128 MiB memory-mapped, 2 GiB disk fallback, 1 thread.
- Zero gem patching: ImageMagick reads these from process env, so all spawned `convert` children inherit them.
- Render-level overrides win via `||=`.

## Why

Confirmed crash on staging today (2026-04-18, ~15:01 UTC):

- Full-board-set PDF print of "Vocal Flair 60" ran for ~4 minutes, processed 23 of 94 boards.
- Container died silently mid-`convert .../tmp/image_stash...-6cvmqb.svg -flatten ...jpg` and restarted (Render's `==> Running '...resque:work'` banner appears 5s later in the logs).
- No Ruby exception. No `Resque::DirtyExit`. Bugsnag not configured on worker, so nothing captured the crash.
- Tracked memory peak: **641 MB** out of the 2 GB plan limit -- but Render samples every 30s, so sub-second `convert` spikes never showed in metrics.

The obf gem (`/lib/obf/pdf.rb#317`) fans out **up to 20 concurrent `convert` processes per block** of 20 raster + 3 SVG images. At density 300, a single SVG rasterization can briefly allocate hundreds of MB. 20 in flight x ~150 MB each = ~3 GB peak, well past the cgroup ceiling. The cgroup OOM killer reaps the whole process group, and the container goes down clean with no app-level signal.

## How

ImageMagick honors these env vars on every `convert` invocation:
- `MAGICK_MEMORY_LIMIT=64MiB` -- heap RAM ceiling per process
- `MAGICK_MAP_LIMIT=128MiB` -- memory-mapped allocation ceiling
- `MAGICK_DISK_LIMIT=2GiB` -- disk-fallback ceiling (so big SVGs still process, just slower)
- `MAGICK_THREAD_LIMIT=1` -- one thread per `convert`, so 20 concurrent processes don't multiply

Sized for the 2 GB worker plan: 64 MiB x 20 concurrent ~ 1.3 GB, leaving headroom for the Ruby/Rails baseline (~600 MB) and Prawn buffers.

## Scope

- Applies to all `convert` shell-outs in the codebase, including:
  - `obf` gem image rasterization (PDF board export -- the path that crashed)
  - `app/models/concerns/uploadable.rb#convert_image` (button image processing)
  - any other `system("convert ...")` callers
- Does NOT touch the obf gem code -- patching the gem directly would be brittle.
- Does NOT change PDF DPI (still 300). Lowering DPI is a quality call left for a follow-up if needed.
- Does NOT reduce the obf gem's parallelism cap (20 raster / 3 SVG per block) -- the per-process limit alone should be sufficient.

## Test plan

- [ ] Deploy to staging and re-run the full-board-set PDF print of Vocal Flair 60 (94 boards)
- [ ] Confirm worker memory stays comfortably under 2 GB throughout
- [ ] Confirm no `Render banner` restart in worker logs during the job
- [ ] Confirm the resulting PDF still renders correctly (image quality OK at the configured limits)

## Follow-up work (separate PRs)

1. **Set BUGSNAG_API_KEY on the staging+prod workers**. Right now any worker crash is invisible outside log-diving.
2. **Reconcile the dev+staging worker startup command with render.yaml**. The dashboard config drifted (`INTERVAL=5` vs the render.yaml `INTERVAL=1.0 RESQUE_WORKER=true`).
3. **Consider a configurable PDF DPI** for full-board-set exports (300 is overkill for a printed grid of 2-inch icons; 150 would halve memory pressure).
4. **Consider lowering obf gem block size** from 20 -> 6 raster, 3 -> 1 SVG via the existing `lib/obf_lingolinq_patch.rb` monkey patch.

## Related

- Crash investigation captured in conversation context (handoff at `/home/scotw/handoff-worker-oom.md`).
- Companion PR #196 (S3 region default) addresses an unrelated BadRequest issue from PR #191.