### PR TITLE
fix(boards): lite serialization for #tree and #bulk to kill as_json N+1 (#286)

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -420,12 +420,27 @@ class Api::BoardsController < ApplicationController
     # as_lite drops the per-board N+1 enrichment (parent_board, find_copies_by,
     # shared_users, per-image ButtonImage lookups) that made this endpoint
     # Rack::Timeout under MAX_TREE fan-out. See RCA 2026-05-24, issue #286.
-    root_json = JsonApi::Board.as_json(root, wrapper: true, permissions: @api_user, skip_subs: true, as_lite: true)
+    # Gated by a deploy-free kill-switch (see lite_board_serialization?).
+    lite = lite_board_serialization?
+    root_json = JsonApi::Board.as_json(root, wrapper: true, permissions: @api_user, skip_subs: true, as_lite: lite)
     descendants_json = descendants.map do |b|
-      JsonApi::Board.as_json(b, wrapper: true, permissions: @api_user, skip_subs: true, as_lite: true)
+      JsonApi::Board.as_json(b, wrapper: true, permissions: @api_user, skip_subs: true, as_lite: lite)
     end
     render json: { root: root_json, descendants: descendants_json }
   end
+
+  # Kill-switch for the #tree / #bulk lite serialization (RCA 2026-05-24,
+  # issue #286). Lite is ON by default. Ops can revert to the full as_json
+  # path WITHOUT a deploy by writing the Setting from a console:
+  #   Setting.set('tree_lite_serialization', 'false')
+  # and re-enable with any other value (or by deleting the Setting). The
+  # Setting.set call busts the Redis cache, so the flip takes effect on the
+  # next request. The unset (default-on) path is one cached lookup, O(1) per
+  # request, negligible next to the per-board fan-out this removes.
+  def lite_board_serialization?
+    Setting.get_cached('tree_lite_serialization') != 'false'
+  end
+  private :lite_board_serialization?
 
   # Bulk-resolve a list of board keys/ids in one request. The frontend
   # uses this to pre-warm the boardDetailCache for a board's reachable
@@ -459,9 +474,10 @@ class Api::BoardsController < ApplicationController
 
     # Same lite serialization as #tree: this is a prefetch warm, not a
     # navigation, so skip the per-board N+1 enrichment (RCA 2026-05-24,
-    # issue #286).
+    # issue #286). Same deploy-free kill-switch as #tree.
+    lite = lite_board_serialization?
     out = visible.map do |board|
-      JsonApi::Board.as_json(board, wrapper: true, permissions: @api_user, skip_subs: true, as_lite: true)
+      JsonApi::Board.as_json(board, wrapper: true, permissions: @api_user, skip_subs: true, as_lite: lite)
     end
     render json: { boards: out }
   end

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -417,9 +417,12 @@ class Api::BoardsController < ApplicationController
       descendants = descendants.select { |b| b && b.allows?(@api_user, 'view', scopes) }
     end
 
-    root_json = JsonApi::Board.as_json(root, wrapper: true, permissions: @api_user, skip_subs: true)
+    # as_lite drops the per-board N+1 enrichment (parent_board, find_copies_by,
+    # shared_users, per-image ButtonImage lookups) that made this endpoint
+    # Rack::Timeout under MAX_TREE fan-out. See RCA 2026-05-24, issue #286.
+    root_json = JsonApi::Board.as_json(root, wrapper: true, permissions: @api_user, skip_subs: true, as_lite: true)
     descendants_json = descendants.map do |b|
-      JsonApi::Board.as_json(b, wrapper: true, permissions: @api_user, skip_subs: true)
+      JsonApi::Board.as_json(b, wrapper: true, permissions: @api_user, skip_subs: true, as_lite: true)
     end
     render json: { root: root_json, descendants: descendants_json }
   end
@@ -454,8 +457,11 @@ class Api::BoardsController < ApplicationController
     scopes = api_permission_scopes
     visible = boards.select { |b| b && b.allows?(@api_user, 'view', scopes) }
 
+    # Same lite serialization as #tree: this is a prefetch warm, not a
+    # navigation, so skip the per-board N+1 enrichment (RCA 2026-05-24,
+    # issue #286).
     out = visible.map do |board|
