### PR TITLE
fix(board-copy): flush_caches no longer wipes in-use cache entries

### DIFF
--- a/app/models/board_downstream_button_set.rb
+++ b/app/models/board_downstream_button_set.rb
@@ -391,11 +391,21 @@ class BoardDownstreamButtonSet < ActiveRecord::Base
       if bs && bs.data['remote_paths']
         changed = false
         bs.data['remote_paths'].each do |hash, obj|
-          if obj['generated'] < timestamp && obj['path']
+          # Only flush entries that are stale per the requested timestamp AND
+          # also past their own `expires` window. `url_for` trusts entries
+          # until `expires` regardless of `generated`, so flushing a
+          # generated-old / expires-fresh entry deletes the S3 object out
+          # from under live users (observed in prod 2026-04-21..22 as an
+          # upload-then-delete race on board_copy hot path).
+          expires = obj['expires'] || 0
+          if obj['generated'] < timestamp && expires < Time.now.to_i && obj['path']
             changed = true
             path = obj['path']
-            # Uploader.invalidate_cdn(path)            
-            Uploader.remote_remove(path)
+            # Uploader.invalidate_cdn(path)
+            # Pass the stored checksum so remote_remove's safety check aborts
+            # if the current S3 version doesn't match what we think we're
+            # cleaning up. Belt-and-suspenders against the above race.
+            Uploader.remote_remove(path, obj['checksum'])
             bs.data['remote_paths'].delete(hash)
           end
         end

--- a/spec/models/board_downstream_button_set_spec.rb
+++ b/spec/models/board_downstream_button_set_spec.rb
@@ -1664,12 +1664,12 @@ describe BoardDownstreamButtonSet, :type => :model do
       BoardDownstreamButtonSet.update_for(b.global_id, true)
       bs = b.reload.board_downstream_button_set
       bs.data['remote_paths'] = {
-        'asdf' => {'path' => 'asdf.asdf', 'generated' => 1234, 'expires' => 4.weeks.from_now.to_i},
-        'jkl' => {'path' => 'jkl.jkl', 'generated' => 12345, 'expires' => 3.weeks.ago.to_i}
+        'asdf' => {'path' => 'asdf.asdf', 'generated' => 1234, 'expires' => 5.weeks.ago.to_i, 'checksum' => 'chk-asdf'},
+        'jkl' => {'path' => 'jkl.jkl', 'generated' => 12345, 'expires' => 3.weeks.ago.to_i, 'checksum' => 'chk-jkl'}
       }
       bs.save
-      expect(Uploader).to receive(:remote_remove).with('asdf.asdf').and_return(true)
-      expect(Uploader).to receive(:remote_remove).with('jkl.jkl').and_return(true)
+      expect(Uploader).to receive(:remote_remove).with('asdf.asdf', 'chk-asdf').and_return(true)
+      expect(Uploader).to receive(:remote_remove).with('jkl.jkl', 'chk-jkl').and_return(true)
       BoardDownstreamButtonSet.flush_caches([b.global_id], Time.now.to_i)
     end
 
@@ -1682,12 +1682,12 @@ describe BoardDownstreamButtonSet, :type => :model do
       BoardDownstreamButtonSet.update_for(b.global_id, true)
       bs = b.reload.board_downstream_button_set
       bs.data['remote_paths'] = {
-        'asdf' => {'path' => 'asdf.asdf', 'generated' => 1234, 'expires' => 4.weeks.from_now.to_i},
-        'jkl' => {'path' => 'jkl.jkl', 'generated' => 12345, 'expires' => 3.weeks.ago.to_i}
+        'asdf' => {'path' => 'asdf.asdf', 'generated' => 1234, 'expires' => 5.weeks.ago.to_i, 'checksum' => 'chk-asdf'},
+        'jkl' => {'path' => 'jkl.jkl', 'generated' => 12345, 'expires' => 3.weeks.ago.to_i, 'checksum' => 'chk-jkl'}
       }
       bs.save
-      expect(Uploader).to receive(:remote_remove).with('asdf.asdf').and_return(true)
-      expect(Uploader).to receive(:remote_remove).with('jkl.jkl').and_return(true)
+      expect(Uploader).to receive(:remote_remove).with('asdf.asdf', 'chk-asdf').and_return(true)
+      expect(Uploader).to receive(:remote_remove).with('jkl.jkl', 'chk-jkl').and_return(true)
       BoardDownstreamButtonSet.flush_caches([b.global_id], Time.now.to_i)
       bs.reload
       expect(bs.data['remote_paths'].keys).to eq([])
