### PR TITLE
compliance(coppa): hard-gate AI calls behind parental consent

### DIFF
--- a/app/controllers/api/words_controller.rb
+++ b/app/controllers/api/words_controller.rb
@@ -1,5 +1,5 @@
 class Api::WordsController < ApplicationController
-  before_action :require_api_token, :except => [:reachable_core, :lang, :predict]
+  before_action :require_api_token, :except => [:reachable_core, :lang]
   
   def index
     return unless allowed?(@api_user, 'admin_support_actions')
@@ -52,11 +52,14 @@ class Api::WordsController < ApplicationController
     sentence = params['sentence'].to_s.strip
     return api_error(400, {error: "sentence required"}) if sentence.blank?
 
+    return api_error(400, {error: "ai_word_prediction is not enabled for this user"}) unless FeatureFlags.ai_feature_enabled_for?('ai_word_prediction', @api_user)
+    return api_error(403, {error: "parental consent required"}) if FeatureFlags.coppa_blocks_ai_for?(@api_user)
+
     locale = params['locale'] || 'en'
     count = [(params['count'] || 4).to_i, 8].min
 
     require_relative '../../lib/ai_word_predictor' unless defined?(AiWordPredictor)
-    words = AiWordPredictor.predict(sentence: sentence, locale: locale, count: count)
+    words = AiWordPredictor.predict(sentence: sentence, locale: locale, count: count, user: @api_user)
 
     render json: { words: words }
   end

--- a/lib/ai_board_generator.rb
+++ b/lib/ai_board_generator.rb
@@ -33,6 +33,14 @@ module AiBoardGenerator
         return err
       end
 
+      # COPPA Final Rule hard-gate: block under-13 users awaiting parental consent.
+      if FeatureFlags.coppa_blocks_ai_for?(user)
+        err = { words: nil, name: nil, description: nil, error: 'AI features require parental consent for this account' }
+        err.merge!(dev_diag(:coppa_consent_pending,
+          'FeatureFlags.coppa_blocks_ai_for?(user) returned true. The user has settings["coppa"]["pending_parent_consent"] set without a parent_consent_granted_at timestamp.'))
+        return err
+      end
+
       cell_count = rows * columns
 
       # Configure blocklist with user names before scrubbing

--- a/lib/ai_word_predictor.rb
+++ b/lib/ai_word_predictor.rb
@@ -1,25 +1,37 @@
 # frozen_string_literal: true
 
+require_relative 'pii_scrubber'
+
 module AiWordPredictor
-  # Use fast/cheap models — predictions need to feel instant
+  # Use fast/cheap models -- predictions need to feel instant
   DEFAULT_ANTHROPIC_MODEL = 'claude-haiku-4-5-20251001'
   DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash'
 
   # In-memory LRU cache: { "context_key" => { words: [...], ts: Time } }
   CACHE = {}
   CACHE_MAX = 500
-  CACHE_TTL = 1800 # 30 minutes — aggressive caching for free-tier rate limits
+  CACHE_TTL = 1800 # 30 minutes -- aggressive caching for free-tier rate limits
 
   class << self
     # Returns an array of predicted next-word strings (up to `count`).
     # sentence: the words the user has built so far, e.g. "I want to"
     # locale: language code, default "en"
     # count: how many predictions to return (default 4)
-    def predict(sentence:, locale: 'en', count: 4)
+    # user: User object. Required for production calls so we can apply
+    #   the org AI opt-out, the COPPA Final Rule consent gate, and audit
+    #   logging. Pass nil only from offline scripts that supply no user
+    #   data (e.g., the n-gram seed generator).
+    def predict(sentence:, locale: 'en', count: 4, user: nil)
       return [] if sentence.blank?
 
       api_config = resolve_api_config
       return [] if api_config.blank?
+
+      # Org-level AI opt-out and per-user feature flag.
+      return [] if user && !FeatureFlags.ai_feature_enabled_for?('ai_word_prediction', user)
+
+      # COPPA Final Rule hard-gate: block under-13 users awaiting parental consent.
+      return [] if FeatureFlags.coppa_blocks_ai_for?(user)
 
       cache_key = "#{locale}:#{sentence.strip.downcase}"
       cached = CACHE[cache_key]
@@ -27,14 +39,71 @@ module AiWordPredictor
         return cached[:words]
       end
 