-      JsonApi::Board.as_json(board, wrapper: true, permissions: @api_user, skip_subs: true)
+      JsonApi::Board.as_json(board, wrapper: true, permissions: @api_user, skip_subs: true, as_lite: true)
     end
     render json: { boards: out }
   end

--- a/lib/json_api/board.rb
+++ b/lib/json_api/board.rb
@@ -82,16 +82,23 @@ module JsonApi::Board
     json['immediately_upstream_boards'] = (board.settings['immediately_upstream_board_ids'] || []).length
     json['current_library'] = board.current_library(false)
     json['user_name'] = board.cached_user_name
-    self.trace_execution_scoped(['json/board/parent_board']) do
-      parent_board = nil
-      if defined?(Octopus)
-        conn = (Octopus.config[Rails.env] || {}).keys.sample
-        parent_board = board.using(conn).parent_board if conn
-      else
-        parent_board = board.parent_board
+    # Lite serialization (:as_lite, used by #tree and #bulk prefetch) skips
+    # the parent_board association load. It's an unindexed per-board lookup
+    # that becomes an N+1 across a MAX_TREE-node tree (RCA 2026-05-24, issue
+    # #286). Prefetch is only a cache warm; the full per-board endpoint
+    # refills parent linkage when the user actually navigates into a board.
+    unless args[:as_lite]
+      self.trace_execution_scoped(['json/board/parent_board']) do
+        parent_board = nil
+        if defined?(Octopus)
+          conn = (Octopus.config[Rails.env] || {}).keys.sample
+          parent_board = board.using(conn).parent_board if conn
+        else
+          parent_board = board.parent_board
+        end
+        json['parent_board_id'] = parent_board && parent_board.global_id
+        json['parent_board_key'] = parent_board && parent_board.key
       end
-      json['parent_board_id'] = parent_board && parent_board.global_id
-      json['parent_board_key'] = parent_board && parent_board.key
     end
     json['link'] = "#{JsonApi::Json.current_host}/#{board.key}"
     
@@ -102,7 +109,11 @@ module JsonApi::Board
       end      
     end
     
-    if json['permissions'] && json['permissions']['edit']
+    # Lite skips the edit-scoped enrichment: copy_key (a find_by_path
+    # query), non_author_starred?, and shared_users. None are needed to
+    # warm a prefetch cache entry, and shared_users in particular is a
+    # per-board fan-out (RCA 2026-05-24, issue #286).
+    if !args[:as_lite] && json['permissions'] && json['permissions']['edit']
       if board.settings['copy_id']
         copy = Board.find_by_path(board.settings['copy_id'])
         if copy
@@ -117,7 +128,10 @@ module JsonApi::Board
         end
       end
     end
-    if (json['permissions'] && json['permissions']['delete']) || (args[:permissions] && args[:permissions].allows?(args[:permissions], 'admin_support_actions'))
+    # Lite skips the delete/admin-scoped using_user_names block: it issues
+    # a UserBoardConnection + User query per board (another N+1 over a tree)
+    # and surfaces support-only metadata the prefetch never reads.
+    if !args[:as_lite] && ((json['permissions'] && json['permissions']['delete']) || (args[:permissions] && args[:permissions].allows?(args[:permissions], 'admin_support_actions')))
       json['downstream_board_ids'] = board.downstream_board_ids
       if args[:permissions] && args[:permissions].respond_to?(:settings)
         # TODO: sharding
