### PR TITLE
compliance(coppa): scrub under-13 PII from Bugsnag and NewRelic

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,6 +1,134 @@
 require_relative '../../lib/pii_scrubber'
 require 'bugsnag'
 
+# COPPA Final Rule (effective 2026-04-22) prohibits silent transmission of
+# child data to third-party SDKs. Bugsnag-Rack auto-captures user_id, IP,
+# request body, headers, and cookies for every error. This module strips
+# that data when the affected user is COPPA-pending (parental consent not
+# yet granted). See docs/legal/COPPA_VERIFICATION_2026-04-26.md item 5a.
+module CoppaBugsnagScrub
+  REDACTED = '[REDACTED]'.freeze
+  REDACTED_ID = '[REDACTED_ID]'.freeze
+  REDACTED_IP = '[REDACTED_IP]'.freeze
+
+  SENSITIVE_HEADER_KEYS = %w[
+    Cookie cookie
+    Set-Cookie set-cookie
+    Authorization authorization
+    X-Forwarded-For x-forwarded-for
+    Forwarded forwarded
+    X-Real-IP x-real-ip
+  ].freeze
+
+  REQUEST_IP_KEYS = %i[clientIp client_ip remoteAddr remote_addr].freeze
+  REQUEST_BODY_KEYS = %i[params body query_parameters request_parameters form_params].freeze
+
+  module_function
+
+  def call(report)
+    return unless report
+    user = lookup_user(report.respond_to?(:user) ? report.user : nil)
+    return unless child_user?(user)
+    scrub!(report)
+  rescue StandardError
+    # Never let a scrub failure raise out of bugsnag delivery.
+    nil
+  end
+
+  def child_user?(user)
+    return false unless user
+    user.respond_to?(:coppa_parental_consent_pending?) && user.coppa_parental_consent_pending?
+  rescue StandardError
+    false
+  end
+
+  def lookup_user(user_hash)
+    return nil unless user_hash.is_a?(Hash)
+    user_id = user_hash[:id] || user_hash['id']
+    return nil if user_id.nil? || user_id.to_s.empty?
+    User.where(id: user_id).first
+  rescue StandardError
+    nil
+  end
+
+  def scrub!(report)
+    report.user = {} if report.respond_to?(:user=)
+    if report.respond_to?(:meta_data) && report.meta_data.is_a?(Hash)
+      scrub_meta_data!(report.meta_data)
+    end
+    if report.respond_to?(:context=) && report.respond_to?(:context)
+      scrubbed_ctx = scrub_context(report.context)
+      report.context = scrubbed_ctx unless scrubbed_ctx.equal?(report.context)
+    end
+  end
+
+  def scrub_meta_data!(meta)
+    request = fetch_tab(meta, :request)
+    scrub_request!(request) if request.is_a?(Hash)
+
+    %i[headers cookies session].each do |tab_name|
+      tab = fetch_tab(meta, tab_name)
+      scrub_headers!(tab) if tab.is_a?(Hash)
+    end
+  end
+
+  def scrub_request!(request)
+    REQUEST_IP_KEYS.each { |k| set_if_present(request, k, REDACTED_IP) }
+    REQUEST_BODY_KEYS.each { |k| set_if_present(request, k, REDACTED) }
+    set_if_present(request, :referer, REDACTED)
+
+    %i[url path].each do |key|
+      val = fetch(request, key)
+      next unless val.is_a?(String)
+      assign(request, key, redact_url(val))
+    end
+  end
+
+  def scrub_headers!(headers)
+    headers.keys.each do |k|
+      headers[k] = REDACTED if SENSITIVE_HEADER_KEYS.include?(k.to_s)
+    end
+  end
+
+  def scrub_context(ctx)
+    return ctx unless ctx.is_a?(String)
+    return REDACTED if ctx.include?('@')
+    return REDACTED if ctx.match?(PiiScrubber::GLOBAL_ID_PATTERN)
+    ctx
+  end
+
+  def redact_url(url)
+    return url unless url.is_a?(String)
+    no_query = url.split('?', 2).first
+    no_query.gsub(PiiScrubber::GLOBAL_ID_PATTERN, REDACTED_ID)
+  end
+
+  def fetch_tab(meta, name)
+    meta[name] || meta[name.to_s]
+  end
+
+  def fetch(hash, key)
+    hash[key] || hash[key.to_s]
+  end
+
+  def set_if_present(hash, key, value)
+    if hash.key?(key)
+      hash[key] = value
+    elsif hash.key?(key.to_s)
+      hash[key.to_s] = value
+    end
+  end
+
+  def assign(hash, key, value)
+    if hash.key?(key)
+      hash[key] = value
+    elsif hash.key?(key.to_s)
+      hash[key.to_s] = value
+    end
+  end
+end
+
 Bugsnag.configure do |config|
   config.meta_data_filters += PiiScrubber::IDENTITY_STRING_KEYS + ['User-Agent', 'X-Device-Id', 'X-Forwarded-For', 'clientIp', 'client_ip', 'params', 'request.clientIp', 'request.params']
