### PR TITLE
Enhance CI workflow: Cache Puppeteer Chrome alongside node_modules an…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,12 @@ jobs:
         with:
           node-version: 20
 
-      - name: Cache node_modules
+      - name: Cache node_modules and Puppeteer Chrome
         uses: actions/cache@v4
         with:
           path: |
             app/frontend/node_modules
+            ~/.cache/puppeteer
           key: ${{ runner.os }}-node20-${{ hashFiles('app/frontend/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node20-
@@ -86,6 +87,12 @@ jobs:
       - name: Install frontend dependencies
         working-directory: app/frontend
         run: npm install
+
+      # Puppeteer downloads Chrome under ~/.cache/puppeteer, not inside node_modules.
+      # Restoring only node_modules leaves executablePath() pointing at a missing binary.
+      - name: Ensure Puppeteer Chrome is present
+        working-directory: app/frontend
+        run: npx puppeteer browsers install chrome
 
       - name: Build Ember app
         working-directory: app/frontend


### PR DESCRIPTION
…d ensure Chrome is installed for Puppeteer. This prevents missing binary issues during builds.