@@ -159,7 +173,13 @@ module JsonApi::Board
       json['board']['sound_urls'] = board.settings['sound_urls'] || {}
       schedule_skin_enrichment = false
       hash['images'].each{|i|
-        if i['id']
+        # Lite skips the per-image ButtonImage.find_by_global_id skin lookup
+        # (the dominant N+1: one query per image per board across the tree,
+        # RCA 2026-05-24, issue #286). image_urls is still populated below
+        # from the already-resolved hash url, so prefetched thumbnails render;
+        # they just fall back to the base url instead of a skin-capable one
+        # until the full per-board fetch enriches them.
+        if i['id'] && !args[:as_lite]
           bi = ButtonImage.find_by_global_id(i['id']) rescue nil
           if bi
             skin_url = bi.skin_capable_url
@@ -196,7 +216,11 @@ module JsonApi::Board
         #   'id' => board.global_id(true),
         #   'key' => board.key(true),
         # }
-      else
+      # Lite skips find_copies_by (board.rb:620, a per-board query with a
+      # board_content join and a limit-15 sort) and copies.count. This is
+      # one of the heaviest per-descendant calls in the tree fan-out
+      # (RCA 2026-05-24, issue #286).
+      elsif !args[:as_lite]
         self.trace_execution_scoped(['json/board/copy_check']) do
           # TODO: if the user has access to a shallow clone, include that as the first result
           copies = board.find_copies_by(args[:permissions])
@@ -211,13 +235,17 @@ module JsonApi::Board
           json['board']['copies'] = copies.count
         end
       end
-      self.trace_execution_scoped(['json/board/parent_board_check']) do
-        parent = board.parent_board
-        if parent
-          json['board']['original'] = {
-            'id' => parent.global_id,
-            'key' => parent.key
-          }
+      # Lite skips the second parent_board association load (build_json
+      # already skips the first). Both are unindexed per-board lookups.
+      unless args[:as_lite]
+        self.trace_execution_scoped(['json/board/parent_board_check']) do
+          parent = board.parent_board
+          if parent
+            json['board']['original'] = {
+              'id' => parent.global_id,
+              'key' => parent.key
+            }
+          end
         end
       end
     end

--- a/spec/controllers/api/boards_controller_spec.rb
+++ b/spec/controllers/api/boards_controller_spec.rb
@@ -2928,4 +2928,200 @@ describe Api::BoardsController, :type => :controller do
       expect(p.settings['arguments']).to eq([nil, ['a', 'b'], @user.global_id])
     end
   end
+
+  # Lite serialization for #tree and #bulk (RCA 2026-05-24, issue #286).
+  # These endpoints fan out as_json across up to MAX_TREE / MAX_BULK boards
+  # to warm the client prefetch cache. The full as_json path issues several
+  # unindexed per-board lookups (parent_board x2, find_copies_by, shared_users,
+  # per-image ButtonImage), which turned #tree into a Rack::Timeout source once
+  # PR #281 started firing it at every login. The :as_lite arg drops that
+  # enrichment so query count is O(1) in descendant count.
+
+  # Counts non-schema, non-transaction SQL queries fired while the block runs.
+  # Returned as an array so failures can print the offending statements.
+  def count_board_sql
+    queries = []
+    sub = ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql].to_s
+      label = payload[:name].to_s
+      next if label == 'SCHEMA' || label == 'TRANSACTION'
+      next if payload[:cached]
+      next if sql =~ /\A\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/i
+      queries << sql
+    end
+    yield
+    queries
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub) if sub
+  end
+
+  # Builds a root with +count+ owned, empty-grid descendants and wires
+  # downstream_board_ids directly (the controller reads it straight from
+  # settings; no linking machinery needed). Empty grids keep the kept-by-lite
+  # images_and_sounds_for call at zero queries so the count reflects only the
+  # serialization path under test.
+  def build_owned_tree(owner, count)
+    root = Board.create(user: owner)
+    children = Array.new(count) { Board.create(user: owner) }
+    root.settings['downstream_board_ids'] = children.map(&:global_id)
+    root.save
+    root.reload
+    expect(root.settings['downstream_board_ids'].length).to eq(count) # guard: persisted
+    [root, children]
+  end
+
+  describe "#tree" do
+    it "returns the root plus permission-filtered descendants" do
+      token_user
+      root, children = build_owned_tree(@user, 3)
+      get :tree, params: { board_id: root.global_id }
+      json = assert_success_json
+      expect(json['root']['board']['id']).to eq(root.global_id)
+      expect(json['descendants'].map { |d| d['board']['id'] }.sort).to eq(children.map(&:global_id).sort)
+    end
+
+    it "404s when the board is missing" do
+      token_user
+      get :tree, params: { board_id: 'no/such-board' }
+      assert_error("Record not found", 404)
+    end
+
+    it "drops descendants the caller is not allowed to view" do
+      token_user
+      other = User.create
+      root = Board.create(user: @user)
+      mine = Board.create(user: @user)
+      theirs = Board.create(user: other) # private, not shared with @user
+      root.settings['downstream_board_ids'] = [mine.global_id, theirs.global_id]
+      root.save
+      get :tree, params: { board_id: root.global_id }
+      json = assert_success_json
+      ids = json['descendants'].map { |d| d['board']['id'] }
+      expect(ids).to include(mine.global_id)
+      expect(ids).to_not include(theirs.global_id)
+    end
+
+    it "caps the descendant list at MAX_TREE" do
+      token_user
+      root, children = build_owned_tree(@user, 3)
+      stub_const("Api::BoardsController::MAX_TREE", 2)
+      get :tree, params: { board_id: root.global_id }
+      json = assert_success_json
+      expect(json['descendants'].length).to eq(2)
+      expect(json['descendants'].map { |d| d['board']['id'] }).to eq(children.first(2).map(&:global_id))
+    end
+
+    it "omits the heavy per-board enrichment keys (lite serialization)" do
+      token_user
+      root = Board.create(user: @user)
+      child = Board.create(user: @user)
+      root.settings['downstream_board_ids'] = [child.global_id]
+      root.save
+      get :tree, params: { board_id: root.global_id }
+      json = assert_success_json
+      board = json['descendants'][0]['board']
+      # Skipped by :as_lite: parent linkage, copy info, share info.
+      expect(board).to_not have_key('parent_board_id')
+      expect(board).to_not have_key('parent_board_key')
+      expect(board).to_not have_key('copy')
+      expect(board).to_not have_key('copies')
+      expect(board).to_not have_key('original')
+      expect(board).to_not have_key('shared_users')
+      # Still present: the core identity the client cache needs.
+      expect(board['id']).to eq(child.global_id)
+      expect(board['key']).to eq(child.key)
+      expect(board).to have_key('permissions')
+    end
+
+    it "serializes the tree with O(1) queries in descendant count" do
+      token_user
+      small_root, _small = build_owned_tree(@user, 3)
+      large_root, _large = build_owned_tree(@user, 18)
+
+      # Warm permission and any per-board caches first so the measurement
+      # reflects steady-state serialization, not cold-cache permission reads.
+      get :tree, params: { board_id: small_root.global_id }
+      get :tree, params: { board_id: large_root.global_id }
+
+      small_q = count_board_sql { get :tree, params: { board_id: small_root.global_id } }
+      large_q = count_board_sql { get :tree, params: { board_id: large_root.global_id } }
+
+      # 15 extra descendants must not add a proportional number of queries.
+      # A regression to the full as_json path adds roughly parent_board x2 +
+      # find_copies_by per descendant (~45+ queries here), so a small fixed
+      # ceiling cleanly separates O(1) from O(N).
+      delta = large_q.length - small_q.length
+      expect(delta).to(be <= 5, lambda {
+        "tree query count grew by #{delta} for 15 extra descendants " \
+        "(small=#{small_q.length}, large=#{large_q.length}); expected O(1).\n" \
+        "large-tree SQL:\n#{large_q.join("\n")}"
+      })
+    end
+  end
+
+  describe "#bulk" do
+    it "returns the requested boards, permission-filtered" do
+      token_user
+      other = User.create
+      mine_a = Board.create(user: @user)
+      mine_b = Board.create(user: @user)
+      theirs = Board.create(user: other)
+      post :bulk, params: { keys: [mine_a.global_id, theirs.global_id, mine_b.global_id] }
+      json = assert_success_json
+      ids = json['boards'].map { |b| b['board']['id'] }
+      expect(ids).to match_array([mine_a.global_id, mine_b.global_id])
+      expect(ids).to_not include(theirs.global_id)
+    end
+
+    it "returns an empty list when no keys are given" do
+      token_user
+      post :bulk, params: { keys: [] }
+      json = assert_success_json
+      expect(json['boards']).to eq([])
+    end
+
+    it "caps the request at MAX_BULK keys" do
+      token_user
+      boards = Array.new(3) { Board.create(user: @user) }
+      stub_const("Api::BoardsController::MAX_BULK", 2)
+      post :bulk, params: { keys: boards.map(&:global_id) }
+      json = assert_success_json
+      expect(json['boards'].length).to eq(2)
+    end
+
+    it "uses the same lite serialization (no per-board copy/share enrichment)" do
+      token_user
+      board = Board.create(user: @user)
+      post :bulk, params: { keys: [board.global_id] }
+      json = assert_success_json
+      b = json['boards'][0]['board']
+      expect(b).to_not have_key('copies')
+      expect(b).to_not have_key('shared_users')
+      expect(b['id']).to eq(board.global_id)
+    end
+
+    it "resolves bulk keys with O(1) queries in board count" do
+      token_user
+      small = Array.new(3) { Board.create(user: @user) }
+      large = Array.new(18) { Board.create(user: @user) }
+
+      post :bulk, params: { keys: small.map(&:global_id) }
+      post :bulk, params: { keys: large.map(&:global_id) }
+
+      small_q = count_board_sql { post :bulk, params: { keys: small.map(&:global_id) } }
+      large_q = count_board_sql { post :bulk, params: { keys: large.map(&:global_id) } }
+
+      # NOTE: #bulk resolves each key with its own Board.find_by_path, so the
+      # lookup itself is O(n) in key count. The lite serialization guarantee
+      # is that as_json adds no further per-board fan-out on top of that. Allow
+      # ~1 lookup query per extra key (15 here) plus a small constant; the full
+      # as_json path would add several more per board on top.
+      delta = large_q.length - small_q.length
+      expect(delta).to(be <= 20, lambda {
+        "bulk query count grew by #{delta} for 15 extra keys " \
+        "(small=#{small_q.length}, large=#{large_q.length}).\n" \
+        "large SQL:\n#{large_q.join("\n")}"
+      })
+    end
+  end
 end

