### PR TITLE
fix(progress): scope idempotency and view permission to the initiating user

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -286,7 +286,7 @@ class Api::BoardsController < ApplicationController
       if !params['q'].blank? && !params['public']
         limited_boards = boards
         if params['allow_job'] #&& boards.limit(26).select('id').length > 25
-          progress = Progress.schedule(Board, :long_query, params['q'], params['locale'], boards.select('id, board_content_id').map(&:global_id) + (other_searchable_board_ids || []))
+          progress = Progress.schedule(Board, :long_query, params['q'], params['locale'], boards.select('id, board_content_id').map(&:global_id) + (other_searchable_board_ids || []), for_user: @api_user)
           boards = []
         else
           # For private user searches this will limit to the user's first 25 boards
@@ -650,7 +650,7 @@ class Api::BoardsController < ApplicationController
     board = Board.find_by_path(params['board_id'])
     return unless exists?(board, params['board_id'])
     return unless allowed?(board, 'edit')
-    progress = Progress.schedule(board, :slice_locales, params['locales'], params['ids_to_update'], (@api_user && @api_user.global_id))
+    progress = Progress.schedule(board, :slice_locales, params['locales'], params['ids_to_update'], (@api_user && @api_user.global_id), for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
   end
 
@@ -726,13 +726,13 @@ class Api::BoardsController < ApplicationController
       'text_only' => params['text_only'] == '1',
       'text_case' => params['text_case'],
       'font' => params['font']
-    })
+    }, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
   end
   
   def import
     if params['url']
-      progress = Progress.schedule(Board, :import, @api_user.global_id, params['url'])
+      progress = Progress.schedule(Board, :import, @api_user.global_id, params['url'], for_user: @api_user)
       render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
     else
       type = (params['type'] == 'obz' ? 'obz' : 'obf')
@@ -763,7 +763,7 @@ class Api::BoardsController < ApplicationController
       'board_ids' => ids,
       'default' => set_as_default,
       'user_key' => user_for_paper_trail
-    })
+    }, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
   end
 
@@ -774,7 +774,7 @@ class Api::BoardsController < ApplicationController
     ids = params['board_ids_to_convert'] || []
     ids << board.global_id
     ids << "new:#{board.global_id}" if params['include_new']
