### PR TITLE
feat(security): add CSP in report-only + wire reporter endpoint

### DIFF
--- a/app/controllers/api/v1/csp_reports_controller.rb
+++ b/app/controllers/api/v1/csp_reports_controller.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# Receives browser-generated Content-Security-Policy violation reports.
+#
+# Wired from config/initializers/content_security_policy.rb via
+# policy.report_uri '/api/v1/csp-reports'.
+#
+# Content types the browser may send:
+#   - application/csp-report          (legacy, report-uri directive)
+#   - application/reports+json        (Reporting API, report-to directive)
+#
+# Both are parsed leniently; a malformed body is logged but still returns 204
+# so browsers do not retry or spam the endpoint.
+#
+# Forwarding:
+#   - If the Sentry Ruby SDK is loaded (constant Sentry is defined and
+#     responds to :capture_event), the violation is sent as a Sentry event
+#     with the report body attached as context.
+#   - Otherwise, the violation is emitted via Rails.logger.warn so it still
+#     lands in the centralized log stream for triage.
+class Api::V1::CspReportsController < ApplicationController
+  # Browsers post CSP reports without credentials or a CSRF token; the base
+  # controller already uses protect_from_forgery with: :null_session, so this
+  # works, but we make the intent explicit.
+  skip_before_action :verify_authenticity_token, raise: false
+  skip_before_action :check_api_token, raise: false
+
+  def create
+    body = parse_report_body
+    violation = extract_violation(body)
+
+    if sentry_available?
+      forward_to_sentry(violation, body)
+    else
+      Rails.logger.warn("[CSP] violation #{violation.to_json}")
+    end
+
+    head :no_content
+  rescue => e
+    # Never let report ingestion raise: a noisy endpoint is worse than a
+    # silent one. Log and swallow.
+    Rails.logger.warn("[CSP] report ingest error: #{e.class}: #{e.message}")
+    head :no_content
+  end
+
+  private
+
+  def parse_report_body
+    raw = request.body.read
+    return {} if raw.blank?
+
+    parsed = JSON.parse(raw)
+    parsed.is_a?(Hash) || parsed.is_a?(Array) ? parsed : {}
+  rescue JSON::ParserError
+    {}
+  end
+
+  # Normalize the report payload into a flat hash regardless of format.
+  # report-uri (legacy) posts: {"csp-report" => {...}}
+  # Reporting API posts:       [{"type" => "csp-violation", "body" => {...}}, ...]
+  def extract_violation(body)
+    case body
+    when Array
+      first = body.find { |r| r.is_a?(Hash) } || {}
+      first['body'].is_a?(Hash) ? first['body'] : first
+    when Hash
+      body['csp-report'].is_a?(Hash) ? body['csp-report'] : body
+    else
+      {}
+    end
+  end
+
+  def sentry_available?
+    defined?(Sentry) && Sentry.respond_to?(:capture_event)
+  end
+
+  def forward_to_sentry(violation, raw_body)
+    event_data = {
+      message: "CSP violation: #{violation['violated-directive'] || violation['effective-directive'] || 'unknown'}",
+      level: 'warning',
+      logger: 'csp',
+      tags: {
+        directive: violation['violated-directive'] || violation['effective-directive'],
+        blocked_uri: violation['blocked-uri'],
+        disposition: violation['disposition'] || 'report'
+      },
+      extra: {
+        csp_report: violation,
+        raw_payload: raw_body,
+        user_agent: request.user_agent,
+        referer: request.referer
+      }
+    }
+    Sentry.capture_event(event_data)
+  rescue => e
+    Rails.logger.warn("[CSP] Sentry forward failed, falling back to logger: #{e.class}: #{e.message}")
+    Rails.logger.warn("[CSP] violation #{violation.to_json}")
+  end
+end

--- a/app/controllers/api/v1/csp_reports_controller.rb
+++ b/app/controllers/api/v1/csp_reports_controller.rb
@@ -25,14 +25,19 @@ class Api::V1::CspReportsController < ApplicationController
   skip_before_action :verify_authenticity_token, raise: false
   skip_before_action :check_api_token, raise: false
 
+  # CSP report payloads are tiny (<2 KB in practice); reject anything larger
+  # to prevent memory/CPU abuse on this unauthenticated endpoint.
+  MAX_REPORT_BYTES = 8_192
+
   def create
     body = parse_report_body
     violation = extract_violation(body)
+    sanitized = sanitize_violation(violation)
 
     if sentry_available?
-      forward_to_sentry(violation, body)
+      forward_to_sentry(sanitized)
     else
-      Rails.logger.warn("[CSP] violation #{violation.to_json}")
+      Rails.logger.warn("[CSP] violation directive=#{sanitized['violated-directive'].inspect} blocked=#{sanitized['blocked-uri'].inspect}")
     end
 
     head :no_content
@@ -46,7 +51,13 @@ class Api::V1::CspReportsController < ApplicationController
   private
 
   def parse_report_body
-    raw = request.body.read
+    content_length = request.content_length.to_i
+    if content_length > MAX_REPORT_BYTES
+      Rails.logger.warn("[CSP] oversized report (#{content_length} bytes), ignoring")
+      return {}
+    end
+
+    raw = request.body.read(MAX_REPORT_BYTES)
     return {} if raw.blank?
 
     parsed = JSON.parse(raw)
@@ -58,42 +69,87 @@ class Api::V1::CspReportsController < ApplicationController
   # Normalize the report payload into a flat hash regardless of format.
   # report-uri (legacy) posts: {"csp-report" => {...}}
   # Reporting API posts:       [{"type" => "csp-violation", "body" => {...}}, ...]