--- a/spec/controllers/api/boards_controller_spec.rb
+++ b/spec/controllers/api/boards_controller_spec.rb
@@ -3046,6 +3046,24 @@ describe Api::BoardsController, :type => :controller do
       expect(board).to have_key('permissions')
     end
 
+    it "honors the deploy-free kill-switch to fall back to full serialization" do
+      token_user
+      root = Board.create(user: @user)
+      child = Board.create(user: @user)
+      root.settings['downstream_board_ids'] = [child.global_id]
+      root.save
+      # Stub the Setting rather than writing it: avoids leaking a Redis cache
+      # entry into sibling examples (Redis is not rolled back between specs).
+      allow(Setting).to receive(:get_cached).and_call_original
+      allow(Setting).to receive(:get_cached).with('tree_lite_serialization').and_return('false')
+      get :tree, params: { board_id: root.global_id }
+      json = assert_success_json
+      board = json['descendants'][0]['board']
+      # Full as_json path restored: the copy enrichment (skipped by lite) is
+      # present again, even when its count is zero.
+      expect(board).to have_key('copies')
+    end
+
     it "does not run the per-board enrichment that caused the timeout" do
       # Behavioral guard for remediation #1: lite must skip the unindexed
       # per-board lookups (parent_board, find_copies_by, shared_users) and the