-      words = case api_config[:provider]
-              when :claude
-                call_anthropic(api_config, sentence.strip, locale, count)
-              when :gemini
-                call_gemini(api_config, sentence.strip, locale, count)
-              else
-                []
-              end
+      # Configure blocklist with the user's name so it cannot leak verbatim.
+      if user
+        names = []
+        names << user.user_name if user.respond_to?(:user_name) && user.user_name.present?
+        if user.respond_to?(:settings) && user.settings.is_a?(Hash) && user.settings['full_name'].present?
+          names << user.settings['full_name']
+        end
+        PiiScrubber.configure_blocklist(names)
+      end
+
+      # Last-line-of-defense PII scrub on the user-typed sentence.
+      scrub_result = PiiScrubber.redact_for_ai(sentence.strip)
+      scrubbed_sentence = scrub_result[:payload]
+      pii_detected = scrub_result[:pii_found]
+      pii_findings = scrub_result[:findings]
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      provider = api_config[:provider]
+      model = api_config[:model]
+      raw_response = nil
+      success = false
+      error_message = nil
+      tokens_sent = nil
+      tokens_received = nil
+
+      words = begin
+        case provider
+        when :claude
+          response = call_anthropic(api_config, scrubbed_sentence, locale, count)
+          raw_response = extract_content_anthropic(response)
+          tokens_sent = response.usage&.input_tokens if response.respond_to?(:usage)
+          tokens_received = response.usage&.output_tokens if response.respond_to?(:usage)
+          success = true
+          parse_words(raw_response, count)
+        when :gemini
+          response = call_gemini(api_config, scrubbed_sentence, locale, count)
+          raw_response = response.dig('choices', 0, 'message', 'content') || ''
+          tokens_sent = response.dig('usage', 'prompt_tokens')
+          tokens_received = response.dig('usage', 'completion_tokens')
+          success = true
+          parse_words(raw_response, count)
+        else
+          []
+        end
+      rescue => e
+        error_message = "#{e.class}: #{e.message}"
+        Rails.logger.error("[AiWordPredictor] #{error_message}")
+        []
+      end
+
+      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round
+      log_ai_call(
+        provider: provider,
+        model: model,
+        user: user,
+        request_summary: "Word prediction: #{scrubbed_sentence.truncate(200)}",
+        response_summary: raw_response.to_s.truncate(500),
+        tokens_sent: tokens_sent,
+        tokens_received: tokens_received,
+        duration_ms: duration_ms,
+        pii_detected: pii_detected,
+        pii_findings: pii_findings,
+        success: success,
+        error_message: error_message
+      )
 
       # Store in cache, evict oldest if full
       if CACHE.size >= CACHE_MAX
@@ -44,9 +113,6 @@ module AiWordPredictor
       CACHE[cache_key] = { words: words, ts: Time.now }
 
       words
-    rescue => e
-      Rails.logger.error("[AiWordPredictor] #{e.class}: #{e.message}")
-      []
     end
 
     private
@@ -74,14 +140,12 @@ module AiWordPredictor
     def call_anthropic(config, sentence, locale, count)
       require 'anthropic'
       client = Anthropic::Client.new(api_key: config[:api_key])
-      response = client.messages.create(
+      client.messages.create(
         model: config[:model],
         max_tokens: 60,
         system: system_prompt(locale, count),
         messages: [{ role: 'user', content: sentence }]
       )
-      raw = response.dig('content', 0, 'text') || ''
-      parse_words(raw, count)
     end
 
     def call_gemini(config, sentence, locale, count)
@@ -90,7 +154,7 @@ module AiWordPredictor
         access_token: config[:api_key],
         uri_base: 'https://generativelanguage.googleapis.com/v1beta/openai/'
       )
