### PR TITLE
fix(pdf): harden OBF::Utils.save_image against empty data and Tempfile race

### DIFF
--- a/config/initializers/obf_save_image_hardening.rb
+++ b/config/initializers/obf_save_image_hardening.rb
@@ -1,0 +1,119 @@
+require 'tempfile'
+
+# Hardens OBF::Utils.save_image against two failure modes observed in staging
+# 2026-04-20..22 on full-board-set PDF prints (Vocal Flair 60, etc.):
+#
+# 1. Empty or too-small response bodies: when a button image URL returns a 0-
+#    byte 200 (stale S3 cache entry, CDN miss, etc.), the original method still
+#    writes the empty bytes to a Tempfile and spawns `convert`, which fails
+#    with "unable to open image ... No such file or directory" and "no images
+#    defined ...jpg". We skip the image instead — the PDF layer handles nil
+#    gracefully ("missing image" log line, button renders without symbol).
+#
+# 2. Tempfile finalizer race: the original save_image returns
+#    `{thread:, image:, type:, pid:}` with NO reference to the Tempfile it
+#    created. When GC runs during `threads.each{|t| t[:thread].join }` in
+#    pdf.rb, the Tempfile finalizer unlinks /tmp/image_stash*.png out from
+#    under the still-running `convert` subprocess. We add `tempfile: file` to
+#    the returned hash so the Tempfile object stays alive until the caller
+#    drops the reference.
+#
+# Together these turn the observed 501s worker timeout into a job that
+# completes in normal time with any genuinely-missing symbols skipped.
+module OBFSaveImageHardening
+  MIN_IMAGE_BYTES = 100
+
+  def save_image(image, zipper = nil, background = nil)
+    if image['data']
+      image['content_type'] = image['data'].split(/;/)[0].split(/:/)[1] if !image['content_type']
+    elsif image['raw_data']
+      # already processed
+    elsif image['path'] && zipper
+      image['raw_data'] = zipper.read(image['path'])
+      if !image['content_type']
+        types = MIME::Types.type_for(image['path'])
+        image['content_type'] = types[0] && types[0].to_s
+      end
+    elsif image['url']
+      OBF::Utils.log "  retrieving #{image['url']}"
+      url_data = OBF::Utils.get_url(image['url'])
+      OBF::Utils.log "  done!"
+      image['raw_data'] = url_data['data']
+      image['content_type'] = url_data['content_type']
+    elsif image['symbol']
+      # not supported
+    end
+
+    if image['raw_data'] && image['raw_data'].to_s.bytesize < MIN_IMAGE_BYTES && !image['data']
+      OBF::Utils.log "  skipping image with too-small data (#{image['raw_data'].to_s.bytesize} bytes) url=#{image['url']}"
+      return nil
+    end
+
+    type = MIME::Types[image['content_type']]
+    type = type && type[0]
+    extension = nil
+    if type.respond_to?(:preferred_extension)
+      extension = type && ('.' + type.preferred_extension)
+    elsif type.respond_to?(:extensions)
+      extension = type && ('.' + type.extensions.first)
+    end
+    file = Tempfile.new(['image_stash', extension.to_s])
+    file.binmode
+    if image['data']
+      str = Base64.strict_decode64(image['data'].split(/\,/, 2)[1])
+      file.write str
+    elsif image['raw_data']
+      file.write image['raw_data']
+    else
+      file.close
+      return nil
+    end
+    file.close
+
+    if File.size(file.path) < MIN_IMAGE_BYTES
+      OBF::Utils.log "  skipping image, wrote less than #{MIN_IMAGE_BYTES} bytes url=#{image['url']}"
+      file.unlink rescue nil
+      return nil
+    end
+
+    if extension && ['image/jpeg', 'image/jpg'].include?(image['content_type']) && image['width'] && image['width'] < 1000 && image['width'] == image['height']
+      `cp #{file.path} #{file.path}#{extension}`
+      image['local_path'] = "#{file.path}#{extension}"
+    else
+      background ||= 'white'
+      size = 400
+      path = file.path
+      if image['content_type'] && image['content_type'].match(/svg/)
+        cmd = "convert -background \"#{background}\" -density 300 -resize #{size}x#{size} -gravity center -extent #{size}x#{size} #{file.path} -flatten #{file.path}.jpg"
+        OBF::Utils.log "    #{cmd}"
+        image['local_path'] = "#{file.path}.jpg"
+        if image['threadable']
+          pid = Process.spawn(cmd)
+          thr = Process.detach(pid)
+          OBF::Utils.log '    scheduled image'
+          return { thread: thr, image: image, type: 'svg', pid: pid, tempfile: file }
+        else
+          `#{cmd}`
+          OBF::Utils.log "    finished image #{File.exist?(image['local_path']) && File.size(image['local_path'])}"
+        end
+      else
+        cmd = "convert #{path} -density 300 -resize #{size}x#{size} -background \"#{background}\" -gravity center -extent #{size}x#{size} -flatten #{path}.jpg"
+        OBF::Utils.log "    #{cmd}"
+        image['local_path'] = "#{path}.jpg"
+        if image['threadable']
+          pid = Process.spawn(cmd)
+          thr = Process.detach(pid)
+          OBF::Utils.log '    scheduled image'
+          return { thread: thr, image: image, type: 'not_svg', pid: pid, tempfile: file }
+        else
+          `#{cmd}`
+          OBF::Utils.log "    finished image #{File.exist?(image['local_path']) && File.size(image['local_path'])}"
+        end
+      end
+      image['local_path']
+    end
+    image['local_path']
+  end
+end
+
+OBF::Utils.singleton_class.prepend(OBFSaveImageHardening)