--- a/spec/controllers/api/boards_controller_spec.rb
+++ b/spec/controllers/api/boards_controller_spec.rb
@@ -2955,14 +2955,27 @@ describe Api::BoardsController, :type => :controller do
     ActiveSupport::Notifications.unsubscribe(sub) if sub
   end
 
-  # Builds a root with +count+ owned, empty-grid descendants and wires
+  # An owned board carrying one real image button. Image-bearing fixtures
+  # matter for the query-count specs: the kept-by-lite images_and_sounds_for
+  # call only touches the DB when a board actually has images, so empty grids
+  # would hide the surviving per-board cost and make a regression test
+  # meaningless.
+  def board_with_image(owner)
+    board = Board.create(user: owner)
+    img = ButtonImage.create(url: "http://example.com/#{SecureRandom.hex(4)}.png")
+    board.settings['buttons'] = [{ 'id' => 1, 'label' => 'x', 'image_id' => img.global_id }]
+    board.settings['grid'] = { 'rows' => 1, 'columns' => 1, 'order' => [[1]] }
+    board.instance_variable_set('@buttons_changed', true)
+    board.save
+    board.reload
+  end
+
+  # Builds a root with +count+ owned, image-bearing descendants and wires
   # downstream_board_ids directly (the controller reads it straight from
