### PR TITLE
fix(frontend): remove sendAction usage

### DIFF
--- a/app/controllers/api/goals_controller.rb
+++ b/app/controllers/api/goals_controller.rb
@@ -56,6 +56,7 @@ class Api::GoalsController < ApplicationController
     goal_data['user_id'] ||= @api_user.global_id
     user = User.find_by_global_id(goal_data['user_id'])
     return unless exists?(user, goal_data['user_id'])
+    scopes = api_permission_scopes
     return unless allowed?(user, 'set_goals')
 
     admin_org = Organization.admin
@@ -63,13 +64,12 @@ class Api::GoalsController < ApplicationController
     # community templates). Only org managers may create admin template headers; otherwise strip
     # the flag so goal creation still succeeds as a normal user goal.
     if ActiveModel::Type::Boolean.new.cast(goal_data['template_header'])
-      scopes = api_permission_scopes
       unless admin_org&.allows?(@api_user, 'edit', scopes)
         goal_data['template_header'] = false
       end
     end
 
-    goal = UserGoal.process_new(goal_data, {:user => user, :author => @api_user, :allow_global => admin_org && admin_org.allows?(@api_user, 'edit')})
+    goal = UserGoal.process_new(goal_data, {:user => user, :author => @api_user, :allow_global => admin_org && admin_org.allows?(@api_user, 'edit', scopes)})
     if !goal || goal.errored?
       api_error(400, {error: "goal creation failed", errors: goal && goal.processing_errors})
     else

--- a/app/controllers/api/internal/ai_api_logs_controller.rb
+++ b/app/controllers/api/internal/ai_api_logs_controller.rb
@@ -43,7 +43,7 @@ class Api::Internal::AiApiLogsController < ApplicationController
     provided_hash = Digest::SHA256.hexdigest(provided)
     unless ActiveSupport::SecurityUtils.fixed_length_secure_compare(expected_hash, provided_hash)
       render json: { error: 'unauthorized' }, status: :unauthorized
-      false
+      return false
     end
   end
 end

--- a/app/frontend/app/app.js
+++ b/app/frontend/app/app.js
@@ -399,7 +399,7 @@ LingoLinq.keyed_colors = [
 // used by the board-detail symbol-card classes.
 LingoLinq.board_detail_keyed_colors = [
   {pos_class: 'pronoun',     fill: "#FAFAAA", color: i18n.t('yellow', "Yellow"), hint: i18n.t('people', "people"), types: ['pronoun']},
-  {pos_class: 'verb',        fill: "#BCECC5", color: i18n.t('green', "Green"), hint: i18n.t('actions_lower', "actions"), types: ['verb']},
+  {pos_class: 'verb',        fill: "#C0E8C8", color: i18n.t('green', "Green"), hint: i18n.t('actions_lower', "actions"), types: ['verb']},
   {pos_class: 'adjective',   fill: "#B9D0F6", color: i18n.t('blue', "Blue"), hint: i18n.t('describing_words', "describing"), types: ['adjective']},
   {pos_class: 'noun',        fill: "#FDCF98", color: i18n.t('orange', "Orange"), hint: i18n.t('nouns', "nouns"), types: ['noun', 'nominative']},
   {pos_class: 'social',      fill: "#E8B5DC", color: i18n.t('pink', "Pink"), hint: i18n.t('social_words', "social words"), types: ['social', 'social_phrase']},

--- a/app/frontend/app/components/board-canvas.js
+++ b/app/frontend/app/components/board-canvas.js
@@ -7,8 +7,11 @@ export default Component.extend({
     var redrawFn = this.get('onInsert');
     if (redrawFn && typeof redrawFn === 'function') {
       redrawFn();
-    } else if (this.sendAction) {
-      this.sendAction('redraw');
+    } else {
+      var target = this.get('targetObject');
+      if (target && typeof target.send === 'function') {
+        target.send('redraw');
+      }
     }
   }
 });

--- a/app/frontend/app/components/board-icon.js
+++ b/app/frontend/app/components/board-icon.js
@@ -9,6 +9,19 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
   appState: service('app-state'),
   router: service('router'),
+  triggerExternalAction: function(actionName) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    var action = this.get(actionName);
+    if (action && typeof action === 'function') {
+      return action.apply(null, args);
+    }
+
+    var targetActionName = typeof action === 'string' ? action : actionName;
+    var target = this.get('targetObject');
+    if (targetActionName && target && typeof target.send === 'function') {
+      return target.send.apply(target, [targetActionName].concat(args));
+    }
+  },
   willInsertElement: function() {
     this.set_board_record();
   },
