### PR TITLE
fix(buttonset): add master timeout to load_buttons work promise

### DIFF
--- a/app/frontend/app/models/buttonset.js
+++ b/app/frontend/app/models/buttonset.js
@@ -271,8 +271,38 @@ LingoLinq.Buttonset = DS.Model.extend({
         reject({error: 'root url not available'});
       }
     });
-    bs.__loadButtonsSerialTail = wait.then(function() { return work; }, function() { return work; });
-    return work;
+    // Master timeout on the work promise itself. The serial-tail timeout above only
+    // unblocks the queue when a PREVIOUS work promise hangs; it does not bound the
+    // current work. If the server-side buttonset generate job never reports back via
+    // progress_tracker (job died mid-flight, Redis state poisoned, etc.) the inner
+    // RSVP.Promise above will sit pending forever. Wrap it so callers (e.g. copy modal)
+    // see a clean rejection instead of an indefinite "loading" state.
+    // Override LingoLinq.Buttonset.WORK_TIMEOUT_MS in tests to keep them fast.
+    var WORK_TIMEOUT_MS = (LingoLinq.Buttonset && LingoLinq.Buttonset.WORK_TIMEOUT_MS) || 60000;
+    var work_with_timeout = new RSVP.Promise(function(resolve, reject) {
+      var done = false;
+      var timeoutId = null;
+      var settle_resolve = function(v) {
+        if(done) { return; }
+        done = true;
+        if(timeoutId !== null) { clearTimeout(timeoutId); timeoutId = null; }
+        resolve(v);
+      };
+      var settle_reject = function(e) {
+        if(done) { return; }
+        done = true;
+        if(timeoutId !== null) { clearTimeout(timeoutId); timeoutId = null; }
+        reject(e);
+      };
+      work.then(settle_resolve, settle_reject);
+      timeoutId = setTimeout(function() {
+        if(done) { return; }
+        try { LingoLinq.track_error('buttonset load_buttons work timed out for board ' + board_id); } catch(e) { }
+        settle_reject({error: 'buttonset load timed out', board_id: board_id});
+      }, WORK_TIMEOUT_MS);
+    });
+    bs.__loadButtonsSerialTail = wait.then(function() { return work_with_timeout; }, function() { return work_with_timeout; });
+    return work_with_timeout;
   },
   redepth: function(from_board_id) {
     var buttons = this.get('buttons') || [];

--- a/app/frontend/app/models/buttonset.js
+++ b/app/frontend/app/models/buttonset.js
@@ -126,6 +126,24 @@ LingoLinq.Buttonset = DS.Model.extend({
         settle();
       }, SERIAL_TAIL_TIMEOUT_MS);
     });