+  config.add_on_error(proc { |report| CoppaBugsnagScrub.call(report) })
 end

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -111,6 +111,30 @@ common: &default_settings
   #     ex: ignored_params: credit_card, ssn, password
   capture_params: false
 
+  # COPPA Final Rule scrub: NewRelic auto-captures request parameters,
+  # request headers, and any custom attributes the app sets. The agent
+  # cannot filter per-user, so these globs apply to every request.
+  # Over-filtering is safe; under-filtering risks a per-violation FTC
+  # penalty up to $53,088. See docs/legal/COPPA_VERIFICATION_2026-04-26.md
+  # item 5b.
+  attributes:
+    exclude:
+      - request.parameters.*
+      - request.headers.cookie
+      - request.headers.authorization
+      - request.headers.referer
+      - request.headers.x-forwarded-for
+      - request.headers.x_forwarded_for
+      - request.headers.forwarded
+      - request.headers.x-real-ip
+      - http.request.headers.cookie
+      - http.request.headers.authorization
+      - http.request.headers.referer
+      - user.*
+      - user_id
+      - global_id
+      - device_id
+
   # Transaction tracer captures deep information about slow
   # transactions and sends this to the New Relic service once a
   # minute. Included in the transaction is the exact call sequence of

--- a/spec/initializers/bugsnag_spec.rb
+++ b/spec/initializers/bugsnag_spec.rb
@@ -1,0 +1,197 @@
+require 'spec_helper'
+
+describe CoppaBugsnagScrub do
+  # Stand-in for Bugsnag::Report. Reproduces the surface the scrubber
+  # touches: user, meta_data, context. No network, no Bugsnag boot.
+  class FakeReport
+    attr_accessor :user, :meta_data, :context
+
+    def initialize(user: nil, meta_data: {}, context: nil)
+      @user = user
+      @meta_data = meta_data
+      @context = context
+    end
+  end
+
+  let(:child_user) { double('User', id: 101, coppa_parental_consent_pending?: true) }
+  let(:adult_user) { double('User', id: 202, coppa_parental_consent_pending?: false) }
+
+  before do
+    allow(User).to receive(:where).with(id: child_user.id).and_return(double(first: child_user))
+    allow(User).to receive(:where).with(id: adult_user.id).and_return(double(first: adult_user))
+    allow(User).to receive(:where).with(id: 0).and_return(double(first: nil))
+  end
+
+  let(:request_meta) do
+    {
+      request: {
+        url: 'https://app.lingolinq.com/api/v1/words/predict?token=abc',
+        path: '/api/v1/users/1_2/words/predict',
+        clientIp: '203.0.113.42',
+        params: { sentence: 'i want juice', user_id: '1_2' },
+        body: { sentence: 'i want juice' },
+        referer: 'https://app.lingolinq.com/users/1_2'
+      },
+      headers: {
+        'Cookie' => 'session=secret',
+        'Authorization' => 'Bearer token-xyz',
+        'X-Forwarded-For' => '203.0.113.42',
+        'User-Agent' => 'Mozilla/5.0'
+      },
+      cookies: {
+        'Cookie' => 'session=secret'
+      }
+    }
+  end
+
+  let(:child_user_hash) { { id: child_user.id, email: 'parent@example.com', name: 'Kid' } }
+  let(:adult_user_hash) { { id: adult_user.id, email: 'adult@example.com' } }
+
+  describe '.call' do
+    context 'when the affected user is COPPA-pending' do
+      it 'clears the user identity hash' do
+        report = FakeReport.new(user: child_user_hash, meta_data: request_meta)
+        described_class.call(report)
+        expect(report.user).to eq({})
+      end
+
+      it 'redacts client IP, body, params, and referer in the request tab' do
+        report = FakeReport.new(user: child_user_hash, meta_data: request_meta)
+        described_class.call(report)
+
+        req = report.meta_data[:request]
+        expect(req[:clientIp]).to eq('[REDACTED_IP]')
+        expect(req[:params]).to eq('[REDACTED]')
+        expect(req[:body]).to eq('[REDACTED]')
+        expect(req[:referer]).to eq('[REDACTED]')
+      end
+
+      it 'strips query strings and redacts global_id segments from urls and paths' do
+        report = FakeReport.new(user: child_user_hash, meta_data: request_meta)
+        described_class.call(report)
+
+        req = report.meta_data[:request]
+        expect(req[:url]).not_to include('token=abc')
+        expect(req[:url]).not_to include('1_2')
+        expect(req[:path]).to include('[REDACTED_ID]')
+        expect(req[:path]).not_to include('1_2')
+      end
+
+      it 'redacts sensitive headers in the headers tab' do
+        report = FakeReport.new(user: child_user_hash, meta_data: request_meta)
+        described_class.call(report)
+
+        headers = report.meta_data[:headers]
+        expect(headers['Cookie']).to eq('[REDACTED]')
+        expect(headers['Authorization']).to eq('[REDACTED]')
+        expect(headers['X-Forwarded-For']).to eq('[REDACTED]')
+        expect(headers['User-Agent']).to eq('Mozilla/5.0')
+      end
+
+      it 'redacts sensitive headers in the cookies tab' do
+        report = FakeReport.new(user: child_user_hash, meta_data: request_meta)
+        described_class.call(report)
+        expect(report.meta_data[:cookies]['Cookie']).to eq('[REDACTED]')
+      end
+
+      it 'redacts context when it contains a global_id' do
+        report = FakeReport.new(user: child_user_hash, meta_data: {}, context: 'users#show 1_2')
+        described_class.call(report)
+        expect(report.context).to eq('[REDACTED]')
+      end
+
+      it 'redacts context when it contains an email-style segment' do
+        report = FakeReport.new(user: child_user_hash, meta_data: {}, context: 'users#show kid@example.com')
+        described_class.call(report)
+        expect(report.context).to eq('[REDACTED]')
+      end
+
+      it 'leaves a plain controller#action context alone' do
+        report = FakeReport.new(user: child_user_hash, meta_data: {}, context: 'users#show')
+        described_class.call(report)
+        expect(report.context).to eq('users#show')
+      end
+
+      it 'tolerates string-keyed meta_data tabs' do
+        meta = {
+          'request' => { 'clientIp' => '203.0.113.42', 'params' => { 'sentence' => 'hi' } },
+          'headers' => { 'Cookie' => 'session=secret' }
+        }
+        report = FakeReport.new(user: child_user_hash, meta_data: meta)
+        described_class.call(report)
+        expect(report.meta_data['request']['clientIp']).to eq('[REDACTED_IP]')
+        expect(report.meta_data['request']['params']).to eq('[REDACTED]')
+        expect(report.meta_data['headers']['Cookie']).to eq('[REDACTED]')
+      end
+    end
+
+    context 'when the affected user is not COPPA-pending' do
+      it 'leaves the report payload intact' do
+        report = FakeReport.new(user: adult_user_hash, meta_data: request_meta.deep_dup, context: 'users#show')
+
+        described_class.call(report)
+
+        expect(report.user).to eq(adult_user_hash)
+        expect(report.meta_data[:request][:clientIp]).to eq('203.0.113.42')
+        expect(report.meta_data[:request][:body]).to eq({ sentence: 'i want juice' })
+        expect(report.meta_data[:headers]['Cookie']).to eq('session=secret')
+        expect(report.context).to eq('users#show')
+      end
+    end
+
+    context 'when the report has no user' do
+      it 'is a no-op when user is nil' do
+        report = FakeReport.new(user: nil, meta_data: request_meta.deep_dup)
+        described_class.call(report)
+        expect(report.meta_data[:request][:clientIp]).to eq('203.0.113.42')
+      end
+
+      it 'is a no-op when the user hash has no id' do
+        report = FakeReport.new(user: { email: 'nobody@example.com' }, meta_data: request_meta.deep_dup)
+        described_class.call(report)
+        expect(report.meta_data[:request][:clientIp]).to eq('203.0.113.42')
+      end
+
+      it 'is a no-op when the user_id does not match a row' do
+        report = FakeReport.new(user: { id: 0 }, meta_data: request_meta.deep_dup)
+        described_class.call(report)
+        expect(report.meta_data[:request][:clientIp]).to eq('203.0.113.42')
+      end
+    end
+
+    context 'failure tolerance' do
+      it 'swallows errors so bugsnag delivery is never blocked' do
+        report = FakeReport.new(user: child_user_hash, meta_data: request_meta)
+        allow(described_class).to receive(:scrub!).and_raise(StandardError, 'boom')
+        expect { described_class.call(report) }.not_to raise_error
+      end
+
+      it 'swallows database errors during user lookup' do
+        allow(User).to receive(:where).and_raise(ActiveRecord::StatementInvalid, 'db down')
+        report = FakeReport.new(user: child_user_hash, meta_data: request_meta.deep_dup)
+        expect { described_class.call(report) }.not_to raise_error
+        expect(report.meta_data[:request][:clientIp]).to eq('203.0.113.42')
+      end
+    end
+  end
+
+  describe '.redact_url' do
+    it 'drops the query string' do
+      url = 'https://app.lingolinq.com/api/v1/words/predict?token=abc&user=1_2'
+      expect(described_class.redact_url(url)).to eq('https://app.lingolinq.com/api/v1/words/predict')
+    end
+
+    it 'redacts global_id segments inside the path' do
+      url = 'https://app.lingolinq.com/api/v1/users/1_2/boards/3_4'
+      result = described_class.redact_url(url)
+      expect(result).to include('[REDACTED_ID]')
+      expect(result).not_to include('1_2')
+      expect(result).not_to include('3_4')
+    end
+
+    it 'returns non-string input unchanged' do
+      expect(described_class.redact_url(nil)).to be_nil
+      expect(described_class.redact_url(42)).to eq(42)
+    end
+  end
+end