-      response = client.chat(
+      client.chat(
         parameters: {
           model: config[:model],
           messages: [
@@ -101,8 +165,6 @@ module AiWordPredictor
           temperature: 0.3
         }
       )
-      raw = response.dig('choices', 0, 'message', 'content') || ''
-      parse_words(raw, count)
     end
 
     def system_prompt(locale, count)
@@ -117,9 +179,9 @@ module AiWordPredictor
         - Predictions should be contextually appropriate for the sentence
         - Prefer short, high-frequency words that AAC users commonly need
         - Language: #{locale}
-        - No punctuation, no explanations, no numbering — just the words
+        - No punctuation, no explanations, no numbering, just the words
         - If the sentence ends mid-word, complete that word first, then predict next words
-        - ALWAYS return #{count} words, even if the sentence seems complete — suggest continuation words like conjunctions (and, but, because), time words (today, tomorrow, now), or new sentence starters (I, we, can)
+        - ALWAYS return #{count} words, even if the sentence seems complete. Suggest continuation words like conjunctions (and, but, because), time words (today, tomorrow, now), or new sentence starters (I, we, can)
 
         Example input: "I want to"
         Example output: play,go,eat,help
@@ -130,12 +192,42 @@ module AiWordPredictor
     end
 
     def parse_words(raw, count)
-      raw.strip
+      raw.to_s.strip
          .split(/[\s,]+/)
          .map { |w| w.gsub(/[^a-zA-Z'\-]/, '').strip }
          .reject(&:blank?)
          .uniq
          .first(count)
+    end
+
+    def extract_content_anthropic(response)
+      return '' unless response&.respond_to?(:content) && response.content.is_a?(Array)
+      text_blocks = response.content.select { |block| block.respond_to?(:type) && block.type.to_s == 'text' }
+      text_blocks.map { |b| b.respond_to?(:text) ? b.text : b.to_s }.join("\n").strip
+    end
+
+    def log_ai_call(provider:, model:, user:, request_summary:, response_summary:,
+                    tokens_sent: nil, tokens_received: nil, duration_ms: nil,
+                    pii_detected: false, pii_findings: [], success: true, error_message: nil)
+      return unless defined?(AiApiLog)
+      AiApiLog.log_ai_call(
+        provider: provider.to_s,
+        model: model,
+        type: 'word_prediction',
+        user: user,
+        request_summary: request_summary,
+        response_summary: response_summary,
+        tokens_sent: tokens_sent,
+        tokens_received: tokens_received,
+        duration_ms: duration_ms,
+        pii_detected: pii_detected,
+        pii_findings: pii_findings,
+        success: success,
+        error_message: error_message,
+        feature_flag: 'ai_word_prediction'
+      )
+    rescue StandardError => e
+      Rails.logger.warn "AiWordPredictor: failed to log AI API call: #{e.message}"
     end
   end
 end

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -92,4 +92,20 @@ module FeatureFlags
     return false unless ai_enabled_for?(user)
     feature_enabled_for?(feature, user)
   end
+
+  # COPPA Final Rule (16 CFR 312.5) hard-gate. Default ON.
+  # Set COPPA_AI_HARD_GATE=false in env for emergency rollback only.
+  def self.coppa_ai_hard_gate_enabled?
+    ENV['COPPA_AI_HARD_GATE'].to_s.downcase != 'false'
+  end
+
+  # Returns true when AI calls must be blocked for this user because COPPA
+  # parental consent is still pending. Used by every AI call site as a
+  # short-circuit before PiiScrubber and any provider request.
+  def self.coppa_blocks_ai_for?(user)
+    return false unless coppa_ai_hard_gate_enabled?
+    return false unless user
+    return false unless user.respond_to?(:coppa_parental_consent_pending?)
+    user.coppa_parental_consent_pending?
+  end
 end

--- a/spec/controllers/api/words_controller_spec.rb
+++ b/spec/controllers/api/words_controller_spec.rb
@@ -107,4 +107,48 @@ describe Api::WordsController, :type => :controller do
       )
     end
   end
+
+  describe "post 'predict'" do
+    it "should require an api token" do
+      post 'predict', params: { 'sentence' => 'I want to' }
+      assert_missing_token
+    end
+
+    it "should require a sentence" do
+      token_user
+      post 'predict', params: { 'sentence' => '' }
+      assert_error('sentence required')
+    end
+
+    it "should reject when ai_word_prediction is disabled for the user" do
+      token_user
+      allow(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_word_prediction', anything).and_return(false)
+      post 'predict', params: { 'sentence' => 'I want to' }
+      assert_error('ai_word_prediction is not enabled for this user')
+    end
+
+    it "should reject when COPPA gate blocks the user" do
+      token_user
+      allow(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_word_prediction', anything).and_return(true)
+      allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).and_return(true)
+      post 'predict', params: { 'sentence' => 'I want to' }
+      expect(response.status).to eq(403)
+    end
+
+    it "should call AiWordPredictor.predict with the api user" do
+      token_user
+      allow(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_word_prediction', anything).and_return(true)
+      allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).and_return(false)
+      expect(AiWordPredictor).to receive(:predict).with(hash_including(
+        sentence: 'I want to',
+        locale: 'en',
+        count: 4,
+        user: @user
+      )).and_return(%w[play go eat help])
+
+      post 'predict', params: { 'sentence' => 'I want to' }
+      json = assert_success_json
+      expect(json).to eq({ 'words' => %w[play go eat help] })
+    end
+  end
 end

--- a/spec/lib/ai_board_generator_spec.rb
+++ b/spec/lib/ai_board_generator_spec.rb
@@ -58,5 +58,32 @@ describe AiBoardGenerator do
       expect(described_class).to have_received(:call_anthropic).twice
       expect(AiApiLog).to have_received(:log_ai_call).with(hash_including(provider: 'claude', success: false))
     end
+
+    context "COPPA Final Rule hard-gate" do
+      it "returns a parental-consent error when coppa_blocks_ai_for? is true" do
+        u = User.new(settings: { 'coppa' => { 'pending_parent_consent' => true } })
+        allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(u).and_return(true)
+        allow(described_class).to receive(:call_anthropic)
+
+        result = described_class.generate_words(prompt: 'snacks', rows: 2, columns: 2, user: u)
+
+        expect(result[:words]).to eq(nil)
+        expect(result[:error]).to include('parental consent')
+        expect(described_class).not_to have_received(:call_anthropic)
+        expect(AiApiLog).not_to have_received(:log_ai_call)
+      end
+
+      it "proceeds when coppa_blocks_ai_for? is false" do
+        u = User.new(settings: {})
+        allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(u).and_return(false)
+        complete = "WORDS: apple, banana, carrot, drink\nNAME: Snacks\nDESCRIPTION: Snack words."
+        allow(described_class).to receive(:call_anthropic).and_return(anthropic_response(complete))
+
+        result = described_class.generate_words(prompt: 'snacks', rows: 2, columns: 2, user: u)
+
+        expect(result[:words]).to eq(%w[apple banana carrot drink])
+        expect(result[:error]).to eq(nil)
+      end
+    end
   end
 end

--- a/spec/lib/ai_word_predictor_spec.rb
+++ b/spec/lib/ai_word_predictor_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AiWordPredictor do
+  def anthropic_response(text)
+    usage = double('usage', input_tokens: 10, output_tokens: 5)
+    block = double('text_block', type: 'text', text: text)
+    double('anthropic_response', content: [block], usage: usage)
+  end
+
+  around(:each) do |example|
+    old_anthropic = ENV['ANTHROPIC_API_KEY']
+    old_gemini = ENV['GEMINI_API_KEY']
+    old_gate = ENV['COPPA_AI_HARD_GATE']
+    ENV['ANTHROPIC_API_KEY'] = 'test-anthropic-key'
+    ENV.delete('GEMINI_API_KEY')
+    ENV.delete('COPPA_AI_HARD_GATE')
+    described_class::CACHE.clear
+    PiiScrubber.reset_blocklist!
+    example.run
+  ensure
+    ENV['ANTHROPIC_API_KEY'] = old_anthropic
+    ENV['GEMINI_API_KEY'] = old_gemini
+    ENV['COPPA_AI_HARD_GATE'] = old_gate
+    described_class::CACHE.clear
+    PiiScrubber.reset_blocklist!
+  end
+
+  before(:each) do
+    allow(AiApiLog).to receive(:log_ai_call)
+    allow(FeatureFlags).to receive(:ai_feature_enabled_for?).and_return(true)
+  end
+
+  describe ".predict" do
+    it "returns an empty array when sentence is blank" do
+      expect(described_class.predict(sentence: '')).to eq([])
+    end
+
+    it "returns an empty array when no API key is configured" do
+      ENV.delete('ANTHROPIC_API_KEY')
+      ENV.delete('GEMINI_API_KEY')
+      expect(described_class.predict(sentence: 'I want to')).to eq([])
+    end
+
+    it "returns predicted words from Anthropic" do
+      allow(described_class).to receive(:call_anthropic).and_return(anthropic_response('play, go, eat, help'))
+
+      words = described_class.predict(sentence: 'I want to')
+
+      expect(words).to eq(%w[play go eat help])
+      expect(AiApiLog).to have_received(:log_ai_call).with(hash_including(
+        provider: 'claude',
+        type: 'word_prediction',
+        success: true,
+        feature_flag: 'ai_word_prediction'
+      ))
+    end
+
+    it "scrubs PII from the sentence before sending it to the provider" do
+      received_sentence = nil
+      allow(described_class).to receive(:call_anthropic) do |_config, sentence, _locale, _count|
+        received_sentence = sentence
+        anthropic_response('today, and, but, because')
+      end
+
+      described_class.predict(sentence: 'email me at jane@example.com tomorrow')
+
+      expect(received_sentence).to include('[REDACTED_EMAIL]')
+      expect(received_sentence).not_to include('jane@example.com')
+      expect(AiApiLog).to have_received(:log_ai_call).with(hash_including(pii_detected: true))
+    end
+
+    context "feature flag and consent gates" do
+      let(:user) { User.new(settings: {}) }
+
+      it "returns empty when ai_feature_enabled_for? is false" do
+        allow(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_word_prediction', user).and_return(false)
+        allow(described_class).to receive(:call_anthropic)
+
+        result = described_class.predict(sentence: 'I want to', user: user)
+
+        expect(result).to eq([])
+        expect(described_class).not_to have_received(:call_anthropic)
+        expect(AiApiLog).not_to have_received(:log_ai_call)
+      end
+
+      it "returns empty when COPPA hard-gate blocks the user" do
+        allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(user).and_return(true)
+        allow(described_class).to receive(:call_anthropic)
+
+        result = described_class.predict(sentence: 'I want to', user: user)
+
+        expect(result).to eq([])
+        expect(described_class).not_to have_received(:call_anthropic)
+        expect(AiApiLog).not_to have_received(:log_ai_call)
+      end
+    end
+
+    it "logs failure when the provider call raises" do
+      allow(described_class).to receive(:call_anthropic).and_raise(StandardError.new('boom'))
+      allow(Rails.logger).to receive(:error)
+
+      result = described_class.predict(sentence: 'I want to')
+
+      expect(result).to eq([])
+      expect(AiApiLog).to have_received(:log_ai_call).with(hash_including(
+        success: false,
+        error_message: a_string_including('boom')
+      ))
+    end
+  end
+end

--- a/spec/lib/feature_flags_spec.rb
+++ b/spec/lib/feature_flags_spec.rb
@@ -51,4 +51,70 @@ describe FeatureFlags do
       expect(FeatureFlags.user_created_after?(u, 'bacon')).to eq(false)
     end
   end
+
+  describe "coppa_ai_hard_gate_enabled?" do
+    around(:each) do |example|
+      old = ENV['COPPA_AI_HARD_GATE']
+      example.run
+    ensure
+      ENV['COPPA_AI_HARD_GATE'] = old
+    end
+
+    it "defaults to true when env var is unset" do
+      ENV.delete('COPPA_AI_HARD_GATE')
+      expect(FeatureFlags.coppa_ai_hard_gate_enabled?).to eq(true)
+    end
+
+    it "returns true for any value other than 'false'" do
+      ENV['COPPA_AI_HARD_GATE'] = 'true'
+      expect(FeatureFlags.coppa_ai_hard_gate_enabled?).to eq(true)
+      ENV['COPPA_AI_HARD_GATE'] = '1'
+      expect(FeatureFlags.coppa_ai_hard_gate_enabled?).to eq(true)
+    end
+
+    it "returns false only when explicitly set to 'false'" do
+      ENV['COPPA_AI_HARD_GATE'] = 'false'
+      expect(FeatureFlags.coppa_ai_hard_gate_enabled?).to eq(false)
+      ENV['COPPA_AI_HARD_GATE'] = 'FALSE'
+      expect(FeatureFlags.coppa_ai_hard_gate_enabled?).to eq(false)
+    end
+  end
+
+  describe "coppa_blocks_ai_for?" do
+    around(:each) do |example|
+      old = ENV['COPPA_AI_HARD_GATE']
+      ENV.delete('COPPA_AI_HARD_GATE')
+      example.run
+    ensure
+      ENV['COPPA_AI_HARD_GATE'] = old
+    end
+
+    it "returns false when user is nil" do
+      expect(FeatureFlags.coppa_blocks_ai_for?(nil)).to eq(false)
+    end
+
+    it "returns false when user has no coppa settings" do
+      u = User.new(settings: {})
+      expect(FeatureFlags.coppa_blocks_ai_for?(u)).to eq(false)
+    end
+
+    it "returns true when user has pending parental consent" do
+      u = User.new(settings: { 'coppa' => { 'pending_parent_consent' => true } })
+      expect(FeatureFlags.coppa_blocks_ai_for?(u)).to eq(true)
+    end
+
+    it "returns false when consent has been granted" do
+      u = User.new(settings: { 'coppa' => {
+        'pending_parent_consent' => true,
+        'parent_consent_granted_at' => Time.now.utc.iso8601
+      }})
+      expect(FeatureFlags.coppa_blocks_ai_for?(u)).to eq(false)
+    end
+
+    it "returns false when the hard gate is disabled, even with pending consent" do
+      ENV['COPPA_AI_HARD_GATE'] = 'false'
+      u = User.new(settings: { 'coppa' => { 'pending_parent_consent' => true } })
+      expect(FeatureFlags.coppa_blocks_ai_for?(u)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes the two highest-stakes gaps from `docs/legal/COPPA_VERIFICATION_2026-04-26.md`:

- **Item 1c:** `AiBoardGenerator` now short-circuits with a parental-consent error when `FeatureFlags.coppa_blocks_ai_for?(user)` is true. The check sits after the org-level AI opt-out and before `PiiScrubber`, so no prompt is built for a blocked user.
- **Item 1a:** `AiWordPredictor.predict` previously sent the user's in-progress sentence verbatim to Anthropic or Gemini with no auth, no feature flag, no PII scrubbing, and no audit log. It now requires a `user:` keyword, runs the org-level AI opt-out, the COPPA hard-gate, the user-name blocklist, `PiiScrubber.redact_for_ai`, and writes an `AiApiLog` entry on every call. `Api::WordsController#predict` now requires `require_api_token`, checks the feature flag and the COPPA gate, and forwards `@api_user`.

The hard-gate is wired through a new `FeatureFlags.coppa_blocks_ai_for?` helper with a global env-var kill-switch (`COPPA_AI_HARD_GATE`) that defaults to ON. Flipping it to `false` in Render is the emergency rollback path if a school district reports a regression.

## Why this matters

The COPPA Final Rule effective date was 2026-04-22. The audit at `docs/legal/COPPA_VERIFICATION_2026-04-26.md` confirms the running code does not enforce parental consent before AI calls. Penalties are up to \$53,088 per violation, and `AiWordPredictor` was an unauthenticated, unscrubbed, unlogged endpoint reachable on every keystroke.

## Hard rules check

- [x] Branch from `origin/staging`
- [x] Feature flag wraps the new behavior (`COPPA_AI_HARD_GATE` env var, default ON)
- [x] PiiScrubber on every AI call site
- [x] No em dashes
- [x] No plaintext secrets
- [x] No new env vars need to be set in Render at deploy time (the env var is optional and defaults to enabled)

## Test plan

- [x] Ruby syntax check passes on every changed file
- [x] CI runs `spec/lib/feature_flags_spec.rb` (covers env-var kill-switch and per-user gate logic)
- [x] CI runs `spec/lib/ai_board_generator_spec.rb` (COPPA short-circuit cases)
- [x] CI runs `spec/lib/ai_word_predictor_spec.rb` (blank input, no key, success, PII scrub, gates, failure logging)
- [x] CI runs `spec/controllers/api/words_controller_spec.rb` (auth requirement, feature flag and consent gates, user pass-through)

Local rspec did not run because the WSL worktree could not reach the test Postgres instance. CI is the verification surface.

## Rollout

1. Merge to `staging` first.
2. Verify in Render staging logs that `AiApiLog` entries are landing for `request_type='word_prediction'`.
3. Manually verify a COPPA-pending test account receives the parental-consent error from both `AiBoardGenerator` and the `predict` endpoint.
4. Promote staging to main.
5. If a regression hits production, set `COPPA_AI_HARD_GATE=false` in Render to disable the hard-gate while keeping the PII scrub and audit log in place.

## Cross-reference

- Audit doc: `docs/legal/COPPA_VERIFICATION_2026-04-26.md`
- Memory: `~/.claude/projects/-home-scotw/memory/project_coppa_final_rule_2026.md`
- Companion PRs (parallel work): `compliance/coppa-observability-scrub` (PR 2), `compliance/coppa-retention-housekeeping` (PR 3)

Reviewer: Melissa per CODEOWNERS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)