+    // Tracks the active progress_tracker track id (if regenerate is called) so that
+    // every settlement path (resolve, reject, master timeout) can untrack and stop
+    // the 2.5s polling loop. Without this the poller leaks: track() returns an id,
+    // but the previous code discarded it, so on timeout the promise rejected while
+    // the poll continued forever.
+    var active_track_id = null;
+    var untrack_active = function() {
+      if(active_track_id) {
+        try { progress_tracker.untrack(active_track_id); } catch(e) { }
+        active_track_id = null;
+      }
+    };
+    // Stalled `started` threshold. If the Resque worker dies mid-flight (SIGKILL/OOM/
+    // redeploy) while the Progress record is at status='started', the record never
+    // advances. The poller keeps returning `started` and without this branch the
+    // wrapping promise hangs until the 60s master timeout fires. 45s is generous for
+    // legitimate large-board generation while still firing before the master timeout.
+    var STARTED_STALL_MS = (LingoLinq.Buttonset && LingoLinq.Buttonset.STARTED_STALL_MS) || 45000;
     var work = new RSVP.Promise(function(resolve, reject) {
       var hash_mismatch = bs.get('buttons_loaded_hash') && bs.get('full_set_revision') != bs.get('buttons_loaded_hash');
       if(hash_mismatch) { force = true; }
@@ -144,10 +162,19 @@ LingoLinq.Buttonset = DS.Model.extend({
                     gen_rej({error: 'generate response missing progress'});
                     return;
                   }
-                  progress_tracker.track(data.progress, function(event) {
+                  var started_seen_at = null;
+                  var settle_gen_res = function(u) {
+                    untrack_active();
+                    gen_res(u);
+                  };
+                  var settle_gen_rej = function(err) {
+                    untrack_active();
+                    gen_rej(err);
+                  };
+                  active_track_id = progress_tracker.track(data.progress, function(event) {
                     try {
                       if(event.status == 'errored') {
-                        gen_rej({error: 'error while generating button set'});
+                        settle_gen_rej({error: 'error while generating button set'});
                       } else if(event.status == 'finished' || event.finished_at) {
                         var r = event && event.result;
                         if(typeof r === 'string') {
@@ -155,15 +182,22 @@ LingoLinq.Buttonset = DS.Model.extend({
                         }
                         var u = r && (r.url || r['url']);
                         if(u) {
-                          gen_res(u);
+                          settle_gen_res(u);
                         } else {
-                          gen_rej({error: 'progress finished without button set url', result: r});
+                          settle_gen_rej({error: 'progress finished without button set url', result: r});
+                        }
+                      } else if(event.status == 'started' || event.status == 'pending') {
+                        if(started_seen_at === null) {
+                          started_seen_at = Date.now();
+                        } else if(Date.now() - started_seen_at > STARTED_STALL_MS) {
+                          try { LingoLinq.track_error('buttonset progress stalled at ' + event.status + ' for board ' + board_id); } catch(e) { }
+                          settle_gen_rej({error: 'generation_stalled', board_id: board_id, status: event.status});
                         }
                       }
                     } catch(e) {
-                      gen_rej({error: 'exception handling button set progress', details: e});
+                      settle_gen_rej({error: 'exception handling button set progress', details: e});
                     }
-                  });  
+                  });
                 } catch(e) {
                   gen_rej({error: 'exception setting up progress track', details: e});
                 }
@@ -286,19 +320,23 @@ LingoLinq.Buttonset = DS.Model.extend({
         if(done) { return; }
         done = true;
         if(timeoutId !== null) { clearTimeout(timeoutId); timeoutId = null; }
+        untrack_active();
         resolve(v);
       };
       var settle_reject = function(e) {
         if(done) { return; }
         done = true;
         if(timeoutId !== null) { clearTimeout(timeoutId); timeoutId = null; }
+        untrack_active();
         reject(e);
       };
       work.then(settle_resolve, settle_reject);
       timeoutId = setTimeout(function() {
         if(done) { return; }
-        try { LingoLinq.track_error('buttonset load_buttons work timed out for board ' + board_id); } catch(e) { }
-        settle_reject({error: 'buttonset load timed out', board_id: board_id});
+        var current_buttons = bs.get('buttons') || [];
+        var buttons_count = current_buttons.length || 0;
+        try { LingoLinq.track_error('buttonset load_buttons work timed out for board ' + board_id + ' (buttons.length=' + buttons_count + ')'); } catch(e) { }
+        settle_reject({error: 'buttonset load timed out', board_id: board_id, buttons_count: buttons_count});
       }, WORK_TIMEOUT_MS);
     });
     bs.__loadButtonsSerialTail = wait.then(function() { return work_with_timeout; }, function() { return work_with_timeout; });

--- a/app/frontend/tests/models/buttonset-test.js
+++ b/app/frontend/tests/models/buttonset-test.js
@@ -1057,4 +1057,57 @@ describe('Buttonset', function() {
       });
     });
   });
+
+  describe('load_buttons work timeout', function() {
+    var original_serial = null;
+    var original_work = null;
+    beforeEach(function() {
+      original_serial = LingoLinq.Buttonset.SERIAL_TAIL_TIMEOUT_MS;
+      original_work = LingoLinq.Buttonset.WORK_TIMEOUT_MS;
+      LingoLinq.Buttonset.SERIAL_TAIL_TIMEOUT_MS = 50;
+      LingoLinq.Buttonset.WORK_TIMEOUT_MS = 100;
+    });
+    afterEach(function() {
+      LingoLinq.Buttonset.SERIAL_TAIL_TIMEOUT_MS = original_serial;
+      LingoLinq.Buttonset.WORK_TIMEOUT_MS = original_work;
+    });
+
+    it('should reject load_buttons when the work promise hangs past the configured timeout', function() {
+      // No cached buttons + no root_url means work is forced through the
+      // root-url-not-available reject path. Simulate a hung server by stubbing
+      // persistence.find_json to never resolve.
+      var bs = LingoLinq.store.createRecord('buttonset', {
+        id: 'bs-hang',
+        root_url: 'https://example.com/bs.json',
+        full_set_revision: 'abc',
+        buttons_loaded: false
+      });
+      stub(bs.persistence, 'find_json', function() {
+        return new RSVP.Promise(function() { /* never settles */ });
+      });
+      stub(bs.persistence, 'store_json', function() {
+        return new RSVP.Promise(function() { /* never settles */ });
+      });
+      stub(bs.persistence, 'ajax', function() {
+        return new RSVP.Promise(function() { /* never settles */ });
+      });
+
+      var resolved = false;
+      var rejected_with = null;
+      bs.load_buttons().then(function() {
+        resolved = true;
+      }, function(err) {
+        rejected_with = err;
+      });
+
+      // Without the master timeout this would hang forever. With it, the call
+      // rejects within WORK_TIMEOUT_MS (100ms here, 60s in prod).
+      waitsFor(function() { return resolved || rejected_with; });
+      runs(function() {
+        expect(resolved).toEqual(false);
+        expect(rejected_with).toNotEqual(null);
+        expect(rejected_with.error).toEqual('buttonset load timed out');
+      });
+    });
+  });
 });

