### PR TITLE
fix(board-copy): stop self-deleting button_set cache objects

### DIFF
--- a/app/models/board_downstream_button_set.rb
+++ b/app/models/board_downstream_button_set.rb
@@ -200,11 +200,12 @@ class BoardDownstreamButtonSet < ActiveRecord::Base
     @unviewable_ids = button_set.data['board_ids'].select{|id| !allowed_ids[id] }
     revision_match = full_set_revision && button_set_revision == full_set_revision
     if @unviewable_ids.blank? && revision_match && !button_set.data['source_id']
-      # Cache the CDN URL for 24 hours
+      # Cache the CDN URL for 10 minutes (was 24h -- reduced 2026-04-21 so a
+      # deleted S3 object doesn't pin users on a stale URL for a full day).
       if button_set.data['private_cdn_url']
         button_set.data['private_cdn_url_checked'] ||= Time.now.to_i
       end
-      if button_set.data['private_cdn_url'] && button_set.data['private_cdn_revision'] == button_set_revision && (button_set.data['private_cdn_url_checked'] || Time.now.to_i) > (24.hours.ago.to_i)
+      if button_set.data['private_cdn_url'] && button_set.data['private_cdn_revision'] == button_set_revision && (button_set.data['private_cdn_url_checked'] || Time.now.to_i) > (10.minutes.ago.to_i)
         return button_set.data['private_cdn_url']
       end
       private_path = button_set.extra_data_private_url
@@ -220,10 +221,18 @@ class BoardDownstreamButtonSet < ActiveRecord::Base
         button_set.data['private_cdn_revision'] = button_set_revision
         button_set.save
         return url
-      elsif button_set.data['buttons']
-        button_set.schedule_once(:detach_extra_data, 'force')
       else
-        BoardDownstreamButtonSet.schedule_once(:update_for, self.related_global_id(self.board_id))
+        if button_set.data['private_cdn_url']
+          button_set.data.delete('private_cdn_url')
+          button_set.data.delete('private_cdn_url_checked')
+          button_set.data.delete('private_cdn_revision')
+          button_set.save
+        end
+        if button_set.data['buttons']
+          button_set.schedule_once(:detach_extra_data, 'force')
+        else
+          BoardDownstreamButtonSet.schedule_once(:update_for, self.related_global_id(self.board_id))
+        end
       end
     end
 
@@ -346,7 +355,13 @@ class BoardDownstreamButtonSet < ActiveRecord::Base
           RemoteAction.create(path: "#{board_id}::#{user_id}", act_at: 5.minutes.from_now, action: 'upload_extra_data')
         elsif res && res[:path] && res[:path] != remote_path
           RemoteAction.where(path: res[:path], action: 'delete').delete_all
-          Uploader.remote_remove_later(remote_path, old_checksum)
+          # Skip scheduling deletion when remote_path already carries a
+          # /chksmXXXXX/ segment. On stable content the new upload resolves
+          # to the same chksm path, so the scheduled delete would wipe the
+          # just-uploaded object (observed in prod 2026-04-13..2026-04-20).
+          unless remote_path.to_s.match?(%r{/chksm[^/]+/})
+            Uploader.remote_remove_later(remote_path, old_checksum)
+          end
           button_set.data['remote_paths'][remote_hash]['path'] = res[:path]
           button_set.data['remote_paths'][remote_hash]['checksum'] = new_checksum
         elsif res && res[:path]

--- a/app/models/concerns/extra_data.rb
+++ b/app/models/concerns/extra_data.rb
@@ -94,7 +94,14 @@ module ExtraData
       return :throttled
     elsif res && res[:path] && (res[:path] != old_path || res[:path] != path || res[:uploaded])
       RemoteAction.where(path: res[:path], action: 'delete').delete_all
-      Uploader.remote_remove_later(old_path, old_checksum) if old_path && res[:path] != old_path && res[:uploaded]
+      # Skip scheduling deletion when old_path already carries a
+      # /chksmXXXXX/ segment -- see BoardDownstreamButtonSet.generate_for
+      # for the full rationale. A new upload with the same first-5 checksum
+      # resolves to the same chksm path, so the scheduled delete would wipe
+      # the just-uploaded object.
+      if old_path && res[:path] != old_path && res[:uploaded] && !old_path.to_s.match?(%r{/chksm[^/]+/})
+        Uploader.remote_remove_later(old_path, old_checksum)
+      end
       self.data["extra_data_#{type}_path"] = res[:path]
       self.data["extra_data_#{type}_checksum"] = new_checksum
       if type == 'private'