--- a/spec/initializers/newrelic_yml_spec.rb
+++ b/spec/initializers/newrelic_yml_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'yaml'
+require 'erb'
+
+describe 'config/newrelic.yml COPPA attribute filters' do
+  let(:config) do
+    raw = File.read(Rails.root.join('config', 'newrelic.yml'))
+    rendered = ERB.new(raw).result
+    YAML.safe_load(rendered, aliases: true)
+  end
+
+  let(:excludes) { config.fetch('common').fetch('attributes').fetch('exclude') }
+
+  it 'parses as valid yaml' do
+    expect(config).to be_a(Hash)
+  end
+
+  it 'declares an attributes:exclude block in common defaults' do
+    expect(config['common']).to have_key('attributes')
+    expect(config['common']['attributes']).to have_key('exclude')
+    expect(excludes).to be_an(Array)
+  end
+
+  it 'filters all request parameters' do
+    expect(excludes).to include('request.parameters.*')
+  end
+
+  it 'filters request headers that can carry session or auth identity' do
+    expect(excludes).to include(
+      'request.headers.cookie',
+      'request.headers.authorization',
+      'request.headers.referer'
+    )
+  end
+
+  it 'filters forwarded-for header variants that leak client IP' do
+    expect(excludes).to include('request.headers.x-forwarded-for')
+    expect(excludes).to include('request.headers.x_forwarded_for')
+  end
+
+  it 'filters user identity custom attribute keys' do
+    expect(excludes).to include('user.*', 'user_id', 'global_id')
+  end
+
+  it 'inherits the filter into every named environment via yaml anchor' do
+    %w[development test production staging].each do |env|
+      expect(config[env]).to be_a(Hash), "expected #{env} env to be defined"
+      expect(config[env]['attributes']['exclude']).to include('request.parameters.*')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two COPPA Final Rule quick wins (effective 2026-04-22) covering items **5a** and **5b** from the COPPA verification audit. Both are config / initializer scrubs only, no model changes, no feature flag.

