### PR TITLE
fix(ai-log): scrub response_summary on save; harden daily_summary findings

### DIFF
--- a/app/models/ai_api_log.rb
+++ b/app/models/ai_api_log.rb
@@ -26,7 +26,11 @@ class AiApiLog < ApplicationRecord
   def pii_scrub(value)
     return value unless value.is_a?(String) && !value.empty?
     result = PiiScrubber.redact_for_ai(value)
-    scrubbed = result.is_a?(Hash) ? result[:payload] : result
+    scrubbed = if result.is_a?(Hash)
+                 result[:payload]
+               else
+                 result
+               end
     scrubbed.is_a?(String) ? scrubbed : '[REDACTED]'
   rescue StandardError => e
     Rails.logger.error("AiApiLog: pii_scrub failed: #{e.message}") if defined?(Rails)

--- a/app/models/ai_api_log.rb
+++ b/app/models/ai_api_log.rb
@@ -1,6 +1,4 @@
 class AiApiLog < ApplicationRecord
-  require_relative '../../lib/pii_scrubber'
-
   # Validations
   validates :ai_provider, presence: true
   validates :request_type, presence: true
@@ -28,7 +26,8 @@ class AiApiLog < ApplicationRecord
   def pii_scrub(value)
     return value unless value.is_a?(String) && !value.empty?
     result = PiiScrubber.redact_for_ai(value)
-    result.is_a?(Hash) ? result[:payload] : value
+    scrubbed = result.is_a?(Hash) ? result[:payload] : result
+    scrubbed.is_a?(String) ? scrubbed : '[REDACTED]'
   rescue StandardError => e
     Rails.logger.error("AiApiLog: pii_scrub failed: #{e.message}") if defined?(Rails)
     '[REDACTED]'
@@ -220,8 +219,11 @@ class AiApiLog < ApplicationRecord
   # finding keys: type, position. The :value preview field is dropped
   # entirely; consumers do not need it for digest aggregation.
   def safe_pii_findings_for_digest
-    parsed_pii_findings.map do |f|
-      next f unless f.is_a?(Hash)
+    findings = parsed_pii_findings
+    return [] unless findings.is_a?(Array)
+
+    findings.filter_map do |f|
+      next unless f.is_a?(Hash)
       {
         'type' => f['type'] || f[:type],
         'position' => f['position'] || f[:position]

--- a/app/models/ai_api_log.rb
+++ b/app/models/ai_api_log.rb
@@ -28,12 +28,14 @@ class AiApiLog < ApplicationRecord
   def pii_scrub(value)
     return value unless value.is_a?(String) && !value.empty?
     result = PiiScrubber.redact_for_ai(value)
-    scrubbed = if result.is_a?(Hash)
-                 result[:payload]
-               else
-                 result
-               end
-    scrubbed.is_a?(String) ? scrubbed : REDACTED_PLACEHOLDER
+    return result if result.is_a?(String)
+
+    if result.is_a?(Hash)
+      payload = result[:payload]
+      return payload if payload.is_a?(String)
+    end
+
+    REDACTED_PLACEHOLDER
   rescue StandardError => e
     Rails.logger.error("AiApiLog: pii_scrub failed: #{e.message}") if defined?(Rails)
     REDACTED_PLACEHOLDER

--- a/app/models/ai_api_log.rb
+++ b/app/models/ai_api_log.rb
@@ -1,4 +1,6 @@
 class AiApiLog < ApplicationRecord
+  require_relative '../../lib/pii_scrubber'
+
   # Validations
   validates :ai_provider, presence: true
   validates :request_type, presence: true
@@ -7,6 +9,30 @@ class AiApiLog < ApplicationRecord
     allow_blank: false,
     message: "%{value} is not a recognized AI provider"
   }