--- a/app/frontend/tests/models/buttonset-test.js
+++ b/app/frontend/tests/models/buttonset-test.js
@@ -13,6 +13,7 @@ import {
 import { queryLog, db_wait, queue_promise } from 'frontend/tests/helpers/ember_helper';
 import LingoLinq from '../../app';
 import persistence from '../../utils/persistence';
+import progress_tracker from '../../utils/progress_tracker';
 import modal from '../../utils/modal';
 import app_state from '../../utils/app_state';
 import { run as emberRun } from '@ember/runloop';
@@ -1107,6 +1108,115 @@ describe('Buttonset', function() {
         expect(resolved).toEqual(false);
         expect(rejected_with).toNotEqual(null);
         expect(rejected_with.error).toEqual('buttonset load timed out');
+        expect(rejected_with.board_id).toNotEqual(undefined);
+        expect(rejected_with.buttons_count).toEqual(0);
+      });
+    });
+
+    it('should untrack the progress_tracker poller when the master timeout fires', function() {
+      var bs = LingoLinq.store.createRecord('buttonset', {
+        id: 'bs-hang-untrack',
+        root_url: 'https://example.com/bs.json',
+        full_set_revision: 'abc',
+        buttons_loaded: false
+      });
+      var tracked_id = null;
+      var untracked_id = null;
+      stub(bs.persistence, 'find_json', function() {
+        return RSVP.reject({error: 'no local copy'});
+      });
+      stub(bs.persistence, 'store_json', function() {
+        return RSVP.reject({error: 'no remote copy'});
+      });
+      stub(bs.persistence, 'ajax', function() {
+        return RSVP.resolve({progress: {status_url: 'https://example.com/progress'}});
+      });
+      stub(progress_tracker, 'track', function(progress, cb) {
+        tracked_id = 'track-id-1';
+        // Never invoke cb -- simulates a worker that died before reporting any status.
+        return tracked_id;
+      });
+      stub(progress_tracker, 'untrack', function(id) {
+        untracked_id = id;
+      });
+
+      var rejected_with = null;
+      bs.load_buttons().then(function() { }, function(err) {
+        rejected_with = err;
+      });
+
+      waitsFor(function() { return rejected_with; });
+      runs(function() {
+        expect(rejected_with.error).toEqual('buttonset load timed out');
+        expect(tracked_id).toEqual('track-id-1');
+        expect(untracked_id).toEqual('track-id-1');
+      });
+    });
+  });
+
+  describe('progress generation_stalled detection', function() {
+    var original_serial = null;
+    var original_work = null;
+    var original_stall = null;
+    beforeEach(function() {
+      original_serial = LingoLinq.Buttonset.SERIAL_TAIL_TIMEOUT_MS;
+      original_work = LingoLinq.Buttonset.WORK_TIMEOUT_MS;
+      original_stall = LingoLinq.Buttonset.STARTED_STALL_MS;
+      LingoLinq.Buttonset.SERIAL_TAIL_TIMEOUT_MS = 50;
+      LingoLinq.Buttonset.WORK_TIMEOUT_MS = 5000;
+      LingoLinq.Buttonset.STARTED_STALL_MS = 30;
+    });
+    afterEach(function() {
+      LingoLinq.Buttonset.SERIAL_TAIL_TIMEOUT_MS = original_serial;
+      LingoLinq.Buttonset.WORK_TIMEOUT_MS = original_work;
+      LingoLinq.Buttonset.STARTED_STALL_MS = original_stall;
+    });
+
+    it('should reject with generation_stalled when progress sticks at started past STARTED_STALL_MS', function() {
+      var bs = LingoLinq.store.createRecord('buttonset', {
+        id: 'bs-stall',
+        root_url: 'https://example.com/bs.json',
+        full_set_revision: 'abc',
+        buttons_loaded: false
+      });
+      var captured_cb = null;
+      var untracked_id = null;
+      stub(bs.persistence, 'find_json', function() {
+        return RSVP.reject({error: 'no local copy'});
+      });
+      stub(bs.persistence, 'store_json', function() {
+        return RSVP.reject({error: 'no remote copy'});
+      });
+      stub(bs.persistence, 'ajax', function() {
+        return RSVP.resolve({progress: {status_url: 'https://example.com/progress'}});
+      });
+      stub(progress_tracker, 'track', function(progress, cb) {
+        captured_cb = cb;
+        return 'track-id-stall';
+      });
+      stub(progress_tracker, 'untrack', function(id) {
+        untracked_id = id;
+      });
+
+      var rejected_with = null;
+      bs.load_buttons().then(function() { }, function(err) {
+        rejected_with = err;
+      });
+
+      // First started event arms the timestamp; second after the stall window rejects.
+      waitsFor(function() { return captured_cb; });
+      runs(function() {
+        captured_cb({status: 'started'});
+        // Simulate the 2.5s poll interval crossing STARTED_STALL_MS.
+        setTimeout(function() {
+          if(captured_cb) { captured_cb({status: 'started'}); }
+        }, 60);
+      });
+      waitsFor(function() { return rejected_with; });
+      runs(function() {
+        expect(rejected_with.error).toEqual('generation_stalled');
+        expect(rejected_with.status).toEqual('started');
+        expect(untracked_id).toEqual('track-id-stall');
       });
     });
   });