Audit doc lives in PR #224 (parent doc PR, will land separately on staging). Stable link to the items:

https://github.com/lingolinq/LingoLinq-AAC/blob/compliance/coppa-final-rule-audit-2026-04-27/docs/legal/COPPA_VERIFICATION_2026-04-26.md

### Item 5a: Bugsnag

`config/initializers/bugsnag.rb` adds a `CoppaBugsnagScrub` module wired through `config.add_on_error`. When the affected user has `settings['coppa']['pending_parent_consent']` set and no `parent_consent_granted_at` (i.e. `User#coppa_parental_consent_pending?` is true at `app/models/user.rb:370`), the callback:

- Clears `event.user` (drops id, email, name)
- Redacts `clientIp`, `body`, `params`, `query_parameters`, `request_parameters`, `form_params`, and `referer` in the `request` meta tab
- Redacts `Cookie`, `Set-Cookie`, `Authorization`, `X-Forwarded-For` (and `Forwarded`, `X-Real-IP` variants) in the `headers` and `cookies` tabs
- Strips query strings from `url` and `path`, and replaces global_id segments with `[REDACTED_ID]`
- Redacts `context` if it contains an `@` or a global_id pattern

Error class, message, stack frames, app version, release stage, and severity all pass through unchanged. Adult users and anonymous reports are not modified.