+
+  # Scrub PII out of free-form summary columns before persistence. Request
+  # summaries are usually built from already-scrubbed prompts, but model
+  # responses are raw model output and frequently echo names / emails from
+  # the prompt or hallucinate new ones. Audit-reports/security-review-2026-05-04
+  # finding #3 flagged response_summary as a latent PII reservoir, one new
+  # SQL caller away from leakage. Scrub on assignment so no future caller
+  # can store raw output even by accident.
+  before_validation :scrub_summary_columns
+
+  def scrub_summary_columns
+    self.response_summary = pii_scrub(response_summary)
+    self.request_summary = pii_scrub(request_summary)
+    nil
+  end
+
+  def pii_scrub(value)
+    return value unless value.is_a?(String) && !value.empty?
+    result = PiiScrubber.redact_for_ai(value)
+    result.is_a?(Hash) ? result[:payload] : value
+  rescue StandardError => e
+    Rails.logger.error("AiApiLog: pii_scrub failed: #{e.message}") if defined?(Rails)
+    '[REDACTED]'
+  end
 
   # Scopes
   scope :by_provider, ->(provider) { where(ai_provider: provider) }
@@ -145,7 +171,7 @@ class AiApiLog < ApplicationRecord
           id: row.id,
           provider: row.ai_provider,
           request_type: row.request_type,
-          findings: row.send(:parsed_pii_findings),
+          findings: row.safe_pii_findings_for_digest,
           created_at: row.created_at.iso8601
         }
       }
@@ -186,6 +212,21 @@ class AiApiLog < ApplicationRecord
       created_at: created_at&.iso8601,
       updated_at: updated_at&.iso8601
     }
+  end
+
+  # Public, defensively-scrubbed view of pii_findings for the n8n daily
+  # digest endpoint. Strips any field that could carry a raw PII value if a
+  # future PiiScrubber change started storing it. Whitelist of allowed
+  # finding keys: type, position. The :value preview field is dropped
+  # entirely; consumers do not need it for digest aggregation.
+  def safe_pii_findings_for_digest
+    parsed_pii_findings.map do |f|
+      next f unless f.is_a?(Hash)
+      {
+        'type' => f['type'] || f[:type],
+        'position' => f['position'] || f[:position]
+      }.compact
+    end
   end
 
   private

--- a/app/models/ai_api_log.rb
+++ b/app/models/ai_api_log.rb
@@ -1,4 +1,6 @@
 class AiApiLog < ApplicationRecord
+  REDACTED_PLACEHOLDER = '[REDACTED]'.freeze
+
   # Validations
   validates :ai_provider, presence: true
   validates :request_type, presence: true
@@ -31,10 +33,10 @@ class AiApiLog < ApplicationRecord
                else
                  result
                end
-    scrubbed.is_a?(String) ? scrubbed : '[REDACTED]'
+    scrubbed.is_a?(String) ? scrubbed : REDACTED_PLACEHOLDER
   rescue StandardError => e
     Rails.logger.error("AiApiLog: pii_scrub failed: #{e.message}") if defined?(Rails)
-    '[REDACTED]'
+    REDACTED_PLACEHOLDER
   end
 
   # Scopes

--- a/spec/models/ai_api_log_spec.rb
+++ b/spec/models/ai_api_log_spec.rb
@@ -292,6 +292,16 @@ describe AiApiLog, :type => :model do
         )
         expect(log.response_summary).to eq('[REDACTED_EMAIL]')
       end
+
+      it "falls back to [REDACTED] on non-hash non-string scrubber return" do
+        allow(PiiScrubber).to receive(:redact_for_ai).and_return(['unexpected'])
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          response_summary: 'contact me at test@example.com'
+        )
+        expect(log.response_summary).to eq('[REDACTED]')
+      end
     end
 
     describe "safe_pii_findings_for_digest" do

--- a/spec/models/ai_api_log_spec.rb
+++ b/spec/models/ai_api_log_spec.rb
@@ -274,6 +274,23 @@ describe AiApiLog, :type => :model do
           response_summary: nil
         )
         expect(log.response_summary).to be_nil