-    progress = Progress.schedule(board, :swap_images, params['library'], @api_user.global_id, ids)
+    progress = Progress.schedule(board, :swap_images, params['library'], @api_user.global_id, ids, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
   end
 
@@ -784,7 +784,7 @@ class Api::BoardsController < ApplicationController
     return unless allowed?(board, 'edit')
     ids = params['board_ids_to_update'] || []
     ids << board.global_id
-    progress = Progress.schedule(board, :update_privacy, params['privacy'], @api_user.global_id, ids)
+    progress = Progress.schedule(board, :update_privacy, params['privacy'], @api_user.global_id, ids, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
   end
 

--- a/app/controllers/api/button_sets_controller.rb
+++ b/app/controllers/api/button_sets_controller.rb
@@ -86,7 +86,7 @@ class Api::ButtonSetsController < ApplicationController
       end
 
       # Default Async Behavior (Restored)
-      progress = Progress.schedule(BoardDownstreamButtonSet, :generate_for, board.global_id, user_id)
+      progress = Progress.schedule(BoardDownstreamButtonSet, :generate_for, board.global_id, user_id, for_user: @api_user)
       render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
     end
   end

--- a/app/controllers/api/logs_controller.rb
+++ b/app/controllers/api/logs_controller.rb
@@ -213,7 +213,7 @@ class Api::LogsController < ApplicationController
       type = 'unspecified'
       type = 'obl' if params['type'] == 'obl'
       type = 'lam' if params['type'] == 'lam'
-      progress = Progress.schedule(Exporter, :process_log, params['url'] || params['content'], type, user.global_id, @api_user.global_id, @api_device_id)
+      progress = Progress.schedule(Exporter, :process_log, params['url'] || params['content'], type, user.global_id, @api_user.global_id, @api_device_id, for_user: @api_user)
       render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
     else
       remote_path = "imports/logs/#{@api_user.global_id}/upload-#{GoSecure.nonce('filename')}.txt"
@@ -273,7 +273,7 @@ class Api::LogsController < ApplicationController
         return unless allowed?(log.user, 'never_allow')
       end    
   
-      progress = Progress.schedule(Exporter, :export_log, log.global_id)
+      progress = Progress.schedule(Exporter, :export_log, log.global_id, for_user: @api_user)
       render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
     elsif params['user_id']
       user = User.find_by_global_id(params['user_id'])
@@ -286,7 +286,7 @@ class Api::LogsController < ApplicationController
       if cutoff
         return unless allowed?(user, 'never_allow')
       end    
-      progress = Progress.schedule(Exporter, :export_logs, user.global_id, !!params['anonymized'])
+      progress = Progress.schedule(Exporter, :export_logs, user.global_id, !!params['anonymized'], for_user: @api_user)
       render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
     end
   end

--- a/app/controllers/api/purchasing_controller.rb
+++ b/app/controllers/api/purchasing_controller.rb
@@ -23,7 +23,7 @@ class Api::PurchasingController < ApplicationController
     user_id = @api_user && @api_user.global_id
     extras = params['extras'] == true || params['extras'] == 'true'
     donate = params['donate'] == true || params['donate'] == 'true'
-    progress = Progress.schedule(GiftPurchase, :process_subscription_token, token.to_unsafe_h, {'type' => params['type'], 'code' => params['code'], 'email' => params['email'], 'user_id' => user_id, 'extras' => extras, 'supporters' => params['supporters'].to_i, 'donate' => donate})
+    progress = Progress.schedule(GiftPurchase, :process_subscription_token, token.to_unsafe_h, {'type' => params['type'], 'code' => params['code'], 'email' => params['email'], 'user_id' => user_id, 'extras' => extras, 'supporters' => params['supporters'].to_i, 'donate' => donate}, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
 end

--- a/app/controllers/api/sounds_controller.rb
+++ b/app/controllers/api/sounds_controller.rb
@@ -30,7 +30,7 @@ class Api::SoundsController < ApplicationController
   
   def import
     if params['url']
-      progress = Progress.schedule(ButtonSound, :import_for, @api_user.global_id, params['url'])
+      progress = Progress.schedule(ButtonSound, :import_for, @api_user.global_id, params['url'], for_user: @api_user)
       render json: JsonApi::Progress.as_json(progress, :wrapper => true).to_json
     else
       remote_path = "imports/sounds/#{@api_user.global_id}/upload-#{GoSecure.nonce('filename')}.zip"

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -359,7 +359,7 @@ class Api::UsersController < ApplicationController
       'immediate' => true,
       'associated_user_id' => (associated_user && associated_user.global_id),
       'button_id' => params['button_id']
-    })
+    }, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
   
@@ -380,7 +380,7 @@ class Api::UsersController < ApplicationController
     user = User.find_by_path(params['user_id'])
     return unless allowed?(user, 'delete')
     return api_error(400, {'flushed' => 'false', 'user_name_math' => (user.user_name == params['user_name']), 'user_id_match' => (user.global_id == params['confirm_user_id'])}) unless user.user_name == params['user_name'] && user.global_id == params['confirm_user_id']
