### PR TITLE
fix(rspec): re-apply idempotent initialize! guard

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -17,7 +17,11 @@ require File.expand_path('../application', __FILE__)
 require 'go_secure'
 
 # Initialize the Rails application.
-LingoLinq::Application.initialize!
+# Guard against re-entry: if a downstream require (e.g. spec_helper)
+# raises after initialize! has already mutated state, the next require
+# of this file would otherwise hit "Application has been already initialized"
+# and mask the real root cause across every subsequent spec file.
+LingoLinq::Application.initialize! unless LingoLinq::Application.instance.initialized?
 
 unless ENV['SKIP_VALIDATIONS']
   GoSecure.validate_encryption_key


### PR DESCRIPTION
## Summary
- Re-applies the one-line guard from PR #216 to `config/environment.rb` so the second `initialize!` call is a no-op instead of raising "Application has been already initialized".
- The 2026-05-04 codebase audit observed 173 spec files cascading on this misleading error, hiding the real root cause (missing env var, missing DB).
- The 2026-05-04 security review separately flagged that the backend test suite has been providing zero protection since the 2026-04-26 revert.

## Why PR #216 didn't stick
PR #216 contained two commits: `4e3d2f330` (the fix) and `8d6cb4356` (a same-day revert with no body text). The PR self-canceled before merge; net change to `main` was zero. No third party touched it.

## Verified locally
- 3 specs, missing `SECURE_ENCRYPTION_KEY`: all three now show the same real error (was: 1 real + 2 cascade).
- 2 specs, `SKIP_VALIDATIONS=1`, no DB: both show `ActiveRecord::DatabaseConnectionError` (was: 1 real + 1 cascade).

## Test plan
- [ ] CI passes on this branch (no-op in the fully-configured CI env)
- [ ] Local: `bundle exec rspec --dry-run` surfaces the real first error consistently across spec files

## Audit reference
- `audit-reports/codebase-audit-2026-05-04.md` finding #1 (CRITICAL)
- `audit-reports/security-review-2026-05-04.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)