+
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          response_summary: ''
+        )
+        expect(log.response_summary).to eq('')
+      end
+
+      it "does not fall back to unsanitized text on non-hash scrubber return" do
+        allow(PiiScrubber).to receive(:redact_for_ai).and_return('[REDACTED_EMAIL]')
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          response_summary: 'contact me at test@example.com'
+        )
+        expect(log.response_summary).to eq('[REDACTED_EMAIL]')
       end
     end
 
@@ -302,6 +319,26 @@ describe AiApiLog, :type => :model do
       it "returns an empty array when there are no findings" do
         log = AiApiLog.log_ai_call(provider: 'claude', type: 'board_generation')
         expect(log.safe_pii_findings_for_digest).to eq([])
+      end
+
+      it "returns an empty array when parsed findings are not an array" do
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          pii_detected: true,
+          pii_findings: { type: 'email', value: 'raw@example.com', position: 1 }.to_json
+        )
+        expect(log.safe_pii_findings_for_digest).to eq([])
+      end
+
+      it "drops non-hash entries from parsed findings" do
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          pii_detected: true,
+          pii_findings: [{ type: 'email', position: 2 }, 'raw@example.com'].to_json
+        )
+        expect(log.safe_pii_findings_for_digest).to eq([{ 'type' => 'email', 'position' => 2 }])
       end
     end
 

--- a/spec/models/ai_api_log_spec.rb
+++ b/spec/models/ai_api_log_spec.rb
@@ -215,6 +215,96 @@ describe AiApiLog, :type => :model do
       expect(log.feature_flag).to eq('ai_board_gen_v2')
     end
 
