### PR TITLE
Traci/styling/styling updates

### DIFF
--- a/app/frontend/app/app.js
+++ b/app/frontend/app/app.js
@@ -245,8 +245,20 @@ DS.Model.reopen({
 });
 
 Route.reopen({
+  // Loading and error substates (e.g. `index_loading`) often have no
+  // controller. `controllerFor` throws an assertion in that case. Guarding
+  // both call sites lets those substates activate cleanly — visible only
+  // under SPA route transitions where the substate's lifecycle completes
+  // (under full page reload, the browser tore down Ember before this fired).
+  _safe_controller_for_self: function() {
+    try {
+      return this.controllerFor(this.routeName);
+    } catch (e) {
+      return null;
+    }
+  },
   update_title_if_present: function() {
-    var controller = this.controllerFor(this.routeName);
+    var controller = this._safe_controller_for_self();
     var title = this.get('title') || (controller && controller.get('title'));
     if(title) {
       LingoLinq.controller.updateTitle(title.toString());
@@ -254,7 +266,7 @@ Route.reopen({
   },
   activate: function() {
     this.update_title_if_present();
-    var controller = this.controllerFor(this.routeName);
+    var controller = this._safe_controller_for_self();
     if(controller) {
       controller.addObserver('title', this, function() {
         this.update_title_if_present();

--- a/app/frontend/app/components/login-form.js
+++ b/app/frontend/app/components/login-form.js
@@ -297,6 +297,104 @@ export default Component.extend({
   noSecret: computed('client_secret', function() {
     return !this.get('client_secret');
   }),
+  // SPA path eligibility predicate. Extracted as a method (not an inline
+  // expression) so plan 07 tests can stub it directly without flipping the
+  // global Ember.testing flag. Returns true iff the SPA transition path
+  // should be taken on a non-installed-app web client.
+  // SPEC R1, plan 04.
+  _login_spa_eligible: function() {
+    return !!this.appState.get('feature_flags.auth_spa_transition');
+  },
+  // Post-auth web dispatch logic. Called from login_success's web `else`
+  // branch (the existing branch after `if(isTesting()) ... else if(installed_app)`).
+  // Extracted as a method so plan 07 tests can call it directly with a
+  // stubbed `wait` promise — bypassing login_success's outer `if(isTesting())`
+  // early-return without needing to mutate Ember.testing globally.
+  // The method assumes:
+  //   - reload=true (the reload=false case is handled in login_success itself)
+  //   - we're on a web client (NOT installed_app — that branch is handled by
+  //     login_success directly)
+  //   - we're NOT under test environment (login_success's outer if(isTesting())
+  //     short-circuits in production; in tests this method is called directly
+  //     by the test, bypassing the outer guard intentionally for test purposes)
+  // It dispatches to the SPA path if `_login_spa_eligible()` returns true,
+  // else to the existing reload path. ANY error in the SPA path falls back
+  // to the reload path.
+  // SPEC R1, R3, R4. Plan 04.
+  _login_dispatch_after_wait: function(wait) {
+    var _this = this;
+    var spaTransitionEnabled = !!_this._login_spa_eligible();
+
+    var reloadDone = false;
+    var doReload = function() {
+      if(reloadDone || _this.isDestroyed || _this.isDestroying) { return; }
+      reloadDone = true;
+      if(_this.get('return')) {
+        _this.session.set('return', true);
+      }
+      _loginDebug('Web: reloading to dashboard');
+      location.assign('/');
+    };
+
+    var removePreReloadOverlay = function() {
+      // The pre-reload overlay was appended to document.body (outside the
+      // Ember outlet) by login_success. On the reload path, browser
+      // navigation discards it. On the SPA path, we must remove it
+      // explicitly AFTER the transition resolves, otherwise it stays
+      // pinned over the dashboard.
+      try {
+        var ov = document.getElementById('ll-pre-reload-overlay');
+        if(ov && ov.parentNode) {
+          ov.parentNode.removeChild(ov);
+        }
+      } catch(e) { /* DOM may be unavailable; ignore */ }
+    };
+
+    var doTransition = function() {
+      if(reloadDone || _this.isDestroyed || _this.isDestroying) { return; }
+      reloadDone = true;
+      try {
+        _loginDebug('SPA transition: transitioning to index (route will redirect to user.home)');
+        // Transition to 'index' — the index route's afterModel
+        // (routes/index.js:35-39) does replaceWith('user.home', user_name)
+        // using the same code path as cold-boot. This avoids duplicate
+        // findRecord('user', 'self') fetches and the username-changed
+        // race that transitionTo('user.home', user_name) would introduce.
+        var promise = _this.router.transitionTo('index');
+        if(promise && typeof promise.then === 'function') {
+          promise.then(function() {
+            if(_this.isDestroyed || _this.isDestroying) { return; }
+            removePreReloadOverlay();
+          }, function(err) {
+            if(_this.isDestroyed || _this.isDestroying) { return; }
+            console.warn('[login_success] SPA transition rejected, falling back to reload', err);
+            reloadDone = false;
+            doReload();
+          });
+        } else {
+          // No thenable returned — defensive: assume success.
+          removePreReloadOverlay();
+        }
+      } catch(err) {
+        console.warn('[login_success] SPA transition threw, falling back to reload', err);
+        reloadDone = false;
+        doReload();
+      }
+    };
+
+    var doNext = spaTransitionEnabled ? doTransition : doReload;
+
+    wait.then(doNext, function(err) {
+      if(_this.isDestroyed || _this.isDestroying) { return; }
+      console.warn('[login_success] User fetch failed, reloading', err);
+      doReload();
+    });
+    // Fallback: if wait hangs (e.g. slow API, IndexedDB), reload after 6s.
+    // The race ALWAYS falls back to doReload — never to doTransition — because
+    // a hanging wait means the SPA path cannot satisfy its preconditions.
+    var timeoutPromise = new RSVP.Promise(function(resolve) { runLater(resolve, 6000); });
+    RSVP.race([wait, timeoutPromise]).then(doNext, function() { doReload(); });
+  },
   actions: {
     login_success: function(reload) {
       var _this = this;
@@ -342,6 +440,32 @@ export default Component.extend({
         if(window.navigator.splashscreen) {
           window.navigator.splashscreen.show();
         }
+        // Cover the login page with a full-screen overlay while we flush stashes,
+        // fetch the session user, and trigger the reload. Without this, the user
+        // sees the login form sitting "ready" during the wait, then a flash of
+        // mid-boot styling on the new page. The boot overlay in index.html picks
+        // up immediately on the reloaded page and stays until the destination
+        // route renders.
+        if(typeof document !== 'undefined' && document.body && !document.getElementById('ll-pre-reload-overlay')) {
+          var overlay = document.createElement('div');
+          overlay.id = 'll-pre-reload-overlay';
+          overlay.className = 'll-loading-overlay';
+          overlay.setAttribute('role', 'status');
+          overlay.setAttribute('aria-live', 'polite');
+          overlay.setAttribute('aria-busy', 'true');
+          var card = document.createElement('div');
+          card.className = 'll-loading-overlay__card';
+          var spinner = document.createElement('div');
+          spinner.className = 'll-loading-overlay__spinner';
+          spinner.setAttribute('aria-hidden', 'true');
+          var msg = document.createElement('p');
+          msg.className = 'll-loading-overlay__message';
+          msg.textContent = i18n.t('loading_your_account', "Loading your account…");
+          card.appendChild(spinner);
+          card.appendChild(msg);
+          overlay.appendChild(card);
+          document.body.appendChild(overlay);
+        }
       }
       // wait = stashes flush -> setup -> refresh_session_user (ensures navbar shows signed-in state before transition)
       var wait = this.stashes.flush(null, 'auth_').then(function() {
@@ -381,28 +505,9 @@ export default Component.extend({
             }
           });
         } else {
-          // Web: use full page reload after login (same approach as installed app).
-          // Client-side transition was unreliable: on index route transitionTo('index') is a no-op,
-          // and the dashboard only shows when appState.currentUser is set by refresh_session_user.
-          // A reload guarantees session restore from localStorage and clean dashboard load.
-          var reloadDone = false;
-          var doReload = function() {
-            if(reloadDone || _this.isDestroyed || _this.isDestroying) { return; }
-            reloadDone = true;
-            if(_this.get('return')) {
-              _this.session.set('return', true);
-            }
-            _loginDebug('Web: reloading to dashboard');
-            location.assign('/');
-          };
-          wait.then(doReload, function(err) {
-            if(_this.isDestroyed || _this.isDestroying) { return; }
-            console.warn('[login_success] User fetch failed, reloading anyway', err);
-            doReload();
-          });
-          // Fallback: if wait hangs (e.g. slow API, IndexedDB), reload after 6s
-          var timeoutPromise = new RSVP.Promise(function(resolve) { runLater(resolve, 6000); });
-          RSVP.race([wait, timeoutPromise]).then(doReload, function() { doReload(); });
+          // Web (non-installed-app): delegate dispatch to _login_dispatch_after_wait
+          // so plan 07 tests can call it directly with a stubbed wait promise.
+          _this._login_dispatch_after_wait(wait);
         }
       }
     },

--- a/app/frontend/app/components/login-form.js
+++ b/app/frontend/app/components/login-form.js
@@ -360,20 +360,75 @@ export default Component.extend({
         // using the same code path as cold-boot. This avoids duplicate
         // findRecord('user', 'self') fetches and the username-changed
         // race that transitionTo('user.home', user_name) would introduce.
-        var promise = _this.router.transitionTo('index');
-        if(promise && typeof promise.then === 'function') {
-          promise.then(function() {
-            if(_this.isDestroyed || _this.isDestroying) { return; }
+
+        // Keep the pre-reload overlay visible across the ENTIRE chained
+        // transition (login -> index -> user.home). The transitionTo('index')
+        // promise resolves before the chained replaceWith('user.home', ...)
+        // settles, which would expose a blank moment + the index_loading
+        // template's secondary "Loading..." overlay. Listen for routeDidChange
+        // and dismiss only after the chain has been quiet for 150ms (= final
+        // route settled). 2x rAF after that lets the destination paint.
+        var routerSvc = _this.router;
+        var pending = null;
+        var safetyTimer = null;
+        var listenerCleanedUp = false;
+        // Bump the pre-reload overlay's z-index so it always wins regardless
+        // of DOM order. Higher than the default .ll-loading-overlay (z 10050).
+        try {
+          var preEl = document.getElementById('ll-pre-reload-overlay');
+          if(preEl) { preEl.style.zIndex = '2147483646'; }
+        } catch(e) {}
+        var cleanup = function() {
+          if(listenerCleanedUp) { return; }
+          listenerCleanedUp = true;
+          try { routerSvc.off('routeDidChange', onRouteDidChange); } catch(e) {}
+          if(pending) { try { cancelLater(pending); } catch(e) {} pending = null; }
+          if(safetyTimer) { try { cancelLater(safetyTimer); } catch(e) {} safetyTimer = null; }
+        };
+        var dismiss = function() {
+          cleanup();
+          if(_this.isDestroyed || _this.isDestroying) { return; }
+          var raf = window.requestAnimationFrame;
+          if(typeof raf === 'function') {
+            raf(function() { raf(function() { removePreReloadOverlay(); }); });
+          } else {
             removePreReloadOverlay();
-          }, function(err) {
-            if(_this.isDestroyed || _this.isDestroying) { return; }
+          }
+        };
+        var onRouteDidChange = function() {
+          if(listenerCleanedUp) { return; }
+          if(pending) { try { cancelLater(pending); } catch(e) {} }
+          pending = runLater(dismiss, 150);
+        };
+        routerSvc.on('routeDidChange', onRouteDidChange);
+        // Safety net: if routeDidChange never fires (edge case), don't trap the
+        // user behind the overlay forever.
+        safetyTimer = runLater(dismiss, 8000);
+
+        var promise = routerSvc.transitionTo('index');
+        if(promise && typeof promise.then === 'function') {
+          promise.then(null, function(err) {
+            if(_this.isDestroyed || _this.isDestroying) { cleanup(); return; }
+            // CRITICAL: TransitionAborted is the EXPECTED rejection when
+            // index's afterModel calls replaceWith('user.home', ...) — Ember
+            // marks the original transition as aborted, but the chain still
+            // succeeds and routeDidChange will fire for user.home. Treating
+            // this as a failure and reloading produces exactly the bug we
+            // are trying to fix (mid-chain page reload → white flash →
+            // index-loading overlay → dashboard). Recognize it and bail out.
+            var errName = err && (err.name || (err.constructor && err.constructor.name));
+            var errMsg = err && err.message;
+            var isTransitionAborted = errName === 'TransitionAborted' ||
+                                       (errMsg && /TransitionAborted|transition.*aborted/i.test(errMsg));
+            if(isTransitionAborted) {
+              _loginDebug('SPA transition: original promise rejected with TransitionAborted (expected — chain replaceWith); routeDidChange will dismiss', { err: errMsg });
+              return;
+            }
             console.warn('[login_success] SPA transition rejected, falling back to reload', err);
+            cleanup();
             reloadDone = false;
             doReload();
           });
-        } else {
-          // No thenable returned — defensive: assume success.
-          removePreReloadOverlay();
         }
       } catch(err) {
         console.warn('[login_success] SPA transition threw, falling back to reload', err);
@@ -440,6 +495,18 @@ export default Component.extend({
         if(window.navigator.splashscreen) {
           window.navigator.splashscreen.show();
         }
+        // Set auth-pending flag in localStorage. The boot overlay in index.html
+        // reads this on the reloaded page and shows "Loading your account…"
+        // instead of the generic "Loading…" so the message is consistent
+        // throughout the auth flow regardless of whether the SPA or reload path
+        // takes. localStorage survives page reload (sessionStorage does too,
+        // but localStorage is also visible to other tabs which is fine here).
+        // Cleared by the boot overlay's remove() once dismissed.
+        try {
+          if(typeof window !== 'undefined' && window.localStorage) {
+            window.localStorage.setItem('lingolinq_auth_pending', 'login');
+          }
+        } catch(e) { /* localStorage unavailable; pre-reload overlay still works */ }
         // Cover the login page with a full-screen overlay while we flush stashes,
         // fetch the session user, and trigger the reload. Without this, the user
         // sees the login form sitting "ready" during the wait, then a flash of

--- a/app/frontend/app/index.html
+++ b/app/frontend/app/index.html
@@ -33,6 +33,59 @@
     <link rel="icon" href="{{rootURL}}images/LL_Logo_Light_Muted.png?v=5" type="image/png" />
     <link rel="apple-touch-icon" href="{{rootURL}}images/LL_Logo_Light_Muted.png?v=5" />
 
+    <style>
+      /* Boot overlay — painted immediately when HTML parses, before vendor.css /
+         frontend.css load and before Ember boots. Sits above #ember-application-root
+         and is dismissed by JS once the destination route's templates have rendered.
+         Mirrors .ll-loading-overlay so the in-app overlay can take over without a
+         visible seam. */
+      #ll-boot-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483647;
+        background: rgba(15, 23, 42, 0.55);
+        -webkit-backdrop-filter: blur(6px);
+        backdrop-filter: blur(6px);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: 'Inter', 'Atkinson Hyperlegible', system-ui, -apple-system, sans-serif;
+        transition: opacity 220ms ease-out;
+      }
+      #ll-boot-overlay[data-hiding='true'] { opacity: 0; pointer-events: none; }
+      #ll-boot-overlay__card {
+        background: #fff;
+        border-radius: 14px;
+        padding: 28px 36px;
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.28);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+        min-width: 240px;
+        max-width: calc(100vw - 32px);
+      }
+      #ll-boot-overlay__spinner {
+        width: 42px;
+        height: 42px;
+        border-radius: 50%;
+        border: 4px solid rgba(42, 157, 143, 0.18);
+        border-top-color: #2a9d8f;
+        animation: ll-boot-overlay-spin 0.9s linear infinite;
+      }
+      #ll-boot-overlay__message {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 500;
+        color: #1f2937;
+        text-align: center;
+      }
+      @keyframes ll-boot-overlay-spin { to { transform: rotate(360deg); } }
+      @media (prefers-reduced-motion: reduce) {
+        #ll-boot-overlay__spinner { animation-duration: 2.5s; }
+      }
+    </style>
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Lexend:wght@400;500;600;700&family=Maitree:wght@400;500;600;700&family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
@@ -53,6 +106,56 @@
     {{content-for "head-footer"}}
   </head>
   <body>
+    <!-- Boot overlay — sibling of the Ember root so it survives Ember mounting and
+         can fade out cleanly once the destination route has rendered. Hidden by
+         window.LingoLinqHideBootOverlay() (called from an instance initializer
+         after the first stable transition) or by a safety timeout. -->
+    <div id="ll-boot-overlay" role="status" aria-live="polite" aria-busy="true">
+      <div id="ll-boot-overlay__card">
+        <div id="ll-boot-overlay__spinner" aria-hidden="true"></div>
+        <p id="ll-boot-overlay__message">Loading&hellip;</p>
+      </div>
+    </div>
+    <script>
+      (function () {
+        var SAFETY_MS = 12000;
+        var FADE_MS = 240;
+        var hidden = false;
+        // If we're booting after an auth event (login posted), use the same
+        // "Loading your account…" message the pre-reload overlay shows. Without
+        // this, the user sees the pre-reload card swap to a generic "Loading…"
+        // boot card during the reload — visually inconsistent. localStorage
+        // survives page reload; the flag is set by login-form before reload
+        // and cleared by the ready signal once the destination route renders.
+        try {
+          var pending = window.localStorage && window.localStorage.getItem('lingolinq_auth_pending');
+          if (pending === 'login') {
+            var msgEl = document.getElementById('ll-boot-overlay__message');
+            if (msgEl) { msgEl.textContent = 'Loading your account…'; }
+          }
+        } catch (e) { /* localStorage unavailable; keep default text */ }
+        function remove() {
+          var el = document.getElementById('ll-boot-overlay');
+          if (el && el.parentNode) { el.parentNode.removeChild(el); }
+          // Clear the auth-pending flag once the overlay is gone — the user
+          // has reached the destination and the message has done its job.
+          try {
+            if (window.localStorage) { window.localStorage.removeItem('lingolinq_auth_pending'); }
+          } catch (e) {}
+        }
+        window.LingoLinqHideBootOverlay = function () {
+          if (hidden) { return; }
+          hidden = true;
+          var el = document.getElementById('ll-boot-overlay');
+          if (!el) { return; }
+          el.setAttribute('data-hiding', 'true');
+          setTimeout(remove, FADE_MS);
+        };
+        // Safety net: never trap the user behind the overlay if the ready signal
+        // never fires (offline boot, JS error in initializer, etc.).
+        setTimeout(function () { window.LingoLinqHideBootOverlay(); }, SAFETY_MS);
+      })();
+    </script>
     <!-- Ember mounts here. config has rootElement: '#ember-application-root'. App template renders #within_ember > header + #content (main outlet). Do not add wrappers inside this div or change its id, or app styles (#content, #within_ember, etc.) may not apply. -->
     <div id="ember-application-root">{{content-for "body"}}</div>
 

--- a/app/frontend/app/instance-initializers/boot-overlay-hide.js
+++ b/app/frontend/app/instance-initializers/boot-overlay-hide.js
@@ -1,0 +1,57 @@
+import { later as runLater, cancel as runCancel } from '@ember/runloop';
+
+export function initialize(appInstance) {
+  if (typeof window === 'undefined' || typeof window.LingoLinqHideBootOverlay !== 'function') {
+    return;
+  }
+
+  var router = appInstance.lookup('service:router');
+  var hideFn = window.LingoLinqHideBootOverlay;
+
+  if (!router) {
+    hideFn();
+    return;
+  }
+
+  var done = false;
+  var pending = null;
+  var sawRouteDidChange = false;
+
+  function finish() {
+    if (done) { return; }
+    done = true;
+    if (pending) { runCancel(pending); pending = null; }
+    var raf = window.requestAnimationFrame;
+    if (typeof raf === 'function') {
+      raf(function () { raf(function () { hideFn(); }); });
+    } else {
+      hideFn();
+    }
+  }
+
+  // Only schedule a hide AFTER routeDidChange has fired at least once. Calling
+  // schedule() at boot would queue a 150ms hide that fires before the index
+  // route's model resolves, exposing the partially-rendered page (white flash
+  // + secondary loading state) before the real destination renders.
+  function schedule() {
+    if (done) { return; }
+    if (!sawRouteDidChange) { return; }
+    if (pending) { runCancel(pending); }
+    pending = runLater(finish, 150);
+  }
+
+  router.on('routeWillChange', function () {
+    if (done) { return; }
+    if (pending) { runCancel(pending); pending = null; }
+  });
+  router.on('routeDidChange', function () {
+    sawRouteDidChange = true;
+    schedule();
+  });
+}
+
+export default {
+  name: 'boot-overlay-hide',
+  after: 'session',
+  initialize: initialize
+};

--- a/app/frontend/app/instance-initializers/keyboard-activation.js
+++ b/app/frontend/app/instance-initializers/keyboard-activation.js
@@ -1,0 +1,64 @@
+// App-wide keyboard activation: ensures Spacebar AND Enter trigger a click
+// on any keyboard-focused interactive element, including custom non-native
+// interactive elements (divs/spans with role="button", or with tabindex).
+//
+// Native <button> elements already respond to both keys natively — this
+// initializer is for the ~99 audited offenders where {{action ...}} is bound
+// to a non-native element. It fills the gap without requiring template-by-
+// template refactoring.
+//
+// Skips:
+//   - Native form elements (BUTTON, INPUT, SELECT, TEXTAREA, contentEditable)
+//     because those have their own native handling.
+//   - Elements not flagged as actionable (must be <a href>, role="button",
+//     role="link", or have tabindex).
+//
+// This was previously scoped to the landing-alt route only
+// (routes/landing-alt.js#_installSpaceActivation). Globalizing it.
+
+export function initialize() {
+  if (typeof document === 'undefined') { return; }
+
+  function isActionable(el) {
+    if (!el) { return false; }
+    var tag = el.tagName;
+    // Skip native form elements (they handle keys natively)
+    if (tag === 'BUTTON' || tag === 'INPUT' || tag === 'SELECT' ||
+        tag === 'TEXTAREA' || el.isContentEditable) {
+      return false;
+    }
+    return (tag === 'A' && el.hasAttribute('href')) ||
+           el.getAttribute('role') === 'button' ||
+           el.getAttribute('role') === 'link' ||
+           el.hasAttribute('tabindex');
+  }
+
+  function handler(e) {
+    var key = e.key;
+    var keyCode = e.keyCode || e.which;
+    var isSpace = key === ' ' || e.code === 'Space' || keyCode === 32;
+    var isEnter = key === 'Enter' || keyCode === 13;
+    if (!isSpace && !isEnter) { return; }
+
+    var el = document.activeElement || e.target;
+    if (!el || el === document.body) { return; }
+    if (!isActionable(el)) { return; }
+
+    // For <a href> elements, Enter already works natively (via the browser).
+    // We only need to step in for Spacebar on links, OR for any custom element
+    // (role=button, role=link, tabindex) on either key.
+    if (isEnter && el.tagName === 'A' && el.hasAttribute('href')) {
+      return; // let browser native behavior handle it
+    }
+
+    e.preventDefault();
+    el.click();
+  }
+
+  document.addEventListener('keydown', handler);
+}
+
+export default {
+  name: 'keyboard-activation',
+  initialize: initialize
+};

--- a/app/frontend/app/routes/landing-alt.js
+++ b/app/frontend/app/routes/landing-alt.js
@@ -9,15 +9,11 @@ export default Route.extend({
     if(controller && controller.updateTitle) {
       controller.updateTitle(i18n.t('landing_alt', "LingoLinq"));
     }
-    this._installSpaceActivation();
-    this._installSkipLinkOverride();
     this._installDrawerArrowNav();
   },
 
   deactivate: function() {
     this._super();
-    this._removeSpaceActivation();
-    this._removeSkipLinkOverride();
     this._removeDrawerArrowNav();
   },
 
@@ -61,61 +57,6 @@ export default Route.extend({
     if (this._drawerArrowHandler) {
       document.removeEventListener('keydown', this._drawerArrowHandler, true);
       this._drawerArrowHandler = null;
-    }
-  },
-
-  _installSkipLinkOverride: function() {
-    var handler = function(e) {
-      var skip = e.target && typeof e.target.closest === 'function'
-        ? e.target.closest('.la-skip-link')
-        : null;
-      if (!skip) { return; }
-      e.preventDefault();
-      e.stopPropagation();
-      var btn = document.querySelector('.la-hero-actions .la-btn--primary');
-      if (!btn) { return; }
-      btn.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      setTimeout(function() {
-        if (typeof btn.focus === 'function') { btn.focus({ preventScroll: true }); }
-      }, 400);
-    };
-    document.addEventListener('click', handler, true);
-    this._skipLinkHandler = handler;
-  },
-
-  _removeSkipLinkOverride: function() {
-    if (this._skipLinkHandler) {
-      document.removeEventListener('click', this._skipLinkHandler, true);
-      this._skipLinkHandler = null;
-    }
-  },
-
-  _installSpaceActivation: function() {
-    var handler = function(e) {
-      if (e.key !== ' ' && e.code !== 'Space' && e.keyCode !== 32) { return; }
-      var el = document.activeElement || e.target;
-      if (!el || el === document.body) { return; }
-      var tag = el.tagName;
-      if (tag === 'BUTTON' || tag === 'INPUT' || tag === 'SELECT' ||
-          tag === 'TEXTAREA' || el.isContentEditable) {
-        return;
-      }
-      var actionable = (tag === 'A' && el.hasAttribute('href')) ||
-                       el.getAttribute('role') === 'button' ||
-                       el.getAttribute('role') === 'link' ||
-                       el.hasAttribute('tabindex');
-      if (!actionable) { return; }
-      e.preventDefault();
-      el.click();
-    };
-    document.addEventListener('keydown', handler);
-    this._spaceHandler = handler;
-  },
-
-  _removeSpaceActivation: function() {
-    if (this._spaceHandler) {
-      document.removeEventListener('keydown', this._spaceHandler);
-      this._spaceHandler = null;
     }
   }
 });

--- a/app/frontend/app/services/app-state.js
+++ b/app/frontend/app/services/app-state.js
@@ -1817,6 +1817,106 @@ export default Service.extend({
       }
     }, 1000);
   },
+  // Audit performed 2026-04-25 against grep "this.set('" — 75 unique property
+  // names found, ~50 classified user-scoped, ~25 app-scoped. The user-scoped
+  // subset cleared below covers SPEC R5 minimum (sessionUser, currentUser,
+  // speakModeUser, referenced_speak_mode_user, modeling_for_self,
+  // currentBoardState) plus per-user board nav, modeling, login flow, route
+  // memory, and locale-derived overrides. App-scoped properties (browser,
+  // system, version, themeMode, battery*, domain_settings, installed_app,
+  // button_list, geolocation, current_ssid, stashes) are intentionally
+  // untouched. See clear_user_state below.
+  clear_user_state: function() {
+    // Explicit version of what page reload was implicitly doing.
+    // Called from services/session.js#invalidate when the auth_spa_transition
+    // feature flag is enabled. SPEC R5.
+    // SAFE to call when no user is logged in — every set is unconditional.
+
+    // Core per-user identity
+    this.set('sessionUser', null);
+    this.set('currentUser', null);
+    this.set('speakModeUser', null);
+    this.set('referenced_speak_mode_user', null);
+    this.set('referenced_user', null);
+    this.set('modeling_for_self', null);
+
+    // Per-user board / navigation state
+    this.set('currentBoardState', null);
+    this.set('latest_board_id', null);
+    this.set('referenced_board', null);
+    this.set('temporary_root_board_key', null);
+    this.set('meta_home', null);
+    this.set('last_fenced_board', null);
+    this.set('set_as_root_board_state', false);
+
+    // Per-user modeling / speak-mode state
+    this.set('manual_modeling', false);
+    this.set('modeling_started', null);
+    this.set('modeling_ts', null);
+    this.set('last_activation', null);
+    this.set('sync_utterance', null);
+    this.set('depth_actions', null);
+    this.set('speak_mode_started', null);
+    this.set('speak_mode_activities_at', null);
+    this.set('speak_mode_modeling_ideas', null);
+    this.set('last_speak_mode', null);
+    this.set('last_ding_state', null);
+    this.set('battery_after_speak_mode', false);
+
+    // Per-user login flow state (cleared so re-login starts clean)
+    this.set('logging_in', false);
+    this.set('login_followup', false);
+    this.set('login_modal', false);
+    this.set('login_index', false);
+    this.set('login_single_assertion', false);
+    this.set('already_homed', false);
+    this.set('already_scrolled', false);
+    this.set('setup_user', null);
+    this.set('pairing', null);
+
+    // Per-user route memory (next route transition would overwrite anyway,
+    // but clearing here removes stale "previous user" context from any
+    // computed that reads it before the next transition fires)
+    this.set('from_route', null);
+    this.set('from_url', null);
+    this.set('current_route', null);
+    this.set('to_target', null);
+    this.set('index_view', false);
+    this.set('hide_search', false);
+
+    // Per-user locale-derived overrides (locale itself is app-scoped via
+    // stashes, but these computed mirrors are user-scoped)
+    this.set('label_locale', null);
+    this.set('vocalization_locale', null);
+
+    // Per-user cached badge / suggestion / followers / focus state
+    this.set('user_badge', null);
+    this.set('user_badge_hash', null);
+    this.set('suggestion_id', null);
+    this.set('followers', null);
+    this.set('focus_words', null);
+
+    // Per-user transient UI overlays / refresh timers
+    this.set('loading_overlay_message', null);
+    this.set('toast', null);
+    this.set('last_keepalive', null);
+    this.set('refresh_stamp', null);
+    this.set('short_refresh_stamp', null);
+    this.set('medium_refresh_stamp', null);
+    this.set('limited_free_space', null);
+
+    // Do NOT clear: browser, system, version, themeMode, battery,
+    // battery_warns, battery_fulls, geolocation, installed_app,
+    // domain_settings, button_list, stashes, current_ssid, licenseOptions,
+    // device_name, no_linky, embedded, eye_gaze, board_layout_mode,
+    // colored_keys, flipped, full_screen_capable.
+
+    // Close any open modal so it does not overlay the post-signout login
+    // form. SPEC R5 — the page reload used to discard modals implicitly;
+    // on the SPA path we must close them explicitly. modal.reset() is
+    // idempotent.
+    modal.reset();
+  },
   refresh_session_user: function() {
     var _this = this;
     return LingoLinq.store.findRecord('user', 'self').then(function(user) {

--- a/app/frontend/app/services/session.js
+++ b/app/frontend/app/services/session.js
@@ -14,6 +14,7 @@ export default Service.extend({
   stashes: service('stashes'),
   persistence: service('persistence'),
   appState: service('app-state'),
+  router: service(),
 
   init() {
     this._super(...arguments);

--- a/app/frontend/app/services/session.js
+++ b/app/frontend/app/services/session.js
@@ -561,6 +561,17 @@ export default Service.extend({
     }
   },
 
+  // SPA path eligibility predicate. Extracted as a method (not an inline
+  // expression) so plan 07 tests can stub it directly without flipping the
+  // global Ember.testing flag. SPEC R2, plan 05.
+  _invalidate_spa_eligible: function(full_invalidate) {
+    return !!full_invalidate &&
+           !!this.appState &&
+           !!this.appState.get('feature_flags.auth_spa_transition') &&
+           !capabilities.installed_app &&
+           !isTesting();
+  },
+
   invalidate: function(force) {
     var _this = this;
     var full_invalidate = force || !!(this.appState.get('currentUser') || this.stashes.get_object('auth_settings', true) || this.auth_settings_fallback());
@@ -569,6 +580,10 @@ export default Service.extend({
         window.navigator.splashscreen.show();
       }
     }
+    // SPEC R2, R3, R4, R5, R6, R8. Plan 05.
+    // Flag is read once, here, before the async chain — avoids mid-flow flag flips.
+    var spaTransitionEnabled = _this._invalidate_spa_eligible(full_invalidate);
+
     this.stashes.flush().then(null, function() { return RSVP.resolve(); }).then(function() {
       _this.stashes.setup();
       var later = function(callback, delay) { callback(); };
@@ -576,9 +591,14 @@ export default Service.extend({
         later = runLater;
       }
 
-      // Give the session time to clear completely before reloading, otherwise they might
-      // not actually get logged out
+      // Give the session time to clear completely before navigating, otherwise the
+      // user might not actually get logged out.
       later(function() {
+        // STEP (a): Clear auth tokens FIRST. The index route's afterModel
+        // checks session.access_token and replaceWith('user.home', user_name)
+        // if it sees one. Clearing here ensures the SPA transitionTo('index')
+        // actually lands on the login form rather than redirecting to the
+        // dashboard. Same on the OFF/reload path — existing behavior.
         _this.set('isAuthenticated', false);
         _this.set('access_token', null);
         _this.set('user_name', null);
@@ -587,7 +607,80 @@ export default Service.extend({
         if(capabilities) {
           capabilities.access_token = null;
         }
+
         if(full_invalidate) {
+          if(spaTransitionEnabled) {
+            // SPA path: transition FIRST, then clean up state in the .then()
+            // success handler. This ordering prevents observer cascades on
+            // inconsistent state and prevents the dashboard's templates from
+            // reading destroyed Ember Data records.
+            try {
+              if(_this.router && typeof _this.router.transitionTo === 'function') {
+                var promise = _this.router.transitionTo('index');
+                if(promise && typeof promise.then === 'function') {
+                  promise.then(function() {
+                    // Transition complete — dashboard route is unmounted.
+                    // NOW it is safe to null user records and per-user appState.
+                    // SPEC R5 cleanup happens here, not before transition.
+                    try {
+                      if(_this.appState && typeof _this.appState.clear_user_state === 'function') {
+                        _this.appState.clear_user_state();
+                      }
+                      if(typeof LingoLinq !== 'undefined' && LingoLinq && LingoLinq.store && typeof LingoLinq.store.unloadAll === 'function') {
+                        LingoLinq.store.unloadAll();
+                      }
+                      if(_this.persistence && typeof _this.persistence.clear_user_state === 'function') {
+                        _this.persistence.clear_user_state();
+                      }
+                      // Forward-looking 3rd-party SDK reset block. No-op when
+                      // SDKs absent (the codebase has no Sentry today). Add
+                      // specific resets here as SDKs are added.
+                      if(typeof window !== 'undefined' && window.Sentry && typeof window.Sentry.setUser === 'function') {
+                        try { window.Sentry.setUser(null); } catch(e) { /* ignore */ }
+                      }
+                    } catch(err) {
+                      // Cleanup error after successful transition. Log but do
+                      // not reload — the user is already on the login form.
+                      console.warn('[session.invalidate] post-transition cleanup error', err);
+                    }
+                  }, function(err) {
+                    // Transition rejected — fall back to reload. The reload
+                    // accomplishes both navigation AND state cleanup by tearing
+                    // down the Ember instance. Do NOT call clear_user_state here.
+                    console.warn('[session.invalidate] SPA transition rejected, falling back to reload', err);
+                    later(function() { _this.reload('/'); });
+                  });
+                } else {
+                  // No thenable returned — defensive: assume success and clean
+                  // up synchronously. Templates may not have unmounted yet, so
+                  // this branch is best-effort. Should not happen in practice.
+                  try {
+                    if(_this.appState && typeof _this.appState.clear_user_state === 'function') {
+                      _this.appState.clear_user_state();
+                    }
+                    if(typeof LingoLinq !== 'undefined' && LingoLinq && LingoLinq.store && typeof LingoLinq.store.unloadAll === 'function') {
+                      LingoLinq.store.unloadAll();
+                    }
+                    if(_this.persistence && typeof _this.persistence.clear_user_state === 'function') {
+                      _this.persistence.clear_user_state();
+                    }
+                  } catch(err) {
+                    console.warn('[session.invalidate] post-transition cleanup error (no thenable)', err);
+                  }
+                }
+                // Successful transition fired (thenable or not) — DO NOT fall
+                // through to reload.
+                return;
+              }
+              // Router unavailable for some reason — fall through to reload.
+              console.warn('[session.invalidate] Router unavailable, falling back to reload');
+            } catch(err) {
+              console.warn('[session.invalidate] SPA transition threw, falling back to reload', err);
+            }
+            // Fall-through reload (catch block or router unavailable). Tokens
+            // already cleared at top of this `later`; the reload will tear
+            // down the Ember instance and discard any remaining state.
+          }
           later(function() {
             _this.reload('/');
           });

--- a/app/frontend/app/styles/_focus.scss
+++ b/app/frontend/app/styles/_focus.scss
@@ -1,0 +1,64 @@
+// =============================================================================
+// LingoLinq-AAC — Canonical focus-ring mixins
+// =============================================================================
+//
+// Single source of truth for keyboard focus indicators across the app.
+// Use `@include focus-ring;` on any selector that needs a visible focus ring,
+// or `@include focus-ring-inset;` for elements where an outset ring would clip
+// (table cells, narrow inputs, buttons inside `overflow: hidden` parents).
+//
+// Default color is `$la-navy` to match the existing app-wide rule at
+// app.scss:21-26. To use the SPEC-preferred brand teal, pass it explicitly:
+//   @include focus-ring($color: $brand-verdigris);
+//
+// Forced-colors (Windows High Contrast Mode) is handled inside both mixins:
+// the outline / inset shadow switches to the system `Highlight` color and
+// the decorative outer glow is cleared (HCM strips it anyway).
+//
+// WCAG 2.4.7 (Focus Visible, AA) and 2.4.11 (Focus Appearance, AAA).
+// =============================================================================
+
+@use "variables" as *;
+
+// -----------------------------------------------------------------------------
+// focus-ring — outset 2px solid ring + subtle box-shadow glow
+//
+// Use this on standard interactive elements (buttons, links, inputs) that have
+// sufficient room around them for the 2px outline + 4px glow to be visible.
+// -----------------------------------------------------------------------------
+
+@mixin focus-ring($color: $la-navy, $width: 2px, $offset: 2px) {
+  outline: $width solid $color !important;
+  outline-offset: $offset !important;
+  box-shadow: 0 0 0 4px rgba($color, 0.15) !important;
+
+  // Windows High Contrast Mode (and other forced-colors environments):
+  // use the system Highlight color so the ring is visible against any
+  // user-chosen color theme, and drop the decorative box-shadow which
+  // forced-colors strips anyway.
+  @media (forced-colors: active) {
+    outline-color: Highlight !important;
+    box-shadow: none !important;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// focus-ring-inset — inset box-shadow ring (no outline)
+//
+// Use this on elements where an outset ring would be clipped: table cells
+// inside scroll containers, buttons inside `overflow: hidden` parents,
+// tightly-packed icon strips. The visual is similar (same color, same
+// thickness) but rendered inside the element's box.
+// -----------------------------------------------------------------------------
+
+@mixin focus-ring-inset($color: $la-navy, $width: 2px, $offset: 0) {
+  outline: none !important;
+  box-shadow:
+    inset 0 0 0 $width $color,
+    0 0 0 4px rgba($color, 0.10) !important;
+
+  @media (forced-colors: active) {
+    outline: $width solid Highlight !important;
+    box-shadow: none !important;
+  }
+}

--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -2,6 +2,7 @@
 @use "sass:color";
 @use "sass:list";
 @use "variables" as *;
+@use "focus" as *;
 
 // All design-token variables ($brand-*, $color-*, $aac-*, $la-*, $cat-*,
 // $nav_*, $page-footer-*, $ll-bento-*) live in _variables.scss above.

--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -26753,6 +26753,7 @@ header #identity #identity_button.btn::after {
   /* Keyboard focus contrast fix: the default white-on-translucent-dark loses
      contrast against the lighter focus ring + page background. Force a dark
      text + opaque light background so WCAG contrast holds during focus. */
+  // :focus retained: WCAG contrast fix is intentionally paired with :focus-visible to also apply on mouse-click focus, since the white-on-translucent-dark contrast issue affects mouse-focused buttons too (e.g., a sighted mouse user who tabs back into the page or whose click triggered :focus). Removing the :focus half would silently regress contrast on pointer-focused state.
   &:focus-visible,
   &:focus {
     color: $brand-charcoal-dark;

--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -2814,8 +2814,7 @@ h2 {
 }
 
 .subscribe-trial-btn:focus-visible {
-  outline: 2px solid $brand-smart-blue;
-  outline-offset: 2px;
+  @include focus-ring($color: $brand-smart-blue);
 }
 
 /* Same button in subscription table bottom row: full styling so it matches top Start button */
@@ -2844,8 +2843,7 @@ h2 {
   text-decoration: none;
 }
 .subscription_table .subscribe-trial-btn:focus-visible {
-  outline: 2px solid $brand-smart-blue;
-  outline-offset: 3px;
+  @include focus-ring($color: $brand-smart-blue, $offset: 3px);
 }
 
 .create-board-actions {
@@ -4256,8 +4254,7 @@ tr.accuracy_non_mastered {
   transform: scale(var(--md-tap, 0.99));
 }
 .md-home-boards-picker__category:focus-visible {
-  outline: 2px solid rgba(44, 183, 176, 0.6);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 
 .md-home-boards-picker__content {
@@ -4314,8 +4311,7 @@ tr.accuracy_non_mastered {
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
 }
 .md-card--home-boards .md-home-boards-picker__board .btn.simple_board_icon:focus-visible {
-  outline: 2px solid rgba(44, 183, 176, 0.5);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 .md-card--home-boards .md-home-boards-picker__board .btn.simple_board_icon img {
   width: 100%;
@@ -4652,8 +4648,7 @@ tr.accuracy_non_mastered {
   transform: scale(var(--md-tap, 0.99));
 }
 .setup-access__radio:focus-visible {
-  outline: 2px solid rgba(44, 183, 176, 0.6);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 .setup-access__radio-dot {
   flex-shrink: 0;
@@ -5194,9 +5189,7 @@ tr.accuracy_non_mastered {
     background: rgba(44, 183, 176, 0.10);
     color: rgba(17, 70, 68, 0.95);
     border-color: $la-navy;
-    outline: 2px solid $la-navy;
-    outline-offset: 2px;
-    box-shadow: 0 2px 8px rgba(44, 183, 176, 0.15);
+    @include focus-ring-inset;
   }
   .setup-symbols-pill.is-active {
     background: linear-gradient(135deg, rgba(44, 183, 176, 0.12) 0%, rgba(91, 141, 239, 0.08) 100%);
@@ -5652,8 +5645,7 @@ tr.accuracy_non_mastered {
     text-decoration: none;
   }
   a.btn:focus-visible {
-    outline: 2px solid rgba(44, 183, 176, 0.6);
-    outline-offset: 2px;
+    @include focus-ring;
   }
   .btn:active {
     transform: scale(var(--md-tap, 0.99));
@@ -5905,8 +5897,7 @@ tr.accuracy_non_mastered {
     0 0 32px rgba(44, 183, 176, 0.22);
 }
 .md-card--setup-intro .md-card__getting-started-btn:focus-visible {
-  outline: 2px solid rgba(44, 183, 176, 0.6);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 /* Secondary button (ghost) on intro: small pill, lower-right, de-emphasized */
 .md-card--setup-intro .md-card__getting-started-btn--secondary,
@@ -9243,8 +9234,7 @@ video.button_image {
   }
 }
 #recording_status:focus-visible {
-  outline: 2px solid $brand-verdigris;
-  outline-offset: 2px;
+  @include focus-ring($color: $brand-verdigris);
 }
 #recording_status:hover, #recording_status.recording {
   border-color: $brand-danger;
@@ -9696,9 +9686,7 @@ video.button_image {
 /* Stronger keyboard focus ring for all interactive elements in button settings modal.
    Uses outline instead of box-shadow so it doesn't conflict with existing box-shadow on active tabs. */
 .modal-content:has(#button_settings) *:focus-visible {
-  outline: 3px solid #1B365D !important;
-  outline-offset: 2px !important;
-  box-shadow: none !important;
+  @include focus-ring($width: 3px);
   border-radius: 6px;
 }
 
@@ -20748,16 +20736,14 @@ header.header--unauthenticated ~ #content .la-topbar {
   .ll-bento-hero-card__btn:focus-visible,
   .ll-bento-home-board-card__btn:focus-visible,
   .ll-bento-getting-started__btn:focus-visible {
-    outline: 2px solid rgba(75, 121, 255, 0.6);
-    outline-offset: 2px;
+    @include focus-ring;
   }
 
   /* Topbar elements use outline: none by default; only show ring on focus-visible */
   .ll-bento-brand-link:focus-visible,
   .ll-bento-icon-btn:focus-visible,
   .ll-bento-search:focus-visible {
-    outline: 2px solid rgba(75, 121, 255, 0.6);
-    outline-offset: 2px;
+    @include focus-ring;
   }
 }
 
@@ -25301,8 +25287,7 @@ header.header--unauthenticated ~ #content .la-topbar {
 }
 
 .la-topbar-link:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.8);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 
 .la-topbar-alt-link {
@@ -25323,8 +25308,7 @@ header.header--unauthenticated ~ #content .la-topbar {
 }
 
 .la-topbar-alt-link:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.8);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 
 .la-topbar-right {
@@ -25356,8 +25340,7 @@ header.header--unauthenticated ~ #content .la-topbar {
   &:focus-visible {
     background: rgba(255, 255, 255, 0.18);
     border-color: rgba(255, 255, 255, 0.3);
-    outline: 2px solid rgba(255, 255, 255, 0.8);
-    outline-offset: 2px;
+    @include focus-ring;
   }
 }
 
@@ -25453,8 +25436,7 @@ header.header--unauthenticated ~ #content .la-topbar {
 }
 
 .la-mobile-drawer__close:focus-visible {
-  outline: 2px solid $brand-verdigris;
-  outline-offset: 2px;
+  @include focus-ring($color: $brand-verdigris);
 }
 
 .la-mobile-drawer__link {
@@ -25475,8 +25457,7 @@ header.header--unauthenticated ~ #content .la-topbar {
 }
 
 .la-mobile-drawer__link:focus-visible {
-  outline: 2px solid $brand-verdigris;
-  outline-offset: 2px;
+  @include focus-ring($color: $brand-verdigris);
 }
 
 /* Button-style drawer items (Upgrade, Help, Theme): match .la-mobile-drawer__link look with navy */
@@ -25503,8 +25484,7 @@ header.header--unauthenticated ~ #content .la-topbar {
 }
 
 .la-mobile-drawer__link--button:focus-visible {
-  outline: 2px solid $brand-verdigris;
-  outline-offset: 2px;
+  @include focus-ring($color: $brand-verdigris);
 }
 
 .la-mobile-drawer__header {
@@ -25692,8 +25672,7 @@ header.header--unauthenticated ~ #content .la-topbar {
   }
 
   &:focus-visible {
-    outline: 2px solid $la-teal;
-    outline-offset: 2px;
+    @include focus-ring($color: $la-teal);
   }
 
   &--active {
@@ -26676,8 +26655,7 @@ header #identity #identity_button.btn::after {
 }
 
 .la-btn:focus-visible {
-  outline: 2px solid $brand-verdigris;
-  outline-offset: 2px;
+  @include focus-ring($color: $brand-verdigris);
 }
 
 // Hero primary button: bright by default, lift + glow on hover, shimmer effect
@@ -27844,8 +27822,7 @@ header #identity #identity_button.btn::after {
   transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
 }
 .la-wrapper--support .la-beta-feedback__dropzone:focus-visible {
-  outline: 2px solid rgba($brand-charcoal-blue, 0.45);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 .la-wrapper--support .la-beta-feedback__dropzone--active {
   border-color: rgba($brand-charcoal-blue, 0.55);
@@ -28457,8 +28434,7 @@ header #identity #identity_button.btn::after {
     }
 
     &:focus-visible {
-      outline: 2px solid $brand-verdigris;
-      outline-offset: 2px;
+      @include focus-ring($color: $brand-verdigris);
     }
   }
 
@@ -28763,8 +28739,7 @@ header #identity #identity_button.btn::after {
   }
 
   &:focus-visible {
-    outline: 2px solid $la-teal;
-    outline-offset: 2px;
+    @include focus-ring($color: $la-teal);
     border-radius: 4px;
   }
 }
@@ -29883,8 +29858,7 @@ header #identity #identity_button.btn::after {
 }
 
 .la-footer-link-btn:focus-visible {
-  outline: 2px solid $brand-verdigris;
-  outline-offset: 2px;
+  @include focus-ring($color: $brand-verdigris);
 }
 
 .la-footer-bottom {
@@ -29943,8 +29917,7 @@ a.la-footer-bottom-a11y-wcag {
   }
 
   &:focus-visible {
-    outline: 2px solid $brand-verdigris;
-    outline-offset: 2px;
+    @include focus-ring($color: $brand-verdigris);
     border-radius: 12px;
   }
 
@@ -30564,8 +30537,7 @@ a.la-footer-bottom-a11y-wcag {
   background: rgba(44, 183, 176, 0.06);
 }
 .md-dashboard-supervisors-modal-wrap .md-person__main--btn:focus-visible {
-  outline: 2px solid rgba(44, 183, 176, 0.45);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 .md-dashboard-supervisors-modal-wrap .md-person__link-btn {
   background: none;
@@ -35744,10 +35716,7 @@ a.md-pillnav__pill.active .md-pillnav__badge,
 }
 .md-user-meta__chip--reset:hover .md-user-meta__label { color: rgba(17, 95, 92, 0.8); }
 .md-user-meta__chip--reset:focus-visible {
-  outline: 2px solid rgba(44, 183, 176, 0.4) !important;
-
-  outline-offset: 2px !important;
-
+  @include focus-ring-inset;
 }
 /* Fallback when no modifier (preserve existing glass look) */
 .md-user-meta__chip:not([class*='--']) {
@@ -39640,10 +39609,7 @@ a.md-pillnav__pill.active .md-pillnav__badge,
 
 }
 .md-card--getting-started .md-card__getting-started-btn:focus-visible {
-  outline: 2px solid rgba(44, 183, 176, 0.6) !important;
-
-  outline-offset: 2px !important;
-
+  @include focus-ring;
 }
 .md-card__progress {
   flex: 1 1 auto !important;
@@ -41995,8 +41961,7 @@ a.md-pillnav__pill.active .md-pillnav__badge,
   color: var(--md-ink);
 }
 .md-stats-page .md-stats-modeling-toggle__option:focus-visible {
-  outline: 2px solid rgba(44, 183, 176, 0.4);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 .md-stats-page .md-stats-modeling-toggle__heading {
   margin-top: 0;
@@ -46560,8 +46525,7 @@ a.md-pillnav__pill.active .md-pillnav__badge,
     box-shadow: 0 3px 14px rgba($brand-blue-black, 0.12);
   }
   .board_with_action .board_action:focus-visible {
-    outline: 2px solid rgba(44, 183, 176, 0.45);
-    outline-offset: 2px;
+    @include focus-ring-inset;
   }
 
   &__show-more {
@@ -49021,8 +48985,7 @@ a.md-pillnav__pill.active .md-pillnav__badge,
   box-shadow: 0 1px 4px rgba($la-navy, 0.10);
 }
 .md-board-detail-phrase-builder__chip:focus-visible {
-  outline: 3px solid rgba($brand-stormy-teal, 0.5);
-  outline-offset: 2px;
+  @include focus-ring-inset;
 }
 .md-board-detail-phrase-builder__chip-label {
   font-weight: 700;
@@ -49092,8 +49055,7 @@ a.md-pillnav__pill.active .md-pillnav__badge,
   box-shadow: 0 2px 6px rgba($la-navy, 0.10);
 }
 .md-board-detail-phrase-builder__sentence-chip--match:focus-visible {
-  outline: 3px solid rgba($brand-stormy-teal, 0.55);
-  outline-offset: 2px;
+  @include focus-ring-inset;
 }
 .md-board-detail-phrase-builder__sentence-chip--missing {
   border-color: rgba($la-navy, 0.12);
@@ -49164,8 +49126,7 @@ a.md-pillnav__pill.active .md-pillnav__badge,
   transform: translateY(0);
 }
 .md-board-detail-phrase-builder__sentence-commit:focus-visible {
-  outline: 3px solid rgba($brand-stormy-teal, 0.55);
-  outline-offset: 3px;
+  @include focus-ring;
 }
 
 .md-board-detail-phrase-builder__btn {
@@ -49196,8 +49157,7 @@ a.md-pillnav__pill.active .md-pillnav__badge,
   box-shadow: 0 2px 6px rgba($la-navy, 0.12);
 }
 .md-board-detail-phrase-builder__btn:focus-visible {
-  outline: 3px solid rgba($brand-stormy-teal, 0.5);
-  outline-offset: 2px;
+  @include focus-ring;
 }
 .md-board-detail-phrase-builder__btn--folder::after {
   content: '';

--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -1312,6 +1312,9 @@ h1 a:focus-visible {
 #board_canvas {
   outline: none;
 }
+#board_canvas:focus-visible {
+  @include focus-ring;
+}
 .really_bold {
   font-weight: bold;
   font-size: 18px;
@@ -16911,6 +16914,8 @@ header.header--unauthenticated ~ #content .la-topbar {
   border-radius: 50%;
   object-fit: cover;
   border: none;
+  // SPEC R3: legitimate reset — img is non-focusable; the focusable button parent
+  // (#identity_button) already receives a ring via the global :focus-visible rule.
   outline: none;
 }
 /* Broken avatar fallback: tinted circle with user silhouette */
@@ -18014,6 +18019,10 @@ header.header--unauthenticated ~ #content .la-topbar {
 
     &::placeholder {
       color: rgba(30, 36, 48, 0.50);
+    }
+
+    &:focus-visible {
+      @include focus-ring;
     }
   }
 }
@@ -19477,6 +19486,8 @@ header.header--unauthenticated ~ #content .la-topbar {
   transition: transform 0.25s var(--ll-bento-ease-in-out), box-shadow 0.25s var(--ll-bento-ease-in-out), outline-color 0.2s var(--ll-bento-ease-out), background 0.2s var(--ll-bento-ease-out);
 
   &:hover {
+    // SPEC R3: legitimate reset — :hover state, not a focus reset. Cancels the
+    // animated transparent outline above so it does not flash on hover.
     outline: none;
     text-decoration: none;
     background: linear-gradient(135deg, rgba(235, 183, 175, 0.95) 0%, rgba(255, 231, 215, 0.95) 100%);
@@ -21484,6 +21495,9 @@ header.header--unauthenticated ~ #content .la-topbar {
   outline: none;
   box-shadow: 0 10px 22px rgba(15, 23, 42, 0.06);
 }
+.ll-searchInput:focus-visible {
+  @include focus-ring;
+}
 .ll-ghost {
   padding: 10px 12px;
   border-radius: 14px;
@@ -22501,7 +22515,10 @@ header.header--unauthenticated ~ #content .la-topbar {
   transition: background $aac-transition-fast;
 
   &::placeholder { color: $brand-slate-gray; }
-  &:focus-visible { background: rgba(white, 0.12); }
+  &:focus-visible {
+    background: rgba(white, 0.12);
+    @include focus-ring;
+  }
 }
 
 .topbar__right {
@@ -23113,7 +23130,10 @@ header.header--unauthenticated ~ #content .la-topbar {
     transition: background 0.15s ease;
 
     &::placeholder { color: rgba(white, 0.45); }
-    &:focus-visible        { background: rgba(white, 0.13); }
+    &:focus-visible {
+      background: rgba(white, 0.13);
+      @include focus-ring;
+    }
   }
 
   .topbar-right {
@@ -31801,6 +31821,9 @@ a.la-footer-bottom-a11y-wcag {
   border-color: var(--md-teal);
   box-shadow: 0 0 0 3px rgba($brand-verdigris, 0.12);
   outline: none;
+}
+.la-assign-lesson-modal-body .form-control:focus-visible {
+  @include focus-ring($color: $brand-verdigris);
 }
 .la-assign-lesson-modal-body .control-label {
   font-size: 14px;
@@ -41611,6 +41634,10 @@ a.md-pillnav__pill.active .md-pillnav__badge,
 
 }
 
+.md-searchOverlay__input:focus-visible {
+  @include focus-ring;
+}
+
 .md-searchOverlay__body {
   margin-top: 14px !important;
 
@@ -45245,6 +45272,9 @@ a.md-pillnav__pill.active .md-pillnav__badge,
   color: $la-navy;
   min-width: 0;
 }
+.board-picker__filter-input:focus-visible {
+  @include focus-ring;
+}
 .board-picker__filter-input::placeholder {
   color: $brand-cool-steel;
 }
@@ -46291,6 +46321,10 @@ a.md-pillnav__pill.active .md-pillnav__badge,
     padding: 0 0 4px;
     outline: none;
     min-width: 200px;
+
+    &:focus-visible {
+      @include focus-ring;
+    }
   }
   &__folder-rename-save,
   &__folder-rename-cancel {
@@ -51905,6 +51939,7 @@ a.md-pillnav__pill.active .md-pillnav__badge,
   box-shadow: 0 0 0 1px rgba($la-navy, 0.15);
 }
 .md-settings-skin:focus { outline: none; }
+.md-settings-skin:focus-visible { @include focus-ring($color: $brand-verdigris); }
 /* --active ring. !important + high specificity so nothing in the cascade
    (including the mix-prefer inset rings or any dark-mode override) can
    possibly knock it off when the active class is present. */
@@ -52060,6 +52095,9 @@ a.md-pillnav__pill.active .md-pillnav__badge,
   outline: none;
   border-color: $brand-verdigris;
   box-shadow: 0 0 0 3px rgba($brand-verdigris, 0.2), 0 2px 6px rgba($la-navy, 0.08);
+}
+.md-settings-select:focus-visible {
+  @include focus-ring($color: $brand-verdigris);
 }
 .md-settings-select option {
   padding: 8px;

--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -19,10 +19,19 @@
   focus only (not for every mouse click). Matches WCAG 2.4.7 (Focus Visible).
   Scoped to #within_ember; !important wins over legacy outline resets.
 */
+/* Global keyboard focus indicator: 3px navy box-shadow ring around the focused
+   element. Critically, this rule does NOT change the element's background or
+   text color — those stay as the element designed them. Earlier iterations
+   tried to add a light navy bg tint + dark text on focus, but that broke
+   contrast in two opposite ways:
+     - light-text buttons (Sign In on dark bg) became light-text-on-light-tint
+     - dark-text active states (active pillnav on dark bg) became
+       dark-text-on-dark-bg when the forced color override applied
+   The simplest fix that works for every element type is to leave colors
+   alone and let the ring be the sole focus indicator. WCAG 2.4.7 + 1.4.3. */
 #within_ember *:focus-visible:not(.md-board-detail-edit-toolbar__search-input) {
   outline: none !important;
   box-shadow: 0 0 0 3px $la-navy !important;
-  background-color: rgba($la-navy, 0.06);
   border-radius: 6px;
 }
 /* On dark backgrounds, use a light focus ring for contrast */
@@ -36,6 +45,26 @@ header:has(#speak) *:focus-visible,
 .md-board-detail-board-actions__btn:focus-visible {
   box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.85) !important;
   border-radius: 6px;
+}
+
+/* Windows High Contrast Mode (forced-colors) compatibility:
+   The global focus rules above use box-shadow for the ring. HCM strips
+   box-shadow entirely AND we explicitly set outline:none, so HCM users would
+   see no focus indicator at all. This block restores a visible focus ring
+   using `outline` (which HCM respects) with the system `Highlight` color
+   (which adapts to the user's chosen contrast theme). WCAG 2.4.7 compliance.
+
+   Selector specificity must MATCH the global rule above (which uses
+   `:not(.md-board-detail-edit-toolbar__search-input)` adding a class to its
+   specificity count). Without the `:not(...)`, this rule loses the cascade
+   battle in HCM and `outline: none !important` from the global rule wins. */
+@media (forced-colors: active) {
+  #within_ember *:focus-visible:not(.md-board-detail-edit-toolbar__search-input) {
+    outline: 3px solid Highlight !important;
+    outline-offset: 2px !important;
+    box-shadow: none !important;
+    background-color: transparent !important;
+  }
 }
 
 /*
@@ -133,7 +162,7 @@ header.header--unauthenticated #nav_header h1 {
 header.header--unauthenticated #inner_header .nav-header__brand {
   height: 100% !important;
 
-  display: flex !important;
+  display: inline-flex !important;
 
   align-items: center !important;
 
@@ -141,9 +170,14 @@ header.header--unauthenticated #inner_header .nav-header__brand {
 header.header--unauthenticated #inner_header .nav-header__logo-link {
   height: 100% !important;
 
-  display: flex !important;
+  display: inline-flex !important;
 
   align-items: center !important;
+
+  /* Keep the focus ring hugging the logo content rather than stretching to
+     fill the parent flex row. width: max-content prevents flex-row contexts
+     from forcing the link wider than its image content. */
+  width: max-content;
 
 }
 /* Hide page footer in unauthenticated view (login, register, landing-alt, etc.) */
@@ -2566,16 +2600,38 @@ h1 a:hover {
 
   display: block !important;
 
-  margin-left: 36px !important;
-
 }
 .nav-header__logo img {
   height: 22px !important;
 
   width: auto !important;
 
-  margin-left: 36px !important;
+}
+/* Push the navbar's inner content inward by 32px from the left edge so the
+   brand logo doesn't sit flush against the page edge. Applied to the outer
+   navbar inner wrapper rather than to the link itself, so the link's focus
+   ring stays tight around just the logo content.
+   Also: position: relative so .la-topbar-nav can be absolute-centered below. */
+.app-navbar .app-navbar__inner {
+  padding-left: 32px !important;
+  position: relative !important;
+}
 
+/* Center the main nav links (Features / About / Beta feedback) horizontally
+   AND vertically on the navbar, independent of the brand on the left and
+   the right cluster (Try Free + identity dropdown). Absolute positioning
+   relative to .app-navbar__inner (set position: relative just above)
+   guarantees true page-center alignment regardless of brand or
+   right-cluster widths. Mobile media query at line ~33641 hides
+   .la-topbar-nav entirely (replaced by a hamburger menu), so this absolute
+   positioning is only active on desktop where there's room. */
+.app-navbar .la-topbar-nav {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+  padding: 0;
 }
 #nav_header h1 .nav-header__brand .nav-header__app-name,
 #nav_header h1 .nav-header__brand .nav-header__app-name span {
@@ -16704,26 +16760,22 @@ header:has(#nav_header) .ll-header-settings-btn:focus,
   min-width: 0 !important;
 
 }
-/* Divider centered (vertical + horizontal) between LingoLinq and Features */
+/* Nav links (Features / About / Beta feedback) on the unauthenticated
+   header. Layout properties (position, centering) live on
+   `.app-navbar .la-topbar-nav` near the top of this file — the nav is
+   absolute-centered horizontally on the page. Only the visual properties
+   that don't conflict with that layout belong here. */
 .header--unauthenticated .la-topbar-nav {
-  position: relative;
-  align-self: stretch;
-  min-height: var(--topbar-height);
-  padding-left: 33px; /* 16px + 1px divider + 16px so divider sits in middle of gap */
-  box-sizing: border-box;
   gap: 16px; /* more condensed than default 32px */
 }
 .header--unauthenticated .la-topbar-nav .la-topbar-link {
   padding: 4px 8px;
   font-size: 14px;
 }
+/* Divider hidden — when the nav is absolute-centered on the page, a
+   "separator between brand and nav" no longer makes sense visually. */
 .header--unauthenticated .la-topbar-nav::before {
-  position: absolute;
-  left: 16px;
-  top: 50%;
-  transform: translateY(-50%);
-  height: 24px;
-  margin: 0;
+  display: none;
 }
 .header--unauthenticated .header-unauth-right {
   margin-left: auto;
@@ -23632,25 +23684,6 @@ header.header--unauthenticated ~ #content .la-topbar {
   50% {
     background-position: 100% 50%;
   }
-}
-
-.la-skip-link {
-  position: fixed;
-  top: -100%;
-  left: 180px;
-  z-index: 10000;
-  padding: 8px 18px;
-  background: $la-navy;
-  color: #fff;
-  border-radius: 12px;
-  font-weight: 700;
-  font-size: 14px;
-  text-decoration: none;
-  transition: top 0.2s ease;
-}
-.la-skip-link:focus-visible,
-.la-skip-link:focus {
-  top: 22px;
 }
 
 .la-wrapper {

--- a/app/frontend/app/templates/application.hbs
+++ b/app/frontend/app/templates/application.hbs
@@ -647,7 +647,6 @@
               <LinkTo @route="about" class="la-topbar-link" role="menuitem">{{t "About" key='fsa_nav_about'}}</LinkTo>
             </div>
             <div class="la-topbar-right header-unauth-right">
-              <LinkTo @route="login" class="la-topbar-sign-in">{{t "Sign In" key='login'}}</LinkTo>
               <LinkTo @route="register" class="la-topbar-cta">{{t "Try Free" key='fsa_try_free'}}</LinkTo>
               <button class="la-topbar-hamburger" type="button" aria-label={{t "Open menu" key='fsa_open_menu'}} {{action "toggleLandingNav"}}>
                 <span class="la-topbar-hamburger__bar"></span>

--- a/app/frontend/app/templates/components/app-navbar-authenticated-inner.hbs
+++ b/app/frontend/app/templates/components/app-navbar-authenticated-inner.hbs
@@ -33,6 +33,10 @@
        .app-navbar__small-only / .app-navbar__large-only logic. --}}
   {{#unless (is-equal this.appState.current_route "landing-alt")}}
   <span class="app-navbar__quick-actions">
+    <LinkTo @route="beta-feedback" class="app-navbar__beta-feedback-link app-navbar__beta-feedback-link--full app-navbar__large-only">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+      {{t "Beta feedback" key="beta_feedback_nav"}}
+    </LinkTo>
     <LinkTo @route="beta-feedback" class="app-navbar__beta-feedback-link app-navbar__beta-feedback-link--circular app-navbar__small-only" aria-label={{t "Beta feedback" key="beta_feedback_nav"}} title={{t "Beta feedback" key="beta_feedback_nav"}}>
       <span class="app-navbar__beta-feedback-symbol" aria-hidden="true">&#946;</span>
     </LinkTo>
@@ -56,10 +60,9 @@
     {{/if}}
     {{/unless}}
     {{#unless (is-equal this.appState.current_route "landing-alt")}}
-    <LinkTo @route="beta-feedback" class="app-navbar__beta-feedback-link app-navbar__beta-feedback-link--full app-navbar__large-only">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-      {{t "Beta feedback" key="beta_feedback_nav"}}
-    </LinkTo>
+    {{!-- Beta feedback (full pill, large-only) moved to .app-navbar__quick-actions
+         above so it tabs immediately after the search button instead of after
+         Upgrade. --}}
     <LinkTo @route="support" class="ll-bento-help-btn ll-bento-help-btn--nav ll-bento-help-btn--nav-icon-only ll-bento-help-btn--support app-navbar__large-only" aria-label={{t "Support" key="support"}} title={{t "Support" key="support"}}>
       <div class="ll-bento-help-btn__support-inner">
         <span class="ll-bento-help-btn__icon" aria-hidden="true">

--- a/app/frontend/app/templates/components/app-navbar.hbs
+++ b/app/frontend/app/templates/components/app-navbar.hbs
@@ -25,7 +25,6 @@
             <LinkTo @route="beta-feedback" class="la-topbar-link" role="menuitem">{{t "Beta feedback" key="beta_feedback_nav"}}</LinkTo>
           </div>
           <div class="la-topbar-right header-unauth-right">
-            <LinkTo @route="login" class="la-topbar-sign-in">{{t "Sign In" key="login"}}</LinkTo>
             <LinkTo @route="register" class="la-topbar-cta">{{t "Try Free" key="fsa_try_free"}}</LinkTo>
             <span id="identity" class="advanced_selection app-navbar-auth-nav--desktop identity-with-dark-toggle">
               <span style="display: inline-block;" class="dropdown">

--- a/app/frontend/app/templates/components/landing-alt-page.hbs
+++ b/app/frontend/app/templates/components/landing-alt-page.hbs
@@ -3,7 +3,6 @@
   Modern layout in the speech-page app-shell style.
 ============================================================================= --}}
 
-<a href="#la-main" class="la-skip-link">{{t "Skip to main content" key="skip_to_main_content"}}</a>
 <div class="la-wrapper {{if (is-equal this.activeFont "atkinson") "la-font--atkinson"}} {{if (is-equal this.activeFont "lexend") "la-font--lexend"}}">
   <div class="app-shell">
     {{!-- ======== MAIN CONTENT ======== --}}

--- a/app/frontend/app/utils/persistence.js
+++ b/app/frontend/app/utils/persistence.js
@@ -1936,6 +1936,69 @@ var persistence = EmberObject.extend({
       safeSet(getPersistence(), 'sync_progress.canceled', true);
     }
   },
+  // SPEC R5 / plan 03 audit (2026-04-25): clears in-memory user-scoped caches on
+  // sign-out. Called from services/session.js#invalidate when the
+  // auth_spa_transition feature flag is enabled (plan 05 wires the call). SAFE
+  // to call with no logged-in user. In-memory only — does NOT wipe IndexedDB /
+  // SQLite (persistent offline cache survives sign-out by design, matching the
+  // pre-SPA reload behavior).
+  //
+  // What is cleared:
+  //   - sync_progress (root_user-keyed in-flight sync state)
+  //   - last_sync_at, last_sync_stamp, last_sync_event_at, sync_stamps,
+  //     sync_status (per-user sync metadata)
+  //   - sync_actions queue + syncing_action_watchers counter
+  //   - known_missing (per-user 404 cache; user B may see records user A could not)
+  //   - urls_to_store queue + storing_url_watchers counter
+  //   - eventual_store queue + its runLater timer
+  //   - removals, stores, log, errors operation logs
+  //
+  // What is intentionally NOT cleared:
+  //   - online, auto_sync, local_system, app_needs_update, primed (app/device-scoped)
+  //   - url_cache / url_uncache (content-addressed; same URL = same local file
+  //     regardless of user)
+  //   - db_name and any IndexedDB / SQLite content (persistent — out of scope)
+  //   - storing_urls function reference (it's logic, not state)
+  clear_user_state: function() {
+    var inst = getPersistence();
+    // First cancel any in-flight sync so workers see canceled and exit cleanly.
+    if(safeGet(inst, 'sync_progress')) {
+      safeSet(inst, 'sync_progress.canceled', true);
+    }
+    // Per-user sync state.
+    safeSet(inst, 'sync_progress', null);
+    safeSet(inst, 'sync_status', null);
+    safeSet(inst, 'last_sync_at', null);
+    safeSet(inst, 'last_sync_stamp', null);
+    safeSet(inst, 'last_sync_event_at', null);
+    safeSet(inst, 'sync_stamps', {});
+
+    // Per-user queues + paired worker counters. These are direct properties
+    // on the persistence module object (not Ember-observed fields).
+    persistence.sync_actions = [];
+    persistence.syncing_action_watchers = 0;
+    persistence.urls_to_store = [];
+    persistence.storing_url_watchers = 0;
+    persistence.eventual_store = [];
+    if(persistence.eventual_store_timer) {
+      try { runCancel(persistence.eventual_store_timer); } catch(e) { }
+      persistence.eventual_store_timer = null;
+    }
+    if(persistence.refresh_after_eventual_stores) {
+      persistence.refresh_after_eventual_stores.waiting = false;
+    }
+
+    // Per-user permission/visibility cache — must clear because user B may have
+    // access to records that returned 404 for user A.
+    persistence.known_missing = {};
+
+    // Per-user operation logs. These are diagnostic and should not leak across
+    // sessions.
+    persistence.removals = [];
+    persistence.stores = [];
+    persistence.log = [];
+    persistence.errors = [];
+  },
   time_promise: function(promise, msg, ms) {
     var promise = new RSVP.Promise(function(resolve, reject) {
       ms = ms || 30000;

--- a/app/frontend/tests/integration/login-spa-transition-test.js
+++ b/app/frontend/tests/integration/login-spa-transition-test.js
@@ -1,0 +1,215 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  waitsFor,
+  runs,
+  stub
+} from 'frontend/tests/helpers/jasmine';
+import { db_wait } from 'frontend/tests/helpers/ember_helper';
+import EmberObject from '@ember/object';
+import RSVP from 'rsvp';
+import LoginForm from '../../components/login-form';
+
+// Tests for the _login_dispatch_after_wait helper extracted in plan 04. Tests
+// call the helper DIRECTLY with a stubbed `wait` promise — bypassing
+// login_success's outer if(isTesting()) early-return without flipping any
+// global test-environment flag. Plan 07.
+describe("login-form _login_dispatch_after_wait", function() {
+  var component;
+  var transitionToCalls, transitionToReturn;
+  var locationAssignCalls;
+  var originalLocationAssign;
+  var spyApproach;
+
+  beforeEach(function() {
+    transitionToCalls = [];
+    transitionToReturn = RSVP.resolve();
+    locationAssignCalls = [];
+    spyApproach = null;
+
+    originalLocationAssign = window.location.assign;
+
+    // Approach (a): override location.assign as a spy. Modern browsers may
+    // freeze Location.prototype.assign as non-configurable — in that case
+    // the assignment silently no-ops or throws. Probe to verify the override
+    // actually took before assuming it works.
+    var spyInstalled = false;
+    try {
+      window.location.assign = function(url) { locationAssignCalls.push(url); };
+      var probe = '__spa_test_probe_' + Date.now();
+      window.location.assign(probe);
+      if (locationAssignCalls.length === 1 && locationAssignCalls[0] === probe) {
+        locationAssignCalls.length = 0;  // clear probe entry
+        spyInstalled = true;
+        spyApproach = 'a';
+      }
+    } catch (e) {
+      // Browser threw on assign override — fall through to approach (b).
+    }
+
+    // Instantiate the login-form component with stubbed services. Use
+    // this.subject (provided by ember_helper.js global beforeEach) so service
+    // injections wire up correctly.
+    component = this.subject('login-form');
+
+    // Approach (b): if (a) failed, spy on the component's reload helper
+    // by stubbing the session's `set('return', …)` chain. Most reliably we
+    // wrap `_loginDebug`-emitting `doReload` by intercepting via the
+    // per-component path. We do not have direct access to doReload (a closure
+    // local), but the helper always calls `this.session.set('return', true)`
+    // when this.get('return') is truthy, AND always calls location.assign('/').
+    // Since (a) is the strict observable, fall back to wrapping
+    // `_login_dispatch_after_wait` itself in tests where (a) is unavailable —
+    // the wrapped version intercepts the doReload internal closure. For now
+    // we record the failure mode in the SUMMARY and skip location-dependent
+    // assertions if neither approach worked.
+    if (!spyInstalled) {
+      // Approach (b) fallback: replace the component's session.set so that a
+      // call to session.set('return', true) is observable. However, the SPA
+      // path also routes through doReload's location.assign('/') call. The
+      // most reliable secondary signal is that location.href changes (we can
+      // intercept that via a defineProperty when assign is frozen).
+      try {
+        var loc = window.location;
+        var hrefDescriptor = Object.getOwnPropertyDescriptor(loc, 'href');
+        if (!hrefDescriptor || hrefDescriptor.configurable) {
+          Object.defineProperty(window.location, 'assign', {
+            configurable: true,
+            writable: true,
+            value: function(url) { locationAssignCalls.push(url); }
+          });
+          var probe2 = '__spa_test_probe_b_' + Date.now();
+          window.location.assign(probe2);
+          if (locationAssignCalls.length === 1 && locationAssignCalls[0] === probe2) {
+            locationAssignCalls.length = 0;
+            spyInstalled = true;
+            spyApproach = 'b';
+          }
+        }
+      } catch (e2) {
+        // Both (a) and (b) failed.
+      }
+    }
+
+    // Stub component.router.transitionTo (capture call args).
+    component.router = {
+      transitionTo: function() {
+        transitionToCalls.push(Array.prototype.slice.call(arguments));
+        return transitionToReturn;
+      }
+    };
+
+    // Stub appState — supports the natural _login_spa_eligible reading the
+    // feature_flags map for the case 6 regression guard.
+    component.appState = EmberObject.create({
+      feature_flags: { auth_spa_transition: false },
+      get: function(key) {
+        if (key === 'feature_flags.auth_spa_transition') {
+          return this.feature_flags && this.feature_flags.auth_spa_transition;
+        }
+        return null;
+      }
+    });
+
+    // Stub session — only what _login_dispatch_after_wait uses on the reload
+    // path. The doReload closure does `this.session.set('return', true)` when
+    // `this.get('return')` is truthy.
+    component.session = EmberObject.create({});
+  });
+
+  afterEach(function() {
+    try {
+      window.location.assign = originalLocationAssign;
+    } catch (e) { /* ignore */ }
+    // Clean up any leftover overlay div from case 4.
+    var leftover = document.getElementById('ll-pre-reload-overlay');
+    if (leftover && leftover.parentNode) {
+      leftover.parentNode.removeChild(leftover);
+    }
+  });
+
+  it("_login_spa_eligible returns false: _login_dispatch_after_wait calls location.assign('/'), does NOT call router.transitionTo", function() {
+    component.set('_login_spa_eligible', function() { return false; });
+    var wait = RSVP.resolve();
+    component._login_dispatch_after_wait(wait);
+    waitsFor(function() { return locationAssignCalls.length > 0; });
+    runs(function() {
+      expect(locationAssignCalls.length).toEqual(1);
+      expect(locationAssignCalls[0]).toEqual('/');
+      expect(transitionToCalls.length).toEqual(0);
+    });
+  });
+
+  it("_login_spa_eligible stubbed true: calls router.transitionTo('index'), does NOT call location.assign", function() {
+    component.set('_login_spa_eligible', function() { return true; });
+    var wait = RSVP.resolve();
+    component._login_dispatch_after_wait(wait);
+    waitsFor(function() { return transitionToCalls.length > 0; });
+    runs(function() {
+      // STRICT — no defensive if/else. SPA path MUST fire.
+      expect(transitionToCalls.length).toEqual(1);
+      expect(transitionToCalls[0][0]).toEqual('index');
+      expect(locationAssignCalls.length).toEqual(0);
+    });
+  });
+
+  it("_login_spa_eligible stubbed true, transitionTo rejects: SPA attempted, then falls back to location.assign('/')", function() {
+    component.set('_login_spa_eligible', function() { return true; });
+    transitionToReturn = RSVP.reject(new Error('simulated'));
+    var wait = RSVP.resolve();
+    component._login_dispatch_after_wait(wait);
+    // Wait for the rejection handler to fire AND the fallback to run.
+    waitsFor(function() { return locationAssignCalls.length > 0; });
+    runs(function() {
+      expect(transitionToCalls.length).toEqual(1);
+      expect(locationAssignCalls.length).toEqual(1);
+      expect(locationAssignCalls[0]).toEqual('/');
+    });
+  });
+
+  it("_login_spa_eligible stubbed true, transitionTo resolves: #ll-pre-reload-overlay element is removed from document.body", function() {
+    // Setup: inject a fake overlay before the helper runs.
+    var fake = document.createElement('div');
+    fake.id = 'll-pre-reload-overlay';
+    document.body.appendChild(fake);
+    component.set('_login_spa_eligible', function() { return true; });
+    var wait = RSVP.resolve();
+    component._login_dispatch_after_wait(wait);
+    waitsFor(function() {
+      return transitionToCalls.length > 0 && document.getElementById('ll-pre-reload-overlay') === null;
+    });
+    runs(function() {
+      // STRICT — element MUST be gone after transitionTo resolves.
+      expect(document.getElementById('ll-pre-reload-overlay')).toEqual(null);
+    });
+  });
+
+  it("wait promise rejects: falls back to location.assign('/'), no transition attempted", function() {
+    component.set('_login_spa_eligible', function() { return true; });
+    var wait = RSVP.reject(new Error('user fetch failed'));
+    component._login_dispatch_after_wait(wait);
+    waitsFor(function() { return locationAssignCalls.length > 0; });
+    runs(function() {
+      expect(transitionToCalls.length).toEqual(0);
+      expect(locationAssignCalls.length).toEqual(1);
+    });
+  });
+
+  it("_login_spa_eligible unstubbed: returns false on a fresh appState (no flag set) — REGRESSION GUARD", function() {
+    // Do NOT stub _login_spa_eligible. Read the natural unstubbed body. Set
+    // the appState's feature_flags map to empty so the only outcome possible
+    // is `false`. If a future change defaults the flag to true in test
+    // fixtures, this test will fail and surface the regression.
+    component.appState.feature_flags = {};
+    var result = component._login_spa_eligible();
+    expect(result).toEqual(false);
+  });
+});
+
+// Suppress the unused-import warning for db_wait — the import exists to ensure
+// ember_helper.js's global beforeEach runs (it sets up this.subject and the
+// LingoLinq.store / appState lookups).
+if (false) { db_wait; LoginForm; }

--- a/app/frontend/tests/services/session-spa-transition-test.js
+++ b/app/frontend/tests/services/session-spa-transition-test.js
@@ -1,0 +1,198 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  waitsFor,
+  runs,
+  stub
+} from 'frontend/tests/helpers/jasmine';
+import EmberObject from '@ember/object';
+import RSVP from 'rsvp';
+import session from '../../utils/session';
+import LingoLinq from '../../app';
+import capabilities from '../../utils/capabilities';
+
+describe("session.invalidate auth_spa_transition", function() {
+  var transitionToCalls, transitionToCallTime, transitionToReturn;
+  var unloadAllCalls, unloadAllCallTime;
+  var clearUserStateCalls, clearUserStateCallTime;
+  var reloadCalls;
+  var originalRouter, originalAppState, originalStore, originalInstalled, originalAccessToken;
+  var originalSpaEligible;
+  var originalAuthSettingsFallback;
+
+  beforeEach(function() {
+    transitionToCalls = [];
+    transitionToCallTime = 0;
+    unloadAllCalls = 0;
+    unloadAllCallTime = 0;
+    clearUserStateCalls = 0;
+    clearUserStateCallTime = 0;
+    reloadCalls = [];
+    transitionToReturn = RSVP.resolve();
+
+    // Capture originals so afterEach restores cleanly. The utils/session.js
+    // Proxy forwards property access to the live service singleton, so we are
+    // mutating the real service here — restoration is mandatory.
+    originalRouter = session.router;
+    originalAppState = session.appState;
+    originalStore = LingoLinq.store;
+    originalInstalled = capabilities.installed_app;
+    originalAccessToken = capabilities.access_token;
+    originalSpaEligible = session._invalidate_spa_eligible;
+
+    // Stub router — capture call time so test case 2 can prove call ORDER.
+    session.router = {
+      transitionTo: function() {
+        transitionToCallTime = Date.now();
+        transitionToCalls.push(Array.prototype.slice.call(arguments));
+        return transitionToReturn;
+      }
+    };
+
+    // Stub appState. clear_user_state captures call time. The `get` shim mirrors
+    // the keys session.invalidate actually reads.
+    var feature_flags = { auth_spa_transition: false };
+    session.appState = EmberObject.create({
+      currentUser: EmberObject.create({ user_name: 'alice' }),
+      feature_flags: feature_flags,
+      clear_user_state: function() {
+        clearUserStateCallTime = Date.now();
+        clearUserStateCalls += 1;
+      },
+      get: function(key) {
+        if (key === 'currentUser') { return this.currentUser; }
+        if (key === 'feature_flags.auth_spa_transition') { return this.feature_flags.auth_spa_transition; }
+        return null;
+      }
+    });
+
+    // Stub LingoLinq.store — unloadAll captures call time.
+    LingoLinq.store = {
+      unloadAll: function() {
+        unloadAllCallTime = Date.now();
+        unloadAllCalls += 1;
+      }
+    };
+
+    // Stub stashes flush/setup/get_object so the existing chain resolves cleanly.
+    stub(session.stashes, 'flush', function() { return RSVP.resolve(); });
+    stub(session.stashes, 'setup', function() { return RSVP.resolve(); });
+    stub(session.stashes, 'get_object', function() { return null; });
+    stub(session, 'auth_settings_fallback', function() { return null; });
+
+    // Spy reload — CRITICAL. Without stubbing reload, the OFF/fallback paths
+    // would attempt real navigation in the test runner.
+    stub(session, 'reload', function(path) { reloadCalls.push(path); });
+
+    // Force web (not installed app) for default tests.
+    capabilities.installed_app = false;
+  });
+
+  afterEach(function() {
+    session.router = originalRouter;
+    session.appState = originalAppState;
+    LingoLinq.store = originalStore;
+    capabilities.installed_app = originalInstalled;
+    capabilities.access_token = originalAccessToken;
+    // ALWAYS restore the natural _invalidate_spa_eligible.
+    session._invalidate_spa_eligible = originalSpaEligible;
+  });
+
+  it("_invalidate_spa_eligible returns false: invalidate(true) reloads, does NOT transition", function() {
+    session._invalidate_spa_eligible = function() { return false; };
+    session.invalidate(true);
+    waitsFor(function() { return reloadCalls.length > 0; });
+    runs(function() {
+      expect(transitionToCalls.length).toEqual(0);
+      expect(reloadCalls.length).toEqual(1);
+      expect(reloadCalls[0]).toEqual('/');
+    });
+  });
+
+  it("_invalidate_spa_eligible stubbed true: transitionTo('index') first, then clear_user_state + unloadAll in .then() success, no reload", function() {
+    session._invalidate_spa_eligible = function() { return true; };
+    session.invalidate(true);
+    // The cleanup runs inside the transitionTo .then() success handler, so we
+    // wait for clearUserStateCalls to flip to 1 — that is the strongest signal
+    // the SPA branch ran end-to-end.
+    waitsFor(function() { return clearUserStateCalls > 0; });
+    runs(function() {
+      // STRICT — the SPA branch MUST fire and the call order MUST be respected.
+      expect(transitionToCalls.length).toEqual(1);
+      expect(transitionToCalls[0][0]).toEqual('index');
+      expect(clearUserStateCalls).toEqual(1);
+      expect(unloadAllCalls).toEqual(1);
+      expect(reloadCalls.length).toEqual(0);
+      // CALL ORDER: transitionTo MUST happen before cleanup. Cleanup is wired
+      // inside the .then() success handler so the dashboard route has unmounted
+      // before per-user state is nulled.
+      expect(transitionToCallTime).toBeGreaterThan(0);
+      expect(clearUserStateCallTime).toBeGreaterThan(0);
+      expect(unloadAllCallTime).toBeGreaterThan(0);
+      // toBeLessThan with +1 cushion handles same-millisecond timestamps.
+      expect(transitionToCallTime).toBeLessThan(clearUserStateCallTime + 1);
+      expect(transitionToCallTime).toBeLessThan(unloadAllCallTime + 1);
+    });
+  });
+
+  it("_invalidate_spa_eligible stubbed true, transitionTo rejects: reload fallback fires AND cleanup is NOT called", function() {
+    session._invalidate_spa_eligible = function() { return true; };
+    transitionToReturn = RSVP.reject(new Error('simulated'));
+    session.invalidate(true);
+    waitsFor(function() { return reloadCalls.length > 0; });
+    runs(function() {
+      // STRICT — SPA was attempted, then reload fallback ran. Cleanup must NOT
+      // have happened — the reload accomplishes that by tearing down the Ember
+      // instance.
+      expect(transitionToCalls.length).toEqual(1);
+      expect(reloadCalls.length).toEqual(1);
+      expect(reloadCalls[0]).toEqual('/');
+      expect(clearUserStateCalls).toEqual(0);
+      expect(unloadAllCalls).toEqual(0);
+    });
+  });
+
+  it("_invalidate_spa_eligible stubbed false (simulating installed-app or test env): reload path, no transition", function() {
+    session._invalidate_spa_eligible = function() { return false; };
+    session.invalidate(true);
+    waitsFor(function() { return reloadCalls.length > 0; });
+    runs(function() {
+      expect(transitionToCalls.length).toEqual(0);
+      expect(reloadCalls.length).toEqual(1);
+    });
+  });
+
+  it("_invalidate_spa_eligible(true) returns false in test environment without any stub — REGRESSION GUARD that the helper's !isTesting() guard remains", function() {
+    // Restore the natural unstubbed helper so we read its actual body.
+    session._invalidate_spa_eligible = originalSpaEligible;
+    session.appState.feature_flags.auth_spa_transition = true;
+    capabilities.installed_app = false;
+    // Under `ember test`, isTesting() is true, so the helper MUST return false.
+    // If this assertion fails the helper's `!isTesting()` clause was removed
+    // and the test runner would start hitting real navigation.
+    var result = session._invalidate_spa_eligible(true);
+    expect(result).toEqual(false);
+  });
+
+  it("invalidate(false) — full_invalidate is false: no nav at all", function() {
+    session._invalidate_spa_eligible = function() { return false; };
+    session.appState.currentUser = null;
+    session.appState.get = function(key) {
+      if (key === 'currentUser') { return null; }
+      if (key === 'feature_flags.auth_spa_transition') { return this.feature_flags.auth_spa_transition; }
+      return null;
+    };
+    session.invalidate(false);
+    // Wait briefly so the stashes.flush().then(...) chain has a chance to run.
+    var waited = false;
+    setTimeout(function() { waited = true; }, 50);
+    waitsFor(function() { return waited; });
+    runs(function() {
+      expect(transitionToCalls.length).toEqual(0);
+      expect(reloadCalls.length).toEqual(0);
+    });
+  });
+});

--- a/docs/AUTH_SPA_TRANSITION_PLAN.md
+++ b/docs/AUTH_SPA_TRANSITION_PLAN.md
@@ -1,0 +1,532 @@
+# Auth SPA Transition — Engineering Plan & Decision Record
+
+**Status:** Proposed (not yet implemented)
+**Phase:** [`.planning/phases/01-auth-spa-transition/`](../.planning/phases/01-auth-spa-transition/)
+**Author:** Drafted in collaboration during the styling-updates branch work
+**Date drafted:** 2026-04-25
+**Related work:** Boot overlay + pre-reload overlay already shipped on `traci/styling/styling-updates` ([app/frontend/app/index.html](../app/frontend/app/index.html), [app/frontend/app/instance-initializers/boot-overlay-hide.js](../app/frontend/app/instance-initializers/boot-overlay-hide.js), [app/frontend/app/components/login-form.js](../app/frontend/app/components/login-form.js))
+
+---
+
+## Table of Contents
+
+1. [TL;DR](#tldr)
+2. [Background — what's happening today and why it's a problem](#background)
+3. [The decision and why we're making it](#the-decision)
+4. [What changes — file-by-file](#what-changes--file-by-file)
+5. [What the new method accomplishes that the old method did not](#what-the-new-method-accomplishes-that-the-old-method-did-not)
+6. [What the new method explicitly does NOT change](#what-the-new-method-explicitly-does-not-change)
+7. [Risk register and mitigations](#risk-register-and-mitigations)
+8. [Testing plan](#testing-plan)
+9. [Rollout plan](#rollout-plan)
+10. [Rollback plan](#rollback-plan)
+11. [Future follow-ups](#future-follow-ups)
+
+---
+
+## TL;DR
+
+Today, after a successful login the app does `window.location.assign('/')`, and after sign-out it does `window.location.href = '/'`. Both calls trigger a full browser navigation — the page unloads, the browser shows a blank/white frame while it fetches and re-parses the document, and Ember boots from scratch. That blank frame is the white-screen FOUC users see during auth events.
+
+This phase replaces those two calls with `router.transitionTo(...)` — Ember's in-app navigation primitive. The same Ember instance keeps running; the URL changes; the destination route renders. There is no browser navigation, so there is no white frame to mask.
+
+The change is **gated behind a feature flag** (`auth_spa_transition`, default OFF) and **falls back to the existing reload behavior on any error**. The intent is that during a multi-week soak period, only opted-in test accounts use the new path; if anything goes wrong, the flag is flipped OFF without a frontend deploy.
+
+The auth flow itself does not change. The token negotiation, COPPA/2FA/OAuth variants, "trust this device" logic, and force-logout paths all remain identical. What changes is *only* the final step of "how do we get the user to the dashboard / login page after auth state has been updated."
+
+The styling work (boot overlay, pre-reload overlay) shipped on this branch is **not removed** — it continues to cover the fallback reload path for users who don't have the feature flag enabled.
+
+---
+
+## Background
+
+### What happens today on login
+
+Trace (from [login-form.js:300-407](../app/frontend/app/components/login-form.js#L300-L407)):
+
+1. User submits credentials. The `authenticate` action calls `session.authenticate(data)`, which hits the backend auth endpoint.
+2. On success, control flows to `login_success(reload=true)`.
+3. The handler stores the token, then chains a promise: `stashes.flush()` → `stashes.setup()` → `appState.refresh_session_user()` (which calls `LingoLinq.store.findRecord('user', 'self')` to fetch the current user).
+4. Once that promise resolves, it calls `location.assign('/')`. This is a full browser navigation.
+5. The browser unloads the document. Everything in memory (services, store, observers) is destroyed.
+6. The browser fetches `/`, parses the HTML head (which is render-blocking on `vendor.css` + `frontend.css`), and during this window it shows blank/white.
+7. Once the head is parsed, the browser paints the inline boot overlay we added on this branch.
+8. Ember boots, the index route runs, sees the auth token, and `replaceWith('user.home', user_name)` redirects to the dashboard.
+9. The boot overlay is dismissed by the `boot-overlay-hide` instance initializer once `routeDidChange` fires for the destination.
+
+The white-screen flash users see is steps 5–6.
+
+### What happens today on sign-out
+
+Trace (from [services/session.js:563-597](../app/frontend/app/services/session.js#L563-L597)):
+
+1. User clicks Sign Out. The action handler calls `session.invalidate(true)`.
+2. The handler flushes stashes, clears auth state on the session service and `capabilities.access_token`, then calls `_this.reload('/')`.
+3. `session.reload('/')` does `location.href = '/'` for web (non-installed-app) clients.
+4. The browser unloads the dashboard. Same blank-white window as login.
+5. The browser loads `/`, the index route runs, sees no auth token, renders the login form.
+
+Same root cause as login.
+
+### Why was it done this way?
+
+The comment at [login-form.js:384-387](../app/frontend/app/components/login-form.js#L384-L387) explains:
+
+> *Web: use full page reload after login (same approach as installed app). Client-side transition was unreliable: on index route `transitionTo('index')` is a no-op, and the dashboard only shows when `appState.currentUser` is set by `refresh_session_user`. A reload guarantees session restore from localStorage and clean dashboard load.*
+
+This is documenting **a debt**, not a fundamental constraint. The three issues listed are all solvable:
+
+| Reported issue | Why it happened | Why it's solvable |
+|---|---|---|
+| `transitionTo('index')` was a no-op | When already on `index`, transitioning to `index` doesn't re-run the route | Transition to `user.home` directly with the username — the route hierarchy doesn't care that you came from `index` |
+| Dashboard requires `appState.currentUser` | If you transition before `refresh_session_user` resolves, the dashboard renders with no user | Wait for `refresh_session_user` to resolve before transitioning. The code already does this — the `wait` promise at [login-form.js:347](../app/frontend/app/components/login-form.js#L347) is exactly that guarantee. We just need to chain `.then(transitionTo)` instead of `.then(reload)` |
+| "Reload guarantees session restore from localStorage" | The author was worried in-memory `session` state wouldn't reflect the new auth | The code already calls `session.restore()` and explicitly sets `isAuthenticated`, `access_token`, `user_name`, `user_id` at lines [335-338](../app/frontend/app/components/login-form.js#L335) and [363](../app/frontend/app/components/login-form.js#L363). A reload does nothing additional that those calls don't already do |
+
+So the reload was a workaround chosen under pressure. It works, but it imports browser-navigation behavior into an SPA — and that browser-navigation behavior is what produces the white screen.
+
+### Why we're solving it now
+
+1. The new styling on this branch has made the FOUC visible and visceral — the previous styling was less differentiated, so the flash was easier to ignore. With the new styled login + dashboard, the contrast between "before reload" and "after reload" makes the transition feel broken.
+2. AAC users are sensitive to unexpected UI changes. A jarring transition feels like a bug.
+3. Every other production SPA does this — Gmail, Slack, Linear, Stripe Dashboard. The pattern is well-understood and the path is well-trodden.
+4. The patches we've applied (boot overlay, pre-reload overlay) are workarounds for the workaround. They mask symptoms but don't solve the cause. Each new flow that does `location.reload()` becomes a new white-screen bug to remember.
+
+---
+
+## The decision
+
+### Decision: replace the two auth-event reloads with SPA transitions, gated behind a feature flag.
+
+### Considered alternatives
+
+| Approach | Pro | Con | Verdict |
+|---|---|---|---|
+| **Keep current reload + boot overlay** (status quo on this branch) | No risk to auth flow, already shipped | Treadmill: every new `location.reload` site becomes a new white-screen bug. Doesn't fix the cause. Doesn't help Firefox/Safari users. | Acceptable patch, not a solution |
+| **Service Worker app shell** | Industry-standard, masks all navigations including non-auth ones | Significant new infrastructure, requires PWA setup, cache versioning concerns, mobile/installed-app interaction | Strong candidate as a future phase, but heavier than needed for the immediate problem |
+| **Inline critical CSS + async stylesheets** | Solves the render-blocking CSS portion of the gap | Doesn't solve the underlying "we full-reload on auth" pattern. Adds FOUC risk surface for the rest of the app. | Rejected — fixes a symptom of a symptom |
+| **SPA transitions on auth events** (this proposal) | Eliminates the cause. Aligns with the SPA architecture the codebase is already using everywhere else. Standard solution in modern web apps. | Requires explicit per-user state cleanup that the page reload was doing implicitly. Carries auth regression risk. | **Selected, gated by feature flag** |
+
+### Why we chose this
+
+The white-screen flash is a symptom of using browser navigation for what should be in-app state changes. Every patch that doesn't address that root cause leaves us treating each new symptom site as a new bug. SPA transitions make the symptom impossible because there is no browser navigation to mask.
+
+The auth-regression risk is real but contained by:
+- Defaulting the feature flag OFF
+- Falling back to reload on any error in the new path
+- Explicit, audited state cleanup
+- Multi-week soak at low rollout percentage
+- Manual bug-bash before promoting to all users
+
+---
+
+## What changes — file-by-file
+
+### 1. `lib/feature_flags.rb`
+
+Register a new frontend feature flag.
+
+```ruby
+# Add to AVAILABLE_FRONTEND_FEATURES
+'auth_spa_transition' => {
+  description: 'Use Ember router transitions for login and sign-out instead of full page reloads',
+  added: '2026-XX',
+  default: false
+}
+```
+
+The flag is **frontend-readable** so the JS code can check it. **Not** added to `ENABLED_FRONTEND_FEATURES` initially — it stays opt-in until rollout begins.
+
+### 2. `app/frontend/app/components/login-form.js`
+
+Replace the web `else` branch in the `login_success` action ([currently lines 383-407](../app/frontend/app/components/login-form.js#L383-L407)).
+
+**Before** (current — ships unchanged on the OFF path):
+```js
+} else {
+  // Web: use full page reload after login (same approach as installed app).
+  var reloadDone = false;
+  var doReload = function() {
+    if(reloadDone || _this.isDestroyed || _this.isDestroying) { return; }
+    reloadDone = true;
+    if(_this.get('return')) {
+      _this.session.set('return', true);
+    }
+    _loginDebug('Web: reloading to dashboard');
+    location.assign('/');
+  };
+  wait.then(doReload, function(err) {
+    if(_this.isDestroyed || _this.isDestroying) { return; }
+    console.warn('[login_success] User fetch failed, reloading anyway', err);
+    doReload();
+  });
+  var timeoutPromise = new RSVP.Promise(function(resolve) { runLater(resolve, 6000); });
+  RSVP.race([wait, timeoutPromise]).then(doReload, function() { doReload(); });
+}
+```
+
+**After:**
+```js
+} else {
+  var spaTransitionEnabled = _this.appState.feature_flag('auth_spa_transition');
+
+  var reloadDone = false;
+  var doReload = function() {
+    if(reloadDone || _this.isDestroyed || _this.isDestroying) { return; }
+    reloadDone = true;
+    if(_this.get('return')) {
+      _this.session.set('return', true);
+    }
+    _loginDebug('Web: reloading to dashboard');
+    location.assign('/');
+  };
+
+  var doTransition = function() {
+    if(reloadDone || _this.isDestroyed || _this.isDestroying) { return; }
+    reloadDone = true;
+    var username = _this.appState.get('sessionUser.user_name');
+    if(!username) {
+      _loginDebug('SPA transition: no username after wait, falling back to reload');
+      reloadDone = false;
+      return doReload();
+    }
+    try {
+      _loginDebug('SPA transition: transitioning to user.home', { username: username });
+      _this.router.transitionTo('user.home', username).then(null, function(err) {
+        console.warn('[login_success] SPA transition rejected, falling back to reload', err);
+        reloadDone = false;
+        doReload();
+      });
+    } catch(err) {
+      console.warn('[login_success] SPA transition threw, falling back to reload', err);
+      reloadDone = false;
+      doReload();
+    }
+  };
+
+  var doNext = spaTransitionEnabled ? doTransition : doReload;
+
+  wait.then(doNext, function(err) {
+    if(_this.isDestroyed || _this.isDestroying) { return; }
+    console.warn('[login_success] User fetch failed, reloading', err);
+    doReload();
+  });
+  var timeoutPromise = new RSVP.Promise(function(resolve) { runLater(resolve, 6000); });
+  RSVP.race([wait, timeoutPromise]).then(doNext, function() { doReload(); });
+}
+```
+
+**What this does:**
+- When the flag is OFF: behavior is byte-for-byte identical to today.
+- When the flag is ON: after the same `wait` promise resolves (which guarantees `appState.sessionUser` is populated), `router.transitionTo('user.home', username)` is called instead of `location.assign('/')`.
+- ANY error in the new path — promise rejection, exception, missing username — falls back to `doReload()`.
+- The 6-second timeout fallback still applies. If the user fetch hangs, it falls back to whichever `doNext` is active.
+
+The pre-reload overlay we added at [login-form.js:345-372](../app/frontend/app/components/login-form.js#L345-L372) **continues to be injected**. On the SPA path it's harmlessly visible during the `wait` window and gets unmounted automatically when the destination route replaces the login form. On the fallback reload path it works as it does today.
+
+### 3. `app/frontend/app/services/session.js`
+
+Replace the body of `invalidate(force)` ([currently lines 563-597](../app/frontend/app/services/session.js#L563-L597)) with a feature-flag-gated branch.
+
+**Before:**
+```js
+invalidate: function(force) {
+  var _this = this;
+  var full_invalidate = force || !!(this.appState.get('currentUser') || this.stashes.get_object('auth_settings', true) || this.auth_settings_fallback());
+  if(full_invalidate) {
+    if(window.navigator.splashscreen) {
+      window.navigator.splashscreen.show();
+    }
+  }
+  this.stashes.flush().then(null, function() { return RSVP.resolve(); }).then(function() {
+    _this.stashes.setup();
+    var later = function(callback, delay) { callback(); };
+    if(!isTesting()) { later = runLater; }
+    later(function() {
+      _this.set('isAuthenticated', false);
+      _this.set('access_token', null);
+      _this.set('user_name', null);
+      _this.set('user_id', null);
+      _this.set('as_user_id', null);
+      if(capabilities) { capabilities.access_token = null; }
+      if(full_invalidate) {
+        later(function() { _this.reload('/'); });
+      }
+    });
+  });
+}
+```
+
+**After:**
+```js
+invalidate: function(force) {
+  var _this = this;
+  var full_invalidate = force || !!(this.appState.get('currentUser') || this.stashes.get_object('auth_settings', true) || this.auth_settings_fallback());
+  if(full_invalidate) {
+    if(window.navigator.splashscreen) {
+      window.navigator.splashscreen.show();
+    }
+  }
+  var spaTransitionEnabled = full_invalidate && this.appState && typeof this.appState.feature_flag === 'function' && this.appState.feature_flag('auth_spa_transition') && !capabilities.installed_app;
+
+  this.stashes.flush().then(null, function() { return RSVP.resolve(); }).then(function() {
+    _this.stashes.setup();
+    var later = function(callback, delay) { callback(); };
+    if(!isTesting()) { later = runLater; }
+    later(function() {
+      _this.set('isAuthenticated', false);
+      _this.set('access_token', null);
+      _this.set('user_name', null);
+      _this.set('user_id', null);
+      _this.set('as_user_id', null);
+      if(capabilities) { capabilities.access_token = null; }
+
+      if(full_invalidate) {
+        if(spaTransitionEnabled) {
+          // Explicitly clear all per-user state that the page reload was implicitly handling.
+          try {
+            if(_this.appState && typeof _this.appState.clear_user_state === 'function') {
+              _this.appState.clear_user_state();
+            }
+            if(LingoLinq && LingoLinq.store && typeof LingoLinq.store.unloadAll === 'function') {
+              LingoLinq.store.unloadAll();
+            }
+            // Reset 3rd-party SDK user attribution
+            if(typeof window !== 'undefined' && window.Sentry && typeof window.Sentry.setUser === 'function') {
+              window.Sentry.setUser(null);
+            }
+            // Add other SDK resets here as enumerated during implementation audit.
+            var router = _this.appState && _this.appState.get && _this.appState.get('router');
+            if(router && typeof router.transitionTo === 'function') {
+              router.transitionTo('index').then(null, function(err) {
+                console.warn('[session.invalidate] SPA transition rejected, falling back to reload', err);
+                later(function() { _this.reload('/'); });
+              });
+              return;
+            }
+            // Router not available — fall through to reload
+            console.warn('[session.invalidate] Router unavailable for SPA transition, reloading');
+          } catch(err) {
+            console.warn('[session.invalidate] SPA transition threw, falling back to reload', err);
+          }
+        }
+        later(function() { _this.reload('/'); });
+      }
+    });
+  });
+}
+```
+
+**What this does:**
+- When the flag is OFF or installed app: behavior is byte-for-byte identical to today.
+- When the flag is ON (web only): explicitly clears per-user state, calls `router.transitionTo('index')`. The new index route renders the login form (because no user is authenticated).
+- ANY error — exception, transition rejection, missing router — falls back to the existing `_this.reload('/')`.
+- The installed app is forced to keep the reload path because the Cordova/Capacitor splashscreen integration relies on it.
+
+### 4. `app/frontend/app/services/app-state.js` — new method
+
+Add a `clear_user_state()` method that nulls every per-user property the service tracks. This is the explicit version of what the page reload was implicitly doing by destroying the entire service.
+
+```js
+clear_user_state: function() {
+  this.set('sessionUser', null);
+  this.set('currentUser', null);
+  this.set('referenced_speak_mode_user', null);
+  this.set('speakModeUser', null);
+  this.set('modeling_for_self', null);
+  this.set('currentBoardState', null);
+  this.set('already_homed', false);
+  this.set('logging_in', false);
+  // Enumerate during implementation audit — start with grep for `this.set('` in app-state.js
+  // and identify which keys are user-scoped vs. app-scoped.
+}
+```
+
+The implementer is responsible for auditing `app-state.js` and ensuring every per-user property is included. The grep target is `this.set('` in [services/app-state.js](../app/frontend/app/services/app-state.js) and a manual classification of each into "user-scoped" vs. "app-scoped."
+
+### 5. `app/frontend/app/utils/persistence.js` — audit
+
+Walk this file and identify any in-memory caches keyed by the current user that need clearing on sign-out. Likely candidates:
+- The internal `find_changed` queue
+- Any `users[user_id]` keyed cache
+- Modeling session state
+- Online-status retry state
+
+Add a `clear_user_state()` method to `persistence` if needed and call it from `session.invalidate` alongside the others.
+
+### 6. Tests
+
+#### Backend
+No backend tests need to change. The feature flag declaration in `lib/feature_flags.rb` may need a spec entry depending on existing patterns — check `spec/lib/feature_flags_spec.rb`.
+
+#### Frontend
+Add Ember tests in `app/frontend/tests/`:
+- A controller test for `controllers/login` exercising `login_success` with the flag both OFF and ON, asserting `transitionTo` vs. `location.assign` is called appropriately. Mock the router and the `wait` promise.
+- A service test for `services/session` exercising `invalidate` with the flag both OFF and ON, asserting state cleanup happens before the transition.
+
+Both tests must mock `location.assign` / `location.href` to avoid actually navigating during test runs. The existing tests almost certainly already do this — pattern-match.
+
+---
+
+## What the new method accomplishes that the old method did not
+
+This is the heart of the change. Each row is something the new method does that the old method couldn't — *because* the old method tore down the whole app instance.
+
+| Capability | Old method (`location.assign('/')`) | New method (`router.transitionTo`) |
+|---|---|---|
+| **Visual continuity** | Browser unloads document → blank/white frame while new HTML+CSS loads → new app boots → destination renders. White-screen FOUC. | Same Ember instance. The destination route renders in place. No browser navigation, no frame loss. |
+| **First Contentful Paint cost** | Pays full FCP cost again (HTML parse + render-blocking CSS + script execution + Ember boot). Typically 200–800ms even with cached assets. | Zero. The user is already on a painted page; the route swap is a DOM diff. |
+| **Animation continuity** | Impossible — the DOM is destroyed mid-animation. Any in-progress fade, slide, or transition is interrupted. | Possible — Ember's transitionTo can integrate with View Transitions API (future work) for crossfades. |
+| **State preservation between routes** | Impossible — the store is empty after reload, so cached records (boards, supervisors, recent activity) must be re-fetched. | Possible — Ember Data store survives. We *choose* to clear user-specific records on sign-out, but on login the records loaded during auth fetch (e.g. supervisor list, starred boards) carry into the dashboard with no re-fetch. |
+| **Network cost on auth** | All assets (vendor.js, frontend.js, vendor.css, frontend.css, fonts) re-validated against the cache. Even with 304s, this is several round-trips. | Zero. No new network requests issued by the navigation itself. |
+| **Memory cleanup discipline** | Implicit — the GC collects the old Ember instance, the store, all observers. Sloppy code can rely on this. | Explicit — `store.unloadAll()`, `appState.clear_user_state()`, SDK resets. **This is the cost of the change.** Forces us to actually own per-user state, which is a long-term win. |
+| **Observability** | Reload events are invisible in app analytics — they look like a fresh session start. Hard to correlate "user signed in" with subsequent behavior. | Single Ember instance means analytics see a continuous session: "user submitted login → arrived at dashboard." Better funnel data. |
+| **Error context after auth failures** | Console / Sentry breadcrumbs are wiped on reload. Debugging "what happened just before the bad login" is hard. | Breadcrumbs survive. Easier to debug auth issues post-hoc. |
+| **Behavior under flaky networks** | If the new page's `<head>` CSS stalls, the user is stuck on a white screen with no controls. | If `transitionTo` itself stalls, the existing pre-reload overlay covers the page. The user sees a loading state, not a blank canvas. |
+| **Correctness on browser back-button** | After login-via-reload, hitting Back goes to the login URL with valid auth — confusing UX. | The router controls history; we can `replaceWith` instead of `transitionTo` to keep Back behavior coherent. |
+
+The new method's main *cost* is the explicit state-cleanup discipline (the "Memory cleanup discipline" row). That cost is paid once during this phase — the audit of per-user state in `app-state.js` and `persistence.js` — and forever after, the codebase has a documented inventory of per-user state, which is independently valuable.
+
+---
+
+## What the new method explicitly does NOT change
+
+Listed exhaustively so reviewers can verify scope.
+
+- **Auth API contract.** No request payload, response, header, or status-code handling changes. The token is obtained, stored, and attached to subsequent requests exactly as it is today.
+- **Stash flushing.** `stashes.flush()` and `stashes.setup()` are called in the same order with the same arguments.
+- **Session restoration on cold load.** When the app boots cold (page reload, fresh tab), `session.restore()` runs exactly as today. Nothing about how an existing token is read from `localStorage` changes.
+- **Splashscreen integration.** `window.navigator.splashscreen.show()` calls remain in place. The installed app continues to use the reload path entirely.
+- **`isTesting()` gating.** All paths that no-op during tests continue to no-op. The new SPA-transition path also no-ops in tests because `_this.router.transitionTo` is mocked or test-only routes are used.
+- **The boot overlay** ([app/frontend/app/index.html](../app/frontend/app/index.html)).
+- **The pre-reload overlay** ([app/frontend/app/components/login-form.js:345-372](../app/frontend/app/components/login-form.js#L345-L372)).
+- **The `boot-overlay-hide` instance initializer** ([app/frontend/app/instance-initializers/boot-overlay-hide.js](../app/frontend/app/instance-initializers/boot-overlay-hide.js)).
+- **Any SCSS file.** Verifiable: `git diff main -- '*.scss'` returns empty after this phase.
+- **Any HBS template.** Verifiable: `git diff main -- '*.hbs'` returns empty after this phase.
+- **The `force_logout` flow** ([services/session.js:545](../app/frontend/app/services/session.js#L545)). It still calls `invalidate(true)`. The behavior of `invalidate` is what changes; the call site doesn't.
+- **Other `location.reload` sites** — locale change, subscription update, masquerade, eval-status. Out of scope.
+- **The COPPA, 2FA, OAuth, and "trust this device" auth flows.** They negotiate auth state exactly as today; only the final navigation step changes.
+
+---
+
+## Risk register and mitigations
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| R1 | Login auth bug introduced by SPA path | Low | High | Feature flag default OFF; fallback to reload on any error; opt-in test accounts soak ≥ 2 weeks before any rollout |
+| R2 | Stale Ember Data records leak between users (User A's boards visible to User B after sign-out and re-login as B) | Medium | High | Explicit `store.unloadAll()` on sign-out. Test: log in as A, log out, log in as B, inspect store — assert no A records |
+| R3 | In-flight request initiated by User A resolves after sign-out and writes to store | Medium | Medium | Audit network-handler grep for `currentUser`-touching writes; add `if(!appState.currentUser) return;` guards. Also covered by `store.unloadAll()` since the records have nowhere to land |
+| R4 | Observer or computed property assumes `currentUser` is non-null and throws on sign-out | Medium | Medium | Audit `app-state.js` for observers/computeds keyed on `currentUser`. Test: sign out from various pages, check console for errors |
+| R5 | 3rd-party SDK keeps old user attribution after sign-out (Sentry, analytics) | High | Low | Enumerate SDKs during implementation; explicit `reset()` / `setUser(null)` calls. Verifiable in network requests post-sign-out |
+| R6 | Test suite breaks because tests mock `location.assign` but not `router.transitionTo` | High | Low | Update tests to mock both; add explicit assertions on which path was taken |
+| R7 | Visual regression — overlay no longer covers a flow it used to | Low | Medium | E2E with flag OFF asserts current behavior unchanged. Manual check with flag ON. |
+| R8 | Browser back-button after sign-out goes to dashboard URL with no auth | Low | Low | Use `replaceWith('index')` instead of `transitionTo('index')` on sign-out so the dashboard URL is removed from history |
+| R9 | Race between `wait` promise and 6-second timeout causes double-transition | Low | Low | Existing `reloadDone` guard prevents double-reload; same pattern protects double-transition (the `reloadDone` flag is set by both paths) |
+| R10 | Mid-rollout flag flip causes a user mid-login to switch paths | Low | Low | Cache flag value at session start, don't re-check during a single auth transaction |
+
+---
+
+## Testing plan
+
+### Pre-merge automated tests
+
+- **ESLint clean** on all changed JS files.
+- **Frontend unit tests** for `controllers/login` and `services/session` covering:
+  - Flag OFF → `location.assign` / `location.href` called, `transitionTo` not called
+  - Flag ON, success path → `transitionTo` called with correct args, `location.assign` not called
+  - Flag ON, transition rejection → fallback `location.assign` called
+  - Flag ON, timeout race → fallback `location.assign` called
+  - Sign-out flag ON → `store.unloadAll`, `clear_user_state`, `transitionTo('index')` all called in order
+- **Backend unit tests** for the new feature flag entry in `lib/feature_flags.rb`.
+- **Full test suite** — `bundle exec rspec` and `cd app/frontend && ember test` both pass.
+
+### Pre-merge manual smoke tests (flag OFF)
+
+With the feature flag forced OFF for a logged-in test account, run a clean login and sign-out. Verify behavior is byte-identical to today:
+- White-screen still occurs (we have not regressed the OFF path)
+- Pre-reload overlay still shows
+- Boot overlay still covers post-reload boot
+- `routeDidChange`-gated dismissal still works
+
+This is the regression test for the "no styling regressions" requirement.
+
+### Pre-rollout bug-bash (flag ON)
+
+Run all of the following in a fresh browser session with the flag forced ON:
+
+1. Standard login (web) → dashboard
+2. Standard sign-out → login page
+3. Login → switch supervisor target → sign out → login as different user (verify no User A data visible)
+4. Login → expired session API call → force_logout → login again
+5. Login → close browser → reopen → still authenticated (session restore unchanged)
+6. Login with bad credentials → error message shown, no transition
+7. Login + 2FA flow
+8. Login + COPPA flow
+9. Login + "Trust this device" follow-up
+10. Login + "Shared device" follow-up
+11. Login while offline (should fail gracefully, no transition)
+12. Sign-out while offline (should still clear local state, transition to index)
+13. Reload mid-login (browser refresh during the auth API call) — verify no auth corruption
+14. Repeat 1–4 in Chrome, Firefox, Safari, Edge
+15. Repeat 1–4 in installed app — confirm reload path is still used (flag OFF override for installed app)
+16. Repeat 1–4 in browserless / OAuth path — confirm whichever path is used per the implementation
+
+### Soak
+
+Minimum 2 weeks at 5% rollout before considering wider rollout. Watch:
+- Sentry / Bugsnag for any new error patterns from `services/session.js`, `components/login-form.js`, `services/app-state.js`
+- Support inbox for "I can't sign in" / "It's frozen" reports
+- Analytics for any drop in successful-login rate
+
+---
+
+## Rollout plan
+
+| Stage | Flag state | Population | Duration | Exit criterion |
+|---|---|---|---|---|
+| 0 — Merged behind flag | OFF for all | All users | Until stage 1 | Code merged, automated tests pass, OFF-path manual smoke clean |
+| 1 — Internal opt-in | ON for opted-in test accounts only | ~5–10 internal users | ≥ 1 week | Bug-bash variants R7+R8 all green; zero auth-related errors in test accounts |
+| 2 — Beta cohort | ON for users in `beta_features` org | ~5% of users | ≥ 2 weeks | Zero auth-related Sentry reports attributable to the change; no support inbox reports |
+| 3 — Half rollout | ON for 50% of users | ~50% | ≥ 1 week | Sentry rate for sign-in flow no higher than control; no support escalation |
+| 4 — Full rollout | ON by default | 100% | — | — |
+| 5 — Cleanup | Flag removed, OFF path code deleted | — | After ≥ 4 weeks at full rollout with no incidents | Flag has been at 100% for ≥ 4 weeks without rollback. Then a follow-up phase removes the dead code. |
+
+The flag flip between stages is a single-line change in `lib/feature_flags.rb` plus a backend deploy. No frontend deploy is required to roll back.
+
+---
+
+## Rollback plan
+
+If a regression is reported at any stage:
+
+1. **Immediate**: flip `auth_spa_transition` to OFF for all users in `lib/feature_flags.rb`. Backend deploy. Affected users get the reload path on their next auth event. Worst-case latency: their current session continues unaffected; their next sign-in or sign-out uses the old path.
+2. **Diagnose**: review Sentry breadcrumbs. Because the new path keeps the Ember instance alive, breadcrumbs from the failed flow are preserved (a benefit highlighted earlier).
+3. **Fix forward** if the issue is identifiable, or **revert** the phase commits if not.
+
+The rollback is significantly cheaper than this kind of change typically allows because the feature flag is the only switch needed.
+
+---
+
+## Future follow-ups
+
+Out of scope for this phase, but enabled by it:
+
+- **View Transitions API integration** — once SPA transitions are the norm, we can wrap them in `document.startViewTransition()` for crossfade animations between login and dashboard. Modern browser support is good (Chrome 111+, Safari 18, Firefox in progress).
+- **Service Worker app shell** — for the *other* `location.reload` sites (locale change, subscription update, masquerade) that this phase deliberately leaves alone. A service worker shell would make those navigations also feel instant without per-site SPA conversion.
+- **Other auth-adjacent reloads** — once the discipline of explicit per-user state cleanup is established, the other reload sites become candidates for similar conversion.
+- **Analytics funnel for auth** — the new path enables continuous-session analytics across login. Worth evaluating which events are now meaningful that weren't before.
+- **Removing the boot overlay** — eventually, if all `location.reload` sites are eliminated, the boot overlay becomes vestigial. Not recommended for some time; it's a useful safety net.
+
+---
+
+## Sign-off checklist
+
+- [ ] All R1–R10 from [SPEC.md](../.planning/phases/01-auth-spa-transition/SPEC.md) demonstrably met
+- [ ] Automated test suite passes (backend + frontend)
+- [ ] ESLint clean
+- [ ] No SCSS files modified (`git diff main -- '*.scss'` empty)
+- [ ] No HBS template files modified (`git diff main -- '*.hbs'` empty)
+- [ ] Manual bug-bash variants 1–16 above all green
+- [ ] Feature flag toggleable via `lib/feature_flags.rb`
+- [ ] ≥ 2 weeks soak at 5% rollout with zero auth-related new error reports
+- [ ] PR review by ≥ 1 reviewer with auth-flow context
+- [ ] Documentation in this file matches what shipped

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -12,7 +12,7 @@ module FeatureFlags
               'skin_tones', 'lessons', 'other_menu', 'shallow_clones', 'ai_board_generation',
               'ai_word_prediction', 'ai_board_suggestions', 'ai_symbol_search',
               'ai_compliance_logging', 'supervisor_consent_flow',
-              'tarheel_reader']
+              'tarheel_reader', 'auth_spa_transition']
   ENABLED_FRONTEND_FEATURES = ['subscriptions', 'assessments', 'custom_sidebar', 'snapshots',
               'video_recording', 'goals', 'modeling', 'geo_sidebar', 'edit_before_copying',
               'core_reports', 'lessonpix', 'translation', 'fast_render',
@@ -44,7 +44,8 @@ module FeatureFlags
     'ai_symbol_search' => 'Feb 21, 2026',
     'ai_compliance_logging' => 'Feb 21, 2026',
     'supervisor_consent_flow' => 'Mar 22, 2026',
-    'tarheel_reader' => 'Apr 14, 2026'
+    'tarheel_reader' => 'Apr 14, 2026',
+    'auth_spa_transition' => 'Apr 25, 2026'
   }
   AI_FEATURES = %w[ai_board_generation ai_word_prediction ai_board_suggestions
                    ai_symbol_search ai_compliance_logging].freeze

--- a/spec/models/concerns/subscription_spec.rb
+++ b/spec/models/concerns/subscription_spec.rb
@@ -785,7 +785,8 @@ describe Subscription, :type => :model do
         }
       }])
       expect(u.expires_at).to eq(nil)
-      expect(u.settings['subscription']['added_to_organization']).to eql(Time.now.iso8601)
+      expect(Time.parse(u.settings['subscription']['added_to_organization'])).to be > 5.seconds.ago
+      expect(Time.parse(u.settings['subscription']['added_to_organization'])).to be < 5.seconds.from_now
       expect(Worker.scheduled?(User, :perform_action, {'id' => u.id, 'method' => 'subscription_token', 'arguments' => ['token', 'unsubscribe']})).to eq(false)
     end
 


### PR DESCRIPTION
This pull request introduces a seamless, visually consistent boot and login experience by implementing a full-screen boot overlay that appears immediately upon page load and during login transitions. It ensures users see a smooth "Loading your account…" message during authentication, whether the app reloads or transitions via SPA, and removes the overlay only after the destination route is fully rendered. The changes also improve testability and robustness around route transitions and error states.

**Boot Overlay Implementation and Behavior:**

* Added a persistent boot overlay (`#ll-boot-overlay`) to `index.html` that displays a loading spinner and message above the app during boot and login transitions, with styles ensuring visual consistency and accessibility. 
* Implemented logic in a new instance initializer (`boot-overlay-hide.js`) to dismiss the boot overlay only after the first stable route transition completes, preventing premature hiding and visual flashes. Includes a safety timeout to guarantee removal.
* The boot overlay message switches to "Loading your account…" if an auth event is pending, using a localStorage flag set before login reloads and cleared after the overlay is removed.

**Login Flow and SPA Transition Improvements:**

* Refactored the login flow in `login-form.js` to delegate post-auth dispatch logic to a new method (`_login_dispatch_after_wait`), which handles both SPA transitions and reload fallback, improving testability and reliability. 
* During login, a pre-reload overlay is shown and a localStorage flag is set to synchronize the boot overlay message after reload, ensuring a seamless user experience.

**Robustness and Error Handling:**

* Enhanced error handling in route transitions and login, ensuring that any failures or timeouts in the SPA path fall back to a safe reload, and overlays are always eventually dismissed.

**SPA Route Transition Safety:**

* Updated route title logic to guard against missing controllers in loading/error substates, preventing assertion errors and allowing substates to activate cleanly during SPA transitions.