### PR TITLE
fix(board-detail): harden skin-tone URLs and speed repeat board loads

### DIFF
--- a/app/frontend/app/controllers/user/board-detail.js
+++ b/app/frontend/app/controllers/user/board-detail.js
@@ -579,14 +579,71 @@ export default Controller.extend(prefClasses, {
     // can cause observer churn on a torn-down controller.
     if(this.get('_exiting') || this.isDestroyed || this.isDestroying) { return; }
     var _this = this;
+    if(!(raw.images && raw.images.length)) {
+      if(_this._board_detail_images && _this._board_detail_images.length) {
+        raw.images = _this._board_detail_images;
+      } else {
+        var cached_raw = boardDetailCache.get(raw.key || raw.id);
+        if(cached_raw && cached_raw.images && cached_raw.images.length) {
+          raw.images = cached_raw.images;
+        }
+      }
+    }
+    if(raw.images && raw.images.length) {
+      _this._board_detail_images = raw.images;
+    }
+    var skin = _this.get('app_state.referenced_user.preferences.skin');
+    var preferred_symbols = _this.get('app_state.referenced_user.preferences.preferred_symbols');
+    if(preferred_symbols && preferred_symbols !== 'original') {
+      _this._preferred_symbols = preferred_symbols;
+    } else {
+      _this._preferred_symbols = null;
+    }
+    var use_ember = _this.get('edit_mode');
+    var stashed_level = parseInt(_this.get('stashes.board_level'), 10);
+    var current_level = (stashed_level >= 1 && stashed_level <= 10) ? stashed_level : 10;
+    var board_has_levels = (raw.buttons || []).some(function(b) {
+      return b && b.level_modifications && Object.keys(b.level_modifications).length > 0;
+    });
+    var cache_token = (raw.key || raw.id);
+    var cache_ctx = {
+      preferred_symbols: _this._preferred_symbols,
+      skin: skin || null,
+      edit_mode: !!use_ember,
+      label_locale: _this.get('app_state.label_locale') || null,
+      url_cache_primed: !!persistence.primed,
+      board_level: current_level,
+      board_has_levels: board_has_levels
+    };
+    // Cache hit — skip skin_image_map and the full grid rebuild loop.
+    if(!use_ember && cache_token) {
+      var cached_ob_early = boardDetailCache.get_ordered_buttons(cache_token, cache_ctx);
+      if(cached_ob_early) {
+        var prev_early = _this._last_raw;
+        var is_same_board_early = prev_early && raw && ((prev_early.id && raw.id && prev_early.id === raw.id) || (prev_early.key && raw.key && prev_early.key === raw.key));
+        if(!is_same_board_early) {
+          _this.set('_hidden_row_stack', []);
+          _this.set('_hidden_col_stack', []);
+        }
+        _this._last_raw = raw;
+        if(_this._board_detail_images && _this._board_detail_images.length) {
+          _this._last_raw.images = _this._board_detail_images;
+        }
+        _this.set('ordered_buttons', cached_ob_early);
+        _this._apply_focus_dim_to_ordered_buttons();
+        _this._preload_grid_images(cached_ob_early);
+        return;
+      }
+    }
     var image_map = raw.image_urls || {};
     (raw.images || []).forEach(function(img) {
       if(img && img.id) {
         var url = img.skin_url || img.url;
-        if(url) { image_map[img.id] = url; }
+        if(url) {
+          image_map[String(img.id)] = url;
+        }
       }
     });
-    var skin = _this.get('app_state.referenced_user.preferences.skin');
     image_map = LingoLinq.Board.skin_image_map(image_map, skin, { persistence: persistence });
     // Cache raw data for preference-triggered rebuilds
     // Reset the row/column hide stacks when the user actually navigates to a
@@ -600,76 +657,13 @@ export default Controller.extend(prefClasses, {
       _this.set('_hidden_col_stack', []);
     }
     _this._last_raw = raw;
-    // Apply preferred_symbols variant URLs
-    var preferred_symbols = _this.get('app_state.referenced_user.preferences.preferred_symbols');
-    if(preferred_symbols && preferred_symbols !== 'original') {
-      _this._preferred_symbols = preferred_symbols;
-    } else {
-      _this._preferred_symbols = null;
+    if(_this._board_detail_images && _this._board_detail_images.length) {
+      _this._last_raw.images = _this._board_detail_images;
     }
     _this._image_map = image_map;
 
     var board = _this.get('model');
     var grid = raw.grid;
-    var use_ember = _this.get('edit_mode');
-
-    // Current speak-mode level: the level the supervisor last selected
-    // (persisted in stashes.board_level). If none was ever selected,
-    // default to 10 (full vocab — untagged boards "show everything").
-    // This MUST match current_speak_level exactly (saved 1–10 else 10)
-    // so the highlighted pill and the actually-filtered grid always
-    // agree, including for boards that ship an author default_level.
-    // This is the level baked into each button's `hidden` via
-    // apply_button_level in _make_btn, and the level that keys the cache
-    // below — otherwise switching from L1 to L10 would return the stale
-    // L1 grid.
-    var stashed_level = parseInt(_this.get('stashes.board_level'), 10);
-    var current_level = (stashed_level >= 1 && stashed_level <= 10) ? stashed_level : 10;
-
-    // Does THIS board actually use Button Levels? (Any button carries a
-    // non-empty level_modifications.) The level filter must be a no-op on
-    // boards that don't use levels — otherwise a stale stashes.board_level
-    // (e.g. 3, carried over from a different leveled board) makes the
-    // untagged `else` branch in _make_btn flag EVERY button
-    // display_as_hidden, which the communicator speak-hide CSS then
-    // renders as a blank board. This is NOT the (reverted) blank-button
-    // rule — it only gates the pre-existing untagged-hide.
-    var board_has_levels = (raw.buttons || []).some(function(b) {
-      return b && b.level_modifications && Object.keys(b.level_modifications).length > 0;
-    });
-
-    // Cache key for the pre-built ordered_buttons. Only used in non-edit
-    // mode: edit-mode buttons are Ember objects with mutable state we
-    // can't safely reuse across navigations.
-    var cache_token = (raw.key || raw.id);
-    var cache_ctx = {
-      preferred_symbols: _this._preferred_symbols,
-      skin: skin || null,
-      edit_mode: !!use_ember,
-      label_locale: _this.get('app_state.label_locale') || null,
-      // Invalidate grid reuse when offline url_cache becomes available so
-      // image_url picks up local paths after prime_caches().
-      url_cache_primed: !!persistence.primed,
-      // Level filter is baked into the cached grid by _make_btn
-      // (display_as_hidden). The cached ordered_buttons MUST therefore key
-      // on the active level / whether the board uses levels — otherwise
-      // changing the level reuses the stale grid and the speak-mode level
-      // filter never re-applies.
-      board_level: current_level,
-      board_has_levels: board_has_levels
-    };
-    if(!use_ember && cache_token) {
-      var cached_ob = boardDetailCache.get_ordered_buttons(cache_token, cache_ctx);
-      if(cached_ob) {
-        // Cache hit — re-use the pre-built grid. Glimmer skips re-render
-        // for cells whose object identity is unchanged, so this nav
-        // costs ~0 CPU on the controller side.
-        _this.set('ordered_buttons', cached_ob);
-        _this._apply_focus_dim_to_ordered_buttons();
-        _this._preload_grid_images(cached_ob);
-        return;
-      }
-    }
 
     if(!grid || !grid.order) {
       var buttons = (raw.buttons || []).map(function(btn) {
@@ -749,8 +743,12 @@ export default Controller.extend(prefClasses, {
     if(cached) { return cached; }
     var unvarianted = remote_url.replace(/\.variant-.+\.(png|svg)$/, '');
     if(unvarianted !== remote_url) {
-      cached = try_url(unvarianted);
-      if(cached) { return cached; }
+      if(LingoLinq.Board.is_skin_tone_variant_url(remote_url)) {
+        try_url(unvarianted);
+      } else {
+        cached = try_url(unvarianted);
+        if(cached) { return cached; }
+      }
     }
     var alt_url = null;
     if(remote_url.match(/^https\:\/\/s3\.amazonaws\.com\/opensymbols\//)) {
@@ -774,8 +772,13 @@ export default Controller.extend(prefClasses, {
         img_url = image_map[btn.image_id];
       }
     }
+    var image_fallback_url = null;
     if(img_url) {
       img_url = this._resolve_cached_image_url(img_url);
+      if(LingoLinq.Board.is_skin_tone_variant_url(img_url)) {
+        image_fallback_url = LingoLinq.Board.unskin_tone_variant_url(img_url);
+        if(image_fallback_url === img_url) { image_fallback_url = null; }
+      }
     }
     // Speak-mode level filter: decide whether the level filter should
     // visually hide this button at the current level. We compute it
@@ -823,6 +826,7 @@ export default Controller.extend(prefClasses, {
       label: btn.label || '',
       vocalization: btn.vocalization || '',
       image_url: img_url,
+      image_fallback_url: image_fallback_url,
       image_id: btn.image_id,
       load_board: btn.load_board,
       hidden: btn.hidden,
@@ -1650,11 +1654,17 @@ export default Controller.extend(prefClasses, {
     'app_state.currentUser.preferences.hidden_buttons',
     'app_state.currentUser.preferences.stretch_buttons',
     'app_state.currentUser.preferences.skin',
+    'app_state.referenced_user.preferences.preferred_symbols',
+    'app_state.referenced_user.preferences.symbol_background',
+    'app_state.referenced_user.preferences.high_contrast',
+    'app_state.referenced_user.preferences.skin',
     function() {
       var pending = this.get('pending_display_prefs');
       if(pending) { return pending; }
-      var prefs = this.get('app_state.currentUser.preferences') || {};
-      var device = prefs.device || {};
+      var pref_user = this._pref_user_for_display();
+      var current_prefs = this.get('app_state.currentUser.preferences') || {};
+      var sym_prefs = (pref_user && pref_user.get('preferences')) || current_prefs;
+      var device = current_prefs.device || {};
       return {
         button_spacing:       device.button_spacing       || 'medium',
         button_border:        device.button_border        || 'medium',
@@ -1662,13 +1672,13 @@ export default Controller.extend(prefClasses, {
         button_text_position: device.button_text_position || 'bottom',
         button_style:         device.button_style         || 'default',
         vocalization_height:  device.vocalization_height  || 'medium',
-        hidden_buttons:       prefs.hidden_buttons        || 'grid',
-        stretch_buttons:      prefs.stretch_buttons       || 'none',
-        preferred_symbols:    prefs.preferred_symbols     || 'original',
-        symbol_background:    prefs.symbol_background     || 'clear',
-        high_contrast:        !!prefs.high_contrast,
+        hidden_buttons:       current_prefs.hidden_buttons        || 'grid',
+        stretch_buttons:      current_prefs.stretch_buttons       || 'none',
+        preferred_symbols:    sym_prefs.preferred_symbols     || 'original',
+        symbol_background:    sym_prefs.symbol_background     || 'clear',
+        high_contrast:        !!sym_prefs.high_contrast,
         utterance_text_only:  !!device.utterance_text_only,
-        skin:                 prefs.skin                  || 'default'
+        skin:                 sym_prefs.skin                  || 'default'
       };
     }
   ),
@@ -2541,9 +2551,10 @@ export default Controller.extend(prefClasses, {
         persistence.ajax('/api/v1/boards/' + lookup, { type: 'GET' }).then(function(data) {
           pending--;
           if(_this.isDestroyed || _this.isDestroying) { return; }
-          if(data && data.board) {
-            boardDetailCache.set(JSON.parse(JSON.stringify(data.board)));
-            walk(data.board, depth - 1);
+          var merged = boardDetailCache.normalize_board_payload(data);
+          if(merged) {
+            boardDetailCache.set(JSON.parse(JSON.stringify(merged)));
+            walk(merged, depth - 1);
           }
           if(pending === 0) { commit_list(); }
         }, function(err) {
@@ -3065,13 +3076,13 @@ export default Controller.extend(prefClasses, {
         }, 0);
       };
       persistence.ajax('/api/v1/boards/' + board.get('key'), { type: 'GET' }).then(function(data) {
-        if(data && data.board) {
-          // Refresh the raw cache with the post-save server state so the
-          // next navigation back to this board (or the cache-first model
-          // hook firing on transition out of edit mode) sees fresh data
-          // instead of pre-save stale data.
-          boardDetailCache.set(JSON.parse(JSON.stringify(data.board)));
-          _this._build_from_raw(data.board);
+        var merged = boardDetailCache.normalize_board_payload(data);
+        if(merged) {
+          if(merged.images && merged.images.length) {
+            _this._board_detail_images = merged.images;
+          }
+          boardDetailCache.set(JSON.parse(JSON.stringify(merged)));
+          _this._build_from_raw(merged);
         }
         finish();
 
@@ -4314,6 +4325,10 @@ export default Controller.extend(prefClasses, {
         user.save();
       }
       if(this._display_pref_render_keys.indexOf(key) >= 0 && this._last_raw) {
+        var rebuild_token = this._last_raw.key || this._last_raw.id;
+        if(rebuild_token) {
+          boardDetailCache.clear_ordered_buttons(rebuild_token);
+        }
         this._build_from_raw(this._last_raw);
       }
     },
@@ -4646,9 +4661,10 @@ export default Controller.extend(prefClasses, {
           actionLock.run('board-link:' + (_this.get('model.key') || _this.get('model.id') || 'board-detail') + ':' + lookup, function() {
             _this._push_nav_history();
             return persistence.ajax('/api/v1/boards/' + lookup, { type: 'GET' }).then(function(data) {
-              if(data && data.board && data.board.key) {
-                boardDetailCache.set(JSON.parse(JSON.stringify(data.board)));
-                return _this._preferred_board_detail_key(data.board.key).then(function(preferred_key) {
+              var merged = boardDetailCache.normalize_board_payload(data);
+              if(merged && merged.key) {
+                boardDetailCache.set(JSON.parse(JSON.stringify(merged)));
+                return _this._preferred_board_detail_key(merged.key).then(function(preferred_key) {
                   var parts = preferred_key.split('/');
                   return _this.get('router').transitionTo('user.board-detail', parts[0], parts.slice(1).join('/'));
                 });
@@ -5147,9 +5163,13 @@ export default Controller.extend(prefClasses, {
           _this.set('board_loading', true);
           var board_key = _this.get('user.user_name') + '/' + _this.get('boardname');
           persistence.ajax('/api/v1/boards/' + board_key, { type: 'GET' }).then(function(data) {
-            if(data && data.board) {
-              _this.set('_raw_board_data', data.board);
-              _this._build_from_raw(data.board);
+            var merged = boardDetailCache.normalize_board_payload(data);
+            if(merged) {
+              if(merged.images && merged.images.length) {
+                _this._board_detail_images = merged.images;
+              }
+              _this.set('_raw_board_data', merged);
+              _this._build_from_raw(merged);
             }
             _this.set('board_loading', false);
           }, function() {

--- a/app/frontend/app/models/board.js
+++ b/app/frontend/app/models/board.js
@@ -1833,6 +1833,17 @@ LingoLinq.Board.is_skinned_url = function(url) {
     return false;
   }
 };
+// True when URL already selects a concrete skin tone (not the varianted-skin base).
+LingoLinq.Board.is_skin_tone_variant_url = function(url) {
+  if(!url || typeof url !== 'string') { return false; }
+  if(url.match(/\.variant-(dark|light|medium|medium-dark|medium-light|unskinned)\.\w+$/i)) {
+    return true;
+  }
+  if(url.match(/\/libraries\/twemoji\//) && url.match(/-var[0-9a-f]+UNI/i)) {
+    return true;
+  }
+  return false;
+};
 LingoLinq.Board.skinned_url = function(url, which_skin, unskin) {
   var which_override = null;
   if(unskin) {
@@ -1869,18 +1880,18 @@ LingoLinq.Board.skinned_url = function(url, which_skin, unskin) {
 // opts.persistence — when provided, falls back to the original URL if the
 //   skinned variant isn't cached locally and the original is (prevents offline
 //    404s when only the base URL has been cached).
-// OpenSymbols library URLs must end in .varianted-skin.{ext} before skin_image_map
-// can rewrite to .variant-{tone}.{ext}. Plain /libraries/.../file.png URLs are
-// upgraded here (same suffix rule as ButtonImage#check_for_variants).
+// Only backend-verified skin bases (.varianted-skin or twemoji skin codes) are
+// rewritten by skin_image_map. Plain /libraries/.../file.png URLs are not
+// speculatively upgraded — many symbols have no variant files on OpenSymbols.
 LingoLinq.Board.upgrade_url_for_skin_variants = function(url) {
   if(!url || typeof url !== 'string') { return url; }
-  if(LingoLinq.Board.is_skinned_url(url)) { return url; }
-  if(url.match(/\/libraries\//) && !url.match(/\.variant-/)) {
-    var filename = (url.split('/').pop() || '');
-    var ext = filename.split('.').pop();
-    if(ext && ext.length <= 5 && !ext.match(/\//)) {
-      return url + '.varianted-skin.' + ext;
-    }
+  return url;
+};
+
+LingoLinq.Board.unskin_tone_variant_url = function(url) {
+  if(!url || typeof url !== 'string') { return url; }
+  if(url.match(/\.variant(?:ed-skin|-[^.]+)\.\w+$/)) {
+    return url.replace(/\.variant(?:ed-skin|-[^.]+)\.\w+$/, '');
   }
   return url;
 };
@@ -1899,7 +1910,8 @@ LingoLinq.Board.skin_image_map = function(image_map, skin, opts) {
       which_skin,
       unskin
     );
-    if(persistence && !persistence.url_cache[url] && persistence.url_cache[base_url] && (!persistence.url_uncache || !persistence.url_uncache[base_url])) {
+    var online = persistence && (typeof persistence.get === 'function' ? persistence.get('online') : persistence.online);
+    if(persistence && !online && !persistence.url_cache[url] && persistence.url_cache[base_url] && (!persistence.url_uncache || !persistence.url_uncache[base_url])) {
       url = base_url;
     }
     return url;

--- a/app/frontend/app/routes/user/board-detail.js
+++ b/app/frontend/app/routes/user/board-detail.js
@@ -65,12 +65,18 @@ export default Route.extend({
   // Build the symbol grid, warm current-board images, prefetch linked boards.
   _finalize_board_display: function(controller, raw) {
     if(!raw || !controller || controller.isDestroyed || controller.isDestroying) { return; }
+    if(raw.images && raw.images.length) {
+      controller._board_detail_images = raw.images;
+    }
     controller._build_from_raw(raw);
     if(controller.get('edit_mode')) { return; }
     // Warm browser HTTP cache for this board's symbols (children are warmed by prefetch_linked).
     runLater(function() {
       if(controller.isDestroyed || controller.isDestroying || controller.get('edit_mode')) { return; }
-      boardDetailCache.warm_images(raw);
+      boardDetailCache.warm_images(raw, {
+        skin: controller.get('app_state.referenced_user.preferences.skin'),
+        preferred_symbols: controller.get('app_state.referenced_user.preferences.preferred_symbols')
+      });
     }, 100);
     runLater(function() {
       if(controller.isDestroyed || controller.isDestroying || controller.get('edit_mode')) { return; }
@@ -149,8 +155,9 @@ export default Route.extend({
 
       var fallbackSingleBoard = function() {
         persistence.ajax('/api/v1/boards/' + board_key, { type: 'GET' }).then(function(data) {
-          if(data && data.board) {
-            handleRoot(data.board);
+          var boardData = boardDetailCache.normalize_board_payload(data);
+          if(boardData) {
+            handleRoot(boardData);
           } else {
             resolve({ error: true, boardname: params.boardname });
           }
@@ -164,9 +171,11 @@ export default Route.extend({
           fallbackSingleBoard();
           return;
         }
-        var rootBoardData = data.root.board;
-        if (data.root.images) { rootBoardData.images = data.root.images; }
-        if (data.root.sounds) { rootBoardData.sounds = data.root.sounds; }
+        var rootBoardData = boardDetailCache.normalize_board_payload(data.root);
+        if (!rootBoardData) {
+          fallbackSingleBoard();
+          return;
+        }
         // Resolve the route with the root FIRST so the user sees the
         // board immediately — descendant caching happens after.
         handleRoot(rootBoardData);
@@ -177,10 +186,8 @@ export default Route.extend({
         // This is the work that makes folder taps instant.
         var subStore = _this.store;
         (data.descendants || []).forEach(function(wrapped) {
-          var sub_raw = wrapped && wrapped.board;
+          var sub_raw = boardDetailCache.normalize_board_payload(wrapped);
           if (!sub_raw) { return; }
-          if (wrapped.images) { sub_raw.images = wrapped.images; }
-          if (wrapped.sounds) { sub_raw.sounds = wrapped.sounds; }
           boardDetailCache.set(sub_raw);
           try {
             var sub_normalized = subStore.normalize('board', JSON.parse(JSON.stringify(sub_raw)));

--- a/app/frontend/app/templates/components/board-detail-grid.hbs
+++ b/app/frontend/app/templates/components/board-detail-grid.hbs
@@ -113,7 +113,7 @@
         {{/if}}
         {{#if btn.image_url}}
           <div class="md-board-detail-symbol-card__image">
-            <img class="symbol" src={{btn.image_url}} alt={{btn.label}} decoding="async" onerror="this.style.display='none';this.nextElementSibling&&(this.nextElementSibling.style.display='flex');">
+            <img class="symbol" src={{btn.image_url}} alt={{btn.label}} decoding="async" data-fallback={{btn.image_fallback_url}} onerror="if(this.dataset.fallback&&this.src!==this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.style.display='none';this.nextElementSibling&&(this.nextElementSibling.style.display='flex');}">
             <img class="md-board-detail-symbol-card__fallback-img" src="/images/square.svg" alt="" draggable="false" style="display:none; max-width: 70%; max-height: 70%;">
           </div>
         {{else}}

--- a/app/frontend/app/utils/board_detail_cache.js
+++ b/app/frontend/app/utils/board_detail_cache.js
@@ -48,8 +48,7 @@ function _index(entry) {
 function _drop(entry) {
   if (entry.key && _by_key[entry.key] === entry) { delete _by_key[entry.key]; }
   if (entry.id && _by_id[entry.id] === entry) { delete _by_id[entry.id]; }
-  delete _warmed[entry.key];
-  delete _warmed[entry.id];
+  _drop_warmed_for(entry);
 }
 
 function _lookup(key_or_id) {
@@ -57,7 +56,80 @@ function _lookup(key_or_id) {
   return _by_key[key_or_id] || _by_id[key_or_id] || null;
 }
 
+function _display_prefs_for_warm() {
+  try {
+    if (typeof window !== 'undefined' && LingoLinq && LingoLinq.appState) {
+      var appState = LingoLinq.appState;
+      var user = appState.get('referenced_user') || appState.get('currentUser');
+      if (user) {
+        return {
+          skin: user.get('preferences.skin'),
+          preferred_symbols: user.get('preferences.preferred_symbols')
+        };
+      }
+    }
+  } catch (e) { /* app may not be booted yet during early prefetch */ }
+  return { skin: null, preferred_symbols: null };
+}
+
+function _warm_cache_key(token, skin, preferred_symbols) {
+  if (!token) { return null; }
+  var skinPart = skin || 'default';
+  var symPart = (preferred_symbols && preferred_symbols !== 'original') ? preferred_symbols : 'original';
+  return token + '|' + skinPart + '|' + symPart;
+}
+
+function _drop_warmed_for(entry) {
+  [entry.key, entry.id].forEach(function(token) {
+    if (!token) { return; }
+    Object.keys(_warmed).forEach(function(k) {
+      if (k === token || k.indexOf(token + '|') === 0) { delete _warmed[k]; }
+    });
+  });
+}
+
+function _is_warmed(token, skin, preferred_symbols) {
+  var key = _warm_cache_key(token, skin, preferred_symbols);
+  return !!(key && _warmed[key]);
+}
+
+// Build the same skinned URL set _build_from_raw uses so prefetch hits
+// the browser cache entries the grid will request.
+function _urls_to_warm(raw, skin) {
+  var image_map = raw.image_urls || {};
+  (raw.images || []).forEach(function(img) {
+    if (img && img.id) {
+      var url = img.skin_url || img.url;
+      if (url) { image_map[String(img.id)] = url; }
+    }
+  });
+  image_map = LingoLinq.Board.skin_image_map(image_map, skin, { persistence: persistence });
+  var urls = [];
+  var seen = {};
+  for (var id in image_map) {
+    if (image_map[id] && !seen[image_map[id]]) {
+      seen[image_map[id]] = true;
+      urls.push(image_map[id]);
+    }
+  }
+  return urls;
+}
+
+// API show/tree/bulk responses wrap images/sounds beside `board`. Merge
+// them onto the raw board object so _build_from_raw can read skin_url.
+function normalize_board_payload(data) {
+  if (!data) { return null; }
+  if (data.board) {
+    var board = JSON.parse(JSON.stringify(data.board));
+    if (data.images) { board.images = data.images; }
+    if (data.sounds) { board.sounds = data.sounds; }
+    return board;
+  }
+  return JSON.parse(JSON.stringify(data));
+}
+
 export default {
+  normalize_board_payload: normalize_board_payload,
   // Returns the cached raw board JSON, or null if missing/stale.
   get: function(key_or_id) {
     var entry = _lookup(key_or_id);
@@ -113,6 +185,13 @@ export default {
     return entry.ordered_buttons;
   },
 
+  clear_ordered_buttons: function(key_or_id) {
+    var entry = _lookup(key_or_id);
+    if (!entry) { return; }
+    entry.ordered_buttons = null;
+    entry.ordered_for = null;
+  },
+
   // Drops a cached entry (e.g. on save or before edit-mode entry).
   invalidate: function(key_or_id) {
     var entry = _lookup(key_or_id);
@@ -128,7 +207,10 @@ export default {
   },
 
   // Warm the browser image cache for every button image URL on the
-  // given raw board.
+  // given raw board, using the active skin tone (same URLs as the grid).
+  //
+  // opts.skin / opts.preferred_symbols — optional overrides; default from
+  // referenced_user (or currentUser) via appState.
   //
   // Returns a Promise that resolves when every image has settled
   // (loaded OR errored). The browser caps parallel fetches per origin
@@ -139,22 +221,19 @@ export default {
   // fully populated before showing the board, OR fire-and-forget for
   // sub-board prefetch.
   //
-  // `_warmed` guard means we never re-dispatch the same board's
-  // images — but we still return a resolved promise so callers can
-  // chain regardless.
-  warm_images: function(raw) {
+  // `_warmed` is keyed by board + skin + symbol library so a skin-tone
+  // change re-warms with the correct variant URLs.
+  warm_images: function(raw, opts) {
+    opts = opts || {};
     if (!raw) { return RSVP.resolve(); }
     var token = raw.key || raw.id;
-    if (token && _warmed[token]) { return RSVP.resolve(); }
-    if (token) { _warmed[token] = true; }
-    var image_map = raw.image_urls || {};
-    (raw.images || []).forEach(function(img) {
-      if (img && img.id && img.url) { image_map[img.id] = img.url; }
-    });
-    var urls = [];
-    for (var id in image_map) {
-      if (image_map[id]) { urls.push(image_map[id]); }
-    }
+    var prefs = _display_prefs_for_warm();
+    var skin = opts.skin !== undefined ? opts.skin : prefs.skin;
+    var preferred_symbols = opts.preferred_symbols !== undefined ? opts.preferred_symbols : prefs.preferred_symbols;
+    var warmKey = _warm_cache_key(token, skin, preferred_symbols);
+    if (warmKey && _warmed[warmKey]) { return RSVP.resolve(); }
+    if (warmKey) { _warmed[warmKey] = true; }
+    var urls = _urls_to_warm(raw, skin);
     if (!urls.length) { return RSVP.resolve(); }
     var promises = urls.map(function(url) {
       return new RSVP.Promise(function(resolve) {
@@ -181,6 +260,9 @@ export default {
     var max = opts.max || MAX_PREFETCH;
     var fetched = 0;
     var _this = this;
+    var prefs = _display_prefs_for_warm();
+    var skin = opts.skin !== undefined ? opts.skin : prefs.skin;
+    var preferred_symbols = opts.preferred_symbols !== undefined ? opts.preferred_symbols : prefs.preferred_symbols;
 
     raw.buttons.forEach(function(btn) {
       if (!btn || !btn.load_board) { return; }
@@ -189,8 +271,9 @@ export default {
 
       var existing = _lookup(lookup);
       if (existing && _is_fresh(existing)) {
-        if (!_warmed[existing.key] && !_warmed[existing.id]) {
-          _this.warm_images(existing.raw);
+        var existingToken = existing.key || existing.id;
+        if (existingToken && !_is_warmed(existingToken, skin, preferred_symbols)) {
+          _this.warm_images(existing.raw, opts);
         }
         return;
       }
@@ -200,9 +283,10 @@ export default {
 
       _inflight[lookup] = persistence.ajax('/api/v1/boards/' + lookup, { type: 'GET' }).then(function(data) {
         delete _inflight[lookup];
-        if (data && data.board) {
-          _this.set(data.board);
-          _this.warm_images(data.board);
+        var board_raw = normalize_board_payload(data);
+        if (board_raw) {
+          _this.set(board_raw);
+          _this.warm_images(board_raw, opts);
         }
       }, function() {
         delete _inflight[lookup];
@@ -236,18 +320,20 @@ export default {
     var lookup = home_key || home_id;
     if (!lookup) { return; }
     var _this = this;
+    var warm_opts = {
+      skin: user.get('preferences.skin'),
+      preferred_symbols: user.get('preferences.preferred_symbols')
+    };
     // Defer slightly so this doesn't compete with the post-login UI
     // render. By the time the user finishes reading the dashboard,
     // the tree is cached and Boards-tab navigation is instant.
     runLater(function() {
       persistence.ajax('/api/v1/boards/' + lookup + '/tree', { type: 'GET' }).then(function(data) {
         if (!data || !data.root || !data.root.board) { return; }
-        // Cache root.
-        var root_raw = data.root.board;
-        if (data.root.images) { root_raw.images = data.root.images; }
-        if (data.root.sounds) { root_raw.sounds = data.root.sounds; }
+        var root_raw = normalize_board_payload(data.root);
+        if (!root_raw) { return; }
         _this.set(root_raw);
-        _this.warm_images(root_raw);
+        _this.warm_images(root_raw, warm_opts);
         // Try to push root into Ember Data store too so the route's
         // cache-hit check (which requires `cached_record`) passes
         // when the user navigates to it. The store may not be the
@@ -260,12 +346,10 @@ export default {
         } catch (e) { /* ignore */ }
         // Cache + push every descendant.
         (data.descendants || []).forEach(function(wrapped) {
-          var sub_raw = wrapped && wrapped.board;
+          var sub_raw = normalize_board_payload(wrapped);
           if (!sub_raw) { return; }
-          if (wrapped.images) { sub_raw.images = wrapped.images; }
-          if (wrapped.sounds) { sub_raw.sounds = wrapped.sounds; }
           _this.set(sub_raw);
-          _this.warm_images(sub_raw);
+          _this.warm_images(sub_raw, warm_opts);
           try {
             if (typeof window !== 'undefined' && LingoLinq && LingoLinq.store) {
               var subNorm = LingoLinq.store.normalize('board', JSON.parse(JSON.stringify(sub_raw)));
@@ -312,7 +396,7 @@ export default {
 
     // Warm the current board's images right away. Fire-and-forget;
     // browser cache is the persistence layer.
-    _this.warm_images(raw);
+    _this.warm_images(raw, opts);
 
     // Collect all unvisited sub-board lookups from this board.
     var collect_layer_keys = function(board_raw) {
@@ -340,7 +424,7 @@ export default {
         if (existing && _is_fresh(existing) && existing.raw) {
           // Already cached — feed its sub-board keys into the next
           // layer directly.
-          _this.warm_images(existing.raw);
+          _this.warm_images(existing.raw, opts);
           next_layer = next_layer.concat(collect_layer_keys(existing.raw));
         } else {
           to_fetch.push(key);
@@ -358,17 +442,10 @@ export default {
         }).then(function(data) {
           var boards = (data && data.boards) || [];
           boards.forEach(function(wrapped) {
-            // bulk endpoint returns wrapped form (mirrors single show).
-            // Merge image_urls from the wrapper if present so the
-            // cached raw has the same shape as a single-board fetch.
-            var board_raw = wrapped && wrapped.board;
+            var board_raw = normalize_board_payload(wrapped);
             if (!board_raw) { return; }
-            // Mirror what /boards/:id does — splice `images` into the
-            // raw object so _build_from_raw's image_map works the same.
-            if (wrapped.images) { board_raw.images = wrapped.images; }
-            if (wrapped.sounds) { board_raw.sounds = wrapped.sounds; }
             _this.set(board_raw);
-            _this.warm_images(board_raw);
+            _this.warm_images(board_raw, opts);
             next_layer = next_layer.concat(collect_layer_keys(board_raw));
           });
         }, function() {
@@ -377,10 +454,11 @@ export default {
           // older deploys.
           var promises = to_fetch.map(function(key) {
             return persistence.ajax('/api/v1/boards/' + key, { type: 'GET' }).then(function(data) {
-              if (data && data.board) {
-                _this.set(data.board);
-                _this.warm_images(data.board);
-                next_layer = next_layer.concat(collect_layer_keys(data.board));
+              var board_raw = normalize_board_payload(data);
+              if (board_raw) {
+                _this.set(board_raw);
+                _this.warm_images(board_raw, opts);
+                next_layer = next_layer.concat(collect_layer_keys(board_raw));
               }
             }, function() { /* swallow individual errors */ });
           });

--- a/app/frontend/tests/unit/controllers/user-board-detail-image-cache-test.js
+++ b/app/frontend/tests/unit/controllers/user-board-detail-image-cache-test.js
@@ -48,6 +48,13 @@ module('Unit | Controller | user/board-detail image cache', function(hooks) {
     assert.equal(controller._resolve_cached_image_url(remote), remote);
   });
 
+  test('_resolve_cached_image_url keeps skin-tone variant when only base is cached', function(assert) {
+    var base = 'https://cdn.example.com/lib/sym.png';
+    var skinned = base + '.variant-dark.png';
+    persistenceSvc.url_cache[base] = 'file:///local/sym.png';
+    assert.equal(controller._resolve_cached_image_url(skinned), skinned);
+  });
+
   test('_make_btn uses cached image URL when available', function(assert) {
     var remote = 'https://cdn.example.com/bi1.png';
     var local = 'file:///local/bi1.png';
@@ -56,14 +63,11 @@ module('Unit | Controller | user/board-detail image cache', function(hooks) {
     assert.equal(btn.image_url, local);
   });
 
-  test('upgrade_url_for_skin_variants appends .varianted-skin for library URLs', function(assert) {
-    var plain = 'https://d18vdu4p71yql0.cloudfront.net/libraries/arasaac/hello.png';
-    var upgraded = LingoLinq.Board.upgrade_url_for_skin_variants(plain);
-    assert.equal(upgraded, plain + '.varianted-skin.png');
-    assert.equal(
-      LingoLinq.Board.upgrade_url_for_skin_variants(upgraded),
-      upgraded
-    );
+  test('upgrade_url_for_skin_variants does not speculate .varianted-skin for plain library URLs', function(assert) {
+    var plain = 'https://d18vdu4p71yql0.cloudfront.net/libraries/arasaac/different.png';
+    assert.equal(LingoLinq.Board.upgrade_url_for_skin_variants(plain), plain);
+    var skinBase = plain.replace('.png', '.png.varianted-skin.png');
+    assert.equal(LingoLinq.Board.upgrade_url_for_skin_variants(skinBase), skinBase);
   });
 
   test('_make_btn applies skin tone via skin_image_map for varianted-skin URLs', function(assert) {

--- a/app/models/button_image.rb
+++ b/app/models/button_image.rb
@@ -282,11 +282,21 @@ class ButtonImage < ActiveRecord::Base
 
   def skin_capable_url
     if settings['library_skin_base_url']
-      return Uploader.fronted_url(settings['library_skin_base_url'])
+      url = Uploader.fronted_url(settings['library_skin_base_url'])
+      return url if url_skinnable?(url)
     end
     lib_url = library_url_for_skin
-    return Uploader.fronted_url(lib_url) if lib_url
-    best_url
+    if lib_url
+      url = Uploader.fronted_url(lib_url)
+      return url if url_skinnable?(url)
+    end
+    nil
+  end
+
+  def url_skinnable?(url)
+    return false unless url
+    url.match(/\.varianted-skin\.\w+$/) ||
+      (url.match(/\/libraries\/twemoji\//) && url.match(/-var\w+UNI/))
   end
 
   def check_for_variants(force=false)

--- a/bin/fresh_start
+++ b/bin/fresh_start
@@ -50,7 +50,7 @@ Tip: COPPA_PARENTAL_CONSENT in .env applies to domain_settings from Rails.
   Ember on :8184 merges /api/v1/domain_settings after load; open Register once
   backend is up, or use http://localhost:5000 for the same HTML as production.
   If new Ember UI changes (e.g. COPPA on Register) shows on :8184 but not :5000, rebuild
-  the Rails bundle: (cd app/frontend && npx ember build) && bundle exec rake extras:assert_js
+  the Rails bundle: (cd app/frontend && npx ember build && bundle exec rake extras:assert_js)
 TIP
 echo "=========================================="
 echo ""

--- a/lib/json_api/board.rb
+++ b/lib/json_api/board.rb
@@ -169,7 +169,10 @@ module JsonApi::Board
             schedule_skin_enrichment = true if bi.needs_library_url_enrichment?
           end
         end
-        json['board']['image_urls'][i['id']] = i['url']
+        # For simple_refs (tree/bulk) the images[] wrapper is omitted for
+        # payload size — expose skin-capable library URLs via image_urls so
+        # the client skin_image_map can rewrite .varianted-skin → .variant-{tone}.
+        json['board']['image_urls'][i['id']] = i['skin_url'].presence || i['url']
         (i['alternates'] || []).each do |alternate|
           json['board']['image_urls']["#{i['id']}-#{alternate['library']}"] = alternate['url'] unless alternate['library'] == 'unknown'
         end


### PR DESCRIPTION
Stop speculatively appending .varianted-skin to plain OpenSymbols URLs — many symbols have no variant files and were 403ing. Only backend-verified skin bases (.varianted-skin or twemoji codes) are exposed via skin_url and rewritten client-side. Add img onerror fallback to the unskinned base URL before showing the square placeholder.

Skip skin_image_map and grid rebuild on ordered_buttons cache hits when prefs match, and warm prefetch URLs with the active skin tone so tree prefetch populates the same browser-cache entries the grid requests. Warm-cache keys now include skin and symbol library so tone changes re-warm correctly.