### PR TITLE
feat(api): internal daily AiApiLog summary endpoint for n8n digest

### DIFF
--- a/app/controllers/api/internal/ai_api_logs_controller.rb
+++ b/app/controllers/api/internal/ai_api_logs_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Internal, machine-to-machine endpoint that exposes a daily rollup of
+# AiApiLog activity for the daily-ai-cost-pii-digest n8n workflow.
+#
+# Auth: shared-secret header `X-Internal-Token` matched against
+# ENV['INTERNAL_API_TOKEN'] using a constant-time comparison. The endpoint
+# returns no PII -- pii_findings are already redacted at write time by
+# PiiScrubber -- but the rollup itself is operationally sensitive so the
+# token is required.
+class Api::Internal::AiApiLogsController < ApplicationController
+  skip_before_action :verify_authenticity_token, raise: false
+  skip_before_action :check_api_token, raise: false
+
+  before_action :require_internal_token
+
+  def daily_summary
+    date =
+      if params[:date].present?
+        begin
+          Date.parse(params[:date])
+        rescue ArgumentError
+          return render(json: { error: 'invalid date; use YYYY-MM-DD' }, status: :bad_request)
+        end
+      else
+        Date.current - 1
+      end
+
+    render json: AiApiLog.daily_summary(date)
+  end
+
+  private
+
+  def require_internal_token
+    expected = ENV['INTERNAL_API_TOKEN'].to_s
+    if expected.blank?
+      render json: { error: 'internal API not configured' }, status: :service_unavailable
+      return
+    end
+
+    provided = request.headers['X-Internal-Token'].to_s
+    expected_hash = Digest::SHA256.hexdigest(expected)
+    provided_hash = Digest::SHA256.hexdigest(provided)
+    unless ActiveSupport::SecurityUtils.fixed_length_secure_compare(expected_hash, provided_hash)
+      render json: { error: 'unauthorized' }, status: :unauthorized
+      false
+    end
+  end
+end

--- a/app/models/ai_api_log.rb
+++ b/app/models/ai_api_log.rb
@@ -100,6 +100,58 @@ class AiApiLog < ApplicationRecord
     }
   end
 
+  # Returns a single-day rollup suitable for the daily AI cost + PII digest
+  # consumed by the n8n daily-ai-cost-pii-digest workflow.
+  #
+  # Provider breakdowns include token totals so n8n can cross-check against
+  # the upstream Anthropic / OpenAI / Gemini billing APIs and flag drift.
+  # PII findings are already redacted by PiiScrubber before persistence, so
+  # surfacing them here is safe.
+  def self.daily_summary(date = Date.current - 1)
+    day_start = date.beginning_of_day
+    day_end = date.end_of_day
+    scope = where(created_at: day_start..day_end)
+
+    pii_rows = scope.with_pii_detected.order(created_at: :asc).limit(50)
+
+    {
+      date: date.iso8601,
+      total_calls: scope.count,
+      total_failures: scope.where(success: false).count,
+      total_pii_detected: scope.where(pii_detected: true).count,
+      total_tokens_sent: scope.sum(:tokens_sent).to_i,
+      total_tokens_received: scope.sum(:tokens_received).to_i,
+      avg_duration_ms: scope.average(:duration_ms).to_f.round(1),
+      by_provider: scope.group(:ai_provider).pluck(
+        :ai_provider,
+        Arel.sql('COUNT(*)'),
+        Arel.sql('COALESCE(SUM(tokens_sent), 0)'),
+        Arel.sql('COALESCE(SUM(tokens_received), 0)'),
+        Arel.sql('SUM(CASE WHEN success = false THEN 1 ELSE 0 END)'),
+        Arel.sql('SUM(CASE WHEN pii_detected = true THEN 1 ELSE 0 END)')
+      ).map { |provider, calls, sent, received, failures, pii|
+        {
+          provider: provider,
+          calls: calls,
+          tokens_sent: sent.to_i,
+          tokens_received: received.to_i,
+          failures: failures.to_i,
+          pii_detected: pii.to_i
+        }
+      },
+      by_request_type: scope.group(:request_type).count,
+      pii_samples: pii_rows.map { |row|
+        {
+          id: row.id,
+          provider: row.ai_provider,
+          request_type: row.request_type,
+          findings: row.send(:parsed_pii_findings),
+          created_at: row.created_at.iso8601
+        }
+      }
+    }
+  end
+
   # Redacts IP addresses on records older than the specified number of days.
   # Supports data minimization requirements (e.g., GDPR, COPPA).
   # Records whose ip_address is already nil or '[REDACTED]' are skipped.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,13 @@ LingoLinq::Application.routes.draw do
     namespace :v1 do
       post 'csp-reports' => 'csp_reports#create'
     end