@@ -1702,15 +1702,35 @@ describe BoardDownstreamButtonSet, :type => :model do
       BoardDownstreamButtonSet.update_for(b.global_id, true)
       bs = b.reload.board_downstream_button_set
       bs.data['remote_paths'] = {
-        'asdf' => {'path' => 'asdf.asdf', 'generated' => 1234, 'expires' => 4.weeks.from_now.to_i},
-        'jkl' => {'path' => 'jkl.jkl', 'generated' => 3.hours.from_now.to_i, 'expires' => 3.weeks.ago.to_i}
+        'asdf' => {'path' => 'asdf.asdf', 'generated' => 1234, 'expires' => 5.weeks.ago.to_i, 'checksum' => 'chk-asdf'},
+        'jkl' => {'path' => 'jkl.jkl', 'generated' => 3.hours.from_now.to_i, 'expires' => 3.weeks.ago.to_i, 'checksum' => 'chk-jkl'}
       }
       bs.save
-      expect(Uploader).to receive(:remote_remove).with('asdf.asdf').and_return(true)
-      expect(Uploader).to_not receive(:remote_remove).with('jkl.jkl')
+      expect(Uploader).to receive(:remote_remove).with('asdf.asdf', 'chk-asdf').and_return(true)
+      expect(Uploader).to_not receive(:remote_remove).with('jkl.jkl', anything)
       BoardDownstreamButtonSet.flush_caches([b.global_id], Time.now.to_i)
       bs.reload
       expect(bs.data['remote_paths'].keys).to eq(['jkl'])
+    end
+
+    it "should NOT flush entries still within their expires window even when generated is old" do
+      u = User.create
+      b = Board.create(user: u)
+      b.process({'buttons' => [
+        {'id' => 1, 'label' => 'jump'}
+      ]})
+      BoardDownstreamButtonSet.update_for(b.global_id, true)
+      bs = b.reload.board_downstream_button_set
+      bs.data['remote_paths'] = {
+        'live' => {'path' => 'live.json', 'generated' => 1234, 'expires' => 5.months.from_now.to_i, 'checksum' => 'chk-live'},
+        'stale' => {'path' => 'stale.json', 'generated' => 5678, 'expires' => 1.day.ago.to_i, 'checksum' => 'chk-stale'}
+      }
+      bs.save
+      expect(Uploader).to_not receive(:remote_remove).with('live.json', anything)
+      expect(Uploader).to receive(:remote_remove).with('stale.json', 'chk-stale').and_return(true)
+      BoardDownstreamButtonSet.flush_caches([b.global_id], Time.now.to_i)
+      bs.reload
+      expect(bs.data['remote_paths'].keys).to eq(['live'])
     end
   end
 end


### PR DESCRIPTION
## Summary
Follow-up to PR #202. After that deploy landed on staging, we still saw the upload-then-delete cycle on board-copy hot paths — just on base (non-chksm) cache keys this time.

Root cause: `BoardDownstreamButtonSet.flush_caches` was deleting cache entries that `url_for` still considered live. The two methods used different TTL definitions:
- `url_for` trusts an entry until its \`expires\` field.
- `flush_caches` deleted on \`generated < timestamp\`.

So a freshly-uploaded entry (generated minutes ago, expires 5 months out) was still being served to users while \`flush_caches\` — kicked off by \`update_for\` on a related board — was busy deleting the S3 object behind its back. Also: \`Uploader.remote_remove(path)\` was called without the stored checksum, bypassing the safety check.

## Evidence (prod 2026-04-22)
S3 version history for \`extras-cache_2078/button_set_cache/1_2078/a26e5a40...json\`:
- 04:41:08 upload → 04:41:21 delete (13s)
- 04:41:47 upload → 04:41:49 delete (2s)
- 04:43:39 upload → 04:43:41 delete (2s, current marker)

Each delete was issued by the worker seconds after the worker's own upload. PR #202 stopped this for chksm paths; this PR stops it for base paths too.

## Changes
- \`flush_caches\` now requires **both** \`generated < timestamp\` **and** \`expires < Time.now.to_i\` before deleting. Matches \`url_for\`'s semantics; entries still within their expires window are left alone regardless of generated.
- \`flush_caches\` now passes the stored \`obj['checksum']\` to \`Uploader.remote_remove\`. Belt-and-suspenders: even under a future race the checksum safety check will abort a mismatched delete.

## Specs
- Updated the three existing \`flush_caches\` specs to match the new semantics (fixtures now use past \`expires\` for entries expected to be flushed; checksum argument verified).
- Added a new spec that pins the fix in place: an entry with old \`generated\` but future \`expires\` must NOT be flushed.

## Test plan
- [ ] CI green (rspec in particular).
- [ ] Staging auto-deploy + bulk clear again + \"Make a Copy\" on vocal-flair-40 — verify S3 object persists and copy succeeds.
- [ ] Verify a couple other boards (vocal-flair-60, Quick Core 60) just to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)