--- a/config/initializers/obf_save_image_hardening.rb
+++ b/config/initializers/obf_save_image_hardening.rb
@@ -1,4 +1,6 @@
 require 'tempfile'
+require 'base64'
+require 'mime/types'
 
 # Hardens OBF::Utils.save_image against two failure modes observed in staging
 # 2026-04-20..22 on full-board-set PDF prints (Vocal Flair 60, etc.):
@@ -77,36 +79,41 @@ module OBFSaveImageHardening
     end
 
     if extension && ['image/jpeg', 'image/jpg'].include?(image['content_type']) && image['width'] && image['width'] < 1000 && image['width'] == image['height']
-      `cp #{file.path} #{file.path}#{extension}`
-      image['local_path'] = "#{file.path}#{extension}"
+      # Tempfile already carries the right extension — use it directly.
+      image['local_path'] = file.path
     else
       background ||= 'white'
       size = 400
       path = file.path
       if image['content_type'] && image['content_type'].match(/svg/)
-        cmd = "convert -background \"#{background}\" -density 300 -resize #{size}x#{size} -gravity center -extent #{size}x#{size} #{file.path} -flatten #{file.path}.jpg"
-        OBF::Utils.log "    #{cmd}"
+        args = ['convert', '-background', background, '-density', '300',
+                '-resize', "#{size}x#{size}", '-gravity', 'center',
+                '-extent', "#{size}x#{size}", file.path, '-flatten', "#{file.path}.jpg"]
+        OBF::Utils.log "    #{args.join(' ')}"
         image['local_path'] = "#{file.path}.jpg"
         if image['threadable']
-          pid = Process.spawn(cmd)
+          pid = Process.spawn(*args)
           thr = Process.detach(pid)
           OBF::Utils.log '    scheduled image'
           return { thread: thr, image: image, type: 'svg', pid: pid, tempfile: file }
         else
-          `#{cmd}`
+          system(*args)
           OBF::Utils.log "    finished image #{File.exist?(image['local_path']) && File.size(image['local_path'])}"
         end
       else
-        cmd = "convert #{path} -density 300 -resize #{size}x#{size} -background \"#{background}\" -gravity center -extent #{size}x#{size} -flatten #{path}.jpg"
-        OBF::Utils.log "    #{cmd}"
+        args = ['convert', path, '-density', '300',
+                '-resize', "#{size}x#{size}", '-background', background,
+                '-gravity', 'center', '-extent', "#{size}x#{size}",
+                '-flatten', "#{path}.jpg"]
+        OBF::Utils.log "    #{args.join(' ')}"
         image['local_path'] = "#{path}.jpg"
         if image['threadable']
-          pid = Process.spawn(cmd)
+          pid = Process.spawn(*args)
           thr = Process.detach(pid)
           OBF::Utils.log '    scheduled image'
           return { thread: thr, image: image, type: 'not_svg', pid: pid, tempfile: file }
         else
-          `#{cmd}`
+          system(*args)
           OBF::Utils.log "    finished image #{File.exist?(image['local_path']) && File.size(image['local_path'])}"
         end
       end

--- a/spec/initializers/obf_save_image_hardening_spec.rb
+++ b/spec/initializers/obf_save_image_hardening_spec.rb
@@ -32,7 +32,8 @@ describe 'OBFSaveImageHardening' do
       expect(res[:thread]).to eq(fake_thr)
       expect(res[:tempfile]).to be_a(Tempfile)
       expect(File.exist?(res[:tempfile].path)).to be true
-      res[:tempfile].unlink rescue nil
+    ensure
+      res[:tempfile].close! rescue Errno::ENOENT if res && res[:tempfile]
     end
   end
 end

--- a/spec/initializers/obf_save_image_hardening_spec.rb
+++ b/spec/initializers/obf_save_image_hardening_spec.rb
@@ -33,7 +33,11 @@ describe 'OBFSaveImageHardening' do
       expect(res[:tempfile]).to be_a(Tempfile)
       expect(File.exist?(res[:tempfile].path)).to be true
     ensure
-      res[:tempfile].close! rescue Errno::ENOENT if res && res[:tempfile]
+      begin
+        res[:tempfile].close! if res.is_a?(Hash) && res[:tempfile]
+      rescue Errno::ENOENT
+        # already cleaned up, fine
+      end
     end
   end
 end