+
+    # Internal, machine-to-machine endpoints. Auth is a shared-secret header
+    # (X-Internal-Token), not a user session, so these are mounted outside the
+    # legacy api/v1 scope to keep the security boundary obvious.
+    namespace :internal do
+      get 'ai_api_logs/daily_summary' => 'ai_api_logs#daily_summary'
+    end
   end
 
   scope 'api/v1', module: 'api' do

--- a/spec/controllers/api/internal/ai_api_logs_controller_spec.rb
+++ b/spec/controllers/api/internal/ai_api_logs_controller_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe Api::Internal::AiApiLogsController, :type => :controller do
+  let(:token) { 'test-internal-token-abc123' }
+
+  before do
+    @prev_token = ENV['INTERNAL_API_TOKEN']
+    ENV['INTERNAL_API_TOKEN'] = token
+  end
+
+  after do
+    ENV['INTERNAL_API_TOKEN'] = @prev_token
+  end
+
+  describe 'GET daily_summary' do
+    it 'returns 401 without the token header' do
+      get :daily_summary
+      expect(response.status).to eq(401)
+      expect(JSON.parse(response.body)['error']).to eq('unauthorized')
+    end
+
+    it 'returns 401 with a wrong token' do
+      request.headers['X-Internal-Token'] = 'nope'
+      get :daily_summary
+      expect(response.status).to eq(401)
+    end
+
+    it 'returns 503 if INTERNAL_API_TOKEN is not configured' do
+      ENV['INTERNAL_API_TOKEN'] = nil
+      request.headers['X-Internal-Token'] = 'anything'
+      get :daily_summary
+      expect(response.status).to eq(503)
+    end
+
+    it 'returns 200 and yesterday\'s rollup with the right token' do
+      yesterday = Date.current - 1
+      log = AiApiLog.create!(
+        ai_provider: 'claude',
+        request_type: 'board_generation',
+        tokens_sent: 100,
+        tokens_received: 200,
+        success: true
+      )
+      log.update_column(:created_at, yesterday.beginning_of_day + 2.hours)
+
+      request.headers['X-Internal-Token'] = token
+      get :daily_summary
+
+      expect(response.status).to eq(200)
+      body = JSON.parse(response.body)
+      expect(body['date']).to eq(yesterday.iso8601)
+      expect(body['total_calls']).to eq(1)
+      expect(body['total_tokens_sent']).to eq(100)
+      expect(body['by_provider'].length).to eq(1)
+      expect(body['by_provider'].first['provider']).to eq('claude')
+    end
+
+    it 'accepts a date param' do
+      target = Date.current - 5
+      log = AiApiLog.create!(ai_provider: 'gemini', request_type: 'word_suggestion')
+      log.update_column(:created_at, target.beginning_of_day + 1.hour)
+
+      request.headers['X-Internal-Token'] = token
+      get :daily_summary, params: { date: target.iso8601 }
+
+      expect(response.status).to eq(200)
+      body = JSON.parse(response.body)
+      expect(body['date']).to eq(target.iso8601)
+      expect(body['total_calls']).to eq(1)
+    end
+
+    it 'returns 400 for an invalid date' do
+      request.headers['X-Internal-Token'] = token
+      get :daily_summary, params: { date: 'not-a-date' }
+      expect(response.status).to eq(400)
+    end
+  end
+end

--- a/spec/models/ai_api_log_spec.rb
+++ b/spec/models/ai_api_log_spec.rb
@@ -225,6 +225,75 @@ describe AiApiLog, :type => :model do
     end
   end
 
