### PR TITLE
test(logs_controller): pin event timestamps to fix flaky spec

### DIFF
--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -1117,10 +1117,12 @@ describe Api::LogsController, :type => :controller do
 
     it 'should return events data if no encryption header sent' do
       token_user
+      event1_ts = 4.seconds.ago.to_i
+      event2_ts = 3.seconds.ago.to_i
       log = LogSession.process_new({
         :events => [
-          {'timestamp' => 4.seconds.ago.to_i, 'type' => 'button', 'button' => {'label' => 'ok', 'board' => {'id' => '1_1'}}},
-          {'timestamp' => 3.seconds.ago.to_i, 'type' => 'button', 'button' => {'label' => 'never mind', 'board' => {'id' => '1_1'}}}
+          {'timestamp' => event1_ts, 'type' => 'button', 'button' => {'label' => 'ok', 'board' => {'id' => '1_1'}}},
+          {'timestamp' => event2_ts, 'type' => 'button', 'button' => {'label' => 'never mind', 'board' => {'id' => '1_1'}}}
         ]
       }, {:user => @user, :device => @device, :author => @user})
       get :show, params: {:id => log.global_id}
@@ -1130,13 +1132,13 @@ describe Api::LogsController, :type => :controller do
         "parts_of_speech"=>{"types"=>["other"]},
         "spoken"=>false,
         "summary"=>"ok",
-        "timestamp"=>4.seconds.ago.to_i,
+        "timestamp"=>event1_ts.to_f,
         "type"=>"button"},
       {"id"=>2,
         "parts_of_speech"=>{"types"=>["other"]},
         "spoken"=>false,
         "summary"=>"never mind",
-        "timestamp"=>3.seconds.ago.to_i,
+        "timestamp"=>event2_ts.to_f,
         "type"=>"button"
       }])
       expect(json['log']['data_url']).to eq(nil)


### PR DESCRIPTION
## Summary

Fixes the timestamp-drift + type-mismatch flake in \`spec/controllers/api/logs_controller_spec.rb:1118\` (\"should return events data if no encryption header sent\"). The test surfaced on the staging CI run for PR #222 (run 25029553351) but is unrelated to PR #222's contents.

## What was wrong

\`4.seconds.ago.to_i\` was evaluated twice -- once at fixture creation, once at expectation -- so on a slow runner the two calls fell into different seconds. The test also asserted Integer timestamps, but \`LogSession\` serializes them as Float, so strict \`eq\` would fail even without the drift.

## What changed

- Captured \`event1_ts\` and \`event2_ts\` once and reused them in both fixture and expectation
- Cast the expected timestamp to \`.to_f\` to match the model's serialization

## Hard rules check

- [x] Branch from \`origin/staging\`
- [x] No em dashes
- [x] No plaintext secrets
- [x] Test-only change, no behavior change

## Test plan

- [ ] CI runs the modified spec and it passes consistently across at least 3 runs
- [ ] No other specs in \`logs_controller_spec.rb\` regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)