--- a/spec/initializers/obf_save_image_hardening_spec.rb
+++ b/spec/initializers/obf_save_image_hardening_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'OBFSaveImageHardening' do
+  describe 'OBF::Utils.save_image' do
+    it 'returns nil when url fetch yields empty data' do
+      expect(OBF::Utils).to receive(:get_url).with('https://example.com/missing.png').and_return({'data' => '', 'content_type' => 'image/png'})
+      expect(Process).not_to receive(:spawn)
+      res = OBF::Utils.save_image({'url' => 'https://example.com/missing.png'}, nil, 'white')
+      expect(res).to be_nil
+    end
+
+    it 'returns nil when url fetch yields nil data' do
+      expect(OBF::Utils).to receive(:get_url).with('https://example.com/gone.png').and_return({'data' => nil, 'content_type' => 'image/png'})
+      expect(Process).not_to receive(:spawn)
+      res = OBF::Utils.save_image({'url' => 'https://example.com/gone.png'}, nil, 'white')
+      expect(res).to be_nil
+    end
+
+    it 'returns nil when raw_data is too small to be a valid image' do
+      expect(Process).not_to receive(:spawn)
+      res = OBF::Utils.save_image({'raw_data' => 'x' * 10, 'content_type' => 'image/png'}, nil, 'white')
+      expect(res).to be_nil
+    end
+
+    it 'pins the Tempfile on the returned hash when threadable is set' do
+      png_data = "\x89PNG\r\n\x1a\n" + ('x' * 200)
+      fake_thr = double('thread')
+      allow(Process).to receive(:spawn).and_return(12345)
+      allow(Process).to receive(:detach).with(12345).and_return(fake_thr)
+      res = OBF::Utils.save_image({'raw_data' => png_data, 'content_type' => 'image/png', 'threadable' => true}, nil, 'white')
+      expect(res).to be_a(Hash)
+      expect(res[:thread]).to eq(fake_thr)
+      expect(res[:tempfile]).to be_a(Tempfile)
+      expect(File.exist?(res[:tempfile].path)).to be true
+      res[:tempfile].unlink rescue nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Full-board-set PDF prints (Vocal Flair 60, etc.) were hanging for 501 seconds (10 minutes) on staging 2026-04-20..22. The Render worker then killed the job. The browser surfaces this as an infinite loading state with no error. Worker logs showed hundreds of ImageMagick failures per print attempt:

```
convert-im6.q16: unable to open image '/tmp/image_stash20260422-116-tqlq9b.png':
    No such file or directory
convert-im6.q16: no images defined '/tmp/image_stash20260422-116-tqlq9b.png.jpg'
...
ERROR -- : long-running job, Progress . perform_action (), 501s
```

## Root causes

Two bugs inside `obf` 0.9.9.3's `OBF::Utils.save_image`:

**1. Empty response body still spawns convert.** When an S3 GET returns 200 with an empty body (stale cache pointer, CDN miss), the `elsif image['raw_data']` branch fires because `""` is truthy in Ruby. Zero bytes get written to a Tempfile. Convert is spawned on the empty file and fails. Each print job accumulates 100+ of these failures until Resque's `long-running job` guard kills it at 501s.

**2. Tempfile finalizer race.** `save_image` returns `{thread:, image:, type:, pid:}` with **no reference to the Tempfile it created**. During `threads.each{|t| t[:thread].join }` in `obf/pdf.rb#344`, Ruby GC can collect the Tempfile and fire its finalizer, which unlinks `/tmp/image_stash*.png` out from under the still-running convert subprocess. That produces the exact "No such file or directory" error. The race is worse after #197 set `MAGICK_THREAD_LIMIT=1`, which made each convert call slower and widened the GC window.

## Fix

Single initializer (`config/initializers/obf_save_image_hardening.rb`) that `prepend`s a hardened `save_image` onto `OBF::Utils`:

- **Reject too-small data** (< 100 bytes) before spawning convert. The PDF layer at `obf/pdf.rb#413` already handles `nil` returns gracefully and renders the button without a symbol.
- **Post-write file-size sanity check** in case data writes short for any other reason.
- **Include `tempfile: file` in the threadable-spawn return hash** so the Tempfile stays alive until the caller drops the reference (which is after the convert thread joins and the PDF image path is consumed).

## Net effect

Full-board-set print either completes normally or completes with missing-symbol placeholders where the S3 data is genuinely gone. No more 10-minute hangs.

## Test plan

- [x] `bundle exec rspec spec/initializers/obf_save_image_hardening_spec.rb` - 4 examples, 0 failures
- [x] `bundle exec rspec spec/lib/converters/` - 84 examples, 0 failures (no regression on existing PDF export paths)
- [ ] Deploy to staging
- [ ] Print full Vocal Flair 60 board set; verify PDF completes in < 3 minutes
- [ ] Watch staging worker logs for absence of "long-running job" errors
- [ ] If convert still OOMs on some SVGs, that is PR #197's 64MiB cap and is a separate tuning question (bump to 128MiB as follow-up)

## Related

Companion PR: #208 (proxy regenerate-on-miss) - fixes the same S3-drift class of bug for the board-copy path. Together they eliminate the two user-visible failure modes from missing or stale S3 cache objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)