-    progress = Progress.schedule(Flusher, :flush_user_logs, user.global_id, user.user_name)
+    progress = Progress.schedule(Flusher, :flush_user_logs, user.global_id, user.user_name, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
   
@@ -434,7 +434,7 @@ class Api::UsersController < ApplicationController
     if existing.instance_variable_get('@fresh')
       render json: existing
     else
-      progress = Progress.schedule(WordData, :update_activities_for, user.global_id, true)
+      progress = Progress.schedule(WordData, :update_activities_for, user.global_id, true, for_user: @api_user)
       render json: JsonApi::Progress.as_json(progress, :wrapper => true)
     end
   end
@@ -526,18 +526,18 @@ class Api::UsersController < ApplicationController
     if params['type'] == 'gift_code'
       return require_api_token unless @api_user
       return unless allowed?(user, 'edit')
-      progress = Progress.schedule(user, :redeem_gift_token, token['code'])
+      progress = Progress.schedule(user, :redeem_gift_token, token['code'], for_user: @api_user || user)
     elsif['never_expires', 'eval', 'add_1', 'add_5_years', 'manual_supporter', 'add_voice', 'communicator_trial', 'force_logout', 'enable_extras', 'supporter_credit', 'check_remote', 'restore', 'manual_modeler'].include?(params['type'])
       return require_api_token unless @api_user
       return unless allowed?(user, 'admin_support_actions')
-      progress = Progress.schedule(user, :subscription_override, params['type'], @api_user && @api_user.global_id)
+      progress = Progress.schedule(user, :subscription_override, params['type'], @api_user && @api_user.global_id, for_user: @api_user)
     else
       if user.registration_code && params['confirmation'] == user.registration_code
       else
         return require_api_token unless @api_user
         return unless allowed?(user, 'edit')
       end
-      progress = Progress.schedule(user, :process_subscription_token, token, params['type'], params['code'])
+      progress = Progress.schedule(user, :process_subscription_token, token, params['type'], params['code'], for_user: @api_user || user)
     end
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
@@ -549,7 +549,7 @@ class Api::UsersController < ApplicationController
     user.settings['subscription'] ||= {}
     user.settings['subscription']['unsubscribe_reason'] = params['reason'] if params['reason']
     user.save_with_sync('unsubscribe')
-    progress = Progress.schedule(user, :process_subscription_token, 'token', 'unsubscribe')
+    progress = Progress.schedule(user, :process_subscription_token, 'token', 'unsubscribe', for_user: @api_user || user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
 
@@ -557,7 +557,7 @@ class Api::UsersController < ApplicationController
     user = User.find_by_path(params['user_id'])
     return unless exists?(user, params['user_id'])
     return unless allowed?(user, 'edit')
-    progress = Progress.schedule(user, :verify_receipt, params['receipt_data'])
+    progress = Progress.schedule(user, :verify_receipt, params['receipt_data'], for_user: @api_user || user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
   
@@ -571,19 +571,19 @@ class Api::UsersController < ApplicationController
     
     make_public = params['make_public'] && params['make_public'] == '1' || params['make_public'] == 'true' || params['make_public'] == true
     progress = Progress.schedule(user, :replace_board, {
-      old_board_id: params['old_board_id'], 
-      new_board_id: params['new_board_id'], 
-      old_default_locale: params['old_default_locale'], 
-      new_default_locale: params['new_default_locale'], 
-      ids_to_copy: params['ids_to_copy'], 
+      old_board_id: params['old_board_id'],
+      new_board_id: params['new_board_id'],
+      old_default_locale: params['old_default_locale'],
+      new_default_locale: params['new_default_locale'],
+      ids_to_copy: params['ids_to_copy'],
       copy_prefix: params['copy_prefix'],
-      update_inline: params['update_inline'], 
+      update_inline: params['update_inline'],
       copier_id: @api_user && @api_user.global_id,
       new_owner: params['new_owner'],
       disconnect: params['disconnect'],
       make_public: make_public,
       user_for_paper_trail: user_for_paper_trail
-    })
+    }, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
   
@@ -603,13 +603,13 @@ class Api::UsersController < ApplicationController
         new_default_locale: params['new_default_locale'], 
         ids_to_copy: params['ids_to_copy'], 
         copy_prefix: params['copy_prefix'],
-        make_public: make_public, 
+        make_public: make_public,
         copier_id: @api_user && @api_user.global_id,
         new_owner: params['new_owner'],
         disconnect: params['disconnect'],
         user_for_paper_trail: user_for_paper_trail,
-        swap_library: params['swap_library']      
-    })
+        swap_library: params['swap_library']
+    }, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
   
@@ -939,7 +939,7 @@ class Api::UsersController < ApplicationController
     if !target || !target.valid_password?(params['password'])
       return api_error(400, {error: 'invalid_credentials'})
     end
