### PR TITLE
fix(coppa): repair CoppaSentryScrub lookup so the COPPA branch actually runs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,11 +44,14 @@ class ApplicationController < ActionController::Base
   
   # Hash the requester IP and attach to the Sentry scope as the synthetic
   # user id so issues group per-requester without exposing raw IPs.
-  # CoppaSentryScrub redacts the user entirely if a logged-in user turns
-  # out to be COPPA-pending.
+  # CoppaSentryScrub redacts the event entirely if a logged-in user turns
+  # out to be COPPA-pending. The actual User reference for that consent
+  # check rides on RequestStore (NOT on the Sentry event itself), because
+  # Sentry.user_hash[:id] is the IP hash and won't resolve to a database id.
   def set_sentry_user
     return unless defined?(Sentry) && Sentry.respond_to?(:initialized?) && Sentry.initialized?
     Sentry.set_user(id: GoSecure.sha512(request.remote_ip, 'user_ip'))
+    RequestStore.store[CoppaSentryScrub::REQUEST_STORE_KEY] = @api_user if defined?(@api_user) && @api_user
   rescue StandardError
     nil
   end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -24,6 +24,16 @@ module CoppaSentryScrub
 
   REQUEST_BODY_KEYS = %w[data params body query_parameters request_parameters form_params query_string].freeze
 
+  # Query-string keys stripped from breadcrumb URLs for ALL users (not just
+  # COPPA-pending). Mirrors filter_parameter_logging plus a few Sentry-specific
+  # sources of leakage (email in subscribe links, support reset tokens, etc).
+  SENSITIVE_QUERY_KEYS = %w[
+    access_token token api_key apikey password secret secret_key auth
+    bearer email reset_token confirmation_token tmp_token
+  ].freeze
+
+  REQUEST_STORE_KEY = :coppa_sentry_user
+
   module_function
 
   def call(event, _hint)
@@ -50,11 +60,29 @@ module CoppaSentryScrub
     false
   end
 
+  # Resolve the User for the active request so the COPPA branch can decide
+  # whether to scrub. Sentry's user_hash[:id] is the SHA-512 hex of the
+  # request IP (set in ApplicationController#set_sentry_user for grouping)
+  # and is NOT a database id, so a User.where(id: hex) lookup never matches.
+  # Read the actual user reference stashed via RequestStore in
+  # set_sentry_user; fall back to event.user[:id] only if it is numeric
+  # (kept for callers that intentionally set a real id, e.g. background
+  # jobs using Sentry.with_scope).
   def lookup_user(user_hash)
+    stored = current_request_user
+    return stored if stored
     return nil unless user_hash.is_a?(Hash)
     user_id = user_hash[:id] || user_hash['id']
     return nil if user_id.nil? || user_id.to_s.empty?
+    return nil unless user_id.is_a?(Integer) || user_id.to_s.match?(/\A\d+\z/)
     User.where(id: user_id).first
+  rescue StandardError
+    nil
+  end
+
+  def current_request_user
+    return nil unless defined?(RequestStore)
+    RequestStore.store[REQUEST_STORE_KEY]
   rescue StandardError
     nil
   end
@@ -113,6 +141,44 @@ module CoppaSentryScrub
     no_query.gsub(PiiScrubber::GLOBAL_ID_PATTERN, REDACTED_ID)
   end
 