+  describe "daily_summary" do
+    let(:target_date) { Date.current - 1 }
+
+    def make_log(attrs = {})
+      log = AiApiLog.create!({
+        ai_provider: 'claude',
+        request_type: 'board_generation',
+        tokens_sent: 50,
+        tokens_received: 75,
+        duration_ms: 1000,
+        success: true
+      }.merge(attrs))
+      log.update_column(:created_at, target_date.beginning_of_day + 4.hours)
+      log
+    end
+
+    it "returns the date as an ISO string" do
+      summary = AiApiLog.daily_summary(target_date)
+      expect(summary[:date]).to eq(target_date.iso8601)
+    end
+
+    it "totals calls, tokens, and failures for the day" do
+      make_log(tokens_sent: 100, tokens_received: 200, success: true)
+      make_log(tokens_sent: 50, tokens_received: 75, success: false)
+
+      summary = AiApiLog.daily_summary(target_date)
+      expect(summary[:total_calls]).to eq(2)
+      expect(summary[:total_failures]).to eq(1)
+      expect(summary[:total_tokens_sent]).to eq(150)
+      expect(summary[:total_tokens_received]).to eq(275)
+    end
+
+    it "groups token usage by provider" do
+      make_log(ai_provider: 'claude', tokens_sent: 100, tokens_received: 200)
+      make_log(ai_provider: 'gemini', tokens_sent: 30, tokens_received: 40)
+
+      summary = AiApiLog.daily_summary(target_date)
+      providers = summary[:by_provider].index_by { |row| row[:provider] }
+      expect(providers['claude'][:tokens_sent]).to eq(100)
+      expect(providers['gemini'][:tokens_received]).to eq(40)
+    end
+
+    it "counts pii_detected rows and includes findings samples" do
+      make_log(pii_detected: false)
+      make_log(
+        pii_detected: true,
+        pii_findings: [{ type: 'email', value: 'a****m', position: 5 }].to_json
+      )
+
+      summary = AiApiLog.daily_summary(target_date)
+      expect(summary[:total_pii_detected]).to eq(1)
+      expect(summary[:pii_samples].length).to eq(1)
+      expect(summary[:pii_samples].first[:findings].first['type']).to eq('email')
+    end
+
+    it "ignores rows from other days" do
+      log = AiApiLog.create!(ai_provider: 'claude', request_type: 'board_generation')
+      log.update_column(:created_at, (target_date - 3).beginning_of_day)
+
+      summary = AiApiLog.daily_summary(target_date)
+      expect(summary[:total_calls]).to eq(0)
+    end
+
+    it "defaults to yesterday when no date is given" do
+      summary = AiApiLog.daily_summary
+      expect(summary[:date]).to eq((Date.current - 1).iso8601)
+    end
+  end
+
   describe "redact_old_ip_addresses!" do
     it "should replace ip_address on records older than 90 days with [REDACTED]" do
       old_log = AiApiLog.create!(ai_provider: 'claude', request_type: 'board_generation', ip_address: '10.0.0.1')


### PR DESCRIPTION
## Summary

Adds `GET /api/internal/ai_api_logs/daily_summary`, the data source for the new n8n `daily-ai-cost-pii-digest` workflow (Item #2 of the automation roadmap). The endpoint returns yesterday's per-provider AI call rollup plus PII flag counts and pre-redacted findings samples, gated by a shared-secret `X-Internal-Token` header.

## Why

Item #2 from the automation roadmap (\`/home/scotw/.claude/plans/yes-search-the-web-inherited-fairy.md\`):
- Two real risk gaps in one workflow: runaway AI cost (cross-checkable against Anthropic/OpenAI/Gemini billing APIs) and PII leakage to external APIs.
- Original idea was \"re-run scrubber on yesterday's logs\"; that's impossible because raw payloads are intentionally not stored. Reframed as: surface what PiiScrubber already flagged.
- Adversarial check from the plan: \"Why a new endpoint and not direct DB query from n8n? Because the n8n service shouldn't have prod DB credentials -- attack surface and cred-rotation overhead. HTTP-with-token is right.\"

## What changed

- \`app/models/ai_api_log.rb\`: new \`AiApiLog.daily_summary(date = Date.current - 1)\` returning a JSON-friendly hash (totals, by_provider, by_request_type, pii_samples).
- \`app/controllers/api/internal/ai_api_logs_controller.rb\`: new namespace; shared-secret auth via constant-time SHA-256 comparison of the \`X-Internal-Token\` header against \`ENV['INTERNAL_API_TOKEN']\`.
- \`config/routes.rb\`: mounts the endpoint at \`api/internal/ai_api_logs/daily_summary\`. Lives outside \`scope 'api/v1'\` to keep the security boundary obvious.
- Tests added for both the model rollup and the controller (auth pass/fail, missing-token 503, invalid date 400, JSON shape).

## Companion infra (already in place)

- \`INTERNAL_API_TOKEN\` set on \`lingolinq-prod\`, \`lingolinq-staging\`, and \`lingolinq-n8n\` Render services. Stored in 1Password Prod vault as \"INTERNAL_API_TOKEN (lingolinq-prod + n8n)\".
- n8n workflow \`daily-ai-cost-pii-digest\` (ID \`7ahMxeLuPSbTDZBL\`) created **inactive**. Will be activated and verified after this PR merges and deploys.

## Test plan

- [x] Model + controller specs pass locally (40 examples, 0 failures)
- [ ] CI green
- [ ] After deploy: \`curl -H \"X-Internal-Token: \$INTERNAL_API_TOKEN\" https://lingolinq-staging.onrender.com/api/internal/ai_api_logs/daily_summary\` returns 200 + JSON
- [ ] Confirm 401 without the header
- [ ] Force a \`pii_detected=true\` row in dev, run the n8n workflow manually, confirm the Google Chat card highlights it

🤖 Generated with [Claude Code](https://claude.com/claude-code)