+  # Reporting API uses camelCase keys; legacy uses hyphen-case. Normalize to
+  # hyphen-case so the rest of the controller can use a single key set.
   def extract_violation(body)
-    case body
-    when Array
-      first = body.find { |r| r.is_a?(Hash) } || {}
-      first['body'].is_a?(Hash) ? first['body'] : first
-    when Hash
-      body['csp-report'].is_a?(Hash) ? body['csp-report'] : body
-    else
-      {}
+    raw =
+      case body
+      when Array
+        first = body.find { |r| r.is_a?(Hash) } || {}
+        first['body'].is_a?(Hash) ? first['body'] : first
+      when Hash
+        body['csp-report'].is_a?(Hash) ? body['csp-report'] : body
+      else
+        {}
+      end
+
+    normalize_violation(raw)
+  end
+
+  def normalize_violation(violation)
+    return {} unless violation.is_a?(Hash)
+
+    v = violation.dup
+    # Map Reporting API camelCase keys to legacy hyphen-case equivalents so
+    # downstream code only needs to look up one key per field.
+    v['violated-directive']  ||= v['violatedDirective']  || v['effectiveDirective'] || v['effective-directive']
+    v['effective-directive']  ||= v['effectiveDirective'] || v['violatedDirective']  || v['violated-directive']
+    v['blocked-uri']          ||= v['blockedURL']         || v['blockedUri']
+    v['document-uri']         ||= v['documentURL']        || v['documentUri']
+    v['original-policy']      ||= v['originalPolicy']
+    v['status-code']          ||= v['statusCode']
+    v
+  end
+
+  # Return a copy of the violation hash with full URLs reduced to
+  # scheme://host/path (query strings and fragments stripped) to prevent
+  # tokens or PII from leaking into logs or the error tracker.
+  def sanitize_violation(violation)
+    return {} unless violation.is_a?(Hash)
+
+    url_keys = %w[document-uri blocked-uri referrer documentURL blockedURL blockedUri documentUri]
+    violation.each_with_object({}) do |(k, v), h|
+      h[k] = url_keys.include?(k) ? strip_url_sensitive_parts(v) : v
     end
+  end
+
+  def strip_url_sensitive_parts(value)
+    return value unless value.is_a?(String) && value =~ /\A https?:/x
+
+    uri = URI.parse(value)
+    URI::Generic.build(scheme: uri.scheme, host: uri.host, port: uri.port, path: uri.path).to_s
+  rescue URI::InvalidURIError
+    # Return origin only (scheme + host) as a safe fallback
+    value.split('?').first
   end
 
   def sentry_available?
     defined?(Sentry) && Sentry.respond_to?(:capture_event)
   end
 
-  def forward_to_sentry(violation, raw_body)
+  def forward_to_sentry(violation)
+    directive   = violation['violated-directive'] || violation['effective-directive'] || 'unknown'
+    blocked_uri = violation['blocked-uri']
+
     event_data = {
-      message: "CSP violation: #{violation['violated-directive'] || violation['effective-directive'] || 'unknown'}",
+      message: "CSP violation: #{directive}",
       level: 'warning',
       logger: 'csp',
       tags: {
-        directive: violation['violated-directive'] || violation['effective-directive'],
-        blocked_uri: violation['blocked-uri'],
+        directive:   directive,
+        blocked_uri: blocked_uri,
         disposition: violation['disposition'] || 'report'
       },
       extra: {
-        csp_report: violation,
-        raw_payload: raw_body,
-        user_agent: request.user_agent,
-        referer: request.referer
+        csp_report: violation
+        # raw_payload, referer, and user_agent are intentionally omitted to
+        # avoid forwarding full URLs with query params or PII to the error
+        # tracker. The sanitized violation hash above is sufficient for triage.
       }
     }
     Sentry.capture_event(event_data)
   rescue => e
     Rails.logger.warn("[CSP] Sentry forward failed, falling back to logger: #{e.class}: #{e.message}")
-    Rails.logger.warn("[CSP] violation #{violation.to_json}")
+    Rails.logger.warn("[CSP] violation directive=#{violation['violated-directive'].inspect} blocked=#{violation['blocked-uri'].inspect}")
   end
 end

--- a/app/controllers/api/v1/csp_reports_controller.rb
+++ b/app/controllers/api/v1/csp_reports_controller.rb
@@ -114,13 +114,15 @@ class Api::V1::CspReportsController < ApplicationController
   end
 
   def strip_url_sensitive_parts(value)
-    return value unless value.is_a?(String) && value =~ /\A https?:/x
+    return value unless value.is_a?(String) && value =~ /\Ahttps?:/
 
     uri = URI.parse(value)
-    URI::Generic.build(scheme: uri.scheme, host: uri.host, port: uri.port, path: uri.path).to_s
+    default_port = { 'http' => 80, 'https' => 443 }[uri.scheme]
+    port = uri.port == default_port ? nil : uri.port
+    URI::Generic.build(scheme: uri.scheme, host: uri.host, port: port, path: uri.path).to_s
   rescue URI::InvalidURIError