### Item 5b: NewRelic

`config/newrelic.yml` adds an `attributes:exclude` block under `common: &default_settings`. The NewRelic Ruby agent cannot filter per-user from yaml, so the conservative read is to over-filter for every user. Over-filtering is safe; under-filtering risks the per-violation $53,088 penalty.

Excluded attributes:
- `request.parameters.*` (covers `/api/v1/words/predict` body and any other route parameter)
- `request.headers.cookie`, `authorization`, `referer`, `x-forwarded-for`, `x_forwarded_for`, `forwarded`, `x-real-ip`
- `http.request.headers.cookie`, `authorization`, `referer` (newer agent key namespace)
- `user.*`, `user_id`, `global_id`, `device_id`

The yaml anchor propagates the exclude block to `development`, `test`, `production`, and `staging`.

## Test plan

- [x] `bundle exec rspec spec/initializers/bugsnag_spec.rb spec/initializers/newrelic_yml_spec.rb` (25 examples, 0 failures)
- [x] Bugsnag spec covers: child user (full scrub across user, request, headers, cookies, url, path, context, string-keyed tabs), adult user (untouched), no user / no id / unknown id (no-op), `scrub!` raise (swallowed), `User.where` raise (swallowed)
- [x] NewRelic spec covers: yaml parses, `attributes:exclude` exists in common, every named env inherits via anchor, all required filter keys are present
- [x] Manual: `ruby -c config/initializers/bugsnag.rb` syntax OK
- [x] Manual: `YAML.safe_load` of `config/newrelic.yml` parses cleanly with aliases
- [ ] Reviewer to confirm no further request fields warrant scrubbing in the audit doc

## Out of scope

- `User#under_13?` (parallel PR thread; using `coppa_parental_consent_pending?` inline as instructed)
- Any model changes
- Secret rotation
- Render env var sync (no new env vars introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)