### PR TITLE
fix(speak-mode): exit-to-home no longer bounces back into speak mode

### DIFF
--- a/app/frontend/app/controllers/user/board-detail.js
+++ b/app/frontend/app/controllers/user/board-detail.js
@@ -3287,6 +3287,13 @@ export default Controller.extend(prefClasses, {
         _this.set('show_options_menu', false);
         _this.set('app_state.board_detail_nav_history', []);
         _this.set('app_state.board_detail_entry_board', null);
+        // Leave speak mode before navigating: without this the index route's
+        // afterModel sees current_mode == 'speak' (or just the user's home
+        // board + setup_done) and bounces straight back into speak_mode.
+        if(app_state.get('speak_mode')) {
+          app_state.toggle_mode('speak');
+        }
+        app_state.set('already_homed', true);
         app_state.show_loading_overlay(i18n.t('loading_home_page', "Loading Home Page..."));
         var transition = _this.get('router').transitionTo('index');
         if(transition && typeof transition.then === 'function') {

--- a/app/frontend/app/routes/index.js
+++ b/app/frontend/app/routes/index.js
@@ -36,9 +36,11 @@ export default Route.extend({
     if (model && model.get('user_name') && session.get('access_token')) {
       var progress = model.get('preferences.progress') || {};
       var home_board_key = model.get('preferences.home_board.key');
-      if (progress.setup_done && home_board_key && !model.get('supporter_view') && !model.get('eval_ended')) {
+      if (progress.setup_done && home_board_key && !model.get('supporter_view') && !model.get('eval_ended') && !this.appState.get('already_homed')) {
         // Regular user past getting-started: jump straight into speak mode on their home board.
         // Done in afterModel (not setupController) so the dashboard doesn't flash first.
+        // Skip when already_homed is set so an explicit Exit Speak Mode -> dashboard
+        // navigation isn't bounced straight back.
         this.appState.home_in_speak_mode({user: model});
         this.appState.set('already_homed', true);
         return;


### PR DESCRIPTION
## Summary
- Modern board-detail \"Exit Speak Mode → To Home Page\" button was navigating to `/` without clearing `stashes.current_mode` or toggling speak mode off.
- Commit 0ee4d6cce3 (#251, May 6) added an auto-jump in `routes/index.js#afterModel` that re-enters speak mode for any user with `setup_done` + a `home_board`.
- Together these produced an infinite bounce: hitting Exit Speak Mode dropped users right back on their home board.
- Fix: have `exit_to_home` toggle speak mode off and set `already_homed = true` before transitioning (mirrors what the classic-view `toggleSpeakMode` exit path already does). Defensive guard added to `afterModel` so any future entrypoint that forgets to clear speak mode won't re-trigger the loop — matches the existing guard at `setupController:95`.

## Why this is the right shape
The action is named `exit_to_home` and the UI label is \"Exit Speak Mode → To Home Page\" — the contract has always been that it leaves speak mode. The original implementation just forgot to do that step.

## Test plan
- [ ] Cold-launch a logged-in user with `setup_done` + home board → still auto-enters speak mode (no regression to login-flow auto-home).
- [ ] In speak mode on modern board-detail, click actions menu → \"Exit Speak Mode → To Home Page\" → lands on dashboard, **stays** on dashboard.
- [ ] From the dashboard, re-enter speak mode → still works.
- [ ] Repeat with the classic-view exit (`application.hbs` → `toggleSpeakMode`) → still works (unchanged code path).
- [ ] PIN-protected user → PIN prompt still appears before exit completes.
- [ ] In eval mode (`obf/eval/*`) → \"End Evaluation\" button still works (separate action, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)