### PR TITLE
fix(frontend): restore copy-on-edit board copy flow

### DIFF
--- a/app/frontend/app/components/copy-board.js
+++ b/app/frontend/app/components/copy-board.js
@@ -24,10 +24,14 @@ export default Component.extend({
                     (modalService && modalService.settingsFor && modalService.settingsFor[template]) ||
                     this.get('model') || {};
     this.set('model', options);
+    this.runOpening();
   },
 
-  didInsertElement() {
-    this._super(...arguments);
+  runOpening() {
+    if (this.get('_copyBoardInitialized')) { return; }
+    if (!this.get('model.board')) { return; }
+    this.set('_copyBoardInitialized', true);
+    // This component is tagless, so initialize modal state without relying on didInsertElement.
     this.set('model.jump_home', true);
     this.set('model.keep_as_self', false);
     this.set('board_name', this.get('model.board.name'));
@@ -61,6 +65,7 @@ export default Component.extend({
       this.set('currently_selected_id', 'self');
     }
     this.set('model.known_supervisees', supervisees);
+    this.user_board();
   },
 
   has_supervisees: computed('model.known_supervisees', 'appState.sessionUser.managed_orgs', function() {
@@ -178,7 +183,9 @@ export default Component.extend({
     close() {
       this.get('modal').close(false);
     },
-    opening() {},
+    opening() {
+      this.runOpening();
+    },
     closing() {},
     more_options() {
       this.set('show_more_options', !this.get('show_more_options'));

--- a/app/frontend/app/components/copy-board.js
+++ b/app/frontend/app/components/copy-board.js
@@ -49,6 +49,7 @@ export default Component.extend({
     this.set('home_board', null);
     const user_name = this.get('model.selected_user_name');
     let supervisees = [];
+    this.set('model.known_supervisees', supervisees);
     if (this.get('appState').get('sessionUser.supervisees.length')) {
       let selected_user_id = null;
       this.get('appState').get('sessionUser.known_supervisees').forEach(function(supervisee) {
@@ -60,12 +61,11 @@ export default Component.extend({
         }
         supervisees.push(res);
       }.bind(this));
+      this.set('model.known_supervisees', supervisees);
       this.set('currently_selected_id', selected_user_id);
     } else {
       this.set('currently_selected_id', 'self');
     }
-    this.set('model.known_supervisees', supervisees);
-    this.user_board();
   },
 
   has_supervisees: computed('model.known_supervisees', 'appState.sessionUser.managed_orgs', function() {


### PR DESCRIPTION
Initialize the tagless copy-board modal without relying on didInsertElement so copy-on-edit saves can create the user-owned board copy again.

Made-with: Cursor