### PR TITLE
fix(frontend): rescue frontend stability fixes from April recovery branch

### DIFF
--- a/app/frontend/app/models/board.js
+++ b/app/frontend/app/models/board.js
@@ -1630,10 +1630,10 @@ LingoLinq.Board = DS.Model.extend({
 LingoLinq.Board.reopenClass({
   clear_fast_html: function() {
     var hasUnsavedImages = LingoLinq.store.peekAll('image').any(function(img) {
-      return img.get('isNew') || img.get('hasDirtyAttributes');
+      return img.get('isSaving');
     });
     if (hasUnsavedImages) {
-      console.log('[BOARD] Skipping clear_fast_html because there are unsaved image records');
+      console.log('[BOARD] Skipping clear_fast_html because image uploads are in progress');
       return;
     }
     LingoLinq.store.peekAll('board').forEach(function(b) {

--- a/app/frontend/app/models/board.js
+++ b/app/frontend/app/models/board.js
@@ -1629,10 +1629,18 @@ LingoLinq.Board = DS.Model.extend({
 
 LingoLinq.Board.reopenClass({
   clear_fast_html: function() {
+    var hasUnsavedImages = LingoLinq.store.peekAll('image').any(function(img) {
+      return img.get('isNew') || img.get('hasDirtyAttributes');
+    });
+    if (hasUnsavedImages) {
+      console.log('[BOARD] Skipping clear_fast_html because there are unsaved image records');
+      return;
+    }
     LingoLinq.store.peekAll('board').forEach(function(b) {
       b.set('fast_html', null);
     });
-    if(this.appState && this.appState.get && this.appState.get('currentBoardState.id') && editManager.controller && !editManager.controller.get('ordered_buttons')) {
+    var appState = this.appState || window.appState || (window.LingoLinq && window.LingoLinq.appState);
+    if(appState && appState.get && appState.get('currentBoardState.id') && editManager.controller && !editManager.controller.get('ordered_buttons')) {
       editManager.process_for_displaying();
     }
   },

--- a/app/frontend/app/services/persistence.js
+++ b/app/frontend/app/services/persistence.js
@@ -84,7 +84,6 @@ var persistence = Service.extend({
       
       
       // Initialize online property immediately - this is critical for early requests
-      // Using a direct property assignment to avoid triggering observers
       try {
         this.online = navigator.onLine !== false;
         if (_vb) { console.log('[PERSISTENCE INIT] online set to:', this.online); }
@@ -3832,7 +3831,13 @@ var persistence = Service.extend({
   ajax: function() {
     var ajax_args = arguments;
     var local_request = ajax_args && ajax_args[0] && ajax_args[0].match && (ajax_args[0].match(/^file:\/\//) || ajax_args[0].match(/^http:\/\/localhost/));
-    if(this.get('online') || local_request) {
+    var is_online = this.get('online');
+    if (is_online === false && navigator.onLine === true) {
+      console.log('[PERSISTENCE AJAX] Service reported offline but navigator.onLine is true. Overriding.');
+      this.set('online', true);
+      is_online = true;
+    }
+    if(is_online || local_request) {
       // TODO: is this wrapper necessary? what's it for? maybe can just listen on
       // global ajax for errors instead...
       return new RSVP.Promise(function(resolve, reject) {

--- a/app/frontend/app/services/persistence.js
+++ b/app/frontend/app/services/persistence.js
@@ -3832,10 +3832,14 @@ var persistence = Service.extend({
     var ajax_args = arguments;
     var local_request = ajax_args && ajax_args[0] && ajax_args[0].match && (ajax_args[0].match(/^file:\/\//) || ajax_args[0].match(/^http:\/\/localhost/));
     var is_online = this.get('online');
-    if (is_online === false && navigator.onLine === true) {
-      console.log('[PERSISTENCE AJAX] Service reported offline but navigator.onLine is true. Overriding.');
-      this.set('online', true);
-      is_online = true;
+    if (is_online === false) {
+      var override = navigator.online_override;
+      var nav_online = (override !== undefined && override !== null) ? !!override : navigator.onLine;
+      if (nav_online === true) {
+        console.log('[PERSISTENCE AJAX] Service reported offline but navigator indicates online. Overriding.');
+        this.set('online', true);
+        is_online = true;
+      }
     }
     if(is_online || local_request) {
       // TODO: is this wrapper necessary? what's it for? maybe can just listen on

--- a/app/frontend/app/utils/edit_manager.js
+++ b/app/frontend/app/utils/edit_manager.js
@@ -27,21 +27,24 @@ export function fastHtmlHasRenderableContent(fast) {
 var editManager = EmberObject.extend({
   _services: {},
   get appState() {
-    return this._services.appState || window.appState || (window.LingoLinq && window.LingoLinq.appState);
+    return (this._services && this._services.appState) || window.appState || (window.LingoLinq && window.LingoLinq.appState);
   },
   set appState(val) {
+    this._services = this._services || {};
     this._services.appState = val;
   },
   get persistence() {
-    return this._services.persistence || window.persistence || (window.LingoLinq && window.LingoLinq.persistence);
+    return (this._services && this._services.persistence) || window.persistence || (window.LingoLinq && window.LingoLinq.persistence);
   },
   set persistence(val) {
+    this._services = this._services || {};
     this._services.persistence = val;
   },
   get stashes() {
-    return this._services.stashes || window.stashes || (window.LingoLinq && window.LingoLinq.stashes);
+    return (this._services && this._services.stashes) || window.stashes || (window.LingoLinq && window.LingoLinq.stashes);
   },
   set stashes(val) {
+    this._services = this._services || {};
     this._services.stashes = val;
   },
 


### PR DESCRIPTION
## Summary

Cherry-picks a single commit from `chore/recover-feb-frontend-stabilization-2026-04-27`, a recovery branch that preserved local work after a WSL failure caused two `staging` resets in late April 2026. The rest of the recovery branch (and its sibling `chore/focus-words-bundle-recovery`) was triaged separately; this PR is the only commit that landed cleanly against current staging and was confirmed not to be already on staging via another PR.

## What's in this commit

Three small defensive fixes against frontend re-render and offline edge cases:

- `app/frontend/app/models/board.js` — skip-clear-fast-html when unsaved images are mid-flight (prevents disappearing-symbols-on-rerender)
- `app/frontend/app/services/persistence.js` — reconcile against `navigator.onLine` so AJAX no-ops don't silently fail when the navigator state drifts
- `app/frontend/app/utils/edit_manager.js` — null-safe `_services` getters/setters

22 insertions, 6 deletions across 3 files.

## Why now

These three fixes are unshipped and address bugs that are still reproducible on staging. The rest of the recovery branch was either superseded by later PRs or would regress current staging if applied.

The focus-words perf work on the sibling recovery branch (`chore/focus-words-bundle-recovery`) is genuine unshipped perf code but requires manual conflict resolution against current staging — that will land in a separate dedicated PR, not bundled here.

## Test plan

- [ ] CI passes (Ember + Rails specs)
- [ ] Smoke test: open a board in edit mode, modify a button image without saving, navigate away and back — verify the symbol does not disappear
- [ ] Smoke test: toggle offline in DevTools, attempt a persistence operation, toggle back online — verify the operation completes without manual refresh

## Related

- Recovery branches still on origin: `chore/recover-feb-frontend-stabilization-2026-04-27` (this PR's source), `chore/focus-words-bundle-recovery` (deferred for a separate perf PR)
- Safety tags from the WSL incident: `local-staging-pre-reset-2026-04-27`, `local-staging-pre-coppa-recovery-2026-04-27`