### PR TITLE
feat(ops): auto-notify Google Chat on key rotation

### DIFF
--- a/.github/workflows/sync-render-secrets.yml
+++ b/.github/workflows/sync-render-secrets.yml
@@ -4,9 +4,9 @@ name: Sync Render Secrets from 1Password
 # Only runs if there are actual changes to apply.
 #
 # REQUIRED REPO SECRETS (Settings > Secrets and variables > Actions):
-#   OP_RENDER_SYNC_TOKEN  -- 1Password service account token (read-only ideally)
-#   RENDER_API_KEY        -- Render API key with write access
-#   GOOGLE_CHAT_WEBHOOK   -- Google Chat webhook URL for notifications
+#   OP_RENDER_SYNC_TOKEN              -- 1Password service account token (read-only ideally)
+#   RENDER_API_KEY                    -- Render API key with write access
+#   GOOGLE_CHAT_WEBHOOK_KEY_ROTATION  -- Google Chat webhook URL for notifications
 #
 # MANUAL TRIGGER:
 #   gh workflow run sync-render-secrets.yml
@@ -77,6 +77,7 @@ jobs:
         env:
           OP_RENDER_SYNC_TOKEN: ${{ secrets.OP_RENDER_SYNC_TOKEN }}
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          GOOGLE_CHAT_WEBHOOK_KEY_ROTATION: ${{ secrets.GOOGLE_CHAT_WEBHOOK_KEY_ROTATION }}
         run: |
           OUTPUT=$(node scripts/sync-render-env.js --source op --apply 2>&1)
           echo "$OUTPUT"
@@ -84,30 +85,10 @@ jobs:
           echo "$OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Notify Google Chat -- changes applied
-        if: steps.dryrun.outputs.has_changes == 'true' && inputs.dry_run != true && success()
-        env:
-          WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-        run: |
-          if [ -z "$WEBHOOK_URL" ]; then
-            echo "No GOOGLE_CHAT_WEBHOOK configured, skipping notification"
-            exit 0
-          fi
-
-          # Extract summary from apply output
-          SUMMARY=$(echo "${{ steps.apply.outputs.output }}" | grep -E "pushed|ERROR" | head -20)
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-          curl -X POST -H "Content-Type: application/json" \
-            -d "{
-              \"text\": \"🔄 *Render secrets synced from 1Password*\n\n\`\`\`\n$SUMMARY\n\`\`\`\n\n<$RUN_URL|View run>\n\n_Senior devs running locally with op run -- your next app restart will pick up the new values._\"
-            }" \
-            "$WEBHOOK_URL"
-
       - name: Notify Google Chat -- sync failed
         if: failure()
         env:
-          WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_KEY_ROTATION }}
         run: |
           if [ -z "$WEBHOOK_URL" ]; then exit 0; fi
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/docs/ROTATING_KEYS.md
+++ b/docs/ROTATING_KEYS.md
@@ -1,0 +1,92 @@
+# Rotating Keys
+
+Quick guide for rotating shared API keys. Anyone with access to 1Password Shared Dev (or Admin for Render) can do this.
+
+## When to rotate
+
+- A key was committed to git or pasted somewhere public.
+- Someone left the team.
+- Routine cycle (every 6 months for non-exposed keys).
+
+## The four shared keys
+
+| Key | Provider URL | 1Password location |
+|---|---|---|
+| GitHub PAT (org/MCP use) | https://github.com/settings/tokens | Shared Dev → "GitHub PAT" |
+| Render API key | https://dashboard.render.com/u/settings#api-keys | Admin → "Render API key" |
+| Notion integration | https://www.notion.so/profile/integrations | Shared Dev → "Notion" |
+| n8n API key | https://lingolinq-n8n.onrender.com/settings/api | Shared Dev → "n8n API" |
+
+## The rotation flow
+
+The same 5 steps for any of the four keys:
+
+```
+1. Go to the provider URL above and revoke the old key.
+2. Generate a new key. Copy the value.
+3. Open the corresponding 1Password item and update the value field.
+   (Field name varies per item - look for the CONCEALED field with caps name like NOTION_API_KEY.)
+4. From the LingoLinq-AAC repo root, run:
+     node scripts/sync-render-env.js --apply --source op
+   This pushes the new value to all 6 Render services (dev, staging, prod, workers, scheduler).
+5. Update your local LingoLinq-AAC/.env with the new value so your dev server uses it.
+```
+
+That's it. The hourly GitHub Actions workflow `.github/workflows/sync-render-secrets.yml` re-runs step 4 on a cron, so even if you forget step 4, prod will be in sync within an hour.
+
+### Auto-notification on rotation
+
+When the sync script pushes a changed value to Render (either manually or via the hourly cron), it posts to the `#key-rotations` Google Chat space so everyone with a local `.env` knows to pull the new value. The notification contains the key name and which environments changed — no secret values are ever included.
+
+If you don't see a notification after running sync with `--apply` but expected one, check:
+1. `GOOGLE_CHAT_WEBHOOK_KEY_ROTATION` env var is set (in your shell or `.env`).
+2. You actually ran with `--apply` (dry-run never notifies).
+3. There was an actual change (unchanged keys don't trigger posts).
+
+## What you need on your machine first
+
+- **1Password CLI** (`op`): https://1password.com/downloads/command-line. Sign in with your existing 1Password account.
+- **Render sync token**: a 1Password service-account token that lets `sync-render-env.js` read 1Password and push to Render. Ask Scot or Dominic for the value (they'll share via 1Password). Add to your local `.env` as `OP_RENDER_SYNC_TOKEN=...`.
+- **Render API key**: the same value stored in 1Password Admin (Render API key item). Add to your local `.env` as `RENDER_API_KEY=...`.
+- **Node 20**: matches Rails app's Ember setup. `nvm use 20`.
+
+## Personal vs shared keys
+
+Some keys are personal (each developer keeps their own, no sharing):
+
+- **Your git push PAT**: lives in `~/.gitconfig` or your OS credential helper. You set this up once during git setup; it's not in 1Password and not shared. Manage it on your own. Different from the shared "GitHub PAT" item in Shared Dev (that one's for org/automation use, not git pushes).
+- **Your personal Clockify key**: only you use it.
+
+Everything else listed above is shared via 1Password.
+
+## Verifying after rotation
+
+Quick verification commands per key:
+
+```
+# GitHub PAT
+curl -s -H "Authorization: Bearer $GITHUB_PERSONAL_ACCESS_TOKEN" https://api.github.com/user | jq .login
+
+# Render API key
+curl -s -H "Authorization: Bearer $RENDER_API_KEY" https://api.render.com/v1/services | jq '.[0].service.name'
+
+# Notion
+curl -s -H "Authorization: Bearer $NOTION_API_KEY" -H "Notion-Version: 2022-06-28" https://api.notion.com/v1/users/me | jq .name
+
+# n8n
+curl -s -H "X-N8N-API-KEY: $N8N_API_KEY" https://lingolinq-n8n.onrender.com/api/v1/workflows | jq '.data | length'
+```
+
+Each should return a non-empty value. If any fail, check the corresponding 1Password item and your local `.env`.
+
+## Common gotchas
+
+- **Render API key has no expiration** but Render allows multiple active keys. Always revoke the old one explicitly after rotation, otherwise it stays valid forever.
+- **n8n JWTs expire**. Current rotation cycle: when the `exp` claim is within 30 days, regenerate.
+- **Notion integration access**: after rotation, double-check the integration still has the right pages/databases connected (notion.so/my-integrations → Access tab). New tokens inherit access, but it's worth verifying.
+- **GitHub PAT scopes**: when generating, copy scope set from the old token's settings. If you get a 403 from gh CLI after rotation, you probably missed a scope.
+
+## Cross-references
+
+- `~/ai-company-brain/docs/KEY_ROTATION.md` (Scot's machine) — fuller runbook covering all org keys, including ones not in this app.
+- `docs/RENDER-ENV-MANIFEST.md` (in this repo) — full list of every env var Render expects.

--- a/scripts/sync-render-env.js
+++ b/scripts/sync-render-env.js
@@ -370,6 +370,9 @@ async function sync(services, source, apply) {
     }
   }
 
+  // Track changes across all environments for end-of-run notification
+  const appliedChanges = {};  // { KEY_NAME: Set<envName> }
+
   // Compare and update each service
   for (const [envName, svc] of Object.entries(services)) {
     console.log(`\n--- ${envName.toUpperCase()} (${svc.name}) ---`);
@@ -433,6 +436,14 @@ async function sync(services, source, apply) {
       try {
         await updateRenderEnvVars(svc.id, mergedVars);
         console.log(`  Applied ${additions.length + updates.length} changes.`);
+        for (const a of additions) {
+          if (!appliedChanges[a.key]) appliedChanges[a.key] = new Set();
+          appliedChanges[a.key].add(envName);
+        }
+        for (const u of updates) {
+          if (!appliedChanges[u.key]) appliedChanges[u.key] = new Set();
+          appliedChanges[u.key].add(envName);
+        }
       } catch (err) {
         console.error(`  Error updating ${svc.name}: ${err.message}`);
       }
@@ -441,7 +452,66 @@ async function sync(services, source, apply) {
     }
   }
 
+  if (apply && Object.keys(appliedChanges).length > 0) {
+    await notifyKeyRotation(appliedChanges);
+  }
+
   console.log('\nDone.\n');
+}
+
+// ---------------------------------------------------------------------------
+// Google Chat notification on key rotation
+// ---------------------------------------------------------------------------
+
+async function notifyKeyRotation(appliedChanges) {
+  const webhookUrl = process.env.GOOGLE_CHAT_WEBHOOK_KEY_ROTATION;
+  if (!webhookUrl) {
+    console.log('\n(No GOOGLE_CHAT_WEBHOOK_KEY_ROTATION set -- skipping Chat notification)');
+    return;
+  }
+
+  const keyLines = Object.entries(appliedChanges)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, envs]) => `• *${key}* (${[...envs].sort().join(', ')})`)
+    .join('\n');
+
+  const message = {
+    text: [
+      '🔑 *Key rotation pushed to Render*',
+      '',
+      keyLines,
+      '',
+      '_If you have any of these in your local `LingoLinq-AAC/.env`, pull the new value from 1Password (Shared Dev or Prod vault) and restart your dev server/MCP clients._',
+      '',
+      `Runbook: \`LingoLinq-AAC/docs/ROTATING_KEYS.md\``,
+      `Pushed at ${new Date().toISOString()}`,
+    ].join('\n'),
+  };
+
+  try {
+    await new Promise((resolve, reject) => {
+      const url = new URL(webhookUrl);
+      const body = JSON.stringify(message);
+      const req = https.request({
+        method: 'POST',
+        hostname: url.hostname,
+        path: url.pathname + url.search,
+        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+      }, res => {
+        let data = '';
+        res.on('data', chunk => (data += chunk));
+        res.on('end', () => (res.statusCode >= 200 && res.statusCode < 300)
+          ? resolve(data)
+          : reject(new Error(`HTTP ${res.statusCode}: ${data}`)));
+      });
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
+    console.log(`\nPosted rotation notice to Google Chat (${Object.keys(appliedChanges).length} keys changed).`);
+  } catch (err) {
+    console.error(`\nWarning: Could not post Chat notification: ${err.message}`);
+  }
 }
 
 async function exportToOp() {


### PR DESCRIPTION
## Summary
- `sync-render-env.js --apply` now posts to Google Chat (space: AI & Integrations) when it actually changes a secret value on any Render service. Message lists key names + affected envs only — never secret values.
- Removes the older post-apply Chat notification step from the workflow (the in-script one is more accurate and fires for both local `--apply` and the hourly GitHub Action).
- Unifies failure notifications onto the same webhook (`GOOGLE_CHAT_WEBHOOK_KEY_ROTATION`).
- New `docs/ROTATING_KEYS.md` gives senior devs a self-contained runbook for rotating the four shared MCP keys (GitHub PAT, Render, Notion, n8n) without co-founder involvement.

## Why
After finding four keys in plaintext inside `claude_desktop_config.json`, we need a lighter-weight signal than "ping everyone in Slack" when shared secrets rotate. People with local `.env` copies need to know to pull the new values and restart their tools. The hourly sync-to-Render pipeline is the natural trigger.

## Config required for this to fire
Repo secret `GOOGLE_CHAT_WEBHOOK_KEY_ROTATION` is already set. Value also stored in:
- `~/ai-company-brain/config/.env`
- 1Password Shared Dev → "Google Chat Webhooks" → `Key Rotation Notifier`

## Test plan
- [x] Manual webhook ping via `curl` — 200 OK, message posted.
- [x] `node -c scripts/sync-render-env.js` — syntax OK.
- [x] `yaml.safe_load` — workflow YAML valid.
- [ ] Merge → wait for next hourly cron (runs at :15 UTC) → verify workflow run succeeds with no notification (no changes expected).
- [ ] Rotate the Render API key (still exposed), run sync manually → verify notification posts to AI & Integrations space with `RENDER_API_KEY (dev, staging, prod)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)