### PR TITLE
fix(secrets): un-collapse SECRET_KEY_BASE / COOKIE_KEY encryption domains

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,11 @@ Rails.application.configure do
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
 
-  config.secret_key_base = ENV["SECRET_KEY_BASE"] || ENV["COOKIE_KEY"]
+  # Fail loud at boot if SECRET_KEY_BASE is missing. The previous form
+  # (`ENV["SECRET_KEY_BASE"] || ENV["COOKIE_KEY"]`) silently collapsed two
+  # encryption domains and made rotation procedures ambiguous.
+  # Render production sets SECRET_KEY_BASE via `generateValue: true`.
+  config.secret_key_base = ENV.fetch("SECRET_KEY_BASE")
   
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,7 +14,10 @@ Rails.application.configure do
   # (`ENV["SECRET_KEY_BASE"] || ENV["COOKIE_KEY"]`) silently collapsed two
   # encryption domains and made rotation procedures ambiguous.
   # Render production sets SECRET_KEY_BASE via `generateValue: true`.
-  config.secret_key_base = ENV.fetch("SECRET_KEY_BASE")
+  secret_key_base = ENV.fetch('SECRET_KEY_BASE')
+  raise ArgumentError, 'SECRET_KEY_BASE must be set and non-blank' if secret_key_base.strip.empty?
+
+  config.secret_key_base = secret_key_base
   
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -10,4 +10,13 @@ require 'oj'
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-LingoLinq::Application.config.secret_key_base = ENV['SECRET_KEY_BASE'] || ENV['COOKIE_KEY']
+# Authoritative source: SECRET_KEY_BASE. The legacy COOKIE_KEY fallback is
+# preserved for non-production environments only, until CI is updated to
+# set SECRET_KEY_BASE directly. Prod must fail loud rather than silently
+# fall back to a different encryption domain.
+LingoLinq::Application.config.secret_key_base = ENV.fetch('SECRET_KEY_BASE') do
+  if Rails.env.production?
+    raise 'SECRET_KEY_BASE env var must be set in production'
+  end
+  ENV['COOKIE_KEY'] || SecureRandom.hex(64)
+end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -14,9 +14,15 @@ require 'oj'
 # preserved for non-production environments only, until CI is updated to
 # set SECRET_KEY_BASE directly. Prod must fail loud rather than silently
 # fall back to a different encryption domain.
-LingoLinq::Application.config.secret_key_base = ENV.fetch('SECRET_KEY_BASE') do
+fetch_nonblank_env = lambda do |key|
+  value = ENV[key]
+  value unless value.nil? || value.strip.empty?
+end
+
+LingoLinq::Application.config.secret_key_base = fetch_nonblank_env.call('SECRET_KEY_BASE') || begin
   if Rails.env.production?
     raise 'SECRET_KEY_BASE env var must be set in production'
   end
-  ENV['COOKIE_KEY'] || SecureRandom.hex(64)
+
+  fetch_nonblank_env.call('COOKIE_KEY') || SecureRandom.hex(64)
 end


### PR DESCRIPTION
## Summary
Replaces \`config.secret_key_base = ENV["SECRET_KEY_BASE"] || ENV["COOKIE_KEY"]\` with a strict \`ENV.fetch\` so production fails loud at boot if the env var is missing, instead of silently swapping in a different encryption domain.

## Why this matters
\`SECRET_KEY_BASE\` is the root for Rails signed cookies, encrypted credentials, and \`MessageVerifier\` artifacts. \`COOKIE_KEY\` is a legacy env var with no other consumers in the codebase (grep confirms only the two .rb sites and the CI workflow). The OR-fallback collapsed two key identifiers into one, making rotation procedures ambiguous and invalidation modes hard to reason about.

Render prod sets \`SECRET_KEY_BASE\` via \`generateValue: true\`, so the fallback was never actually reached in prod. The audit flagged the template itself, not a live outage.

## Files
- \`config/environments/production.rb\`: \`ENV.fetch("SECRET_KEY_BASE")\`. Boots loudly.
- \`config/initializers/secret_token.rb\`: Same \`ENV.fetch\` form with a non-prod-only fallback to \`COOKIE_KEY\` (CI compatibility) then \`SecureRandom.hex(64)\` for local dev. Prod still raises.

## What's NOT in this PR
- \`render.yaml\` is untouched (changing it can trigger redeploys with new env values; safer to remove \`COOKIE_KEY\` once CI is updated).
- \`.github/workflows/ci.yml\` is untouched. Adding \`SECRET_KEY_BASE: \${{ secrets.SECRET_KEY_BASE }}\` to CI requires the secret to be added in GitHub repo settings first.

## Audit reference
- \`audit-reports/infra-audit-2026-05-04.md\` finding NEW HIGH (Section 2a)

## Test plan
- [ ] CI passes (the secret_token.rb fallback chain still covers \`COOKIE_KEY\` in CI today).
- [ ] On staging deploy: confirm app boots; \`SECRET_KEY_BASE\` is already set in Render.
- [ ] After staging soak, follow-up PR adds \`SECRET_KEY_BASE\` to GitHub Actions secrets and removes the \`COOKIE_KEY\` fallback in secret_token.rb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)