### PR TITLE
chore: bump net-imap to fix 6 CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
     nenv (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
Bumps transitive dep net-imap from 0.6.3 to
  0.6.4 via conservative bundle update. Resolves 6 CVEs flagged by bundle-audit on PR #267 (CVE-2026-42245, -42246, -42256, plus
   3 more from the 2026-05-14 ruby-advisory-db drop). Diff is one line in Gemfile.lock.