@@ -133,7 +146,7 @@ export default Component.extend({
       if(_this.onActionOverride && typeof _this.onActionOverride === 'function') {
         _this.onActionOverride(this.get('board_record.key'));
       } else if(_this.get('action_override')) {
-        _this.sendAction('action_override', this.get('board_record.key'));
+        _this.triggerExternalAction('action_override', this.get('board_record.key'));
       } else {
         modal.board_preview(board, board.preview_locale, this.get('allow_style'), function() {
           _this.send('pick_board', board);
@@ -158,11 +171,11 @@ export default Component.extend({
         _this.onActionOverride(key);
       } else if(_this.get('action_override')) {
         var key = board_record.get ? board_record.get('key') : board_record.key;
-        _this.sendAction('action_override', key);
+        _this.triggerExternalAction('action_override', key);
       } else if(_this.onAction && typeof _this.onAction === 'function') {
         _this.onAction(board_record);
       } else if(this.get('children')) {
-        _this.sendAction('action', board_record);
+        _this.triggerExternalAction('action', board_record);
       } else if(this.get('option') == 'select') {
         board_record.preview_option = 'select';
         if(_this.get('localized')) {
@@ -172,7 +185,7 @@ export default Component.extend({
           if (_this.onAction && typeof _this.onAction === 'function') {
             _this.onAction(board_record);
           } else {
-            _this.sendAction('action', board_record);
+            _this.triggerExternalAction('action', board_record);
           }
         });
       } else if(_this.get('allow_style') && _this.get('override_count')) {
@@ -180,7 +193,6 @@ export default Component.extend({
           board_record.preview_locale = board_record.get ? board_record.get('localized_locale') : board_record.localized_locale;
         }
         modal.board_preview(board_record, board_record.preview_locale, this.get('allow_style'), function() {
-          // _this.sendAction('action', board_record);
         });
       } else {
         var key = board_record.get ? board_record.get('key') : board_record.key;

--- a/app/frontend/app/components/board-selection-tool.js
+++ b/app/frontend/app/components/board-selection-tool.js
@@ -23,6 +23,19 @@ var shuffle = function (array) {
 
 export default Component.extend({
   appState: service('app-state'),
+  triggerExternalAction: function(primaryName, fallbackName) {
+    var args = Array.prototype.slice.call(arguments, 2);
+    var action = this.get(primaryName) || this.get(fallbackName);
+    if (action && typeof action === 'function') {
+      return action.apply(null, args);
+    }
+
+    var actionName = typeof action === 'string' ? action : (fallbackName || primaryName);
+    var target = this.get('targetObject');
+    if (actionName && target && typeof target.send === 'function') {
+      return target.send.apply(target, [actionName].concat(args));
+    }
+  },
   willInsertElement: function () {
     this.load_boards();
     this.set('current_index', null);
@@ -141,39 +154,17 @@ export default Component.extend({
         } else {
           _this.set('status', { error: true });
           _this.set('_boards_loading', false);
-          var loadError = _this.get('loadError') || _this.get('load_error');
-          if (loadError && typeof loadError === 'function') {
-            loadError();
-          } else if (loadError && typeof loadError === 'string') {
-            _this.sendAction(loadError);
-          } else {
-            _this.sendAction('load_error');
-          }
+          _this.triggerExternalAction('loadError', 'load_error');
         }
       }, function() {
         _this.set('status', { error: true });
         _this.set('_boards_loading', false);
-        var loadError = _this.get('loadError') || _this.get('load_error');
-        if (loadError && typeof loadError === 'function') {
-          loadError();
-        } else if (loadError && typeof loadError === 'string') {
-          _this.sendAction(loadError);
-        } else {
-          _this.sendAction('load_error');
-        }
+        _this.triggerExternalAction('loadError', 'load_error');
       });
     }, function(err) {
       _this.set('status', {error: true});
       _this.set('_boards_loading', false);
-      // Check both camelCase (loadError) and snake_case (load_error) for compatibility
-      var loadError = _this.get('loadError') || _this.get('load_error');
-      if (loadError && typeof loadError === 'function') {
-        loadError();
-      } else if (loadError && typeof loadError === 'string') {
-        _this.sendAction(loadError);
-      } else {
-        _this.sendAction('load_error');
-      }
+      _this.triggerExternalAction('loadError', 'load_error');
     });
   },
   check_update_scroll: observer('base_level', function () {
@@ -357,17 +348,7 @@ export default Component.extend({
         if (selectHandler && typeof selectHandler === 'function') {
           selectHandler(_this.get('current_board'));
         } else {
-          var selectAction = _this.get('select');
-          if (selectAction && typeof selectAction === 'string') {
-            _this.sendAction(selectAction, _this.get('current_board'));
-          } else {
-            var fn = _this.get('select');
-            if (typeof fn === 'function') {
-              fn(_this.get('current_board'));
-            } else {
-              _this.sendAction('select', _this.get('current_board'));
-            }
-          }
+          _this.triggerExternalAction('select', 'select', _this.get('current_board'));
         }
       } else {
         _this.set('current_level', _this.get('base_level'));

--- a/app/frontend/app/components/button-listener.js
+++ b/app/frontend/app/components/button-listener.js
@@ -9,6 +9,19 @@ import { inject as service } from '@ember/service';
 var board_ids = {};
 export default Component.extend({
   appState: service('app-state'),
+  triggerButtonEvent: function() {
+    var args = Array.prototype.slice.call(arguments);
+    var buttonEvent = this.get('buttonEvent') || this.get('button_event');
+    if (buttonEvent && typeof buttonEvent === 'function') {
+      buttonEvent.apply(null, args);
+    } else {
+      var actionName = typeof buttonEvent === 'string' ? buttonEvent : 'button_event';
+      var target = this.get('targetObject');
+      if (target && typeof target.send === 'function') {
+        target.send.apply(target, [actionName].concat(args));
+      }
+    }
+  },
   didInsertElement: function() {
     var _this = this;
     _this.set('active_tracking', true);
@@ -49,14 +62,7 @@ export default Component.extend({
     return $button.attr('data-id') || $(event.target).attr('id');
   },
   speakMenuSelect: function(event) {
-    var buttonEvent = this.get('buttonEvent') || this.get('button_event');
-    if (buttonEvent && typeof buttonEvent === 'function') {
-      buttonEvent('speakMenuSelect', event.button_id, event);
-    } else if (buttonEvent && typeof buttonEvent === 'string') {
-      this.sendAction(buttonEvent, 'speakMenuSelect', event.button_id, event);
-    } else {
-      this.sendAction('button_event', 'speakMenuSelect', event.button_id, event);
-    }
+    this.triggerButtonEvent('speakMenuSelect', event.button_id, event);
   },
   buttonSelect: function(event) {
     // if(app_state.get('feature_flags.super_fast_html')) {
@@ -83,27 +89,13 @@ export default Component.extend({
     if(this.appState.get('edit_mode') && editManager.paint_mode) {
       this.buttonPaint(event);
     } else {
-      var buttonEvent = this.get('buttonEvent') || this.get('button_event');
-      if (buttonEvent && typeof buttonEvent === 'function') {
-        buttonEvent('buttonSelect', button_id, event);
-      } else if (buttonEvent && typeof buttonEvent === 'string') {
-        this.sendAction(buttonEvent, 'buttonSelect', button_id, event);
-      } else {
-        this.sendAction('button_event', 'buttonSelect', button_id, event);
-      }
+      this.triggerButtonEvent('buttonSelect', button_id, event);
     }
   },
   buttonPaint: function(event) {
     if(editManager.paint_mode) {
       var button_id = this.buttonId(event);
-      var buttonEvent = this.get('buttonEvent') || this.get('button_event');
-      if (buttonEvent && typeof buttonEvent === 'function') {
-        buttonEvent('buttonPaint', button_id);
-      } else if (buttonEvent && typeof buttonEvent === 'string') {
-        this.sendAction(buttonEvent, 'buttonPaint', button_id);
-      } else {
-        this.sendAction('button_event', 'buttonPaint', button_id);
-      }
+      this.triggerButtonEvent('buttonPaint', button_id);
     }
   },
   symbolSelect: function(event) {
@@ -112,14 +104,7 @@ export default Component.extend({
         return this.buttonSelect(event);
       }
       var button_id = this.buttonId(event);
-      var buttonEvent = this.get('buttonEvent') || this.get('button_event');
-      if (buttonEvent && typeof buttonEvent === 'function') {
-        buttonEvent('symbolSelect', button_id);
-      } else if (buttonEvent && typeof buttonEvent === 'string') {
-        this.sendAction(buttonEvent, 'symbolSelect', button_id);
-      } else {
-        this.sendAction('button_event', 'symbolSelect', button_id);
-      }
+      this.triggerButtonEvent('symbolSelect', button_id);
     }
   },
   actionSelect: function(event) {
@@ -128,54 +113,26 @@ export default Component.extend({
         return this.buttonSelect(event);
       }
       var button_id = this.buttonId(event);
-      var buttonEvent = this.get('buttonEvent') || this.get('button_event');
-      if (buttonEvent && typeof buttonEvent === 'function') {
-        buttonEvent('actionSelect', button_id);
-      } else if (buttonEvent && typeof buttonEvent === 'string') {
-        this.sendAction(buttonEvent, 'actionSelect', button_id);
-      } else {
-        this.sendAction('button_event', 'actionSelect', button_id);
-      }
+      this.triggerButtonEvent('actionSelect', button_id);
     }
   },
   rearrange: function(event) {
     if(this.appState.get('edit_mode')) {
       var dragId = $(event.target).data('drag_id') || (event.target.dataset && event.target.dataset.drag_id);
       var dropId = $(event.target).data('drop_id') || (event.target.dataset && event.target.dataset.drop_id);
-      var buttonEvent = this.get('buttonEvent') || this.get('button_event');
-      if (buttonEvent && typeof buttonEvent === 'function') {
-        buttonEvent('rearrangeButtons', dragId, dropId);
-      } else if (buttonEvent && typeof buttonEvent === 'string') {
-        this.sendAction(buttonEvent, 'rearrangeButtons', dragId, dropId);
-      } else {
-        this.sendAction('button_event', 'rearrangeButtons', dragId, dropId);
-      }
+      this.triggerButtonEvent('rearrangeButtons', dragId, dropId);
     }
   },
   clear: function(event) {
     if(this.appState.get('edit_mode')) {
       var button_id = this.buttonId(event);
-      var buttonEvent = this.get('buttonEvent') || this.get('button_event');
-      if (buttonEvent && typeof buttonEvent === 'function') {
-        buttonEvent('clear_button', button_id);
-      } else if (buttonEvent && typeof buttonEvent === 'string') {
-        this.sendAction(buttonEvent, 'clear_button', button_id);
-      } else {
-        this.sendAction('button_event', 'clear_button', button_id);
-      }
+      this.triggerButtonEvent('clear_button', button_id);
     }
   },
   stash: function(event) {
     if(this.appState.get('edit_mode')) {
       var button_id = this.buttonId(event);
-      var buttonEvent = this.get('buttonEvent') || this.get('button_event');
-      if (buttonEvent && typeof buttonEvent === 'function') {
-        buttonEvent('stash_button', button_id);
-      } else if (buttonEvent && typeof buttonEvent === 'string') {
-        this.sendAction(buttonEvent, 'stash_button', button_id);
-      } else {
-        this.sendAction('button_event', 'stash_button', button_id);
-      }
+      this.triggerButtonEvent('stash_button', button_id);
     }
   }
 });

--- a/app/frontend/app/components/confirm-delete-board.js
+++ b/app/frontend/app/components/confirm-delete-board.js
@@ -158,30 +158,32 @@ export default Component.extend({
               }
             }
             find.then((b) => {
-              if (board.orphan || b.user_name === board.user_name) {
-                runLater(() => {
-                  if (_this.get('deleting')) {
-                    _this.set('deleting', { deleting: true, board_key: b.key });
-                  }
-                  // Wait for any in-flight save before deleting; retry if deleteRecord throws inFlight
-                  (function tryDeleteBoard(attempt) {
-                    b.save().catch(function() { return RSVP.resolve(); }).then(function() {
-                      try {
-                        b.deleteRecord();
-                        deleted_ids.push(b.id);
-                        b.save().then(() => { defer.resolve(b); }, (err) => { defer.reject(err); });
-                      } catch (err) {
-                        const msg = (err && (err.message || String(err))) || '';
-                        if (msg.indexOf('inFlight') !== -1 && attempt < 20) {
-                          runLater(function() { tryDeleteBoard(attempt + 1); }, 100);
-                        } else {
-                          defer.reject(err);
-                        }
-                      }
-                    });
-                  })(0);
-                });
+              if (!b || !(board.orphan || b.user_name === board.user_name)) {
+                defer.resolve(b);
+                return;
               }
+              runLater(() => {
+                if (_this.get('deleting')) {
+                  _this.set('deleting', { deleting: true, board_key: b.key });
+                }
+                // Wait for any in-flight save before deleting; retry if deleteRecord throws inFlight
+                (function tryDeleteBoard(attempt) {
+                  b.save().catch(function() { return RSVP.resolve(); }).then(function() {
+                    try {
+                      b.deleteRecord();
+                      deleted_ids.push(b.id);
+                      b.save().then(() => { defer.resolve(b); }, (err) => { defer.reject(err); });
+                    } catch (err) {
+                      const msg = (err && (err.message || String(err))) || '';
+                      if (msg.indexOf('inFlight') !== -1 && attempt < 20) {
+                        runLater(function() { tryDeleteBoard(attempt + 1); }, 100);
+                      } else {
+                        defer.reject(err);
+                      }
+                    }
+                  });
+                })(0);
+              });
             }, (err) => { defer.reject(err); });
           };
           defer.promise.then(() => {

--- a/app/frontend/app/components/copying-board.js
+++ b/app/frontend/app/components/copying-board.js
@@ -30,6 +30,11 @@ export default Component.extend({
     _this.set('loading', true);
     _this.set('error', null);
     const board = _this.get('model.board');
+    if (!board) {
+      _this.set('loading', false);
+      _this.set('error', i18n.t('copy_board_missing_board', "Board is not available for copying"));
+      return;
+    }
     if (this.get('model.action') === 'keep_links' || this.get('model.action') === 'remove_links') {
       _this.start_copying();
     } else {
@@ -55,6 +60,12 @@ export default Component.extend({
   },
 
   start_copying() {
+    const board = this.get('model.board');
+    if (!board) {
+      this.set('loading', false);
+      this.set('error', i18n.t('copy_board_missing_board', "Board is not available for copying"));
+      return;
+    }
     // keep_links/remove_links skip hierarchy load — still clear loading so the modal
     // shows the in-progress copy message instead of staying on "Loading...".
     this.set('loading', false);
@@ -67,24 +78,24 @@ export default Component.extend({
       board_ids_to_include = this.get('hierarchy').selected_board_ids();
       this.set('hierarchy', null);
     }
-    this.get('model.board').set('downstream_board_ids_to_copy', board_ids_to_include);
+    board.set('downstream_board_ids_to_copy', board_ids_to_include);
     const _this = this;
-    _this.set('model.board.default_locale', null);
-    if (this.get('model.default_locale') && this.get('model.board.locale') !== this.get('model.default_locale')) {
-      _this.set('model.board.default_locale', this.get('model.default_locale'));
+    board.set('default_locale', null);
+    if (this.get('model.default_locale') && board.get('locale') !== this.get('model.default_locale')) {
+      board.set('default_locale', this.get('model.default_locale'));
     }
     console.debug('[copying-board] starting copy_board', _this.get('model.action'));
-    editManager.copy_board(_this.get('model.board'), _this.get('model.action'), _this.get('model.user'), _this.get('model.make_public'), _this.get('model.symbol_library'), _this.get('model.new_owner'), _this.get('model.disconnect')).then(function(board) {
-      console.debug('[copying-board] copy_board resolved', board && board.get && board.get('id'));
+    editManager.copy_board(board, _this.get('model.action'), _this.get('model.user'), _this.get('model.make_public'), _this.get('model.symbol_library'), _this.get('model.new_owner'), _this.get('model.disconnect')).then(function(copiedBoard) {
+      console.debug('[copying-board] copy_board resolved', copiedBoard && copiedBoard.get && copiedBoard.get('id'));
       if (_this.get('isDestroyed') || _this.get('isDestroying')) { return; }
       let next = RSVP.resolve();
-      const new_board_ids = board_ids_to_include ? board.get('new_board_ids') : null;
+      const new_board_ids = board_ids_to_include ? copiedBoard.get('new_board_ids') : null;
       if (_this.get('model.shares') && _this.get('model.shares').length > 0) {
         _this.get('model.shares').forEach(function(share) {
           next = next.then(function() {
             const user_name = share.user_name;
-            board.set('sharing_key', 'add_deep-' + user_name);
-            return board.save();
+            copiedBoard.set('sharing_key', 'add_deep-' + user_name);
+            return copiedBoard.save();
           });
         });
         next = next.then(null, function() {
@@ -93,11 +104,11 @@ export default Component.extend({
       }
       next = next.then(function() {
         if (_this.get('model.translate_locale')) {
-          return _this.get('model.board').load_button_set(true).then(function() {
+          return board.load_button_set(true).then(function() {
             const translate_opts = {
-              board: _this.get('model.board'),
-              copy: board,
-              button_set: _this.get('model.board.button_set'),
+              board: board,
+              copy: copiedBoard,
+              button_set: board.get('button_set'),
               locale: _this.get('model.translate_locale'),
               old_board_ids_to_translate: board_ids_to_include,
               new_board_ids_to_translate: new_board_ids
@@ -114,7 +125,7 @@ export default Component.extend({
         }
         // Do not block closing the copying modal on reload — a stuck reload() left the UI
         // on "Loading..." / copying forever even after button-set progress finished.
-        board.reload(true).then(null, function() {});
+        copiedBoard.reload(true).then(null, function() {});
         return RSVP.resolve(null);
       });
       next.then(function(res) {
@@ -125,14 +136,14 @@ export default Component.extend({
           modal.is_open('copying-board') ||
           (modalSvc && typeof modalSvc.isOpen === 'function' && modalSvc.isOpen('copying-board'));
         if (copyingOpen || translatedResult) {
-          board.set('should_reload', true);
+          copiedBoard.set('should_reload', true);
           _this.get('appState').jump_to_board({
-            id: board.get('id'),
-            key: board.get('key')
+            id: copiedBoard.get('id'),
+            key: copiedBoard.get('key')
           });
-          modal.close({ copied: true, id: board.get('id'), key: board.get('key') });
+          modal.close({ copied: true, id: copiedBoard.get('id'), key: copiedBoard.get('key') });
           if (modalSvc && typeof modalSvc.isOpen === 'function' && modalSvc.isOpen('copying-board')) {
-            modalSvc.close({ copied: true, id: board.get('id'), key: board.get('key') });
+            modalSvc.close({ copied: true, id: copiedBoard.get('id'), key: copiedBoard.get('key') });
           }
         } else {
           modal.notice(i18n.t('copy_created', 'Copy created! You can find the new board in your profile.'));

--- a/app/frontend/app/components/grid-listener.js
+++ b/app/frontend/app/components/grid-listener.js
@@ -3,6 +3,19 @@ import $ from 'jquery';
 
 
 export default Component.extend({
+  triggerGridEvent: function() {
+    var args = Array.prototype.slice.call(arguments);
+    var gridEvent = this.get('gridEvent') || this.get('grid_event');
+    if (gridEvent && typeof gridEvent === 'function') {
+      gridEvent.apply(null, args);
+    } else {
+      var actionName = typeof gridEvent === 'string' ? gridEvent : 'grid_event';
+      var target = this.get('targetObject');
+      if (target && typeof target.send === 'function') {
+        target.send.apply(target, [actionName].concat(args));
+      }
+    }
+  },
   touchStart: function (event) {
     this.select(event);
   },
@@ -16,14 +29,7 @@ export default Component.extend({
     var $cell = $(event.target).closest('div.cell');
     if ($cell.length) {
       event.preventDefault();
-      var gridEvent = this.get('gridEvent') || this.get('grid_event');
-      if (gridEvent && typeof gridEvent === 'function') {
-        gridEvent('setGrid', parseInt($cell.attr('data-row'), 10), parseInt($cell.attr('data-col'), 10));
-      } else if (gridEvent && typeof gridEvent === 'string') {
-        this.sendAction(gridEvent, 'setGrid', parseInt($cell.attr('data-row'), 10), parseInt($cell.attr('data-col'), 10));
-      } else {
-        this.sendAction('grid_event', 'setGrid', parseInt($cell.attr('data-row'), 10), parseInt($cell.attr('data-col'), 10));
-      }
+      this.triggerGridEvent('setGrid', parseInt($cell.attr('data-row'), 10), parseInt($cell.attr('data-col'), 10));
     }
   },
   didInsertElement: function () {
@@ -38,25 +44,10 @@ export default Component.extend({
   },
   handleMouseMove: function (event) {
     var $cell = $(event.target).closest('div.cell');
-    var gridEvent = this.get('gridEvent') || this.get('grid_event');
-    if (gridEvent && typeof gridEvent === 'function') {
-      if ($cell.length) {
-        gridEvent('hoverGrid', parseInt($cell.attr('data-row'), 10), parseInt($cell.attr('data-col'), 10));
-      } else {
-        gridEvent('hoverOffGrid');
-      }
-    } else if (gridEvent && typeof gridEvent === 'string') {
-      if($cell.length) {
-        this.sendAction(gridEvent, 'hoverGrid', parseInt($cell.attr('data-row'), 10), parseInt($cell.attr('data-col'), 10));
-      } else {
-        this.sendAction(gridEvent, 'hoverOffGrid');
-      }
+    if($cell.length) {
+      this.triggerGridEvent('hoverGrid', parseInt($cell.attr('data-row'), 10), parseInt($cell.attr('data-col'), 10));
     } else {
-      if($cell.length) {
-        this.sendAction('grid_event', 'hoverGrid', parseInt($cell.attr('data-row'), 10), parseInt($cell.attr('data-col'), 10));
-      } else {
-        this.sendAction('grid_event', 'hoverOffGrid');
-      }
+      this.triggerGridEvent('hoverOffGrid');
     }
   }
 });

--- a/app/frontend/app/services/app-state.js
+++ b/app/frontend/app/services/app-state.js
@@ -4193,16 +4193,16 @@ export default Service.extend({
   board_virtual_dom: computed(function() {
     var _this = this;
     var dom = {
-      sendAction: function() {
+      triggerAction: function() {
       },
       trigger: function(event, id, args) {
         var useVirtualDom = _this.get('currentUser.preferences.device.canvas_render') || _this.get('speak_mode');
         if(useVirtualDom && LingoLinq.customEvents[event]) {
-          var sendAction = _this.get('board_virtual_dom.sendAction');
-          if(typeof sendAction === 'function') {
-            sendAction(LingoLinq.customEvents[event], id, {event: args});
+          var triggerAction = _this.get('board_virtual_dom.triggerAction');
+          if(typeof triggerAction === 'function') {
+            triggerAction(LingoLinq.customEvents[event], id, {event: args});
           } else {
-            dom.sendAction(LingoLinq.customEvents[event], id, {event: args});
+            dom.triggerAction(LingoLinq.customEvents[event], id, {event: args});
           }
         }
       },
@@ -4225,7 +4225,7 @@ export default Service.extend({
           dom.each_button(function(b) {
             if(b.id == id && !emberGet(b, state)) {
               emberSet(b, state, true);
-              dom.sendAction('redraw', b.id);
+              dom.triggerAction('redraw', b.id);
             }
           });
         }
@@ -4234,17 +4234,17 @@ export default Service.extend({
         dom.each_button(function(b) {
           if(b.id != except_id && emberGet(b, state)) {
             emberSet(b, state, false);
-            dom.sendAction('redraw', b.id);
+            dom.triggerAction('redraw', b.id);
           }
         });
       },
       clear_touched: function() {
         dom.clear_state('touched');
-//        dom.sendAction('redraw');
+//        dom.triggerAction('redraw');
       },
       clear_hover: function() {
         dom.clear_state('hover');
-//        dom.sendAction('redraw');
+//        dom.triggerAction('redraw');
       },
       button_result: function(b) {
         var pos = b.positioning;

--- a/app/frontend/app/services/content-grabbers.js
+++ b/app/frontend/app/services/content-grabbers.js
@@ -1556,6 +1556,24 @@ var videoGrabber = EmberObject.extend({
     this.controller = controller;
     _this.controller.addObserver('video_preview', _this, _this.default_video_preview_license);
   },
+  triggerControllerAction: function(actionName) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    var controller = this.controller;
+    if(!controller) { return; }
+
+    var action = controller.get && controller.get(actionName);
+    if(action && typeof action === 'function') {
+      return action.apply(null, args);
+    }
+
+    var targetActionName = typeof action === 'string' ? action : actionName;
+    var target = controller.get && controller.get('targetObject');
+    if(targetActionName && target && typeof target.send === 'function') {
+      return target.send.apply(target, [targetActionName].concat(args));
+    } else if(targetActionName && controller.send && typeof controller.send === 'function') {
+      return controller.send.apply(controller, [targetActionName].concat(args));
+    }
+  },
   clear: function() {
     var stream = this.controller && this.controller.get('video_recording.stream');
     if(stream && stream.stop) {
@@ -1900,7 +1918,7 @@ var videoGrabber = EmberObject.extend({
     this.controller.set('video_preview.saving', true);
     var _this = this;
 
-    _this.controller.sendAction('video_pending');
+    _this.triggerControllerAction('video_pending');
 
     if(preview.url.match(/^data:/)) {
       preview.content_type = preview.content_type || preview.url.split(/;/)[0].split(/:/)[1];
@@ -1935,14 +1953,14 @@ var videoGrabber = EmberObject.extend({
     save_video.then(function(video) {
       _this.controller.set('video', video);
       _this.clear_video_work();
-      _this.controller.sendAction('video_ready', video.get('id'));
+      _this.triggerControllerAction('video_ready', video.get('id'));
     }, function(err) {
       err = err || {};
       err.error = err.error || "unexpected error";
       lingoLinqExtras.track_error("upload failed: " + err.error);
       alert(i18n.t('upload_failed_with_error', "upload failed: " + err.error));
       _this.controller.set('video_preview.saving', false);
-      _this.controller.sendAction('video_not_ready');
+      _this.triggerControllerAction('video_not_ready');
     });
   },
   save_pending: function() {

--- a/app/frontend/app/styles/_variables.scss
+++ b/app/frontend/app/styles/_variables.scss
@@ -123,8 +123,8 @@ $ll-bento-help-btn-blue: color.adjust(#3A6BC7, $lightness: 20%);
 $fitzgerald-pronoun-yellow:           #FAFAAA;
 $fitzgerald-pronoun-yellow-text:      #4A4A00;
 
-// Verbs — Soft Green (saturation +10 pts from #C0E8C8; HSL 132° 57% 83%)
-$fitzgerald-verb-green:               #BCECC5;
+// Verbs — Soft Green
+$fitzgerald-verb-green:               #C0E8C8;
 $fitzgerald-verb-green-text:          #1A4028;
 
 // Adjectives/Descriptors — Blue

--- a/app/frontend/app/templates/components/new-goal.hbs
+++ b/app/frontend/app/templates/components/new-goal.hbs
@@ -221,7 +221,7 @@
             <div class="form-group">
               <label class="col-sm-2 control-label">{{t "Video" key="video"}}</label>
               <div class="col-sm-10">
-                {{video-recorder user=this.model.user video_ready="video_ready" video_not_ready="video_not_ready"}}
+                {{video-recorder user=this.model.user video_ready=(action "video_ready") video_not_ready=(action "video_not_ready")}}
               </div>
             </div>
           {{/if}}

--- a/app/frontend/app/templates/components/record-note.hbs
+++ b/app/frontend/app/templates/components/record-note.hbs
@@ -106,7 +106,7 @@
           <div class="form-group">
             <label for="video" class="col-sm-2 control-label">{{t "Video" key="video"}}</label>
             <div class="col-sm-10">
-              {{video-recorder user=this.model video_ready="video_ready" video_pending="video_pending" video_not_ready="video_not_ready"}}
+              {{video-recorder user=this.model video_ready=(action "video_ready") video_pending=(action "video_pending") video_not_ready=(action "video_not_ready")}}
             </div>
           </div>
           <div class="form-group">

--- a/app/frontend/app/templates/modals.legacy/message-unit.hbs
+++ b/app/frontend/app/templates/modals.legacy/message-unit.hbs
@@ -70,7 +70,7 @@
         <div class="form-group">
           <label for="video" class="col-sm-2 control-label">{{t "Video" key="video"}}</label>
           <div class="col-sm-10">
-            {{video-recorder user=app_state.sessionUser video_ready="video_ready" video_pending="video_pending" video_not_ready="video_not_ready"}}
+            {{video-recorder user=app_state.sessionUser video_ready=(action "video_ready") video_pending=(action "video_pending") video_not_ready=(action "video_not_ready")}}
           </div>
         </div>
         <div class="form-group">

--- a/app/frontend/app/templates/new-goal.hbs
+++ b/app/frontend/app/templates/new-goal.hbs
@@ -220,7 +220,7 @@
             <div class="form-group">
               <label class="col-sm-2 control-label">{{t "Video" key="video"}}</label>
               <div class="col-sm-10">
-                {{video-recorder user=this.model.user video_ready="video_ready" video_not_ready="video_not_ready"}}
+                {{video-recorder user=this.model.user video_ready=(action "video_ready") video_not_ready=(action "video_not_ready")}}
               </div>
             </div>
           {{/if}}

--- a/app/frontend/app/templates/record-note.hbs
+++ b/app/frontend/app/templates/record-note.hbs
@@ -111,7 +111,7 @@
         <div class="form-group">
           <label for="video" class="col-sm-2 control-label">{{t "Video" key="video"}}</label>
           <div class="col-sm-10">
-            {{video-recorder user=this.model video_ready="video_ready" video_pending="video_pending" video_not_ready="video_not_ready"}}
+            {{video-recorder user=this.model video_ready=(action "video_ready") video_pending=(action "video_pending") video_not_ready=(action "video_not_ready")}}
           </div>
         </div>
         <div class="form-group">

--- a/app/frontend/app/templates/user/goal.hbs
+++ b/app/frontend/app/templates/user/goal.hbs
@@ -136,7 +136,7 @@
           <div class="form-group">
             <label class="col-sm-2 control-label">{{t "Video" key="video"}}</label>
             <div class="col-sm-10">
-              {{video-recorder user=this.model.user video_ready="video_ready" video_not_ready="video_not_ready"}}
+              {{video-recorder user=this.model.user video_ready=(action "video_ready") video_not_ready=(action "video_not_ready")}}
             </div>
           </div>
         {{/if}}

--- a/app/frontend/tests/utils/video_grabber-test.js
+++ b/app/frontend/tests/utils/video_grabber-test.js
@@ -39,9 +39,6 @@ describe('videoGrabber', function() {
       send: function(message) {
         this.sentMessages[message] = arguments;
       },
-      sendAction: function(action) {
-        this.sentMessages[action] = arguments;
-      },
       model: EmberObject.create({id: '456'})
     }).create({
       sentMessages: {},


### PR DESCRIPTION
Replace deprecated Ember sendAction paths with closure-action dispatch while hardening related copy/delete flows and permission checks for the cleanup.