### PR TITLE
chore: ignore Word temp and lock files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@
 
 .DS_Store
 *.code-workspace
+*.docx
+~$*.docx
+~$*.doc
 /lib/domains.json
 # Ignore master key for decrypting credentials and more.
 /config/master.key


### PR DESCRIPTION
## Summary
Adds gitignore patterns for Word document temp files and lock files that can clutter the working tree.

## Context
This was originally bundled into PR #218 with a typo (`~.docx` instead of `~$*.docx`). PR #218 was closed as superseded because it contained extensive unrelated regressions (Rails 6 downgrade, AWS SDK removal, etc.). This PR isolates just the gitignore intent with the correct pattern.

## Changes
- `*.docx` - Word documents (typically not committed to this repo)
- `~$*.docx` - Word lock files (created when a doc is open in Word)
- `~$*.doc` - Legacy Word format lock files

## Testing
N/A - gitignore change only, no runtime impact.