--- a/spec/models/concerns/extra_data_spec.rb
+++ b/spec/models/concerns/extra_data_spec.rb
@@ -609,11 +609,28 @@ describe ExtraData, :type => :model do
       checksum = Digest::MD5.hexdigest(bs.encrypted_json({a: 1}))
       expect(Uploader).to receive(:remote_remove_later).with('z/y/x.json', 'checksm')
       res = bs.upload_remote_data({a: 1}, 'a/b/c.json', 'private')
-      expect(res).to eq(:uploaded)    
+      expect(res).to eq(:uploaded)
       expect(bs.data['extra_data_private_path']).to eq('c/d/e.json')
       expect(bs.data['extra_data_private_checksum']).to eq(checksum)
     end
-  end 
+
+    it 'should NOT schedule deletion when the previous path carries a /chksm.../ segment' do
+      u = User.create
+      b = Board.create(user: u)
+      bs = BoardDownstreamButtonSet.create(board: b)
+      bs.data['extra_data_private_path'] = 'a/b/chksm12345/c.json'
+      bs.data['extra_data_private_checksum'] = 'checksm'
+      bs.save
+      expect(Uploader).to receive(:remote_upload) do |remote_path, local_path, type, digest|
+        str = File.read(local_path)
+        expect(bs.decrypted_json(str)).to eq({'a' => 1})
+      end.and_return({path: 'a/b/chksm67890/c.json', uploaded: true})
+      expect(Uploader).to_not receive(:remote_remove_later)
+      res = bs.upload_remote_data({a: 1}, 'a/b/c.json', 'private')
+      expect(res).to eq(:uploaded)
+      expect(bs.data['extra_data_private_path']).to eq('a/b/chksm67890/c.json')
+    end
+  end
 
   describe 'allow_encryption?' do
     it 'should return the correct value for the type' do


### PR DESCRIPTION
## Summary
Three related fixes for the board-copy / PDF-print stale-cache failure we hunted through the night of 2026-04-20. Button_set cache objects were being created in S3 and then deleted within seconds by the same worker process, leaving users stuck on URLs that pointed at nothing.

- `BoardDownstreamButtonSet.generate_for` (`bdbs.rb:349`) and `ExtraData#upload_remote_data` (`extra_data.rb:97`) no longer schedule `Uploader.remote_remove_later` when the "old" path already carries a `/chksmXXXXX/` segment. On stable button-set content the uploader's mismatch branch deterministically re-derives the same chksm suffix every run, so yesterday's 24-hour-deferred delete was routinely wiping today's just-uploaded object.
- `BoardDownstreamButtonSet#url_for` trust window for `private_cdn_url` narrowed from 24 hours to 10 minutes, so when an S3 object does disappear, users aren't pinned on a dead URL for a full day.
- `url_for` now also drops `private_cdn_url` / `private_cdn_url_checked` / `private_cdn_revision` whenever live verification misses, forcing the next request to rebuild from scratch rather than re-hitting the cached dead URL.

## Evidence (prod 2026-04-20)
S3 version history on `extras-cache_2079/button_set_cache/1_2079/chksme2629/....json` shows a create-then-delete cycle every few minutes, one pair per scheduler tick:
- `03:37:03` version created
- `03:37:05` delete marker placed (2s later)
- `03:29:02` / `03:28:55` — same pattern
- repeated continuously since 2026-04-13

After clearing pending `RemoteAction` rows and the Resque `slow` queue on 2026-04-21T04:36, the cycle stopped. This PR keeps it from re-starting after the next regeneration.

## Why this was hard to find
- The `private_cdn_url` 24h window meant the symptom persisted for a full day even after the object recovered.
- The scheduled delete fires in a worker, not the request path, so the web-service logs didn't point at it. Only S3 object-version history showed the pattern.
- Existing specs only exercised base-path vs base-path transitions; no test covered the chksm→chksm same-first-5 collision that triggers the bug on stable content.

## Test plan
- [x] `spec/models/concerns/extra_data_spec.rb` — new case asserts `remote_remove_later` is NOT called when `old_path` contains a `/chksm.../` segment.
- [ ] Existing suite — none of the affected specs use chksm paths, so the new guard is a no-op for them.
- [ ] Manual QA on staging after deploy: clear `private_cdn_url` on a previously-failing button_set, trigger "Make a Copy", verify the regenerated S3 object persists and the copy succeeds.

## Follow-ups (separate PR)
- Bulk `rake` task to repair historically stale `BoardDownstreamButtonSet` rows (hundreds of boards currently point at deleted chksm paths; they'll self-heal on next access but a bulk nudge unblocks users faster).
- Audit `Uploader.remote_remove` for a second-level safety check that refuses to delete the key currently stored as the authoritative path in any `remote_paths[*]['path']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)