-  # settings; no linking machinery needed). Empty grids keep the kept-by-lite
-  # images_and_sounds_for call at zero queries so the count reflects only the
-  # serialization path under test.
+  # settings; no linking machinery needed).
   def build_owned_tree(owner, count)
     root = Board.create(user: owner)
-    children = Array.new(count) { Board.create(user: owner) }
+    children = Array.new(count) { board_with_image(owner) }
     root.settings['downstream_board_ids'] = children.map(&:global_id)
     root.save
     root.reload
@@ -3033,12 +3046,33 @@ describe Api::BoardsController, :type => :controller do
       expect(board).to have_key('permissions')
     end
 
-    it "serializes the tree with O(1) queries in descendant count" do
+    it "does not run the per-board enrichment that caused the timeout" do
+      # Behavioral guard for remediation #1: lite must skip the unindexed
+      # per-board lookups (parent_board, find_copies_by, shared_users) and the
+      # per-image ButtonImage.find_by_global_id skin lookup. This is the real
+      # regression guard and does not depend on absolute query counts.
+      token_user
+      root, _children = build_owned_tree(@user, 3)
+      expect_any_instance_of(Board).to_not receive(:find_copies_by)
+      expect_any_instance_of(Board).to_not receive(:shared_users)
+      expect(ButtonImage).to_not receive(:find_by_global_id)
+      get :tree, params: { board_id: root.global_id }
+      assert_success_json
+    end
+
+    # NOTE: lite is NOT O(1). It removes the ~4-queries-per-board fan-out
+    # (parent_board x2 + find_copies_by + the delete/admin using_user_names
+    # block) but keeps images_and_sounds_for, which still issues ~1 query per
+    # image-bearing board (known_button_images). That residual is remediation
+    # #3 (request-scoped image cache), tracked separately in issue #286. This
+    # spec therefore asserts the per-descendant marginal cost is a small bounded
+    # constant, well under the pre-fix path, rather than claiming O(1).
+    it "keeps the per-descendant query cost to a small bounded constant" do
       token_user
       small_root, _small = build_owned_tree(@user, 3)
       large_root, _large = build_owned_tree(@user, 18)
 
-      # Warm permission and any per-board caches first so the measurement
+      # Warm permission caches (Redis, not counted here) so the measurement
       # reflects steady-state serialization, not cold-cache permission reads.
       get :tree, params: { board_id: small_root.global_id }
       get :tree, params: { board_id: large_root.global_id }
@@ -3046,15 +3080,15 @@ describe Api::BoardsController, :type => :controller do
       small_q = count_board_sql { get :tree, params: { board_id: small_root.global_id } }
       large_q = count_board_sql { get :tree, params: { board_id: large_root.global_id } }
 
-      # 15 extra descendants must not add a proportional number of queries.
-      # A regression to the full as_json path adds roughly parent_board x2 +
-      # find_copies_by per descendant (~45+ queries here), so a small fixed
-      # ceiling cleanly separates O(1) from O(N).
+      # 15 extra image-bearing descendants. Lite measures ~1 query/board, so
+      # a ceiling of 2/board (<= 30) passes lite while the pre-fix ~5/board
+      # fan-out (>= 75) blows past it. The previous empty-grid version masked
+      # the surviving images_and_sounds_for cost (adversary review, 2026-05-26).
       delta = large_q.length - small_q.length
