### PR TITLE
Pin gitleaks version in secret-detection CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks (CLI - no license required)
+        env:
+          GITLEAKS_VERSION: 8.21.2
         run: |
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/v//')_linux_x64.tar.gz | tar -xz gitleaks
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
           ./gitleaks detect --source . --log-opts="--all" --exit-code 1 || true


### PR DESCRIPTION
## Summary
- The `secret-detection` job in `.github/workflows/ci.yml` was failing on every PR (e.g. #212).
- Root cause: the install step looked up gitleaks' "latest" release via the unauthenticated GitHub API. When that call returns nothing usable (rate limit / shape change / transient), the version interpolated to empty, producing a 404 download URL and a `tar` failure with exit code 2.
- Fix: pin `GITLEAKS_VERSION=8.21.2` and download that asset directly. No more dependency on api.github.com or anonymous rate limits.

## Test plan
- [ ] CI's `secret-detection` job passes on this PR
- [ ] Re-run CI on PR #212 (or rebase it) and confirm `secret-detection` is now green
- [ ] gitleaks still surfaces real findings (verify by inspecting job log output)