### PR DESCRIPTION
## Summary
Master timeout safety net + root-cause fixes for the buttonset hang on staging boards (e.g. `1_1807`, `1_1920`).

The hang on staging is caused by the progress_tracker callback in `buttonset.js` ignoring `status='started'`. When a Resque worker dies mid-flight (SIGKILL / OOM / Render redeploy) the Progress record stays at `started` indefinitely; without explicit handling the wrapping promise hangs forever. PR #237 originally added a 60s master timeout as a symptom-level fix; this revision addresses the actual stranded path and a related poller leak found in adversarial review.

### What changed

1. **Master timeout** wraps the inner `work` RSVP promise (default 60s, configurable via `LingoLinq.Buttonset.WORK_TIMEOUT_MS`). Rejects with `{error: 'buttonset load timed out', board_id, buttons_count}` if `work` never settles.

2. **Stalled `started` detection.** The progress callback now records a timestamp on the first `started`/`pending` event and rejects with `{error: 'generation_stalled', board_id, status}` after `STARTED_STALL_MS` (default 45s, configurable for tests). This is the root-cause fix; with it in place the 60s master timeout is belt-and-suspenders rather than the only line of defense.

3. **Untrack-on-settle.** `progress_tracker.track` returns an id used by `untrack(id)` to stop the 2.5s polling loop. The previous code discarded the id, so master-timeout-reject left polling running forever (one leaked poller per hang event). Every settlement path (resolve, reject, master timeout, generation_stalled) now calls `untrack`.

4. **Telemetry.** Master-timeout error log now includes `buttons.length` so we can tell whether the hang correlates with large board sets.

5. **Test coverage.**
   - `should reject load_buttons when the work promise hangs past the configured timeout` (existing, asserts `board_id` + `buttons_count` in payload)
   - `should untrack the progress_tracker poller when the master timeout fires` (new)
   - `should reject with generation_stalled when progress sticks at started past STARTED_STALL_MS` (new)

### Why both timeouts?
- `SERIAL_TAIL_TIMEOUT_MS` (30s, PR #229) bounds the **previous** call's tail so a stuck prior load doesn't queue-block new ones.
- `WORK_TIMEOUT_MS` (60s, this PR) bounds the **current** call's work in case generation_stalled detection misses an unforeseen stranded path.

### Followups (deliberately not in this PR)
- `Progress.clear_old_progresses` should also delete records where `started_at IS NULL AND created_at < 7.days.ago`. 14 such records exist on staging from Feb 2026. Will add logging before deletion since "queued for 7 days without starting" is a worker-starvation canary.

### Rejected followups
- Wrapping `Redis.del(key)` in `BoardDownstreamButtonSet.update_for` with `ensure`. The `del` is at the start of the method (delete-on-read pattern), not the end -- there is nothing to wrap.

## Test plan
- [ ] `npm test` (frontend) -- new tests should pass without flake
- [ ] Staging deploy
- [ ] Trigger copy on board `1_1807` from production data clone, verify clean error after generation_stalled fires (45s) instead of 60s master timeout
- [ ] Confirm Sentry/log volume for `generation_stalled` vs `buttonset load timed out` to validate the 45s threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)