-    progress = Progress.schedule(user, :transfer_eval_to, target.global_id, @api_device_id, true)
+    progress = Progress.schedule(user, :transfer_eval_to, target.global_id, @api_device_id, true, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
 
@@ -967,7 +967,7 @@ class Api::UsersController < ApplicationController
       opts['expires'] = params['expires']
     end
 
-    progress = Progress.schedule(user, :reset_eval, @api_device_id, opts)
+    progress = Progress.schedule(user, :reset_eval, @api_device_id, opts, for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -526,7 +526,7 @@ class Api::UsersController < ApplicationController
     if params['type'] == 'gift_code'
       return require_api_token unless @api_user
       return unless allowed?(user, 'edit')
-      progress = Progress.schedule(user, :redeem_gift_token, token['code'], for_user: @api_user || user)
+      progress = Progress.schedule(user, :redeem_gift_token, token['code'], for_user: @api_user)
     elsif['never_expires', 'eval', 'add_1', 'add_5_years', 'manual_supporter', 'add_voice', 'communicator_trial', 'force_logout', 'enable_extras', 'supporter_credit', 'check_remote', 'restore', 'manual_modeler'].include?(params['type'])
       return require_api_token unless @api_user
       return unless allowed?(user, 'admin_support_actions')
@@ -537,7 +537,14 @@ class Api::UsersController < ApplicationController
         return require_api_token unless @api_user
         return unless allowed?(user, 'edit')
       end
-      progress = Progress.schedule(user, :process_subscription_token, token, params['type'], params['code'], for_user: @api_user || user)
+      # for_user: @api_user (NOT `|| user`). The confirmation-code branch
+      # above intentionally allows anonymous calls (no @api_user). The
+      # frontend then polls /api/v1/progress/<id> anonymously, and
+      # Api::ProgressController authorizes against @api_user. Owner-scoping
+      # to the target user would 401 those polls and hang the purchase UI.
+      # When @api_user is nil here, the progress falls back to legacy
+      # permissive view (protected by the global_id nonce on Progress).
+      progress = Progress.schedule(user, :process_subscription_token, token, params['type'], params['code'], for_user: @api_user)
     end
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
@@ -549,7 +556,7 @@ class Api::UsersController < ApplicationController
     user.settings['subscription'] ||= {}
     user.settings['subscription']['unsubscribe_reason'] = params['reason'] if params['reason']
     user.save_with_sync('unsubscribe')
-    progress = Progress.schedule(user, :process_subscription_token, 'token', 'unsubscribe', for_user: @api_user || user)
+    progress = Progress.schedule(user, :process_subscription_token, 'token', 'unsubscribe', for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
 
@@ -557,7 +564,7 @@ class Api::UsersController < ApplicationController
     user = User.find_by_path(params['user_id'])
     return unless exists?(user, params['user_id'])
     return unless allowed?(user, 'edit')
-    progress = Progress.schedule(user, :verify_receipt, params['receipt_data'], for_user: @api_user || user)
+    progress = Progress.schedule(user, :verify_receipt, params['receipt_data'], for_user: @api_user)
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
   

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -6,7 +6,18 @@ class Progress < ActiveRecord::Base
   before_save :generate_defaults
   
   include Permissions
-  add_permissions('view' ,['*']) { true }
+  # Restrict 'view' to the user who scheduled the progress (recorded via
+  # `for_user:` keyword on Progress.schedule). Legacy progresses without an
+  # owner remain world-readable for backward-compat with in-flight records;
+  # all new sensitive callers (downloads, exports, billing) now pass for_user.
+  add_permissions('view', ['*']) do |user|
+    owner = settings.is_a?(Hash) ? settings['for_user_global_id'] : nil
+    if owner.nil?
+      true
+    else
+      user && user.respond_to?(:global_id) && user.global_id == owner
+    end
+  end
   
   
   def generate_defaults
@@ -73,24 +84,38 @@ class Progress < ActiveRecord::Base
     @@progress_error = str
   end
   
-  def self.schedule(obj, method, *args)
+  # `for_user:` records the user who initiated the progress so:
+  #   1. Idempotency does NOT pool work across users (User B is not handed
+  #      User A's progress with its result hash + presigned download_url).
+  #   2. The 'view' permission can scope to that owner.
+  # Legacy callers that pass nil keep the pre-2026-05-04 permissive behavior.
+  def self.schedule(obj, method, *args, for_user: nil)
     # TODO: this (clear_old_progresses) should probably be more of a cron task
     clear_old_progresses
-    
+
     id = nil
     if obj.is_a?(ActiveRecord::Base)
       id = obj.id
       obj = obj.class
     end
 
+    for_user_global_id = if for_user.respond_to?(:global_id)
+      for_user.global_id
+    else
+      for_user.to_s.presence
+    end
+
     # Check for existing pending or started progress for the same operation
+    # AND the same initiating user. Mismatched user means we create a new
+    # record so each user gets their own result hash.
     existing = Progress.where("started_at > ? OR (started_at IS NULL AND created_at > ?)", 4.hours.ago, 1.hour.ago)
                        .where(finished_at: nil)
                        .find do |p|
       p.settings['class'] == obj.to_s &&
       p.settings['id'] == id &&
       p.settings['method'].to_s == method.to_s &&
-      p.settings['arguments'] == args
+      p.settings['arguments'] == args &&
+      p.settings['for_user_global_id'] == for_user_global_id
     end
     return existing if existing
 
@@ -99,7 +124,8 @@ class Progress < ActiveRecord::Base
       'class' => obj.to_s,
       'id' => id,
       'method' => method,
-      'arguments' => args
+      'arguments' => args,
+      'for_user_global_id' => for_user_global_id
     }
     progress.save!
     Worker.schedule_for(:priority, Progress, :perform_action, progress.id)

--- a/spec/controllers/api/boards_controller_spec.rb
+++ b/spec/controllers/api/boards_controller_spec.rb
@@ -2088,7 +2088,7 @@ describe Api::BoardsController, :type => :controller do
     it "should schedule processing for url" do
       token_user
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(Board, :import, @user.global_id, 'http://www.example.com/file.obf').and_return(p)
+      expect(Progress).to receive(:schedule).with(Board, :import, @user.global_id, 'http://www.example.com/file.obf', for_user: @user).and_return(p)
       post :import, params: {:url => 'http://www.example.com/file.obf'}
       expect(response).to be_successful
       json = JSON.parse(response.body)

--- a/spec/controllers/api/purchasing_controller_spec.rb
+++ b/spec/controllers/api/purchasing_controller_spec.rb
@@ -21,7 +21,7 @@ describe Api::PurchasingController, :type => :controller do
     it "should call the purchasing library and return a progress object" do
       token_user
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(GiftPurchase, :process_subscription_token, {'id' => 'abc'}, {'type' => 'long_term_200', 'email' => nil, 'user_id' => @user.global_id, 'code' => nil, 'extras' => false, 'supporters' => 0, 'donate' => false}).and_return(p)
+      expect(Progress).to receive(:schedule).with(GiftPurchase, :process_subscription_token, {'id' => 'abc'}, {'type' => 'long_term_200', 'email' => nil, 'user_id' => @user.global_id, 'code' => nil, 'extras' => false, 'supporters' => 0, 'donate' => false}, for_user: @user).and_return(p)
       post :purchase_gift, params: {:token => {'id' => 'abc'}, :type => 'long_term_200'}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
@@ -31,7 +31,7 @@ describe Api::PurchasingController, :type => :controller do
     it "should pass the code if specified" do
       token_user
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(GiftPurchase, :process_subscription_token, {'id' => 'abc'}, {'type' => 'long_term_200', 'email' => nil, 'user_id' => @user.global_id, 'code' => 'asdfasdf', 'extras' => false, 'supporters' => 0, 'donate' => false}).and_return(p)
+      expect(Progress).to receive(:schedule).with(GiftPurchase, :process_subscription_token, {'id' => 'abc'}, {'type' => 'long_term_200', 'email' => nil, 'user_id' => @user.global_id, 'code' => 'asdfasdf', 'extras' => false, 'supporters' => 0, 'donate' => false}, for_user: @user).and_return(p)
       post :purchase_gift, params: {:token => {'id' => 'abc'}, :type => 'long_term_200', :code => 'asdfasdf'}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
@@ -41,7 +41,7 @@ describe Api::PurchasingController, :type => :controller do
     it "should pass extra options if specified" do
       token_user
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(GiftPurchase, :process_subscription_token, {'id' => 'abc'}, {'type' => 'long_term_200', 'email' => nil, 'user_id' => @user.global_id, 'code' => 'asdfasdf', 'extras' => true, 'supporters' => 0, 'donate' => true}).and_return(p)
+      expect(Progress).to receive(:schedule).with(GiftPurchase, :process_subscription_token, {'id' => 'abc'}, {'type' => 'long_term_200', 'email' => nil, 'user_id' => @user.global_id, 'code' => 'asdfasdf', 'extras' => true, 'supporters' => 0, 'donate' => true}, for_user: @user).and_return(p)
       post :purchase_gift, params: {:token => {'id' => 'abc'}, :type => 'long_term_200', :code => 'asdfasdf', 'extras' => true, 'donate' => true}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)

--- a/spec/controllers/api/sounds_controller_spec.rb
+++ b/spec/controllers/api/sounds_controller_spec.rb
@@ -230,7 +230,7 @@ describe Api::SoundsController, :type => :controller do
     it "should schedule processing for url" do
       token_user
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(ButtonSound, :import_for, @user.global_id, 'http://www.example.com/sound.zip').and_return(p)
+      expect(Progress).to receive(:schedule).with(ButtonSound, :import_for, @user.global_id, 'http://www.example.com/sound.zip', for_user: @user).and_return(p)
       post :import, params: {:url => 'http://www.example.com/sound.zip'}
       expect(response).to be_successful
       json = JSON.parse(response.body)

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -1830,7 +1830,7 @@ describe Api::UsersController, :type => :controller do
     it "should schedule token processing" do
       token_user
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(@user, :process_subscription_token, {'code' => 'abc'}, 'monthly_6', nil).and_return(p)
+      expect(Progress).to receive(:schedule).with(@user, :process_subscription_token, {'code' => 'abc'}, 'monthly_6', nil, for_user: @user).and_return(p)
       post :subscribe, params: {:user_id => @user.global_id, :token => {'code' => 'abc'}, :type => 'monthly_6'}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
@@ -1840,7 +1840,7 @@ describe Api::UsersController, :type => :controller do
     it "should allow redeeming a gift purchase" do
       token_user
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(@user, :redeem_gift_token, 'abc').and_return(p)
+      expect(Progress).to receive(:schedule).with(@user, :redeem_gift_token, 'abc', for_user: @user).and_return(p)
       post :subscribe, params: {:user_id => @user.global_id, :token => {'code' => 'abc'}, :type => 'gift_code'}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
@@ -2016,7 +2016,7 @@ describe Api::UsersController, :type => :controller do
     it "should allow updating a subscription with no api token, but a confirmation code" do
       @user = User.create
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(@user, :process_subscription_token, {'code' => 'abc'}, 'monthly_6', nil).and_return(p)
+      expect(Progress).to receive(:schedule).with(@user, :process_subscription_token, {'code' => 'abc'}, 'monthly_6', nil, for_user: nil).and_return(p)
       post :subscribe, params: {:user_id => @user.global_id, :confirmation => @user.registration_code, :token => {'code' => 'abc'}, :type => 'monthly_6'}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
@@ -2052,7 +2052,7 @@ describe Api::UsersController, :type => :controller do
     it "should schedule token processing" do
       token_user
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(@user, :process_subscription_token, 'token', 'unsubscribe').and_return(p)
+      expect(Progress).to receive(:schedule).with(@user, :process_subscription_token, 'token', 'unsubscribe', for_user: @user).and_return(p)
       delete :unsubscribe, params: {:user_id => @user.global_id}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
@@ -3639,7 +3639,7 @@ describe Api::UsersController, :type => :controller do
       json = assert_success_json
       expect(json['progress']).to_not eq(nil)
       p = Progress.find_by_path(json['progress']['id'])
-      expect(p.settings).to eq({'class' => 'User', 'id' => @user.id, 'method' => 'reset_eval', 'state' => 'pending', 'arguments' => [@user.devices[0].global_id, {'email' => nil, 'home_board_key' => nil, 'password' => nil, 'symbol_library' => nil}]})
+      expect(p.settings).to eq({'class' => 'User', 'id' => @user.id, 'method' => 'reset_eval', 'state' => 'pending', 'arguments' => [@user.devices[0].global_id, {'email' => nil, 'home_board_key' => nil, 'password' => nil, 'symbol_library' => nil}], 'for_user_global_id' => @user.global_id})
     end
   end
 

--- a/spec/features/throttling_spec.rb
+++ b/spec/features/throttling_spec.rb
@@ -133,7 +133,7 @@ describe "throttling URLs" do
       @user = User.create
       @device = Device.create(:user => @user, :developer_key_id => 1, :device_key => 'hippo')
       p = Progress.create
-      expect(Progress).to receive(:schedule).with(GiftPurchase, :process_subscription_token, {'id' => 'abc'}, {'type' => 'long_term_200', 'email' => nil, 'user_id' => @user.global_id, 'code' => nil, 'extras' => false, 'supporters' => 0, 'donate' => false}).and_return(p).exactly(10).times
+      expect(Progress).to receive(:schedule).with(GiftPurchase, :process_subscription_token, {'id' => 'abc'}, {'type' => 'long_term_200', 'email' => nil, 'user_id' => @user.global_id, 'code' => nil, 'extras' => false, 'supporters' => 0, 'donate' => false}, for_user: @user).and_return(p).exactly(10).times
       aggressive_throttle_check(->{
         header 'Authorization', "Bearer #{@device.tokens[0]}"
         header 'Check-Token', 'true'

--- a/spec/models/progress_idempotency_spec.rb
+++ b/spec/models/progress_idempotency_spec.rb
@@ -68,4 +68,98 @@ describe Progress, "idempotency" do
     p2 = Progress.schedule(obj, method, *args)
     expect(p2.id).not_to eq(p1.id)
   end
+
+  describe "cross-user safety (audit-reports/security-review-2026-05-04 finding #2)" do
+    it "does NOT pool a progress across users when for_user differs" do
+      obj = User.create
+      user_a = User.create
+      user_b = User.create
+      method = :count
+      args = [11, 12]
+
+      p1 = Progress.schedule(obj, method, *args, for_user: user_a)
+      p2 = Progress.schedule(obj, method, *args, for_user: user_b)
+
+      expect(p1.id).not_to eq(p2.id)
+      expect(p1.settings['for_user_global_id']).to eq(user_a.global_id)
+      expect(p2.settings['for_user_global_id']).to eq(user_b.global_id)
+    end
+
+    it "DOES pool a progress for the same user when args match" do
+      obj = User.create
+      user_a = User.create
+      method = :count
+      args = [13, 14]
+
+      p1 = Progress.schedule(obj, method, *args, for_user: user_a)
+      p2 = Progress.schedule(obj, method, *args, for_user: user_a)
+
+      expect(p1.id).to eq(p2.id)
+    end
+
+    it "treats two nil-owner progresses as poolable (legacy / system path)" do
+      obj = User.create
+      method = :count
+      args = [15, 16]
+
+      p1 = Progress.schedule(obj, method, *args)
+      p2 = Progress.schedule(obj, method, *args)
+
+      expect(p1.id).to eq(p2.id)
+      expect(p1.settings['for_user_global_id']).to be_nil
+    end
+
+    it "does NOT pool a nil-owner progress with a for_user-scoped one" do
+      obj = User.create
+      user_a = User.create
+      method = :count
+      args = [17, 18]
+
+      p1 = Progress.schedule(obj, method, *args)
+      p2 = Progress.schedule(obj, method, *args, for_user: user_a)
+
+      expect(p1.id).not_to eq(p2.id)
+    end
+
+    it "stores for_user_global_id when a User object is passed" do
+      obj = User.create
+      user_a = User.create
+      method = :count
+
+      p1 = Progress.schedule(obj, method, for_user: user_a)
+      expect(p1.settings['for_user_global_id']).to eq(user_a.global_id)
+    end
+
+    it "stores for_user_global_id when a string global_id is passed" do
+      obj = User.create
+      method = :count
+
+      p1 = Progress.schedule(obj, method, for_user: '42_test')
+      expect(p1.settings['for_user_global_id']).to eq('42_test')
+    end
+  end
+
+  describe "view permission (audit-reports/security-review-2026-05-04 finding #2)" do
+    it "denies view to a user who is not the owner" do
+      user_a = User.create
+      user_b = User.create
+      progress = Progress.schedule(User.create, :count, 1, for_user: user_a)
+
+      expect(progress.allows?(user_b, 'view')).to eq(false)
+    end
+
+    it "allows view for the owner" do
+      user_a = User.create
+      progress = Progress.schedule(User.create, :count, 2, for_user: user_a)
+
+      expect(progress.allows?(user_a, 'view')).to eq(true)
+    end
+
+    it "allows view for any authenticated user when there is no owner (legacy)" do
+      user_a = User.create
+      progress = Progress.schedule(User.create, :count, 3)
+
+      expect(progress.allows?(user_a, 'view')).to eq(true)
+    end
+  end
 end

--- a/spec/models/progress_spec.rb
+++ b/spec/models/progress_spec.rb
@@ -108,12 +108,12 @@ describe Progress, :type => :model do
     it "should schedule a worker action for classes or objects" do
       p = Progress.schedule(User, :count)
       expect(Worker.scheduled_for?('priority', Progress, :perform_action, p.id)).to eq(true)
-      expect(p.settings).to eq({'class' => 'User', 'id' => nil, 'method' => 'count', 'arguments' => [], 'state' => 'pending'})
+      expect(p.settings).to eq({'class' => 'User', 'id' => nil, 'method' => 'count', 'arguments' => [], 'for_user_global_id' => nil, 'state' => 'pending'})
 
-      u = User.create      
+      u = User.create
       p = Progress.schedule(u, :touch, true, false)
       expect(Worker.scheduled_for?('priority', Progress, :perform_action, p.id)).to eq(true)
-      expect(p.settings).to eq({'class' => 'User', 'id' => u.id, 'method' => 'touch', 'arguments' => [true, false], 'state' => 'pending'})
+      expect(p.settings).to eq({'class' => 'User', 'id' => u.id, 'method' => 'touch', 'arguments' => [true, false], 'for_user_global_id' => nil, 'state' => 'pending'})
     end
   end
 


### PR DESCRIPTION
## Summary
Closes the cross-user pooling and view-permission gaps in `Progress` flagged as HIGH by `audit-reports/security-review-2026-05-04.md` finding #2.

Today: `Progress` exposes \`add_permissions('view', ['*']) { true }\` and pools work purely on \`(class, id, method, args)\`. If two users happen to fire the same operation with identical args, the second one is handed back the first one's progress object and can later see its result hash. For \`generate_download\` that result hash contains a presigned S3 \`download_url\`. Existing safety relies on convention (most callers thread \`user_global_id\` into args); the audit's concern is the next caller that omits it.

## What changed
- \`Progress.schedule\` now accepts a \`for_user:\` keyword. The initiating user's global_id is recorded in \`settings['for_user_global_id']\` and participates in the idempotency match alongside class/id/method/args.
- \`'view'\` permission rule rewritten: owner-only when \`for_user_global_id\` is recorded; permissive when nil (backward-compat for legacy / admin / background progresses).
- All security-sensitive call sites updated to pass \`for_user: @api_user\`. Admin/system call sites (global stats, admin trends, anonymous logs, webhook test, background sound suggestions) deliberately left as nil-owner.

## Tests added (\`spec/models/progress_idempotency_spec.rb\`)
- Cross-user pooling is blocked.
- Same-user pooling still works.
- Two nil-owner progresses still pool (legacy / system path).
- nil-owner and for_user-scoped progresses do not pool.
- View permission: owner allowed, non-owner denied, legacy permissive.

## Files
- \`app/models/progress.rb\`
- \`app/controllers/api/{boards,logs,users,sounds,button_sets,purchasing}_controller.rb\`
- \`spec/models/progress_idempotency_spec.rb\`

## What's NOT in this PR
- The remaining benign call sites (admin/background) keep the nil-owner shape; in-flight records also keep it. Once all in-flight records age out (4-hour window), a follow-up PR can remove the legacy \`owner.nil? -> true\` branch and require ownership unconditionally.

## Audit reference
- \`audit-reports/security-review-2026-05-04.md\` finding #2 (HIGH)

## Test plan
- [ ] CI passes.
- [ ] Manual on staging: User A scheduling \`generate_download\` while User B simultaneously schedules the same board+type yields two distinct progress IDs.
- [ ] Manual on staging: User B polling User A's progress ID returns 401 / not found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)