-      expect(delta).to(be <= 5, lambda {
+      expect(delta).to(be <= 30, lambda {
         "tree query count grew by #{delta} for 15 extra descendants " \
-        "(small=#{small_q.length}, large=#{large_q.length}); expected O(1).\n" \
-        "large-tree SQL:\n#{large_q.join("\n")}"
+        "(small=#{small_q.length}, large=#{large_q.length}); expected <= 30 " \
+        "(~2/board ceiling).\nlarge-tree SQL:\n#{large_q.join("\n")}"
       })
     end
   end
@@ -3100,10 +3134,27 @@ describe Api::BoardsController, :type => :controller do
       expect(b['id']).to eq(board.global_id)
     end
 
-    it "resolves bulk keys with O(1) queries in board count" do
+    it "does not run the per-board enrichment that caused the timeout" do
       token_user
-      small = Array.new(3) { Board.create(user: @user) }
-      large = Array.new(18) { Board.create(user: @user) }
+      board = board_with_image(@user)
+      expect_any_instance_of(Board).to_not receive(:find_copies_by)
+      expect_any_instance_of(Board).to_not receive(:shared_users)
+      expect(ButtonImage).to_not receive(:find_by_global_id)
+      post :bulk, params: { keys: [board.global_id] }
+      assert_success_json
+    end
+
+    # NOTE: #bulk is inherently O(n) in keys: it resolves each key with its own
+    # Board.find_by_path, and lite still pays ~1 image query per image-bearing
+    # board (images_and_sounds_for, remediation #3). The guarantee under test is
+    # that as_json adds no heavy per-board fan-out on top of the unavoidable
+    # per-key lookup. The behavioral guard above is the precise check; this one
+    # bounds the marginal cost (~2/board) so a regression to the full path
+    # (~5/board on top of lookups) fails.
+    it "keeps the per-key query cost to a small bounded constant" do
+      token_user
+      small = Array.new(3) { board_with_image(@user) }
+      large = Array.new(18) { board_with_image(@user) }
 
       post :bulk, params: { keys: small.map(&:global_id) }
       post :bulk, params: { keys: large.map(&:global_id) }
@@ -3111,15 +3162,11 @@ describe Api::BoardsController, :type => :controller do
       small_q = count_board_sql { post :bulk, params: { keys: small.map(&:global_id) } }
       large_q = count_board_sql { post :bulk, params: { keys: large.map(&:global_id) } }
 
-      # NOTE: #bulk resolves each key with its own Board.find_by_path, so the
-      # lookup itself is O(n) in key count. The lite serialization guarantee
-      # is that as_json adds no further per-board fan-out on top of that. Allow
-      # ~1 lookup query per extra key (15 here) plus a small constant; the full
-      # as_json path would add several more per board on top.
       delta = large_q.length - small_q.length
-      expect(delta).to(be <= 20, lambda {
+      expect(delta).to(be <= 45, lambda {
         "bulk query count grew by #{delta} for 15 extra keys " \
-        "(small=#{small_q.length}, large=#{large_q.length}).\n" \
+        "(small=#{small_q.length}, large=#{large_q.length}); expected <= 45 " \
+        "(~3/key: one find_by_path + one image query + slack).\n" \
         "large SQL:\n#{large_q.join("\n")}"
       })
     end

--- a/spec/lib/json_api/board_spec.rb
+++ b/spec/lib/json_api/board_spec.rb
@@ -196,7 +196,13 @@ describe JsonApi::Board do
       
       hash = JsonApi::Board.as_json(b.reload, :permissions => u, :wrapper => true)
       expect(hash['images'].length).to eq(5)
-      images = hash['images'].sort_by{|i| i['id'] }
+      # Sort by the ButtonImage's numeric id, not the global_id string. A
+      # lexicographic string sort misorders once the id sequence crosses a
+      # digit boundary (e.g. "1_100_..." sorts before "1_97_..."), so this
+      # assertion used to flip depending on how many ButtonImages earlier
+      # specs had created. Mapping back to the records keeps it creation-order.
+      by_global_id = [bbi1, bbi2, bbi3, bbi4, bbi5].index_by(&:global_id)
+      images = hash['images'].sort_by{|i| by_global_id[i['id']].id }
       expect(images[0]['id']).to eq(bbi1.global_id)
       expect(images[0]['url']).to eq('http://www.example.com/bacon/cache/1')
       expect(images[1]['id']).to eq(bbi2.global_id)
@@ -254,7 +260,13 @@ describe JsonApi::Board do
       
       hash = JsonApi::Board.as_json(b.reload, :permissions => u, :wrapper => true)
       expect(hash['images'].length).to eq(5)
-      images = hash['images'].sort_by{|i| i['id'] }
+      # Sort by the ButtonImage's numeric id, not the global_id string. A
+      # lexicographic string sort misorders once the id sequence crosses a
+      # digit boundary (e.g. "1_100_..." sorts before "1_97_..."), so this
+      # assertion used to flip depending on how many ButtonImages earlier
+      # specs had created. Mapping back to the records keeps it creation-order.
+      by_global_id = [bbi1, bbi2, bbi3, bbi4, bbi5].index_by(&:global_id)
+      images = hash['images'].sort_by{|i| by_global_id[i['id']].id }
       expect(images[0]['id']).to eq(bbi1.global_id)
       expect(images[0]['url']).to eq('http://www.example.com/bacon/cache/1')
       expect(images[1]['id']).to eq(bbi2.global_id)


### PR DESCRIPTION
Implements remediation #1 from the #tree Rack::Timeout RCA (`outputs/docs/2026-05-24-tree-bulk-rca.md`, issue #286). Freeze-scoped.

## Problem
`#tree` and `#bulk` serialized every board through the full `JsonApi::Board.as_json` path used by `#show`. Across `MAX_TREE=500` descendants that path fans out into thousands of unindexed per-board queries: `parent_board` (x2), `find_copies_by` (`board.rb:620`, a `board_content` join + limit-15 sort), `shared_users`, the delete/admin `using_user_names` `UserBoardConnection`+`User` lookup, and a per-image `ButtonImage.find_by_global_id` skin lookup. PR #281's login prefetch started firing `#tree` at session-start scale, which surfaced as `Rack::Timeout` in Sentry.

## Fix
Add an `:as_lite` arg to `JsonApi::Board` honored by `build_json` and `extra_includes`. When set it skips that enrichment while keeping board identity, `permissions`, grid content, and `image_urls` (so prefetched thumbnails still render). `#tree` and `#bulk` pass it; the full `#show` / `#index` path is untouched (guards are truthy-only).

Validated against staging head `148839e89` before implementing: all RCA findings still hold (with line drift); `parent_board` actually fires twice per board, not once.

### Measured impact
On image-bearing boards: **5 queries/board -> 1 query/board** (5x). Not O(1): the surviving 1/board is `images_and_sounds_for` (`known_button_images`), which is remediation #3 (request-scoped image cache), tracked separately in #286.

### Kill-switch (deploy-free)
Lite is ON by default. Revert without a deploy from a console:
`Setting.set('tree_lite_serialization', 'false')` (busts the Redis cache; effective next request).

## Tests
`spec/controllers/api/boards_controller_spec.rb`: contract specs (404, permission filtering, `MAX_TREE`/`MAX_BULK` caps, lite payload shape), a threshold-free behavioral guard (`find_copies_by` / `shared_users` / `ButtonImage.find_by_global_id` never fire), bounded per-descendant query specs, and a kill-switch fallback spec. Full file: 195 examples, 0 failures (1 pre-existing pending). Verified the guard fails when `as_lite` is removed.

## Dual-reviewer pass
- **Adversary:** found the original query specs were tautological (empty-grid boards hid the surviving image cost and falsely claimed O(1)) -> **fixed** here (image-bearing fixtures + honest reframing + behavioral guard). Also flagged a Medium client-contract gap (lite-cached boards show empty share lists in the Ember modals on a cache hit) -> filed as #293 with the kill-switch as the interim lever.
- **Senior-dev pass:** Codex CLI was unavailable in the authoring environment, so this was a Claude senior-dev checklist pass, not a cross-model second opinion. Flagged the missing kill-switch (added here) and confirmed the change is a net PII reduction (drops supervisor identities from the prefetch payload).

## Index overlap
`#index`/`paginate` shares the same `build_json`/`extra_includes`. Technical interaction with Traci's `#index` N+1 work is low (index passes no `:permissions`), but merge-collision probability on these lines is high. Whoever lands second should rebase.

Addresses #286 (remediation #1 only; #2 batch-preload and #3 image cache remain). Fast-follow: #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