+    # Audit-reports/security-review-2026-05-04 finding #3: response_summary
+    # was a latent PII reservoir because raw model output landed verbatim in
+    # the DB. The model now scrubs both summary columns on save.
+    describe "summary column scrubbing" do
+      it "redacts an email address from response_summary" do
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          response_summary: 'Welcome jane.doe@example.com to the board'
+        )
+        expect(log.response_summary).not_to include('jane.doe@example.com')
+        expect(log.response_summary).to include('[REDACTED_EMAIL]')
+      end
+
+      it "redacts an SSN from response_summary" do
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          response_summary: 'Confirm number 123-45-6789 in your records'
+        )
+        expect(log.response_summary).not_to include('123-45-6789')
+        expect(log.response_summary).to include('[REDACTED_SSN]')
+      end
+
+      it "redacts an email address from request_summary too" do
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'word_suggestion',
+          request_summary: 'Suggest words for kid@example.com',
+          response_summary: 'cat dog tree'
+        )
+        expect(log.request_summary).not_to include('kid@example.com')
+      end
+
+      it "leaves a clean response_summary unchanged" do
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          response_summary: 'Returned 12 buttons with symbols'
+        )
+        expect(log.response_summary).to eq('Returned 12 buttons with symbols')
+      end
+
+      it "is idempotent on already-redacted text" do
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          response_summary: 'See [REDACTED_EMAIL] for details'
+        )
+        expect(log.response_summary).to eq('See [REDACTED_EMAIL] for details')
+      end
+
+      it "passes nil and empty values through unchanged" do
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          response_summary: nil
+        )
+        expect(log.response_summary).to be_nil
+      end
+    end
+
+    describe "safe_pii_findings_for_digest" do
+      it "returns only type and position, not value/preview" do
+        findings = [
+          { type: 'email', position: 5, value: 'jane@example.com', preview: 'j***m' },
+          { type: 'ssn', position: 30, value: '123-45-6789' }
+        ]
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          pii_detected: true,
+          pii_findings: findings
+        )
+
+        result = log.safe_pii_findings_for_digest
+        expect(result.length).to eq(2)
+        expect(result.first.keys).to contain_exactly('type', 'position')
+        expect(result.first['type']).to eq('email')
+        expect(result.first['position']).to eq(5)
+        expect(result.first.values.join).not_to include('jane@example.com')
+        expect(result.first.values.join).not_to include('j***m')
+      end
+
+      it "returns an empty array when there are no findings" do
+        log = AiApiLog.log_ai_call(provider: 'claude', type: 'board_generation')
+        expect(log.safe_pii_findings_for_digest).to eq([])
+      end
+    end
+
     it "should store the request payload hash" do
       log = AiApiLog.log_ai_call(
         provider: 'claude',

--- a/spec/models/ai_api_log_spec.rb
+++ b/spec/models/ai_api_log_spec.rb
@@ -283,7 +283,7 @@ describe AiApiLog, :type => :model do
         expect(log.response_summary).to eq('')
       end
 
-      it "does not fall back to unsanitized text on non-hash scrubber return" do
+      it "uses scrubber result directly when scrubber returns a string" do
         allow(PiiScrubber).to receive(:redact_for_ai).and_return('[REDACTED_EMAIL]')
         log = AiApiLog.log_ai_call(
           provider: 'claude',

--- a/spec/models/ai_api_log_spec.rb
+++ b/spec/models/ai_api_log_spec.rb
@@ -302,6 +302,16 @@ describe AiApiLog, :type => :model do
         )
         expect(log.response_summary).to eq('[REDACTED]')
       end
+
+      it "falls back to [REDACTED] when scrubber hash has no payload" do
+        allow(PiiScrubber).to receive(:redact_for_ai).and_return({})
+        log = AiApiLog.log_ai_call(
+          provider: 'claude',
+          type: 'board_generation',
+          response_summary: 'contact me at test@example.com'
+        )
+        expect(log.response_summary).to eq('[REDACTED]')
+      end
     end
 
     describe "safe_pii_findings_for_digest" do


### PR DESCRIPTION
## Summary
- Closes the latent PII reservoir in \`ai_api_logs.response_summary\` flagged HIGH by the 2026-05-04 security review.
- Closes the \`row.send(:parsed_pii_findings)\` boundary fragility flagged WARN by the 2026-05-04 compliance check.

## Why
- \`PiiScrubber.redact_for_ai\` was applied to AI **requests** only. The raw model **response** landed in the DB verbatim. AI hallucinations and prompt echoes regularly include names / emails. Today no endpoint surfaces \`response_summary\` directly, but it is one new SQL caller away.
- The daily digest endpoint exposed \`pii_findings\` by reaching into a private method (\`row.send(:parsed_pii_findings)\`) and returning the raw findings array. Today the entries only carry \`type\` and \`position\`, so it is safe; the structural fragility is the issue.

## What changed
- \`AiApiLog.before_validation :scrub_summary_columns\` runs \`PiiScrubber.redact_for_ai\` on both \`request_summary\` and \`response_summary\` at save time. Idempotent on already-redacted text. nil / empty pass through. Falls back to \`'[REDACTED]'\` if the scrubber raises (defense in depth).
- New public method \`AiApiLog#safe_pii_findings_for_digest\` returns only \`type\` and \`position\`. \`daily_summary\` now uses this instead of \`.send(:parsed_pii_findings)\`. Even if a future PiiScrubber change started storing raw matches in \`findings[:value]\`, the digest cannot leak them.

## Tests
- Scrub: email, SSN, request_summary path, clean text, idempotent, nil.
- safe_pii_findings_for_digest: drops value / preview / unknown keys, empty fallback.

## Audit reference
- \`audit-reports/security-review-2026-05-04.md\` finding #3 (HIGH)
- \`audit-reports/compliance-check-2026-05-04.md\` warning #3

## Test plan
- [ ] CI passes.
- [ ] Manual: trigger an AI board generation with a name in the prompt, confirm \`AiApiLog.last.response_summary\` does not contain the raw name.
- [ ] Manual: hit the internal daily-summary endpoint, confirm \`pii_samples[*].findings[*]\` keys are exactly type and position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)