-    # Return origin only (scheme + host) as a safe fallback
-    value.split('?').first
+    # Return origin only (scheme + host) as a safe fallback; strip query and fragment
+    value.split(/[?#]/).first
   end
 
   def sentry_available?

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Content Security Policy for LingoLinq AAC.
+#
+# Ships in REPORT-ONLY mode. Violations are emitted as
+# Content-Security-Policy-Report-Only headers; nothing is blocked yet.
+# After one full deploy cycle on staging with violation review, flip
+# content_security_policy_report_only to false to enforce.
+#
+# Rollout plan and allowlist rationale: docs/security/csp-rollout-plan.md
+
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self
+
+  policy.base_uri    :self
+  policy.object_src  :none
+  policy.frame_ancestors :none
+
+  # SSO form posts go to external IdPs (Clever, Microsoft, Google,
+  # generic SAML). Keep permissive for initial rollout; tighten after
+  # reviewing reports from staging.
+  policy.form_action :self, :https
+
+  policy.img_src     :self, :https, :data, :blob
+  policy.font_src    :self, :https, :data
+  policy.media_src   :self, :https, :data, :blob
+
+  # Ember 3.28 build output includes inline bootstrap code that
+  # requires unsafe-inline / unsafe-eval. Follow-up PR will replace
+  # these with per-request nonces once reports confirm coverage.
+  policy.script_src  :self,
+                     :unsafe_inline,
+                     :unsafe_eval,
+                     'https://api.opensymbols.org',
+                     'https://js.hs-scripts.com',
+                     'https://translate.google.com'
+
+  policy.style_src   :self,
+                     :unsafe_inline,
+                     'https://fonts.googleapis.com'
+
+  # Outbound API calls from the browser. wss covers the LLWebSocket
+  # live-updates channel used by the Communicator surface.
+  policy.connect_src :self,
+                     :wss,
+                     'https://api.iplocate.io',
+                     'https://api.opensymbols.org',
+                     'https://translate.google.com',
+                     'https://*.s3.amazonaws.com',
+                     'https://api.hubapi.com'
+
+  policy.worker_src   :self, :blob
+  policy.manifest_src :self
+end
+
+Rails.application.config.content_security_policy_report_only = true
+
+# Future: wire a report collector endpoint so violations land in
+# AiApiLog-style storage for triage.
+# Rails.application.config.content_security_policy do |policy|
+#   policy.report_uri '/api/v1/csp-reports'
+# end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,12 +2,22 @@
 
 # Content Security Policy for LingoLinq AAC.
 #
-# Ships in REPORT-ONLY mode. Violations are emitted as
-# Content-Security-Policy-Report-Only headers; nothing is blocked yet.
-# After one full deploy cycle on staging with violation review, flip
-# content_security_policy_report_only to false to enforce.
+# REPORT-ONLY. Browsers emit Content-Security-Policy-Report-Only headers;
+# nothing is blocked. Do NOT flip `content_security_policy_report_only` to
+# false until we have at least 2 full weeks of clean staging reports with
+# no uncovered violations on the core surfaces (communicator, board editor,
+# admin, SSO flows).
 #
-# Rollout plan and allowlist rationale: docs/security/csp-rollout-plan.md
+# Report endpoint: POST /api/v1/csp-reports -> Api::V1::CspReportsController
+# which forwards to Sentry when the Sentry Ruby SDK is present, and falls
+# back to Rails.logger.warn otherwise.
+#
+# Rollout phases and per-directive allowlist rationale live in
+# docs/security/csp-rollout-plan.md.
+#
+# Out of scope for this commit: removing :unsafe_inline / :unsafe_eval from
+# script-src. That requires per-request nonces plumbed through the Ember
+# index.html served by Rails and is tracked as a separate Phase 2 change.
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
@@ -33,6 +43,12 @@ Rails.application.config.content_security_policy do |policy|
                      :unsafe_eval,
                      'https://api.opensymbols.org',
                      'https://js.hs-scripts.com',
+                     'https://*.hs-analytics.net',
+                     'https://*.hsforms.net',
+                     'https://js.hsforms.net',
+                     'https://cdn.jsdelivr.net',
+                     'https://checkout.stripe.com',
+                     'https://js.stripe.com',
                      'https://translate.google.com'
 
   policy.style_src   :self,
@@ -41,22 +57,56 @@ Rails.application.config.content_security_policy do |policy|
 
   # Outbound API calls from the browser. wss covers the LLWebSocket
   # live-updates channel used by the Communicator surface.
+  #
+  # Sentry ingest hosts are kept ahead of adoption so that when/if the
+  # Sentry browser SDK is wired in, reports are not blocked (currently
+  # neither the Ruby nor JS SDK is present in this repo — see PR body).
   policy.connect_src :self,
                      :wss,
                      'https://api.iplocate.io',
                      'https://api.opensymbols.org',
+                     'https://www.opensymbols.org',
                      'https://translate.google.com',
                      'https://*.s3.amazonaws.com',
-                     'https://api.hubapi.com'
+                     'https://*.cloudfront.net',
+                     'https://fonts.googleapis.com',
+                     'https://fonts.gstatic.com',
+                     'https://cdn.jsdelivr.net',
+                     'https://api.hubapi.com',
+                     'https://track.hubspot.com',
+                     'https://forms.hsforms.com',
+                     'https://forms-api.hsforms.com',
+                     'https://*.ingest.sentry.io',
+                     'https://*.ingest.us.sentry.io',
+                     'https://api.flickr.com',
+                     'https://openclipart.org',
+                     'https://pixabay.com',
+                     'https://www.googleapis.com',
+                     'https://checkout.stripe.com',
+                     'https://js.stripe.com',
+                     'https://app.covidspeak.org'
+
+  # Embedded iframes. Current surfaces (per template grep):
+  #   - opensymbols.org (badge_maker, word_maker, editor embeds)
+  #   - YouTube (video buttons) + img.youtube.com thumbnails
+  #   - Clever / SSO integration iframe (embed-frame.hbs, dynamic src)
+  #   - Lesson content iframe (lesson.hbs, dynamic src -> any https)
+  #   - External link preview iframe (confirm-external-link.hbs, sandboxed)
+  # Lesson and confirm-external-link iframes legitimately load arbitrary
+  # external URLs, so frame-src stays broad (:https) until Phase 2 narrows
+  # it. No embedded HubSpot form / Vimeo currently in templates.
+  policy.frame_src   :self,
+                     :https,
+                     'https://www.opensymbols.org',
+                     'https://www.youtube.com',
+                     'https://www.youtube-nocookie.com'
 
   policy.worker_src   :self, :blob
   policy.manifest_src :self
+
+  # Violations from the browser post here; see
+  # app/controllers/api/v1/csp_reports_controller.rb.
+  policy.report_uri '/api/v1/csp-reports'
 end
 
 Rails.application.config.content_security_policy_report_only = true
-
-# Future: wire a report collector endpoint so violations land in
-# AiApiLog-style storage for triage.
-# Rails.application.config.content_security_policy do |policy|
-#   policy.report_uri '/api/v1/csp-reports'
-# end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,7 +17,7 @@
 #
 # Out of scope for this commit: removing :unsafe_inline / :unsafe_eval from
 # script-src. That requires per-request nonces plumbed through the Ember
-# index.html served by Rails and is tracked as a separate Phase 2 change.
+# index.html served by Rails and is tracked as a separate Phase 4 change.
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
@@ -94,7 +94,8 @@ Rails.application.config.content_security_policy do |policy|
   #   - External link preview iframe (confirm-external-link.hbs, sandboxed)
   # Lesson and confirm-external-link iframes legitimately load arbitrary
   # external URLs, so frame-src stays broad (:https) until Phase 2 narrows
-  # it. No embedded HubSpot form / Vimeo currently in templates.
+  # it based on collected violation reports. No embedded HubSpot form / Vimeo
+  # currently in templates.
   policy.frame_src   :self,
                      :https,
                      'https://www.opensymbols.org',

--- a/config/initializers/csp_report_mime_types.rb
+++ b/config/initializers/csp_report_mime_types.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Browsers POST CSP violation reports with these media types (legacy report-uri
+# and Reporting API). Register them so Mime lookup works and controller tests
+# can assign POST parameters without ActionController::TestRequest raising
+# "Unknown Content-Type".
+Mime::Type.register 'application/csp-report', :csp_report
+Mime::Type.register 'application/reports+json', :reports_json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,15 @@ LingoLinq::Application.routes.draw do
   get 'api/v1/status/heartbeat' => 'session#heartbeat'
   get 'api/v1/health' => 'session#health'
 
+  # CSP violation reports (browser -> Rails). Lives under Api::V1:: rather
+  # than Api:: to keep the security surface cleanly separable from the
+  # legacy Api:: controllers mounted via `scope 'api/v1', module: 'api'` below.
+  namespace :api do
+    namespace :v1 do
+      post 'csp-reports' => 'csp_reports#create'
+    end
+  end
+
   scope 'api/v1', module: 'api' do
     get 'users/cache' => 'boards#cache'
     post 'forgot_password' => 'users#forgot_password'

--- a/docs/security/csp-rollout-plan.md
+++ b/docs/security/csp-rollout-plan.md
@@ -1,0 +1,91 @@
+# Content Security Policy Rollout Plan
+
+**Owner:** Melissa (implementation) + Scot (compliance sign-off)
+**Status:** Report-only (initial commit on `feat/csp-headers-report-only`)
+**Target:** Enforcing CSP on all Rails-served responses by end of Q2 2026
+
+## Why CSP
+
+- Defense-in-depth against XSS. Even if a payload lands in a template, the browser refuses to execute inline/remote scripts outside the allowlist.
+- Clickjacking protection via `frame-ancestors 'none'`.
+- Required by FERPA/HIPAA reviewers as a baseline browser security control.
+- Closes an open gap flagged in the April 2026 compliance status report.
+
+## Rollout Phases
+
+### Phase 1: Report-only (this PR)
+
+Ship `config/initializers/content_security_policy.rb` with `content_security_policy_report_only = true`.
+
+The browser emits `Content-Security-Policy-Report-Only` headers. Violations generate console warnings (and reports, once a collector exists) but nothing is blocked. Zero user-visible risk.
+
+**Exit criteria for Phase 1:**
+
+- Deployed to staging for at least 7 days.
+- Manual walkthrough of every major surface: login, dashboard, communicator, board editor, admin, organization pages, SSO flows (Clever, Microsoft, Google, generic SAML).
+- Violation reports reviewed and allowlist updated as needed.
+
+### Phase 2: Add a report collector
+
+Stand up `/api/v1/csp-reports` that accepts the browser's JSON reports and stores them (either in `AiApiLog` with a `kind: csp_violation` marker, or a new `CspViolation` model).
+
+Enable the `report_uri` line in the initializer.
+
+### Phase 3: Tighten allowlist
+
+Review collected violations. Remove allowlist entries that are never legitimately used. Narrow wildcards where possible (for example, replace `https://*.s3.amazonaws.com` with the specific bucket hostname once confirmed).
+
+### Phase 4: Replace unsafe-inline / unsafe-eval with nonces
+
+Ember 3.28's initial bootstrap and any `<script>` tags in Rails-served templates get a per-request nonce. The layout injects the nonce into `<script nonce=...>` and `<style nonce=...>` tags; the initializer's `script_src` and `style_src` switch to `:nonce` instead of `:unsafe_inline`.
+
+This is the highest-value step but also the highest-risk. Do it only after Phase 3 stabilizes.
+
+### Phase 5: Flip to enforcing
+
+Set `content_security_policy_report_only = false`. Deploy to staging first, monitor for 48 hours, then promote to production.
+
+## Allowlist rationale
+
+| Directive | Entry | Why |
+|---|---|---|
+| `script-src` | `'unsafe-inline'`, `'unsafe-eval'` | Ember 3.28 bootstrap; replaced with nonces in Phase 4 |
+| `script-src` | `api.opensymbols.org` | Symbol search pulls JS assets |
+| `script-src` | `js.hs-scripts.com` | HubSpot tracking (gated by consent; remove if HubSpot is dropped) |
+| `script-src` | `translate.google.com` | Google Translate TTS inline callback |
+| `style-src` | `'unsafe-inline'` | Ember template-driven inline styles; nonces later |
+| `style-src` | `fonts.googleapis.com` | Google Fonts CSS |
+| `connect-src` | `wss:` | LLWebSocket live-update channel |
+| `connect-src` | `api.iplocate.io` | IP geolocation |
+| `connect-src` | `api.opensymbols.org` | Symbol search API |
+| `connect-src` | `translate.google.com` | TTS playback |
+| `connect-src` | `*.s3.amazonaws.com` | User uploads |
+| `connect-src` | `api.hubapi.com` | HubSpot API |
+| `img-src`, `font-src`, `media-src` | `:https`, `:data`, `:blob` | Broad during rollout; narrow once reports land |
+| `form-action` | `:self`, `:https` | SSO posts; narrow to specific IdP hosts once confirmed |
+| `frame-ancestors` | `'none'` | Hard block on clickjacking |
+| `object-src` | `'none'` | Hard block on Flash / plugin content |
+
+## Known risks and mitigations
+
+- **Ember might hit violations we didn't anticipate.** Report-only mode is the mitigation. Nothing breaks; we learn what the allowlist actually needs.
+- **Third-party vendor updates may change asset hosts.** Track any host change that shows up in reports and add to the allowlist.
+- **Browser extensions inject their own scripts.** These trigger violations but are out of scope for us; document to avoid confusion.
+
+## Testing checklist before Phase 5 (enforcing)
+
+- [ ] Login page loads cleanly, no console errors.
+- [ ] Dashboard loads, avatar images render.
+- [ ] Communicator surface renders the board, plays TTS, accepts input.
+- [ ] Board editor saves, uploads work against S3.
+- [ ] Symbol search returns results and renders images.
+- [ ] SSO flows complete for Clever, Microsoft, Google, and SAML.
+- [ ] Admin panel renders and all admin-specific JS works.
+- [ ] Organization settings page saves without CSP errors.
+- [ ] Mobile Cordova/Capacitor app still talks to the API (it shouldn't be affected, but confirm).
+
+## References
+
+- Rails CSP DSL: https://guides.rubyonrails.org/security.html#content-security-policy-header
+- MDN CSP reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+- April 2026 compliance status: Notion page `Engineering & Compliance Status - April 2026`

--- a/docs/security/csp-rollout-plan.md
+++ b/docs/security/csp-rollout-plan.md
@@ -21,9 +21,9 @@ The browser emits `Content-Security-Policy-Report-Only` headers. Violations gene
 
 **Exit criteria for Phase 1:**
 
-- Deployed to staging for at least 7 days.
+- Deployed to staging for at least 2 full weeks.
 - Manual walkthrough of every major surface: login, dashboard, communicator, board editor, admin, organization pages, SSO flows (Clever, Microsoft, Google, generic SAML).
-- Violation reports reviewed and allowlist updated as needed.
+- Staging violation reports remain clean during that period, with the allowlist reviewed and updated as needed.
 
 ### Phase 2: Add a report collector
 

--- a/docs/security/csp-rollout-plan.md
+++ b/docs/security/csp-rollout-plan.md
@@ -6,18 +6,21 @@
 
 ## Why CSP
 
-- Defense-in-depth against XSS. Even if a payload lands in a template, the browser refuses to execute inline/remote scripts outside the allowlist.
-- Clickjacking protection via `frame-ancestors 'none'`.
+- Defense-in-depth against XSS. Even if a payload lands in a template, the browser refuses to execute inline/remote scripts outside the allowlist once CSP is enforced.
+- Clickjacking protection via `frame-ancestors 'none'` — **note:** this directive has no effect in report-only mode and will not provide clickjacking protection until CSP is enforced (Phase 4). If immediate clickjacking protection is required, ship a separate `X-Frame-Options: DENY` header independently of this rollout.
 - Required by FERPA/HIPAA reviewers as a baseline browser security control.
 - Closes an open gap flagged in the April 2026 compliance status report.
 
 ## Rollout Phases
 
-### Phase 1: Report-only (this PR)
+### Phase 1: Report-only + violation collector (this PR)
 
-Ship `config/initializers/content_security_policy.rb` with `content_security_policy_report_only = true`.
+Ship `config/initializers/content_security_policy.rb` with `content_security_policy_report_only = true`
+and the `/api/v1/csp-reports` collector endpoint.
 
-The browser emits `Content-Security-Policy-Report-Only` headers. Violations generate console warnings (and reports, once a collector exists) but nothing is blocked. Zero user-visible risk.
+The browser emits `Content-Security-Policy-Report-Only` headers. Violations generate console warnings
+and reports are forwarded to Sentry (or logged when Sentry is unavailable) but nothing is blocked.
+Zero user-visible risk.
 
 **Exit criteria for Phase 1:**
 
@@ -25,23 +28,17 @@ The browser emits `Content-Security-Policy-Report-Only` headers. Violations gene
 - Manual walkthrough of every major surface: login, dashboard, communicator, board editor, admin, organization pages, SSO flows (Clever, Microsoft, Google, generic SAML).
 - Staging violation reports remain clean during that period, with the allowlist reviewed and updated as needed.
 
-### Phase 2: Add a report collector
-
-Stand up `/api/v1/csp-reports` that accepts the browser's JSON reports and stores them (either in `AiApiLog` with a `kind: csp_violation` marker, or a new `CspViolation` model).
-
-Enable the `report_uri` line in the initializer.
-
-### Phase 3: Tighten allowlist
+### Phase 2: Tighten allowlist
 
 Review collected violations. Remove allowlist entries that are never legitimately used. Narrow wildcards where possible (for example, replace `https://*.s3.amazonaws.com` with the specific bucket hostname once confirmed).
 
-### Phase 4: Replace unsafe-inline / unsafe-eval with nonces
+### Phase 3: Replace unsafe-inline / unsafe-eval with nonces
 
 Ember 3.28's initial bootstrap and any `<script>` tags in Rails-served templates get a per-request nonce. The layout injects the nonce into `<script nonce=...>` and `<style nonce=...>` tags; the initializer's `script_src` and `style_src` switch to `:nonce` instead of `:unsafe_inline`.
 
-This is the highest-value step but also the highest-risk. Do it only after Phase 3 stabilizes.
+This is the highest-value step but also the highest-risk. Do it only after Phase 2 stabilizes.
 
-### Phase 5: Flip to enforcing
+### Phase 4: Flip to enforcing
 
 Set `content_security_policy_report_only = false`. Deploy to staging first, monitor for 48 hours, then promote to production.
 
@@ -49,7 +46,7 @@ Set `content_security_policy_report_only = false`. Deploy to staging first, moni
 
 | Directive | Entry | Why |
 |---|---|---|
-| `script-src` | `'unsafe-inline'`, `'unsafe-eval'` | Ember 3.28 bootstrap; replaced with nonces in Phase 4 |
+| `script-src` | `'unsafe-inline'`, `'unsafe-eval'` | Ember 3.28 bootstrap; replaced with nonces in Phase 3 |
 | `script-src` | `api.opensymbols.org` | Symbol search pulls JS assets |
 | `script-src` | `js.hs-scripts.com` | HubSpot tracking (gated by consent; remove if HubSpot is dropped) |
 | `script-src` | `translate.google.com` | Google Translate TTS inline callback |
@@ -63,7 +60,7 @@ Set `content_security_policy_report_only = false`. Deploy to staging first, moni
 | `connect-src` | `api.hubapi.com` | HubSpot API |
 | `img-src`, `font-src`, `media-src` | `:https`, `:data`, `:blob` | Broad during rollout; narrow once reports land |
 | `form-action` | `:self`, `:https` | SSO posts; narrow to specific IdP hosts once confirmed |
-| `frame-ancestors` | `'none'` | Hard block on clickjacking |
+| `frame-ancestors` | `'none'` | Blocks clickjacking once enforced (Phase 4); no effect in report-only mode |
 | `object-src` | `'none'` | Hard block on Flash / plugin content |
 
 ## Known risks and mitigations
@@ -72,7 +69,7 @@ Set `content_security_policy_report_only = false`. Deploy to staging first, moni
 - **Third-party vendor updates may change asset hosts.** Track any host change that shows up in reports and add to the allowlist.
 - **Browser extensions inject their own scripts.** These trigger violations but are out of scope for us; document to avoid confusion.
 
-## Testing checklist before Phase 5 (enforcing)
+## Testing checklist before Phase 4 (enforcing)
 
 - [ ] Login page loads cleanly, no console errors.
 - [ ] Dashboard loads, avatar images render.

--- a/spec/controllers/api/v1/csp_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/csp_reports_controller_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+describe Api::V1::CspReportsController, :type => :controller do
+  describe 'create' do
+    def post_report(body, content_type: 'application/csp-report')
+      request.headers['Content-Type'] = content_type
+      post 'create', body: body.is_a?(String) ? body : body.to_json
+    end
+
+    it 'returns 204 for a valid legacy csp-report payload' do
+      payload = {
+        'csp-report' => {
+          'violated-directive' => 'script-src',
+          'blocked-uri'        => 'https://evil.example.com/x.js',
+          'document-uri'       => 'https://app.example.com/boards'
+        }
+      }
+      post_report(payload)
+      expect(response.status).to eq(204)
+    end
+
+    it 'returns 204 for a valid Reporting API array payload' do
+      payload = [
+        {
+          'type' => 'csp-violation',
+          'body' => {
+            'effectiveDirective' => 'script-src',
+            'blockedURL'         => 'https://evil.example.com/x.js',
+            'documentURL'        => 'https://app.example.com/boards'
+          }
+        }
+      ]
+      post_report(payload, content_type: 'application/reports+json')
+      expect(response.status).to eq(204)
+    end
+
+    it 'returns 204 for malformed JSON without raising' do
+      request.headers['Content-Type'] = 'application/csp-report'
+      post 'create', body: 'this is not json at all {{{'
+      expect(response.status).to eq(204)
+    end
+
+    it 'returns 204 for an empty body' do
+      request.headers['Content-Type'] = 'application/csp-report'
+      post 'create', body: ''
+      expect(response.status).to eq(204)
+    end
+
+    it 'returns 204 and logs via Rails.logger when Sentry is unavailable' do
+      payload = {
+        'csp-report' => {
+          'violated-directive' => 'img-src',
+          'blocked-uri'        => 'https://evil.example.com/img.png',
+          'document-uri'       => 'https://app.example.com/'
+        }
+      }
+      expect(Rails.logger).to receive(:warn).with(/\[CSP\] violation/)
+      hide_const('Sentry') if defined?(Sentry)
+      post_report(payload)
+      expect(response.status).to eq(204)
+    end
+
+    it 'forwards to Sentry when the Sentry SDK is available' do
+      payload = {
+        'csp-report' => {
+          'violated-directive' => 'script-src',
+          'blocked-uri'        => 'https://cdn.example.com/lib.js',
+          'document-uri'       => 'https://app.example.com/dash'
+        }
+      }
+      sentry = double('Sentry', capture_event: nil)
+      stub_const('Sentry', sentry)
+      allow(sentry).to receive(:respond_to?).with(:capture_event).and_return(true)
+      expect(sentry).to receive(:capture_event).once
+      post_report(payload)
+      expect(response.status).to eq(204)
+    end
+
+    it 'normalizes Reporting API camelCase keys to hyphen-case equivalents' do
+      sentry = double('Sentry', capture_event: nil)
+      stub_const('Sentry', sentry)
+      allow(sentry).to receive(:respond_to?).with(:capture_event).and_return(true)
+
+      captured = nil
+      allow(sentry).to receive(:capture_event) { |ev| captured = ev }
+
+      payload = [
+        {
+          'type' => 'csp-violation',
+          'body' => {
+            'effectiveDirective' => 'connect-src',
+            'blockedURL'         => 'https://evil.example.com/api'
+          }
+        }
+      ]
+      post_report(payload, content_type: 'application/reports+json')
+      expect(response.status).to eq(204)
+      expect(captured[:tags][:directive]).to eq('connect-src')
+      expect(captured[:tags][:blocked_uri]).to eq('https://evil.example.com/api')
+    end
+
+    it 'strips query strings from URLs before logging to prevent PII leakage' do
+      warned = nil
+      allow(Rails.logger).to receive(:warn) { |msg| warned = msg }
+      hide_const('Sentry') if defined?(Sentry)
+
+      payload = {
+        'csp-report' => {
+          'violated-directive' => 'script-src',
+          'blocked-uri'        => 'https://evil.example.com/x.js?token=SECRET',
+          'document-uri'       => 'https://app.example.com/dash?session=ABC'
+        }
+      }
+      post_report(payload)
+      expect(warned).not_to include('SECRET')
+      expect(warned).not_to include('ABC')
+    end
+
+    it 'rejects oversized payloads and returns 204 without parsing' do
+      large_body = 'x' * (Api::V1::CspReportsController::MAX_REPORT_BYTES + 1)
+      allow(request).to receive(:content_length).and_return(large_body.bytesize)
+      expect(Rails.logger).to receive(:warn).with(/oversized/)
+      request.headers['Content-Type'] = 'application/csp-report'
+      post 'create', body: large_body
+      expect(response.status).to eq(204)
+    end
+  end
+end

--- a/spec/controllers/api/v1/csp_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/csp_reports_controller_spec.rb
@@ -5,8 +5,9 @@ describe Api::V1::CspReportsController, :type => :controller do
     def post_report(body, content_type: 'application/csp-report')
       json = body.is_a?(String) ? body : body.to_json
       request.headers['Content-Type'] = content_type
-      request.env['RAW_POST_DATA'] = json
-      post 'create'
+      # Rails 7.2 rebuilds the test request in #process; pass body: so it is set
+      # on the new request (RAW_POST_DATA on the old env is dropped by scrub_env!).
+      post 'create', body: json
     end
 
     it 'returns 204 for a valid legacy csp-report payload' do
@@ -38,15 +39,13 @@ describe Api::V1::CspReportsController, :type => :controller do
 
     it 'returns 204 for malformed JSON without raising' do
       request.headers['Content-Type'] = 'application/csp-report'
-      request.env['RAW_POST_DATA'] = 'this is not json at all {{{'
-      post 'create'
+      post 'create', body: 'this is not json at all {{{'
       expect(response.status).to eq(204)
     end
 
     it 'returns 204 for an empty body' do
       request.headers['Content-Type'] = 'application/csp-report'
-      request.env['RAW_POST_DATA'] = ''
-      post 'create'
+      post 'create', body: ''
       expect(response.status).to eq(204)
     end
 
@@ -120,14 +119,14 @@ describe Api::V1::CspReportsController, :type => :controller do
       expect(warned).not_to include('ABC')
     end
 
-    it 'rejects oversized payloads and returns 204 without parsing' do
-      large_body = ('x' * (Api::V1::CspReportsController::MAX_REPORT_BYTES + 1))
-      allow(request).to receive(:content_length).and_return(large_body.bytesize)
+    it 'parse_report_body rejects when Content-Length exceeds the cap' do
+      max = Api::V1::CspReportsController::MAX_REPORT_BYTES
+      req = double('Request', content_length: max + 1, body: StringIO.new(''))
+      ctrl = described_class.new
+      allow(ctrl).to receive(:request).and_return(req)
       expect(Rails.logger).to receive(:warn).with(/oversized/)
-      request.headers['Content-Type'] = 'application/csp-report'
-      request.env['RAW_POST_DATA'] = large_body
-      post 'create'
-      expect(response.status).to eq(204)
+      expect(ctrl.send(:parse_report_body)).to eq({})
     end
+
   end
 end

--- a/spec/controllers/api/v1/csp_reports_controller_spec.rb
+++ b/spec/controllers/api/v1/csp_reports_controller_spec.rb
@@ -3,8 +3,10 @@ require 'spec_helper'
 describe Api::V1::CspReportsController, :type => :controller do
   describe 'create' do
     def post_report(body, content_type: 'application/csp-report')
+      json = body.is_a?(String) ? body : body.to_json
       request.headers['Content-Type'] = content_type
-      post 'create', body: body.is_a?(String) ? body : body.to_json
+      request.env['RAW_POST_DATA'] = json
+      post 'create'
     end
 
     it 'returns 204 for a valid legacy csp-report payload' do
@@ -36,13 +38,15 @@ describe Api::V1::CspReportsController, :type => :controller do
 
     it 'returns 204 for malformed JSON without raising' do
       request.headers['Content-Type'] = 'application/csp-report'
-      post 'create', body: 'this is not json at all {{{'
+      request.env['RAW_POST_DATA'] = 'this is not json at all {{{'
+      post 'create'
       expect(response.status).to eq(204)
     end
 
     it 'returns 204 for an empty body' do
       request.headers['Content-Type'] = 'application/csp-report'
-      post 'create', body: ''
+      request.env['RAW_POST_DATA'] = ''
+      post 'create'
       expect(response.status).to eq(204)
     end
 
@@ -55,7 +59,7 @@ describe Api::V1::CspReportsController, :type => :controller do
         }
       }
       expect(Rails.logger).to receive(:warn).with(/\[CSP\] violation/)
-      hide_const('Sentry') if defined?(Sentry)
+      allow(subject).to receive(:sentry_available?).and_return(false)
       post_report(payload)
       expect(response.status).to eq(204)
     end
@@ -102,7 +106,7 @@ describe Api::V1::CspReportsController, :type => :controller do
     it 'strips query strings from URLs before logging to prevent PII leakage' do
       warned = nil
       allow(Rails.logger).to receive(:warn) { |msg| warned = msg }
-      hide_const('Sentry') if defined?(Sentry)
+      allow(subject).to receive(:sentry_available?).and_return(false)
 
       payload = {
         'csp-report' => {
@@ -117,11 +121,12 @@ describe Api::V1::CspReportsController, :type => :controller do
     end
 
     it 'rejects oversized payloads and returns 204 without parsing' do
-      large_body = 'x' * (Api::V1::CspReportsController::MAX_REPORT_BYTES + 1)
+      large_body = ('x' * (Api::V1::CspReportsController::MAX_REPORT_BYTES + 1))
       allow(request).to receive(:content_length).and_return(large_body.bytesize)
       expect(Rails.logger).to receive(:warn).with(/oversized/)
       request.headers['Content-Type'] = 'application/csp-report'
-      post 'create', body: large_body
+      request.env['RAW_POST_DATA'] = large_body
+      post 'create'
       expect(response.status).to eq(204)
     end
   end


### PR DESCRIPTION
## Summary
Ships a Content Security Policy in **report-only** mode for all Rails-served responses, plus a reporter endpoint that forwards violations to Sentry (logger fallback when the Sentry SDK is not loaded).

Two commits:
1. `9aee1a7c2` Initial report-only CSP with baseline directives.
2. `8b2c28f62` Wires `/api/v1/csp-reports`, expands connect-src/script-src/frame-src based on a frontend audit.

## Why report-only first
Flipping straight to enforcing would break undiscovered outbound hosts. Report-only collects real violation data on staging without blocking anything. Plan: 2+ weeks of clean staging data, then flip.

## What's in the allowlist (notable)
- connect-src: Sentry ingest (ready for future SDK), HubSpot tracking/forms, jsdelivr (chart.js + sankey), Stripe, Google Fonts, opensymbols, cloudfront (audio), image search hosts (Flickr/OpenClipart/Pixabay/Google), covidspeak
- script-src: HubSpot analytics/forms (defensive), jsdelivr, Stripe, opensymbols, translate
- frame-src: broad `:https` for now (lesson + external-link iframes legitimately embed arbitrary https)

## What's deliberately NOT in this PR
- No Pusher hosts — `lib/pusher.rb` is an AWS SNS SMS wrapper, name collision only
- No Google Analytics — not in the codebase
- **`:unsafe_inline` / `:unsafe_eval` are kept** — removing them requires per-request nonce plumbing through Ember's Rails-served index.html (Phase 2)

## Rollout plan
See docs/security/csp-rollout-plan.md. Phase gate for enforcing:
- 2+ weeks of report-only on staging with zero new violation types for 7 consecutive days
- Explicit Melissa sign-off per directive
- Staged prod rollout via feature flag, never on a Friday

## Test plan
- [ ] Deploy to staging, verify `Content-Security-Policy-Report-Only` header appears in response to any Rails-served page
- [ ] Verify `POST /api/v1/csp-reports` returns 204 on valid payload
- [ ] Trigger a synthetic violation (inline script without allow) and confirm it lands in logs
- [ ] Melissa: walk the core surfaces (communicator, board editor, admin, SSO) and verify no breakage from the policy even in report-only
- [ ] Review DevTools "Violations" tab after 24h of staging traffic and sanity check the directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)