+  # Scrub breadcrumbs for ALL users, regardless of COPPA status. Targets the
+  # outbound HTTP breadcrumbs Sentry-Rails auto-captures (active_support_logger,
+  # http_logger), where URLs frequently carry access_token, reset_token, etc.
+  # This complements (does NOT replace) the COPPA branch in #call which fully
+  # nukes the event for under-13 users.
+  def scrub_breadcrumb(breadcrumb)
+    return breadcrumb unless breadcrumb
+    scrub_breadcrumb_data!(breadcrumb)
+    scrub_breadcrumb_message!(breadcrumb)
+    breadcrumb
+  rescue StandardError
+    breadcrumb
+  end
+
+  def scrub_breadcrumb_data!(breadcrumb)
+    data = breadcrumb.respond_to?(:data) ? breadcrumb.data : nil
+    return unless data.is_a?(Hash)
+    %w[url full_url].each do |k|
+      val = data[k] || data[k.to_sym]
+      next unless val.is_a?(String)
+      cleaned = strip_sensitive_query(val)
+      assign(data, k, cleaned)
+    end
+  end
+
+  def scrub_breadcrumb_message!(breadcrumb)
+    return unless breadcrumb.respond_to?(:message=)
+    msg = breadcrumb.respond_to?(:message) ? breadcrumb.message : nil
+    return unless msg.is_a?(String)
+    breadcrumb.message = strip_sensitive_query(msg)
+  end
+
+  def strip_sensitive_query(str)
+    return str unless str.is_a?(String) && str.include?('=')
+    pattern = /\b(#{SENSITIVE_QUERY_KEYS.join('|')})=([^&\s"']+)/i
+    str.gsub(pattern) { "#{Regexp.last_match(1)}=#{REDACTED}" }
+  end
+
   def responds(obj, key)
     obj.respond_to?("#{key}=") || (obj.is_a?(Hash) && (obj.key?(key) || obj.key?(key.to_sym)))
   end
@@ -155,5 +221,6 @@ if ENV['SENTRY_DSN'].to_s.strip != ''
     config.send_default_pii = false
 
     config.before_send = ->(event, hint) { CoppaSentryScrub.call(event, hint) }
+    config.before_breadcrumb = ->(breadcrumb, _hint) { CoppaSentryScrub.scrub_breadcrumb(breadcrumb) }
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -173,10 +173,11 @@ module CoppaSentryScrub
     breadcrumb.message = strip_sensitive_query(msg)
   end
 
+  SENSITIVE_QUERY_PATTERN = /\b(#{Regexp.union(SENSITIVE_QUERY_KEYS).source})=([^&\s"']+)/i.freeze
+
   def strip_sensitive_query(str)
     return str unless str.is_a?(String) && str.include?('=')
-    pattern = /\b(#{SENSITIVE_QUERY_KEYS.join('|')})=([^&\s"']+)/i
-    str.gsub(pattern) { "#{Regexp.last_match(1)}=#{REDACTED}" }
+    str.gsub(SENSITIVE_QUERY_PATTERN) { "#{Regexp.last_match(1)}=#{REDACTED}" }
   end
 
   def responds(obj, key)

--- a/spec/initializers/sentry_spec.rb
+++ b/spec/initializers/sentry_spec.rb
@@ -30,7 +30,10 @@ describe CoppaSentryScrub do
     allow(User).to receive(:where).with(id: 42).and_return(double(first: child_user_record))
     allow(User).to receive(:where).with(id: 99).and_return(double(first: adult_user_record))
     allow(User).to receive(:where).with(id: 0).and_return(double(first: nil))
+    RequestStore.clear!
   end
+
+  after { RequestStore.clear! }
 
   describe '#call' do
     it 'returns the event unchanged when user is nil' do
@@ -98,6 +101,48 @@ describe CoppaSentryScrub do
       described_class.call(event, nil)
       expect(event.request.data).to eq('sensitive')
     end
+
+    # Regression: the production set_sentry_user path stores
+    # SHA-512(remote_ip) into Sentry.user.id for issue grouping. That hex
+    # string never matches a User row, so before this fix the COPPA branch
+    # was dead code in production. The User reference must come from
+    # RequestStore, not from the event's user.id field.
+    it 'scrubs a child user when only RequestStore identifies them (hashed IP id)' do
+      RequestStore.store[CoppaSentryScrub::REQUEST_STORE_KEY] = child_user_record
+      sha_id = '0' * 128
+      event = Event.new(
+        user: { id: sha_id },
+        request: Request.new(data: { board: 'private' }, ip_address: '203.0.113.7')
+      )
+
+      described_class.call(event, nil)
+
+      expect(event.user).to eq({ id: '[REDACTED_ID]' })
+      expect(event.request.data).to eq('[REDACTED]')
+      expect(event.request.ip_address).to eq('[REDACTED_IP]')
+    end
+
+    it 'leaves an adult event alone even when RequestStore is set' do
+      RequestStore.store[CoppaSentryScrub::REQUEST_STORE_KEY] = adult_user_record
+      event = Event.new(
+        user: { id: 'a' * 128 },
+        request: Request.new(data: 'sensitive')
+      )
+
+      described_class.call(event, nil)
+
+      expect(event.request.data).to eq('sensitive')
+    end
+
+    it 'leaves the event alone when only a hex hash id is set and RequestStore is empty' do
+      sha_id = 'f' * 128
+      event = Event.new(user: { id: sha_id }, request: Request.new(data: 'sensitive'))
+
+      described_class.call(event, nil)
+
+      expect(event.user).to eq({ id: sha_id })
+      expect(event.request.data).to eq('sensitive')
+    end
   end
 
   describe '#redact_url' do
@@ -108,6 +153,54 @@ describe CoppaSentryScrub do
 
     it 'leaves urls without identifiers alone' do
       expect(described_class.redact_url('https://example.com/health')).to eq('https://example.com/health')
+    end
+  end
+
+  # before_breadcrumb runs for ALL users, COPPA-pending or not. This is the
+  # global second line of defense against access_token / reset_token / email
+  # leaking through Sentry's auto-captured HTTP and ActiveSupport breadcrumbs.
+  describe '#scrub_breadcrumb' do
+    Breadcrumb = Struct.new(:message, :data, :category) do
+      def initialize(message: nil, data: nil, category: nil)
+        super(message, data, category)
+      end
+    end
+
+    it 'redacts access_token from breadcrumb url' do
+      bc = Breadcrumb.new(
+        category: 'http',
+        data: { 'url' => 'https://api.example.com/v1/things?access_token=abc123&page=2' }
+      )
+      described_class.scrub_breadcrumb(bc)
+      expect(bc.data['url']).to include('access_token=[REDACTED]')
+      expect(bc.data['url']).to include('page=2')
+    end
+
+    it 'redacts multiple sensitive keys in one url' do
+      bc = Breadcrumb.new(
+        data: { url: 'https://x.test/?token=t1&password=p1&page=ok' }
+      )
+      described_class.scrub_breadcrumb(bc)
+      expect(bc.data[:url]).to include('token=[REDACTED]')
+      expect(bc.data[:url]).to include('password=[REDACTED]')
+      expect(bc.data[:url]).to include('page=ok')
+    end
+
+    it 'redacts sensitive keys appearing in the breadcrumb message string' do
+      bc = Breadcrumb.new(message: 'GET /reset?reset_token=r1&user=42')
+      described_class.scrub_breadcrumb(bc)
+      expect(bc.message).to include('reset_token=[REDACTED]')
+      expect(bc.message).to include('user=42')
+    end
+
+    it 'is safe on a breadcrumb with no data and no message' do
+      bc = Breadcrumb.new
+      expect { described_class.scrub_breadcrumb(bc) }.not_to raise_error
+    end
+
+    it 'never raises when breadcrumb shape is unexpected' do
+      bc = Breadcrumb.new(data: 'not_a_hash', message: nil)
+      expect { described_class.scrub_breadcrumb(bc) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## Summary
- The COPPA Sentry scrub introduced in the Sentry adoption PR is dead code in production. `set_sentry_user` writes `SHA-512(remote_ip)` into `Sentry.user.id` (correct, for issue grouping), but `CoppaSentryScrub#lookup_user` then runs `User.where(id: <128-char hex>).first`, which never resolves. `child_user?` returns false, `scrub!` never fires.
- Net effect: child PII has been shipping to Sentry on every event since the Sentry migration, despite the privacy promise documented in PR #225.

## Fix
- Stash `@api_user` in `RequestStore` from `set_sentry_user` (request-scoped, auto-cleared per request via the existing `request_store` gem middleware).
- `lookup_user` reads `RequestStore` first. Numeric-id fallback retained for background-job paths that explicitly use `Sentry.with_scope`.
- Issue grouping in Sentry UI is unchanged; `user.id` is still the IP hash.

## Also addresses (compliance-check WARN #1)
- New `config.before_breadcrumb` strips `access_token`, `token`, `password`, `reset_token`, `confirmation_token`, `tmp_token`, `api_key`, `secret_key`, `auth`, `bearer`, and `email` query params from breadcrumb URLs and message strings, for ALL users regardless of COPPA status. Closes the adult / unauthenticated breadcrumb leakage gap.

## Tests
- New regression case: hex-string `user.id` + child user reachable only via RequestStore -> full scrub fires.
- New negative case: hex-string id + empty RequestStore -> event left alone.
- 5 new `before_breadcrumb` cases.

## Audit reference
- `audit-reports/security-review-2026-05-04.md` finding #1 (CRITICAL ship-blocker)
- `audit-reports/compliance-check-2026-05-04.md` warning #1

## Test plan
- [ ] CI passes
- [ ] Manual: trigger a Sentry event in staging while logged in as a COPPA-pending test account; confirm event payload in Sentry UI shows `[REDACTED]` for user, request body, and ip.
- [ ] Manual: trigger a Sentry event with `?access_token=foo` in the URL; confirm breadcrumb shows `access_token=[REDACTED]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)