### PR TITLE
fix: persistence JSON parse context and actioncable require

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,15 +25,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Before you make any edit in this repo, you MUST be on a properly-named branch.
 
 1. **Branch from `staging`, not `main`.** PRs target `staging` first; release PRs from `staging` to `main` are a separate operation.
-2. **Branch name format:** `<type>/scot-<kebab-case-description>`
-   - `<type>` is one of: `fix`, `feat`, `chore`, `docs`, `perf`, `refactor`, `test`, `compliance`, `security`. The type prefix is REQUIRED. A bare `scot-<description>` (no type) is wrong.
-   - `scot-` is REQUIRED so Scot's branches are visually distinct from Melissa, Traci, Dominic.
-   - Use kebab-case after `scot-` (lowercase, hyphens between words).
-   - Examples: `fix/scot-copy-modal-fast-fallback`, `chore/scot-staging-slow-queue-capacity`, `test/scot-feature-flag-stub`.
-3. **Never edit on `main` or `staging` directly.** If you find yourself on one of those branches, `git checkout staging && git pull && git checkout -b <type>/scot-<description>` first.
+2. **Branch name format:** use the **developer** doing the work, not a fixed name. Two conventions both work:
+   - `<type>/<developer>-<kebab-case-description>` — e.g. `fix/melissa-persistence-bg-parse-json`, `fix/scot-copy-modal-fast-fallback`
+   - `<developer>/<type>/<kebab-case-description>` — e.g. `melissa/fix/sidebar-actions`, `traci/styling/styling-updates`
+   - `<type>` is one of: `fix`, `feat`, `chore`, `docs`, `perf`, `refactor`, `test`, `compliance`, `security`. The type prefix is REQUIRED in the `<type>/…` form.
+   - `<developer>` is a short lowercase handle: `melissa`, `scot`, `traci`, `dominic`, etc.
+   - Use kebab-case for the description (lowercase, hyphens between words).
+3. **Never edit on `main` or `staging` directly.** If you find yourself on one of those branches, `git checkout staging && git pull && git checkout -b <type>/<developer>-<description>` (or `<developer>/<type>/<description>`) first.
 4. Date suffixes like `-2026-05-08` are only for time-bound recovery/release branches, not regular feature work.
 
-If you produced a branch name without a type prefix (e.g. `scot-something`), rename it before opening a PR: `git branch -m <type>/scot-something`.
+If you produced a branch name without a type prefix (e.g. `melissa-sidebar`), rename it before opening a PR: `git branch -m fix/melissa-sidebar`.
 
 ## Project Overview
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,5 @@
 //= require application-preload.js
-//= require action_cable
+//= require actioncable
 //= require vendor.js
 //= require frontend.js
 

--- a/app/frontend/app/services/persistence.js
+++ b/app/frontend/app/services/persistence.js
@@ -1042,6 +1042,7 @@ var persistence = Service.extend({
     return token;
   },
   decrypt_json: function(str, encryption_settings) {
+    var _this = this;
     if(str.match(/^aes256-/)) {
       var te = new TextEncoder();
       str = str.replace(/^aes256-/, '');
@@ -1065,7 +1066,7 @@ var persistence = Service.extend({
           var buff = new Uint8Array(res);
           var str = buff.reduce((acc, i) => acc += String.fromCharCode.apply(null, [i]), '')
           try {
-            return this.bg_parse_json(str);
+            return _this.bg_parse_json(str);
           } catch(e) {
             return RSVP.reject({error: 'JSON parse failed on decrypted content', err: e});
           }
@@ -1073,7 +1074,7 @@ var persistence = Service.extend({
       });
     } else {
       try {
-        return this.bg_parse_json(str);
+        return _this.bg_parse_json(str);
       } catch(e) {
         return RSVP.reject({error: 'JSON parse failed', err: e});
       }
@@ -1145,7 +1146,7 @@ var persistence = Service.extend({
       _this.find_url(url, 'json').then(function(uri) {
         if(typeof(uri) == 'string' && uri.match(/^data:/)) {
           try {
-            this.bg_parse_json(atob(uri.split(/,/)[1])).then(function(json) {
+            _this.bg_parse_json(atob(uri.split(/,/)[1])).then(function(json) {
               resolve(json);
             }, function(err) {
               LingoLinq.track_error("No JSON dataURI");
@@ -1159,7 +1160,7 @@ var persistence = Service.extend({
           var filename = uri.split(/\//).pop();
           capabilities.storage.get_file_url('json', filename, true).then(function(data_uri) {
             try {
-              this.bg_parse_json(atob(data_uri.split(/,/)[1])).then(function(result) {
+              _this.bg_parse_json(atob(data_uri.split(/,/)[1])).then(function(result) {
                 resolve(result || []);
               });
             } catch(e) {
@@ -1172,14 +1173,14 @@ var persistence = Service.extend({
         } else if(typeof(uri) == 'string') {
           var res = _this.ajax(uri + "?cr=" + Math.random(), {type: 'GET', dataType: 'text'});
           res.then(function(res) {
-            this.bg_parse_json(res.text).then(function(json) { 
+            _this.bg_parse_json(res.text).then(function(json) { 
               resolve(json);
             }, function(err) {
               reject(err);
             });
           }, function(err) {
             if(err && err.message == 'error' && err.fakeXHR && err.fakeXHR.status == 0) {
-              this.remove('dataCache', url);
+              _this.remove('dataCache', url);
               persistence.url_cache[url] = null;
             }
             LingoLinq.track_error("JSON data retrieval error", (err || {}).error || err);


### PR DESCRIPTION
Use _this.bg_parse_json in decrypt_json/find_json callbacks so cached extra_data JSON parses correctly. Require actioncable instead of deprecated action_cable. Document per-developer branch naming in CLAUDE.md.