### PR TITLE
Improve board-detail speak image loading and restore post-login sync

### DIFF
--- a/app/frontend/app/controllers/user/board-detail.js
+++ b/app/frontend/app/controllers/user/board-detail.js
@@ -513,7 +513,7 @@ export default Controller.extend(prefClasses, {
       edit_mode: !!use_ember,
       label_locale: _this.get('app_state.label_locale') || null
     };
-    if(!use_ember && cache_token) {
+    if(!use_ember && cache_token && persistence.primed) {
       var cached_ob = boardDetailCache.get_ordered_buttons(cache_token, cache_ctx);
       if(cached_ob) {
         // Cache hit — re-use the pre-built grid. Glimmer skips re-render
@@ -577,6 +577,40 @@ export default Controller.extend(prefClasses, {
     }
   },
 
+  // Prefer a locally-synced copy from persistence.url_cache when available
+  // (same lookup order as Board#render_fast_html).
+  _resolve_cached_image_url: function(remote_url) {
+    if(!remote_url) { return null; }
+    var url_cache = persistence.url_cache;
+    if(!url_cache) { return remote_url; }
+    var url_uncache = persistence.url_uncache;
+    var try_url = function(u) {
+      if(!u) { return null; }
+      if(url_uncache && url_uncache[u]) { return null; }
+      var cached = url_cache[u];
+      if(cached && cached !== false) { return cached; }
+      return null;
+    };
+    var cached = try_url(remote_url);
+    if(cached) { return cached; }
+    var unvarianted = remote_url.replace(/\.variant-.+\.(png|svg)$/, '');
+    if(unvarianted !== remote_url) {
+      cached = try_url(unvarianted);
+      if(cached) { return cached; }
+    }
+    var alt_url = null;
+    if(remote_url.match(/^https\:\/\/s3\.amazonaws\.com\/opensymbols\//)) {
+      alt_url = remote_url.replace(/^https\:\/\/s3\.amazonaws\.com\/opensymbols\//, 'https://d18vdu4p71yql0.cloudfront.net/');
+    } else if(remote_url.match(/^https\:\/\/opensymbols\.s3\.amazonaws\.com\//)) {
+      alt_url = remote_url.replace(/^https\:\/\/opensymbols\.s3\.amazonaws\.com\//, 'https://d18vdu4p71yql0.cloudfront.net/');
+    }
+    if(alt_url) {
+      cached = try_url(alt_url);
+      if(cached) { return cached; }
+    }
+    return remote_url;
+  },
+
   _make_btn: function(btn, image_map) {
     var img_url = null;
     if(btn.image_id && image_map) {
@@ -585,6 +619,9 @@ export default Controller.extend(prefClasses, {
       } else if(image_map[btn.image_id]) {
         img_url = image_map[btn.image_id];
       }
+    }
+    if(img_url) {
+      img_url = this._resolve_cached_image_url(img_url);
     }
     return {
       id: btn.id,
@@ -614,6 +651,9 @@ export default Controller.extend(prefClasses, {
       } else if(image_map[btn.image_id]) {
         img_url = image_map[btn.image_id];
       }
+    }
+    if(img_url) {
+      img_url = this._resolve_cached_image_url(img_url);
     }
     var more_args = { board: board };
     if(img_url) { more_args.image_url = img_url; }

--- a/app/frontend/app/controllers/user/board-detail.js
+++ b/app/frontend/app/controllers/user/board-detail.js
@@ -511,9 +511,12 @@ export default Controller.extend(prefClasses, {
       preferred_symbols: _this._preferred_symbols,
       skin: skin || null,
       edit_mode: !!use_ember,
-      label_locale: _this.get('app_state.label_locale') || null
+      label_locale: _this.get('app_state.label_locale') || null,
+      // Invalidate grid reuse when offline url_cache becomes available so
+      // image_url picks up local paths after prime_caches().
+      url_cache_primed: !!persistence.primed
     };
-    if(!use_ember && cache_token && persistence.primed) {
+    if(!use_ember && cache_token) {
       var cached_ob = boardDetailCache.get_ordered_buttons(cache_token, cache_ctx);
       if(cached_ob) {
         // Cache hit — re-use the pre-built grid. Glimmer skips re-render

--- a/app/frontend/app/routes/user/board-detail.js
+++ b/app/frontend/app/routes/user/board-detail.js
@@ -44,6 +44,12 @@ export default Route.extend({
         return RSVP.resolve();
       });
     }
+    var route = this;
+    var clearPrimePromiseIfUnprimed = function() {
+      if(!persistenceSvc.get('primed')) {
+        route._prime_caches_promise = null;
+      }
+    };
     this._prime_caches_promise = ensure_local.then(function() {
       var localAfter = persistenceSvc.get('local_system');
       if(!localAfter || !localAfter.available || !localAfter.allowed) {
@@ -52,7 +58,7 @@ export default Route.extend({
       return persistenceSvc.prime_caches(true).then(null, function() {
         return RSVP.resolve();
       });
-    });
+    }).then(clearPrimePromiseIfUnprimed, clearPrimePromiseIfUnprimed);
     return this._prime_caches_promise;
   },
 

--- a/app/frontend/app/routes/user/board-detail.js
+++ b/app/frontend/app/routes/user/board-detail.js
@@ -7,6 +7,7 @@ import speecher from '../../utils/speecher';
 import editManager from '../../utils/edit_manager';
 import contentGrabbers from '../../utils/content_grabbers';
 import persistence from '../../utils/persistence';
+import capabilities from '../../utils/capabilities';
 import boardDetailCache from '../../utils/board_detail_cache';
 
 export default Route.extend({
@@ -14,6 +15,62 @@ export default Route.extend({
   stashes: service('stashes'),
   appState: service('app-state'),
   persistence: service('persistence'),
+
+  // One-shot promise so concurrent board-detail entries share a single prime.
+  _prime_caches_promise: null,
+
+  // Load offline url_cache from IndexedDB/filesystem before building buttons
+  // so _make_btn can resolve local image URLs (mirrors legacy fast_html).
+  _maybe_prime_caches: function() {
+    var persistenceSvc = this.persistence;
+    if(!persistenceSvc || persistenceSvc.get('primed')) {
+      return RSVP.resolve();
+    }
+    if(!this.stashes || !this.stashes.get('auth_settings')) {
+      return RSVP.resolve();
+    }
+    if(this._prime_caches_promise) {
+      return this._prime_caches_promise;
+    }
+    var ensure_local = RSVP.resolve();
+    var local = persistenceSvc.get('local_system');
+    if(!local || local.available === undefined) {
+      ensure_local = capabilities.storage.status().then(function(res) {
+        if(res.available && !res.requires_confirmation) {
+          res.allowed = true;
+        }
+        persistenceSvc.set('local_system', res);
+      }, function() {
+        return RSVP.resolve();
+      });
+    }
+    this._prime_caches_promise = ensure_local.then(function() {
+      var localAfter = persistenceSvc.get('local_system');
+      if(!localAfter || !localAfter.available || !localAfter.allowed) {
+        return RSVP.resolve();
+      }
+      return persistenceSvc.prime_caches(true).then(null, function() {
+        return RSVP.resolve();
+      });
+    });
+    return this._prime_caches_promise;
+  },
+
+  // Build the symbol grid, warm current-board images, prefetch linked boards.
+  _finalize_board_display: function(controller, raw) {
+    if(!raw || !controller || controller.isDestroyed || controller.isDestroying) { return; }
+    controller._build_from_raw(raw);
+    if(controller.get('edit_mode')) { return; }
+    // Warm browser HTTP cache for this board's symbols (children are warmed by prefetch_linked).
+    runLater(function() {
+      if(controller.isDestroyed || controller.isDestroying || controller.get('edit_mode')) { return; }
+      boardDetailCache.warm_images(raw);
+    }, 100);
+    runLater(function() {
+      if(controller.isDestroyed || controller.isDestroying || controller.get('edit_mode')) { return; }
+      boardDetailCache.prefetch_linked(raw);
+    }, 500);
+  },
 
   model: function(params) {
     var _this = this;
@@ -218,17 +275,10 @@ export default Route.extend({
     // so nothing overwrites them
     var raw = _this.get('_raw_board_data');
     if(raw) {
-      controller._build_from_raw(raw);
-      // Background-prefetch immediate child boards + warm their image
-      // cache so folder navigation feels instant. Deferred 500ms so
-      // initial paint lands first; also gives the edit subroute time to
-      // flip edit_mode = true (we skip prefetch in edit mode to avoid
-      // any chance of stale reads while the user mutates buttons).
-      runLater(function() {
+      _this._maybe_prime_caches().then(function() {
         if(controller.isDestroyed || controller.isDestroying) { return; }
-        if(controller.get('edit_mode')) { return; }
-        boardDetailCache.prefetch_linked(raw);
-      }, 500);
+        _this._finalize_board_display(controller, raw);
+      });
     }
 
     // Store original name for rename detection

--- a/app/frontend/app/services/persistence.js
+++ b/app/frontend/app/services/persistence.js
@@ -4185,25 +4185,10 @@ var persistence = Service.extend({
     var _this = this;
     this.set('online', navigator.onLine);
 
-    var onBackOnline = function() {
-      runLater(function() {
-        if(!_this || _this.isDestroyed || _this.isDestroying) { return; }
-        if(_this.stashes && typeof _this.stashes.get === 'function' && _this.stashes.get('auth_settings') &&
-          (!LingoLinq.testing || LingoLinq.sync_testing)) {
-          _this.check_for_needs_sync(true);
-        }
-        if(typeof _this.getBrowserToken === 'function') {
-          _this.tokens = {};
-          if(LingoLinq.session) {
-            LingoLinq.session.restore(!_this.getBrowserToken());
-          }
-        }
-      }, 500);
-    };
-
+    // Sync/token restore on reconnect is handled by the on_connect observer
+    // when online flips to true; only update state here to avoid duplicate work.
     window.addEventListener('online', function() {
       _this.set('online', true);
-      onBackOnline();
     });
     window.addEventListener('offline', function() {
       _this.set('online', false);
@@ -4211,7 +4196,6 @@ var persistence = Service.extend({
     // Cordova notifies on the document object
     document.addEventListener('online', function() {
       _this.set('online', true);
-      onBackOnline();
     });
     document.addEventListener('offline', function() {
       _this.set('online', false);

--- a/app/frontend/app/services/persistence.js
+++ b/app/frontend/app/services/persistence.js
@@ -128,6 +128,18 @@ var persistence = Service.extend({
         }
       }, 0);
       */
+      // Deferred hooks (post-login sync, online listeners) without calling full setup().
+      var _this = this;
+      runLater(function() {
+        if(!_this || _this.isDestroyed || _this.isDestroying) { return; }
+        if(typeof _this._setupOnlineListeners === 'function' && !_this._online_listeners_ready) {
+          _this._online_listeners_ready = true;
+          _this._setupOnlineListeners();
+        }
+        if(typeof _this.schedulePostLoginSyncIfNeeded === 'function') {
+          _this.schedulePostLoginSyncIfNeeded();
+        }
+      }, 0);
       if (_vb) {
         console.log('[PERSISTENCE INIT] Skipping setup() call to prevent observer firing');
         console.log('[PERSISTENCE INIT] ========== init() END ==========');
@@ -3872,30 +3884,22 @@ var persistence = Service.extend({
       return RSVP.reject({offline: true, error: "not online", short_circuit: true});
     }
   },
-  // TEMPORARILY COMMENTED OUT TO TEST
-  /*
   on_connect: observer('online', function() {
-    // Guard: check this before assigning to _this
-    if(!this || typeof this !== 'object') {
-      console.warn('on_connect observer: this is invalid', this);
+    if(!this || typeof this !== 'object' || typeof this.get !== 'function' || !this.stashes) {
       return;
     }
     var _this = this;
-    // Guard: ensure service is fully initialized before accessing anything
-    if(typeof _this.get !== 'function' || !_this.stashes) {
-      return;
-    }
     try {
       if(_this.stashes && typeof _this.stashes.set === 'function') {
         _this.stashes.set('online', _this.get('online'));
       }
       if(_this.get('online') && (!LingoLinq.testing || LingoLinq.sync_testing)) {
         runLater(function() {
-          // TODO: maybe do a quick xhr to a static asset to make sure we're for reals online?
-          if(_this && _this.stashes && typeof _this.stashes.get === 'function' && _this.stashes.get('auth_settings')) {
+          if(_this.isDestroyed || _this.isDestroying) { return; }
+          if(_this.stashes && typeof _this.stashes.get === 'function' && _this.stashes.get('auth_settings')) {
             _this.check_for_needs_sync(true);
           }
-          if(_this && typeof _this.getBrowserToken === 'function') {
+          if(typeof _this.getBrowserToken === 'function') {
             _this.tokens = {};
             if(LingoLinq.session) {
               LingoLinq.session.restore(!_this.getBrowserToken());
@@ -3907,7 +3911,118 @@ var persistence = Service.extend({
       console.warn('Error in on_connect observer:', e);
     }
   }),
-  */
+  // After login, schedule a background sync check (10s delay so the UI can settle).
+  schedulePostLoginSyncIfNeeded: function() {
+    var _this = this;
+    if(isTesting()) { return; }
+    runLater(function() {
+      try {
+        var svc = _this || window.persistence;
+        if(!svc || typeof svc.get !== 'function' || svc.isDestroyed || svc.isDestroying) { return; }
+        var stashesSvc = svc.stashes;
+        if(!stashesSvc || typeof stashesSvc.get !== 'function') { return; }
+        if(stashesSvc.get('allow_local_filesystem_request') === false) {
+          capabilities.storage.already_limited_size = true;
+        }
+        if(!stashesSvc.get_object || typeof stashesSvc.get_object !== 'function') { return; }
+        if(!stashesSvc.get_object('just_logged_in', false)) { return; }
+        if(!stashesSvc.get('auth_settings')) { return; }
+        stashesSvc.persist_object('just_logged_in', null, false);
+        runLater(function() {
+          if(svc.isDestroyed || svc.isDestroying) { return; }
+          if(typeof svc.check_for_needs_sync === 'function') {
+            svc.check_for_needs_sync(true);
+          }
+        }, 10 * 1000);
+      } catch(e) {
+        console.warn('schedulePostLoginSyncIfNeeded:', e);
+      }
+    }, 0);
+  },
+
+  check_for_needs_sync: function(force) {
+    try {
+      var _this = this;
+      if(!_this || typeof _this !== 'object' || typeof _this.get !== 'function') {
+        _this = window.persistence;
+        if(!_this || typeof _this !== 'object' || typeof _this.get !== 'function') {
+          return false;
+        }
+      }
+      force = (force === true);
+      if(!_this.stashes || typeof _this.stashes.get !== 'function') {
+        return false;
+      }
+
+      if(_this.stashes.get('auth_settings') && window.lingoLinqExtras && window.lingoLinqExtras.ready) {
+        var synced = _this.get('last_sync_at') || 0;
+        var syncable = _this.get('online') && !isTesting() && !_this.get('syncing');
+        var interval = _this.get('last_sync_stamp_interval') || (5 * 60 * 1000);
+        interval = interval + (0.2 * interval * Math.random());
+        if(_this.get('last_sync_event_at')) {
+          syncable = syncable && (_this.get('last_sync_event_at') < ((new Date()).getTime() - interval));
+        }
+        var now = (new Date()).getTime() / 1000;
+        if(!isTesting() && capabilities.mobile && !force && loaded && (now - loaded) < (30) && synced > 1) {
+          return false;
+        } else if(_this.get('auto_sync') === false || _this.get('auto_sync') == null) {
+          return false;
+        } else if(synced > 0 && (now - synced) > (48 * 60 * 60) && syncable) {
+          console.debug('syncing because it has been more than 48 hours');
+          _this.sync('self', null, null, 'long_time_since_sync:' + synced + ":" + now).then(null, function() { });
+          return true;
+        } else if(force || (syncable && _this.get('last_sync_stamp'))) {
+          var last_check = _this.get('last_sync_stamp_check');
+          if(force || !last_check || (last_check < (new Date()).getTime() - interval)) {
+            _this.set('last_sync_stamp_check', (new Date()).getTime());
+            _this.ajax('/api/v1/users/self/sync_stamp', {type: 'GET'}).then(function(res) {
+              _this.set('last_sync_stamp_check', (new Date()).getTime());
+              if(!_this.get('last_sync_stamp') || res.sync_stamp != _this.get('last_sync_stamp')) {
+                var not_still_changing = false;
+                var cutoff = window.moment && window.moment(res.sync_stamp).add(5, 'minutes');
+                var now_m = window.moment && window.moment();
+                if(now_m && now_m.toISOString().substring(0, 10) != res.sync_stamp.substring(0, 10)) {
+                  not_still_changing = true;
+                } else if(cutoff) {
+                  not_still_changing = cutoff < window.moment();
+                } else {
+                  not_still_changing = true;
+                }
+                if(not_still_changing) {
+                  console.debug('syncing because sync_stamp has changed');
+                  _this.sync('self', null, null, 'sync_stamp_changed:' + res.sync_stamp + ":" + _this.get('last_sync_stamp')).then(null, function() { });
+                }
+              }
+              if(window.app_state && window.app_state.get('currentUser')) {
+                window.app_state.set('currentUser.last_sync_stamp_check', (new Date()).getTime());
+                if(res.unread_messages != null) {
+                  window.app_state.set('currentUser.unread_messages', res.unread_messages);
+                }
+                if(res.unread_alerts != null) {
+                  window.app_state.set('currentUser.unread_alerts', res.unread_alerts);
+                }
+              }
+            }, function(err) {
+              _this.set('last_sync_stamp_check', (new Date()).getTime());
+              if(err && err.result && err.result.invalid_token) {
+                if(_this.stashes && _this.stashes.get && _this.stashes.get('auth_settings') && !isTesting()) {
+                  if(LingoLinq.session && !LingoLinq.session.get('invalid_token')) {
+                    LingoLinq.session.check_token(false);
+                  }
+                }
+              }
+            });
+            return true;
+          }
+        }
+      }
+      return false;
+    } catch(e) {
+      console.warn('Error in check_for_needs_sync:', e);
+      return false;
+    }
+  },
+
   // TEMPORARILY DISABLED TO DEBUG INITIALIZATION ERROR
   /*
   check_for_needs_sync: observer('refresh_stamp', 'last_sync_at', function(ref) {
@@ -4069,9 +4184,26 @@ var persistence = Service.extend({
   _setupOnlineListeners: function() {
     var _this = this;
     this.set('online', navigator.onLine);
-    
+
+    var onBackOnline = function() {
+      runLater(function() {
+        if(!_this || _this.isDestroyed || _this.isDestroying) { return; }
+        if(_this.stashes && typeof _this.stashes.get === 'function' && _this.stashes.get('auth_settings') &&
+          (!LingoLinq.testing || LingoLinq.sync_testing)) {
+          _this.check_for_needs_sync(true);
+        }
+        if(typeof _this.getBrowserToken === 'function') {
+          _this.tokens = {};
+          if(LingoLinq.session) {
+            LingoLinq.session.restore(!_this.getBrowserToken());
+          }
+        }
+      }, 500);
+    };
+
     window.addEventListener('online', function() {
       _this.set('online', true);
+      onBackOnline();
     });
     window.addEventListener('offline', function() {
       _this.set('online', false);
@@ -4079,6 +4211,7 @@ var persistence = Service.extend({
     // Cordova notifies on the document object
     document.addEventListener('online', function() {
       _this.set('online', true);
+      onBackOnline();
     });
     document.addEventListener('offline', function() {
       _this.set('online', false);

--- a/app/frontend/app/services/session.js
+++ b/app/frontend/app/services/session.js
@@ -87,7 +87,16 @@ export default Service.extend({
     }
     this.stashes.persist('prior_login', 'true');
     this.stashes.persist_object('just_logged_in', true, false);
-    return RSVP.all_wait(promises).then(null, function() { return RSVP.resolve(); });
+    return RSVP.all_wait(promises).then(function() {
+      if(_this.persistence && typeof _this.persistence.schedulePostLoginSyncIfNeeded === 'function') {
+        _this.persistence.schedulePostLoginSyncIfNeeded();
+      }
+    }, function() {
+      if(_this.persistence && typeof _this.persistence.schedulePostLoginSyncIfNeeded === 'function') {
+        _this.persistence.schedulePostLoginSyncIfNeeded();
+      }
+      return RSVP.resolve();
+    });
   },
 
   hashed_password: function(password) {

--- a/app/frontend/app/utils/board_detail_cache.js
+++ b/app/frontend/app/utils/board_detail_cache.js
@@ -107,6 +107,7 @@ export default {
     if (built_for.skin !== ctx.skin) { return null; }
     if (built_for.edit_mode !== ctx.edit_mode) { return null; }
     if (built_for.label_locale !== ctx.label_locale) { return null; }
+    if (!!built_for.url_cache_primed !== !!ctx.url_cache_primed) { return null; }
     return entry.ordered_buttons;
   },
 

--- a/app/frontend/tests/test-helper.js
+++ b/app/frontend/tests/test-helper.js
@@ -58,6 +58,7 @@ QUnit.on('runEnd', function(runEnd) {
 // their `module()`/`test()` calls fire before `start()` below.
 import 'frontend/tests/acceptance/board-detail-empty-state-test';
 import 'frontend/tests/unit/controllers/copying-board-test';
+import 'frontend/tests/unit/controllers/user-board-detail-image-cache-test';
 
 // loadTests: false — we already pre-loaded all test modules above
 start({ loadTests: false });

--- a/app/frontend/tests/unit/controllers/user-board-detail-image-cache-test.js
+++ b/app/frontend/tests/unit/controllers/user-board-detail-image-cache-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import BoardDetailController from 'frontend/controllers/user/board-detail';
+import persistence from 'frontend/utils/persistence';
+
+module('Unit | Controller | user/board-detail image cache', function(hooks) {
+  var controller;
+  var url_cache_backup;
+  var url_uncache_backup;
+
+  hooks.beforeEach(function() {
+    url_cache_backup = persistence.url_cache;
+    url_uncache_backup = persistence.url_uncache;
+    persistence.url_cache = {};
+    persistence.url_uncache = {};
+    controller = BoardDetailController.create();
+  });
+
+  hooks.afterEach(function() {
+    persistence.url_cache = url_cache_backup;
+    persistence.url_uncache = url_uncache_backup;
+    if(controller) { controller.destroy(); }
+  });
+
+  test('_resolve_cached_image_url returns remote URL when cache is empty', function(assert) {
+    var remote = 'https://cdn.example.com/symbol.png';
+    assert.equal(controller._resolve_cached_image_url(remote), remote);
+  });
+
+  test('_resolve_cached_image_url prefers url_cache entry', function(assert) {
+    var remote = 'https://cdn.example.com/symbol.png';
+    var local = 'file:///local/symbol.png';
+    persistence.url_cache[remote] = local;
+    assert.equal(controller._resolve_cached_image_url(remote), local);
+  });
+
+  test('_resolve_cached_image_url skips url_uncache entries', function(assert) {
+    var remote = 'https://cdn.example.com/symbol.png';
+    persistence.url_cache[remote] = 'file:///local/symbol.png';
+    persistence.url_uncache[remote] = true;
+    assert.equal(controller._resolve_cached_image_url(remote), remote);
+  });
+
+  test('_make_btn uses cached image URL when available', function(assert) {
+    var remote = 'https://cdn.example.com/bi1.png';
+    var local = 'file:///local/bi1.png';
+    persistence.url_cache[remote] = local;
+    var btn = controller._make_btn({ id: '1', image_id: 'bi1', label: 'go' }, { bi1: remote });
+    assert.equal(btn.image_url, local);
+  });
+});

--- a/app/frontend/tests/unit/controllers/user-board-detail-image-cache-test.js
+++ b/app/frontend/tests/unit/controllers/user-board-detail-image-cache-test.js
@@ -1,23 +1,30 @@
 import { module, test } from 'qunit';
 import BoardDetailController from 'frontend/controllers/user/board-detail';
-import persistence from 'frontend/utils/persistence';
 
 module('Unit | Controller | user/board-detail image cache', function(hooks) {
   var controller;
+  var persistenceSvc;
   var url_cache_backup;
   var url_uncache_backup;
 
   hooks.beforeEach(function() {
-    url_cache_backup = persistence.url_cache;
-    url_uncache_backup = persistence.url_uncache;
-    persistence.url_cache = {};
-    persistence.url_uncache = {};
+    persistenceSvc = window.persistence;
+    if(!persistenceSvc) {
+      persistenceSvc = { url_cache: {}, url_uncache: {}, primed: false };
+      window.persistence = persistenceSvc;
+    }
+    url_cache_backup = persistenceSvc.url_cache;
+    url_uncache_backup = persistenceSvc.url_uncache;
+    persistenceSvc.url_cache = {};
+    persistenceSvc.url_uncache = {};
     controller = BoardDetailController.create();
   });
 
   hooks.afterEach(function() {
-    persistence.url_cache = url_cache_backup;
-    persistence.url_uncache = url_uncache_backup;
+    if(persistenceSvc) {
+      persistenceSvc.url_cache = url_cache_backup;
+      persistenceSvc.url_uncache = url_uncache_backup;
+    }
     if(controller) { controller.destroy(); }
   });
 
@@ -29,21 +36,21 @@ module('Unit | Controller | user/board-detail image cache', function(hooks) {
   test('_resolve_cached_image_url prefers url_cache entry', function(assert) {
     var remote = 'https://cdn.example.com/symbol.png';
     var local = 'file:///local/symbol.png';
-    persistence.url_cache[remote] = local;
+    persistenceSvc.url_cache[remote] = local;
     assert.equal(controller._resolve_cached_image_url(remote), local);
   });
 
   test('_resolve_cached_image_url skips url_uncache entries', function(assert) {
     var remote = 'https://cdn.example.com/symbol.png';
-    persistence.url_cache[remote] = 'file:///local/symbol.png';
-    persistence.url_uncache[remote] = true;
+    persistenceSvc.url_cache[remote] = 'file:///local/symbol.png';
+    persistenceSvc.url_uncache[remote] = true;
     assert.equal(controller._resolve_cached_image_url(remote), remote);
   });
 
   test('_make_btn uses cached image URL when available', function(assert) {
     var remote = 'https://cdn.example.com/bi1.png';
     var local = 'file:///local/bi1.png';
-    persistence.url_cache[remote] = local;
+    persistenceSvc.url_cache[remote] = local;
     var btn = controller._make_btn({ id: '1', image_id: 'bi1', label: 'go' }, { bi1: remote });
     assert.equal(btn.image_url, local);
   });


### PR DESCRIPTION
Board-detail speak now uses offline url_cache when building symbols, primes caches on entry, and warms the current board's images (not only linked subboards). Re-enable check_for_needs_sync, post-login sync scheduling after login, and online reconnect checks without restoring the full disabled persistence setup() block.

- Resolve image_url via persistence.url_cache in _make_btn (mirrors fast_html)
- Prime url_cache on board-detail entry; warm_images for current board
- Add schedulePostLoginSyncIfNeeded; call from session.confirm_authentication
- Restore check_for_needs_sync as a method and on_connect observer
- Unit tests for cached image URL resolution