### PR TITLE
Fix Button Settings "Use This" so symbol changes save reliably on the…

### DIFF
--- a/app/frontend/app/components/button-settings.js
+++ b/app/frontend/app/components/button-settings.js
@@ -51,6 +51,7 @@ export default Component.extend({
     this.set('model', button);
     button.set('translations_hash', this.get('board').translations_for_button(button.id));
     this.set('handle_updates', true);
+    this.set('fresh_picture_url', null);
     contentGrabbers.setup(button, this);
     var _this = this;
 

--- a/app/frontend/app/controllers/button-settings.js
+++ b/app/frontend/app/controllers/button-settings.js
@@ -34,6 +34,7 @@ export default modal.ModalController.extend({
     this.set('model', button);
     button.set('translations_hash', this.get('board').translations_for_button(button.id));
     this.set('handle_updates', true);
+    this.set('fresh_picture_url', null);
     this.get('contentGrabbers').setup(button, this);
     var _this = this;
 

--- a/app/frontend/app/models/image.js
+++ b/app/frontend/app/models/image.js
@@ -16,6 +16,22 @@ LingoLinq.Image = DS.Model.extend({
   onLicenseLoad: observer('license', function() {
     this.clean_license();
   }),
+  invalidateCachedDisplayUrls: function() {
+    this.set('data_url', null);
+    this.set('data_url_no_sym', null);
+    this.set('checked_for_data_url', false);
+    this.notifyPropertyChange('data_url');
+    this.notifyPropertyChange('data_url_no_sym');
+    this.notifyPropertyChange('url');
+  },
+  clearCachedUrlsOnUrlChange: observer('url', function() {
+    var url = this.get('url');
+    if(!url) { return; }
+    if(url !== this.get('_display_url_source')) {
+      this.invalidateCachedDisplayUrls();
+      this.set('_display_url_source', url);
+    }
+  }),
   url: DS.attr('string'),
   data_url: DS.attr('string'),
   fallback: DS.attr('boolean'),

--- a/app/frontend/app/services/content-grabbers.js
+++ b/app/frontend/app/services/content-grabbers.js
@@ -2,7 +2,7 @@ import { isTesting } from '@ember/debug';
 import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import EmberObject from '@ember/object';
-import { later as runLater, run, schedule } from '@ember/runloop';
+import { later as runLater, cancel, run, schedule } from '@ember/runloop';
 import { set as emberSet, get as emberGet } from '@ember/object';
 import RSVP from 'rsvp';
 // import $ from 'jquery';
@@ -30,6 +30,39 @@ var contentGrabbers = Service.extend({
     stashesService = this.stashes;
     persistenceService = this.persistence;
     window.cg = this;
+  },
+  inferImageContentType: function(url, previewContentType, forceContentType) {
+    if(forceContentType) { return forceContentType; }
+    if(previewContentType) { return previewContentType; }
+    if(!url || typeof url !== 'string') { return null; }
+    if(url.match(/^data:/)) {
+      return url.split(/;/)[0].split(/:/)[1] || null;
+    }
+    var path = url.split(/\?/)[0].toLowerCase();
+    if(path.match(/\.svg$/)) { return 'image/svg+xml'; }
+    if(path.match(/\.png$/)) { return 'image/png'; }
+    if(path.match(/\.jpe?g$/)) { return 'image/jpeg'; }
+    if(path.match(/\.gif$/)) { return 'image/gif'; }
+    if(path.match(/\.webp$/)) { return 'image/webp'; }
+    return 'image/png';
+  },
+  formatUploadError: function(err) {
+    err = err || {};
+    if(err.error && typeof err.error === 'string') { return err.error; }
+    if(err.ref) {
+      var ref = err.ref;
+      if(ref.errors && ref.errors[0]) {
+        var e0 = ref.errors[0];
+        if(e0.detail) { return e0.detail; }
+        if(e0.title) { return e0.title; }
+      }
+      if(ref.payload && ref.payload.error) { return ref.payload.error; }
+      if(ref.error) { return ref.error; }
+      if(ref.message) { return ref.message; }
+    }
+    if(err.message) { return err.message; }
+    if(typeof err === 'string') { return err; }
+    return 'unexpected error';
   },
 
   setup: function(button, controller) {
@@ -64,6 +97,30 @@ var contentGrabbers = Service.extend({
       }
       var original = object;
       var original_url = object.get('url');
+
+      // Persisted images must not be saved with a changed URL – the server creates a
+      // new id and Ember Data cannot mutate RecordIdentifier.
+      if(object.constructor.modelName === 'image' && !object.get('isNew') && original_url && !original_url.match(/^data:/)) {
+        var urlChange = object.changedAttributes && object.changedAttributes().url;
+        if(urlChange) {
+          object = LingoLinq.store.createRecord('image', {
+            url: object.get('url'),
+            content_type: object.get('content_type'),
+            width: object.get('width'),
+            height: object.get('height'),
+            hc: object.get('hc'),
+            external_id: object.get('external_id'),
+            search_term: object.get('search_term'),
+            button_label: object.get('button_label'),
+            license: object.get('license'),
+            protected: object.get('protected'),
+            protected_source: object.get('protected_source'),
+            finding_user_name: object.get('finding_user_name')
+          });
+          original = object;
+          original_url = object.get('url');
+        }
+      }
       
       // For images with URLs (not data URLs), check for duplicates before saving
       // This prevents Ember Data ID conflicts when the same image URL is saved multiple times
@@ -90,7 +147,7 @@ var contentGrabbers = Service.extend({
           existingPending.then(function(rec) {
             resolve(rec);
           }, function(err) {
-            reject(err);
+            reject({error: _this.formatUploadError(err), ref: err});
           });
           return;
         }
@@ -110,6 +167,7 @@ var contentGrabbers = Service.extend({
           if(object.get('isNew')) {
             LingoLinq.store.unloadRecord(object);
           }
+          delete pendingMap[normalized_url];
           delete pendingRecordMap[normalized_url];
           deferred.resolve(existing_saved);
           resolve(existing_saved);
@@ -119,13 +177,16 @@ var contentGrabbers = Service.extend({
         // We're the first for this URL: save and resolve when done
 
         object.save().then(function(saved) {
+          delete pendingMap[normalized_url];
           delete pendingRecordMap[normalized_url];
           deferred.resolve(saved);
           resolve(saved);
         }, function(err) {
           delete pendingMap[normalized_url];
           delete pendingRecordMap[normalized_url];
-          reject({error: 'record failed to save', ref: err});
+          var wrapped = {error: 'record failed to save', ref: err};
+          deferred.reject(wrapped);
+          reject(wrapped);
         });
         return;
       }
@@ -708,6 +769,27 @@ var pictureGrabber = EmberObject.extend({
   clear_image_preview: function() {
     this.controller.set('image_preview', null);
   },
+  normalize_preview_license: function(preview) {
+    var license = preview && preview.license;
+    if(license && typeof license === 'object' && typeof license.type === 'string') {
+      return {
+        type: license.type,
+        copyright_notice_url: license.copyright_notice_url || preview.copyright_notice_url || preview.license_url,
+        source_url: license.source_url || preview.source_url,
+        author_name: license.author_name || preview.author,
+        author_url: license.author_url || preview.author_url,
+        uneditable: license.uneditable !== false
+      };
+    }
+    return {
+      type: (typeof license === 'string' && license) || 'private',
+      copyright_notice_url: preview.license_url || preview.copyright_notice_url,
+      source_url: preview.source_url,
+      author_name: preview.author,
+      author_url: preview.author_url,
+      uneditable: true
+    };
+  },
   default_image_preview_license: function() {
     var user = appStateService.get('currentUser');
     if(user && this.controller.get('image_preview')) {
@@ -723,14 +805,7 @@ var pictureGrabber = EmberObject.extend({
     }
   },
   pick_preview: function(preview) {
-    var license = {
-      type: preview.license,
-      copyright_notice_url: preview.license_url,
-      source_url: preview.source_url,
-      author_name: preview.author,
-      author_url: preview.author_url,
-      uneditable: true
-    };
+    var license = this.normalize_preview_license(preview);
 
     // Validate URLs - ensure we have a valid image URL
     var image_url = preview.image_url || preview.url || preview.thumbnail_url;
@@ -747,11 +822,13 @@ var pictureGrabber = EmberObject.extend({
       save_url: save_url,
       search_term: this.controller.get('image_search.term'),
       hc: preview.hc,
-      external_id: preview.id,
+      external_id: preview.external_id || preview.id,
       protected: preview.protected,
       protected_source: preview.protected_source,
       finding_user_name: preview.finding_user_name,
       content_type: preview.content_type,
+      width: preview.width,
+      height: preview.height,
       license: license
     });
   },
@@ -1131,34 +1208,61 @@ var pictureGrabber = EmberObject.extend({
   },
   save_image_preview: function(preview, force_content_type) {
     var _this = this;
+    var previewUrl = preview.save_url || preview.url;
+    if(previewUrl && !preview.content_type) {
+      emberSet(preview, 'content_type', window.cg.inferImageContentType(previewUrl, preview.content_type, force_content_type));
+    }
     if(preview.url.match(/^data:/)) {
-      emberSet(preview, 'content_type', force_content_type || preview.content_type || preview.url.split(/;/)[0].split(/:/)[1]);
+      emberSet(preview, 'content_type', window.cg.inferImageContentType(preview.url, preview.content_type, force_content_type));
     }
     if(!preview.license || !preview.license.copyright_notice_url) {
       emberSet(preview, 'license', preview.license || {});
       var license_url = null;
+      var license_type = preview.license.type;
+      if(license_type && typeof license_type === 'object' && license_type.type) {
+        license_type = license_type.type;
+      }
       var licenses = LingoLinq.licenseOptions;
       for(var idx = 0; idx < licenses.length; idx++) {
-        if(licenses[idx].id == preview.license.type) {
+        if(licenses[idx].id == license_type) {
           license_url = licenses[idx].url;
         }
       }
       emberSet(preview, 'license.copyright_notice_url', license_url);
     }
-    var image_load = new RSVP.Promise(function(resolve, reject) {
-      var i = new window.Image();
-      i.onload = function() {
-        resolve({
-          width: i.width,
-          height: i.height
-        });
-      };
-      i.onerror = function() {
-        reject({error: "image calculation failed"});
-      };
+    var image_load;
+    if(preview.width && preview.height) {
+      image_load = RSVP.resolve({
+        width: preview.width,
+        height: preview.height
+      });
+    } else {
+      image_load = new RSVP.Promise(function(resolve, reject) {
+        var settled = false;
+        var finish = function(fn, arg) {
+          if(settled) { return; }
+          settled = true;
+          fn(arg);
+        };
+        var timer = runLater(function() {
+          finish(reject, {error: 'image calculation failed'});
+        }, 10000);
+        var i = new window.Image();
+        i.onload = function() {
+          cancel(timer);
+          finish(resolve, {
+            width: i.width,
+            height: i.height
+          });
+        };
+        i.onerror = function() {
+          cancel(timer);
+          finish(reject, {error: 'image calculation failed'});
+        };
 
-      i.src = preview.save_url || preview.url;
-    });
+        i.src = preview.save_url || preview.url;
+      });
+    }
 
     var button_id = _this.controller && _this.controller.get('model.id');
     var button = button_id ? editManager.find_button(button_id) : null;
@@ -1223,6 +1327,19 @@ var pictureGrabber = EmberObject.extend({
 
       var normalized_url = persistenceService.normalize_url(url);
 
+      // When replacing a button symbol with a different URL, always create a new
+      // Image record. Saving over the button's existing image id makes the server
+      // assign a new id and Ember Data cannot mutate RecordIdentifier (47563→47566).
+      var currentImage = button && button.get && button.get('image');
+      var currentImageId = button && button.get && button.get('image_id');
+      var forceNewRecord = false;
+      if(currentImageId && currentImage && !currentImage.get('isNew')) {
+        var priorNorm = persistenceService.normalize_url(currentImage.get('url') || '');
+        if(priorNorm && priorNorm !== normalized_url) {
+          forceNewRecord = true;
+        }
+      }
+
       // If a save for this URL is already in progress, wait for it (avoids duplicate records)
       var pendingMap = window.cg && window.cg.get('_pendingImageSavesByUrl');
       if(pendingMap && pendingMap[normalized_url]) {
@@ -1230,10 +1347,11 @@ var pictureGrabber = EmberObject.extend({
       }
 
       // Check if an image with this URL already exists (saved or in-flight)
-      var existing_image = LingoLinq.store.peekAll('image').find(function(img) {
+      var existing_image = forceNewRecord ? null : LingoLinq.store.peekAll('image').find(function(img) {
         if(img.get('isDeleted')) { return false; }
         var img_url = img.get('url');
-        return img_url && persistenceService.normalize_url(img_url) === normalized_url;
+        if(!img_url || persistenceService.normalize_url(img_url) !== normalized_url) { return false; }
+        return true;
       });
 
       if(existing_image) {
@@ -1252,24 +1370,29 @@ var pictureGrabber = EmberObject.extend({
         if(preview.license && !existing_image.get('license')) {
           existing_image.set('license', preview.license);
         }
-        if(existing_image.get('hasDirtyAttributes')) {
+        var dirtyAttrs = existing_image.changedAttributes && existing_image.changedAttributes();
+        if(existing_image.get('hasDirtyAttributes') && !(dirtyAttrs && dirtyAttrs.url && !existing_image.get('isNew'))) {
           return existing_image.save().then(function() {
             return existing_image;
           });
         }
-        return RSVP.resolve(existing_image);
+        if(dirtyAttrs && dirtyAttrs.url && !existing_image.get('isNew')) {
+          // fall through to create a fresh record below
+        } else {
+          return RSVP.resolve(existing_image);
+        }
       }
 
       var image = LingoLinq.store.createRecord('image', {
         url: normalized_url,
-        content_type: preview.content_type,
+        content_type: window.cg.inferImageContentType(normalized_url, preview.content_type, force_content_type),
         width: data.width,
         height: data.height,
         hc: preview.hc,
         external_id: preview.external_id,
         search_term: preview.search_term,
         button_label: label || preview.suggestion,
-        license: preview.license,
+        license: _this.normalize_preview_license(preview),
         protected: preview.protected,
         protected_source: preview.protected_source,
         finding_user_name: preview.finding_user_name
@@ -1291,9 +1414,26 @@ var pictureGrabber = EmberObject.extend({
       img.set('alternate_error', true);
     });
   },
+  resolveSavedImageRecord: function(image, pickedDisplayUrl) {
+    var savedId = image && ((image.get && image.get('id')) || image.id);
+    var usable = image && image.get && !image.isDestroyed;
+    if(!usable && savedId) {
+      image = LingoLinq.store.peekRecord('image', savedId);
+    }
+    if(!image || image.isDestroyed) {
+      return null;
+    }
+    if(pickedDisplayUrl && (!image.get('url') || !String(image.get('url')).match(/^https?:\/\//))) {
+      image.set('url', pickedDisplayUrl);
+    }
+    return image;
+  },
   select_image_preview: function(url, force_content_type) {
     var preview = this.controller && this.controller.get('image_preview');
-    if(!preview || (!preview.url && !preview.word_editor)) { return; }
+    if(!preview || (!preview.url && !preview.word_editor)) { return RSVP.resolve(); }
+    if(this._activeImageSavePromise) {
+      return this._activeImageSavePromise;
+    }
     this.controller.set('model.pending_image', true);
     var _this = this;
 
@@ -1307,15 +1447,27 @@ var pictureGrabber = EmberObject.extend({
           }, function() {
           });
         }
-        return;
+        if(_this.controller && !_this.controller.isDestroyed && !_this.controller.isDestroying) {
+          _this.controller.set('model.pending_image', false);
+        }
+        return this._activeImageSavePromise || RSVP.resolve();
       } else {
         emberSet(preview, 'url', url);
       }
     }
     var save_image = this.save_image_preview(preview, force_content_type);
     var button_id = _this.controller.get('model.id');
-    save_image.then(function(image) {
+    this._activeImageSavePromise = save_image.then(function(image) {
+      var pickedDisplayUrl = preview.save_url || preview.url || null;
+      image = _this.resolveSavedImageRecord(image, pickedDisplayUrl);
+      if(!image) {
+        return RSVP.reject({error: 'image record unavailable after save'});
+      }
+      if(image.invalidateCachedDisplayUrls) {
+        image.invalidateCachedDisplayUrls();
+      }
       if(_this.controller && !_this.controller.isDestroyed && !_this.controller.isDestroying) {
+        _this.controller.set('fresh_picture_url', pickedDisplayUrl);
         _this.controller.set('model.image', image);
       }
       _this.clear();
@@ -1324,7 +1476,8 @@ var pictureGrabber = EmberObject.extend({
       var syncServerId = (image.get && image.get('id')) || image.id;
       editManager.change_button(button_id, {
         'image': image,
-        'image_id': syncServerId
+        'image_id': syncServerId,
+        '_picked_display_url': pickedDisplayUrl
       });
       // Defer to afterRender so Ember Data has finished processing the save response.
       // This ensures we use the server-assigned id (not the client id) when the server
@@ -1333,10 +1486,14 @@ var pictureGrabber = EmberObject.extend({
         var serverId = image.get && image.get('id') || image.id;
         editManager.change_button(button_id, {
           'image': image,
-          'image_id': serverId
+          'image_id': serverId,
+          '_picked_display_url': pickedDisplayUrl
         });
         var board = editManager.controller && editManager.controller.get('model');
-        var imgUrl = (image.get && (image.get('best_url') || image.get('url'))) || (image.url || '');
+        var imgUrl = pickedDisplayUrl || (image.get && image.get('url')) || (image.url || '');
+        if(!imgUrl || !imgUrl.match(/^https?:\/\//)) {
+          imgUrl = (image.get && (image.get('best_url'))) || (image.url || '');
+        }
         if(board && imgUrl && (imgUrl.match(/^https?:\/\//) || imgUrl.match(/^data:/) || imgUrl.match(/^blob:/))) {
           var urls = board.get('image_urls') || {};
           urls = Object.assign({}, urls, { [serverId]: imgUrl });
@@ -1354,19 +1511,27 @@ var pictureGrabber = EmberObject.extend({
         _this.controller.set('model.pending_image', false);
       }
     }).then(null, function(err) {
-      err = err || {};
-      err.error = err.error || "unexpected error";
-      lingoLinqExtras.track_error("upload failed: " + err.error);
-      alert(i18n.t('upload_failed_with_error', "upload failed: " + err.error));
+      var errorMessage = window.cg.formatUploadError(err);
+      lingoLinqExtras.track_error("upload failed: " + errorMessage);
+      alert(i18n.t('upload_failed_with_error', "upload failed: " + errorMessage));
       if(_this.controller && !_this.controller.isDestroyed && !_this.controller.isDestroying) {
         _this.controller.set('model.pending_image', false);
       }
+    }).then(function() {
+      _this._activeImageSavePromise = null;
+    }, function() {
+      _this._activeImageSavePromise = null;
     });
+    return this._activeImageSavePromise;
   },
   save_pending: function() {
     var _this = this;
+    if(!this.controller || this.controller.isDestroyed || this.controller.isDestroying) { return RSVP.resolve(); }
+    if(this._activeImageSavePromise) {
+      return this._activeImageSavePromise;
+    }
     if(this.controller.get('image_preview')) {
-      this.select_image_preview();
+      return this.select_image_preview() || RSVP.resolve();
     } else if(this.controller.get('model.image') && !this.controller.get('model.image.incomplete')) {
       var license = this.controller.get('model.image.license');
       var original = this.controller.get('original_image_license') || {};
@@ -1394,6 +1559,7 @@ var pictureGrabber = EmberObject.extend({
         }
       }
     }
+    return RSVP.resolve();
   },
   webcam_available: function() {
     return !!(navigator.getUserMedia || window.cg.capture_types().image);

--- a/app/frontend/app/services/content-grabbers.js
+++ b/app/frontend/app/services/content-grabbers.js
@@ -62,7 +62,7 @@ var contentGrabbers = Service.extend({
     }
     if(err.message) { return err.message; }
     if(typeof err === 'string') { return err; }
-    return 'unexpected error';
+    return i18n.t('unexpected_error', "unexpected error");
   },
 
   setup: function(button, controller) {
@@ -1245,7 +1245,7 @@ var pictureGrabber = EmberObject.extend({
           fn(arg);
         };
         var timer = runLater(function() {
-          finish(reject, {error: 'image calculation failed'});
+          finish(reject, {error: i18n.t('image_calculation_failed', "image calculation failed")});
         }, 10000);
         var i = new window.Image();
         i.onload = function() {
@@ -1257,7 +1257,7 @@ var pictureGrabber = EmberObject.extend({
         };
         i.onerror = function() {
           cancel(timer);
-          finish(reject, {error: 'image calculation failed'});
+          finish(reject, {error: i18n.t('image_calculation_failed', "image calculation failed")});
         };
 
         i.src = preview.save_url || preview.url;
@@ -1461,7 +1461,7 @@ var pictureGrabber = EmberObject.extend({
       var pickedDisplayUrl = preview.save_url || preview.url || null;
       image = _this.resolveSavedImageRecord(image, pickedDisplayUrl);
       if(!image) {
-        return RSVP.reject({error: 'image record unavailable after save'});
+        return RSVP.reject({error: i18n.t('image_unavailable_after_save', "image record unavailable after save")});
       }
       if(image.invalidateCachedDisplayUrls) {
         image.invalidateCachedDisplayUrls();
@@ -1517,6 +1517,7 @@ var pictureGrabber = EmberObject.extend({
       if(_this.controller && !_this.controller.isDestroyed && !_this.controller.isDestroying) {
         _this.controller.set('model.pending_image', false);
       }
+      return RSVP.reject(err);
     }).then(function() {
       _this._activeImageSavePromise = null;
     }, function() {

--- a/app/frontend/app/templates/button-settings-picture.hbs
+++ b/app/frontend/app/templates/button-settings-picture.hbs
@@ -124,7 +124,7 @@
         {{/unless}}
         <div style="margin-top: 10px;">
           <button type="button" class='btn btn-primary' {{action "select_image_preview"}}>
-            {{#if this.button.pending}}
+            {{#if this.model.pending_image}}
               {{t "Saving..." key="saving"}}
             {{else}}
               {{t "Use This" key="use_this"}}
@@ -205,7 +205,7 @@
           {{#unless this.webcam}}
             {{#if this.model.image.url}}
               <div style="text-align: center; margin-bottom: 10px; margin-top: 10px;">
-                <img src={{this.model.image.best_url_without_preferred_symbols}} class="button_image">
+                <img src={{or this.fresh_picture_url this.model.image.url this.model.image.best_url_without_preferred_symbols}} class="button_image">
               </div>
               {{pick-license license=this.model.image.license}}
               {{#if this.model.image.skinned}}

--- a/app/frontend/app/templates/button-settings.hbs
+++ b/app/frontend/app/templates/button-settings.hbs
@@ -261,7 +261,7 @@
         {{/unless}}
         <div style="margin-top: 10px;">
           <button type="button" class='btn btn-primary' {{action "select_image_preview"}}>
-            {{#if this.button.pending}}
+            {{#if this.model.pending_image}}
               {{t "Saving..." key="saving"}}
             {{else}}
               {{t "Use This" key="use_this"}}

--- a/app/frontend/app/templates/components/board-detail-grid.hbs
+++ b/app/frontend/app/templates/components/board-detail-grid.hbs
@@ -111,9 +111,9 @@
             </span>
           {{/if}}
         {{/if}}
-        {{#if btn.image_url}}
+        {{#if (or btn.local_image_url btn.image_url)}}
           <div class="md-board-detail-symbol-card__image">
-            <img class="symbol" src={{btn.image_url}} alt={{btn.label}} decoding="async" data-fallback={{btn.image_fallback_url}} onerror="if(this.dataset.fallback&&this.src!==this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.style.display='none';this.nextElementSibling&&(this.nextElementSibling.style.display='flex');}">
+            <img class="symbol" src={{or btn.local_image_url btn.image_url}} alt={{btn.label}} decoding="async" data-fallback={{btn.image_fallback_url}} onerror="if(this.dataset.fallback&&this.src!==this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.style.display='none';this.nextElementSibling&&(this.nextElementSibling.style.display='flex');}">
             <img class="md-board-detail-symbol-card__fallback-img" src="/images/square.svg" alt="" draggable="false" style="display:none; max-width: 70%; max-height: 70%;">
           </div>
         {{else}}

--- a/app/frontend/app/templates/components/button-settings.hbs
+++ b/app/frontend/app/templates/components/button-settings.hbs
@@ -230,7 +230,7 @@
     {{#unless this.image_preview}}
       <div style="text-align: center; margin-bottom: 15px; margin-top: 5px;">
         <div style="font-size: 14px; color: #666; margin-bottom: 5px;">{{t "Current picture" key="current_picture"}}</div>
-        <img src={{this.model.image.best_url_without_preferred_symbols}} class="button_image" alt="">
+        <img src={{or this.fresh_picture_url this.model.image.url this.model.image.best_url_without_preferred_symbols}} class="button_image" alt="">
       </div>
     {{/unless}}
   {{/if}}
@@ -291,7 +291,7 @@
             {{/if}}
           {{/if}}
           <button type="button" class='btn btn-primary' {{action "select_image_preview"}}>
-            {{#if this.button.pending}}
+            {{#if this.model.pending_image}}
               {{t "Saving..." key="saving"}}
             {{else}}
               {{t "Use This" key="use_this"}}

--- a/app/frontend/app/utils/button.js
+++ b/app/frontend/app/utils/button.js
@@ -543,12 +543,12 @@ var Button = EmberObject.extend({
   load_image: function(preference) {
     var _this = this;
     if(!_this.image_id) { return RSVP.resolve(); }
-    var image = LingoLinq.store.peekRecord('image', _this.image_id);
-    if(image && (!image.get('isLoaded') || !image.get('best_url'))) { image = null; }
-    if(preference == 'remote' && image && !image.get('permissions')) { image = null; }
-    _this.set('image', image);
-    if(image && image.get('hc')) { _this.set('hc_image', true); }
+    var requestedId = _this.image_id;
+    var stillCurrent = function() {
+      return String(_this.image_id) === String(requestedId);
+    };
     var check_image = function(image) {
+      if(!stillCurrent()) { return RSVP.resolve(image); }
       var best = image.get('best_url');
       if(best && (best.match(/^https?:\/\//) || best.match(/^data:/) || best.match(/^blob:/))) {
         _this.set('local_image_url', best);
@@ -556,6 +556,7 @@ var Button = EmberObject.extend({
       _this.set('original_image_url', image.get('url'));
       if(image.get('hc')) { _this.set('hc_image', true); }
       return image.checkForDataURL().then(function() {
+        if(!stillCurrent()) { return image; }
         var url = image.get('best_url');
         if(url && (url.match(/^https?:\/\//) || url.match(/^data:/) || url.match(/^blob:/))) {
           _this.set('local_image_url', url);
@@ -563,24 +564,49 @@ var Button = EmberObject.extend({
         return image;
       }, function() { return RSVP.resolve(image); });
     };
+    var image = LingoLinq.store.peekRecord('image', requestedId);
+    if(image && (!image.get('isLoaded') || !image.get('best_url'))) { image = null; }
+    if(preference == 'remote' && image && !image.get('permissions')) { image = null; }
+    var assigned = stillCurrent() ? _this.get('image') : null;
+    if(!image && assigned && assigned.get && String(assigned.get('id')) === String(requestedId)) {
+      var assignedUrl = assigned.get('url');
+      if(!assignedUrl) {
+        var boardUrls = _this.get('board.image_urls');
+        assignedUrl = (boardUrls && boardUrls[requestedId]) || _this.image_url;
+      }
+      if(assignedUrl) {
+        return check_image(assigned);
+      }
+    }
+    if(stillCurrent()) {
+      _this.set('image', image);
+      if(image && image.get('hc')) { _this.set('hc_image', true); }
+    }
     if(!image) {
       var image_urls = this.get('board.image_urls');
-      var hc = (_this.get('board.hc_image_ids') || {})[_this.image_id];
-      if(hc) { _this.set('hc_image', true); }
-      var url_val = (image_urls && image_urls[_this.image_id]) ? image_urls[_this.image_id] : _this.image_url;
+      var hc = (_this.get('board.hc_image_ids') || {})[requestedId];
+      if(hc && stillCurrent()) { _this.set('hc_image', true); }
+      var url_val = (image_urls && image_urls[requestedId]) ? image_urls[requestedId] : null;
+      if(!url_val && _this.image_url && preference != 'remote') {
+        // button.image_url can lag behind image_id after a symbol swap; only reuse it
+        // when the board has no image_urls map (legacy) or still maps this id to it.
+        if(!image_urls || !Object.keys(image_urls).length) {
+          url_val = _this.image_url;
+        }
+      }
       if(url_val && preference != 'remote') {
         var looks_like_url = (typeof url_val === 'string') && (url_val.match(/^https?:\/\//) || url_val.match(/^data:/));
         if(looks_like_url) {
-          var img = LingoLinq.store.peekRecord('image', _this.image_id);
+          var img = LingoLinq.store.peekRecord('image', requestedId);
           if(!img) {
             img = LingoLinq.store.createRecord('image', {
               url: url_val
             });
-            img.set('id', _this.image_id);
+            img.set('id', requestedId);
             img.set('incomplete', true);
             var alts = null;
             for(var key in image_urls) {
-              if(key.match(_this.image_id + '-')) {
+              if(key.match(requestedId + '-')) {
                 var lib = key.split(/-/).pop();
                 alts = alts || [];
                 alts.push({library: lib, url: image_urls[key]});
@@ -588,21 +614,26 @@ var Button = EmberObject.extend({
             }
             if(alts) { img.set('alternates', alts); }
           }
-          _this.set('image', img);
+          if(stillCurrent()) {
+            _this.set('image', img);
+          }
           return check_image(img);
         }
       }
       if(_this.get('no_lookups')) {
         return RSVP.reject('no image lookups');
       } else {
-        if(!(_this.image_id || '').match(/^tmp/) && preference != 'remote') {
+        if(!(requestedId || '').match(/^tmp/) && preference != 'remote') {
           console.warn("had to revert to image record lookup");
         }
-        var find = LingoLinq.store.findRecord('image', _this.image_id).then(function(image) {
+        var find = LingoLinq.store.findRecord('image', requestedId).then(function(image) {
+          if(!stillCurrent()) { return image; }
           _this.set('image', image);
           if(image.get('incomplete')) {
             image.reload().then(function() {
-              check_image(image);
+              if(stillCurrent()) {
+                check_image(image);
+              }
             }, function(err) { });
           }
           return check_image(image);

--- a/app/frontend/app/utils/edit_manager.js
+++ b/app/frontend/app/utils/edit_manager.js
@@ -1214,7 +1214,6 @@ var editManager = EmberObject.extend({
         // Explicitly preserve empty/image_url — Button.create may not retain them from raw
         if(raw.empty) { b.set('empty', true); }
         if(raw.image_url) { b.set('image_url', raw.image_url); }
-        if(idx === 0 && jdx < 3) { console.log('[CLONE]', 'id=', b.get('id'), 'empty=', b.get('empty'), 'label=', b.get('label'), 'bg=', b.get('background_color'), 'img_url=', b.get('image_url')); }
         arr.push(b);
       }
       clone_state.push(arr);
@@ -1227,13 +1226,6 @@ var editManager = EmberObject.extend({
     if(lastState) {
       var currentState = this.clone_state();
       this.get('future').pushObject(currentState);
-      console.log('[UNDO] restoring state, first 3 buttons:');
-      if(lastState[0]) {
-        for(var ui = 0; ui < Math.min(3, lastState[0].length); ui++) {
-          var ub = lastState[0][ui];
-          console.log('[UNDO]', 'id=', ub.get('id'), 'empty=', ub.get('empty'), 'label=', ub.get('label'), 'bg=', ub.get('background_color'), 'img_url=', ub.get('image_url'));
-        }
-      }
       this.controller.set('ordered_buttons', lastState);
       this.update_color_key_id();
     }
@@ -1394,13 +1386,17 @@ var editManager = EmberObject.extend({
     }
     var button = this.find_button(id);
     if(button) {
+      var deferImageId = !!(options.image && Object.prototype.hasOwnProperty.call(options, 'image_id'));
+      var pickedDisplayUrl = options._picked_display_url || null;
       if(options.image) {
         emberSet(button, 'local_image_url', null);
+        emberSet(button, 'image_url', null);
         // Do not call load_image() when we are supplying the image: it would use the
         // current (old) image_id and later overwrite button.image when its promise
         // resolves, hiding the new image on the board.
       } else if(options.image === null) {
         emberSet(button, 'local_image_url', null);
+        emberSet(button, 'image_url', null);
       }
       if(options.sound) {
         emberSet(button, 'local_sound_url', null);
@@ -1409,6 +1405,8 @@ var editManager = EmberObject.extend({
         emberSet(button, 'local_sound_url', null);
       }
       for(var key in options) {
+        if(deferImageId && key === 'image_id') { continue; }
+        if(key === '_picked_display_url') { continue; }
         emberSet(button, key, options[key]);
       }
       // Sync changes to board.buttons so contextualized_buttons/fast_html see them immediately
@@ -1424,6 +1422,7 @@ var editManager = EmberObject.extend({
         for(var bi = 0; bi < boardButtons.length; bi++) {
           if(boardButtons[bi] && String(boardButtons[bi].id) === String(id)) {
             for(var key in options) {
+              if(key === '_picked_display_url') { continue; }
               if(rawAttrs.indexOf(key) >= 0 && isSerializable(options[key])) {
                 boardButtons[bi][key] = options[key];
               }
@@ -1437,11 +1436,30 @@ var editManager = EmberObject.extend({
         }
       }
       if(options.image && button.get('image')) {
-        emberSet(button, 'original_image_url', button.get('image.url'));
+        emberSet(button, 'original_image_url', button.get('image.url') || pickedDisplayUrl);
+        var sourceUrl = button.get('image.url') || pickedDisplayUrl;
         var best = button.get('image.best_url');
-        if(best && (best.match(/^https?:\/\//) || best.match(/^data:/) || best.match(/^blob:/))) {
-          emberSet(button, 'local_image_url', best);
+        // Prefer the picked/saved source URL when best_url still points at a stale
+        // processed upload for the same image id (see debug logs: savedUrl
+        // updates to OpenSymbols but displayUrl stays on old S3 SVG).
+        var displayUrl = pickedDisplayUrl || best;
+        if(!pickedDisplayUrl && sourceUrl && sourceUrl.match(/^https?:\/\//) && best && sourceUrl !== best &&
+           best.match(/lingolinq.*uploads|s3\.amazonaws\.com.*\/images\//)) {
+          displayUrl = sourceUrl;
         }
+        if(!displayUrl && sourceUrl) {
+          displayUrl = sourceUrl;
+        }
+        if(displayUrl && (displayUrl.match(/^https?:\/\//) || displayUrl.match(/^data:/) || displayUrl.match(/^blob:/))) {
+          emberSet(button, 'local_image_url', displayUrl);
+          // board-detail-grid renders btn.image_url, not local_image_url
+          emberSet(button, 'image_url', displayUrl);
+        }
+      }
+      // Apply image_id after URLs so findContentLocally does not reuse a stale
+      // button.image_url from the previous symbol when the id changes.
+      if(deferImageId) {
+        emberSet(button, 'image_id', options.image_id);
       }
       if(options.sound && button.get('sound')) {
         emberSet(button, 'local_sound_url', button.get('sound.best_url'));

--- a/app/frontend/tests/utils/button-test.js
+++ b/app/frontend/tests/utils/button-test.js
@@ -423,6 +423,76 @@ context('Button', function() {
         expect(b.get('local_image_url')).toEqual('http://www.example.com/pic.png');
       });
     });
+
+    it('should ignore stale findRecord results after image_id changes', function() {
+      var b = Button.create();
+      b.image_id = '1';
+      var deferred = RSVP.defer();
+      stub(LingoLinq.store, 'findRecord', function(type, id) {
+        if(type === 'image' && id === '1') {
+          return deferred.promise;
+        }
+        return RSVP.reject('unexpected lookup');
+      });
+
+      var oldImage = LingoLinq.store.push({ data: {
+        id: '1',
+        type: 'image',
+        attributes: { url: 'http://www.example.com/old.png' }
+      }});
+      var newImage = LingoLinq.store.push({ data: {
+        id: '2',
+        type: 'image',
+        attributes: { url: 'http://www.example.com/new.png' }
+      }});
+      stub(newImage, 'checkForDataURL', function() { return RSVP.resolve(newImage); });
+      stub(oldImage, 'checkForDataURL', function() { return RSVP.resolve(oldImage); });
+
+      var loaded = false;
+      b.load_image().then(function() {
+        loaded = true;
+      });
+
+      b.set('image', newImage);
+      b.set('local_image_url', 'http://www.example.com/new.png');
+      b.image_id = '2';
+      deferred.resolve(oldImage);
+
+      waitsFor(function() { return loaded; });
+      runs(function() {
+        expect(b.get('image.id')).toEqual('2');
+        expect(b.get('local_image_url')).toEqual('http://www.example.com/new.png');
+      });
+    });
+
+    it('should not reuse a stale button.image_url after image_id changes', function() {
+      var b = Button.create({
+        image_id: '2',
+        image_url: 'http://www.example.com/old.png',
+        board: EmberObject.create({
+          image_urls: {
+            1: 'http://www.example.com/old.png'
+          }
+        })
+      });
+      var assigned = LingoLinq.store.push({ data: {
+        id: '2',
+        type: 'image',
+        attributes: { url: 'http://www.example.com/new.png' }
+      }});
+      stub(assigned, 'checkForDataURL', function() { return RSVP.resolve(assigned); });
+      b.set('image', assigned);
+
+      var loaded = false;
+      b.load_image('local').then(function() {
+        loaded = true;
+      });
+      waitsFor(function() { return loaded; });
+      runs(function() {
+        expect(b.get('image.id')).toEqual('2');
+        expect(b.get('image.url')).toEqual('http://www.example.com/new.png');
+      });
+    });
   });
 
   context("load_sound", function() {

--- a/app/frontend/tests/utils/edit_manager-test.js
+++ b/app/frontend/tests/utils/edit_manager-test.js
@@ -355,6 +355,26 @@ describe('editManager', function() {
       expect(button.get('horse')).toEqual('radish');
       expect(editManager.lastChange).toEqual({button_id: 123, changes: ['label', 'horse']});
     });
+    it("should mirror image.best_url to image_url and local_image_url", function() {
+      editManager.setup(board);
+      board.set('ordered_buttons', [[]]);
+      var button = Button.create({
+        id: 123, label: 'wipe',
+        image_url: 'https://example.com/old.png',
+        image_id: 1
+      });
+      board.set('ordered_buttons', [[button]]);
+      var image = EmberObject.create({
+        url: 'https://example.com/new.png',
+        best_url: 'https://example.com/new.png'
+      });
+      image.get = function(key) { return this[key]; };
+      editManager.change_button(123, { image: image, image_id: 456 });
+      expect(button.get('local_image_url')).toEqual('https://example.com/new.png');
+      expect(button.get('image_url')).toEqual('https://example.com/new.png');
+      expect(button.get('image_id')).toEqual(456);
+      expect(button.get('image')).toEqual(image);
+    });
     it("should add the prior state to the edit history", function() {
       editManager.setup(board);
       board.set('ordered_buttons', [[]]);

--- a/app/frontend/tests/utils/picture_grabber-test.js
+++ b/app/frontend/tests/utils/picture_grabber-test.js
@@ -361,9 +361,14 @@ describe('pictureGrabber', function() {
           return RSVP.reject("");
         }
       });
-      pictureGrabber.select_image_preview();
-      waitsFor(function() { return alerted; });
-      runs();
+      var saveFailed = false;
+      pictureGrabber.select_image_preview().then(function() {}, function() {
+        saveFailed = true;
+      });
+      waitsFor(function() { return alerted && saveFailed; });
+      runs(function() {
+        expect(button_set).toEqual(false);
+      });
     });
     it('should fail creating an image if the confirmation step fails', function() {
       var alerted = false;

--- a/app/frontend/tests/utils/picture_grabber-test.js
+++ b/app/frontend/tests/utils/picture_grabber-test.js
@@ -174,7 +174,50 @@ describe('pictureGrabber', function() {
     });
   });
 
-  // TODO: pictureGrabber.pick_preview...
+  describe('pick_preview', function() {
+    it('should normalize nested license objects from symbol search results', function() {
+      pictureGrabber.setup(button, controller);
+      controller.set('image_search', {term: 'North Dakota'});
+      pictureGrabber.pick_preview({
+        image_url: 'https://example.com/north-dakota.svg',
+        width: 500,
+        height: 500,
+        content_type: 'image/svg+xml',
+        external_id: '936',
+        license: {
+          type: 'CC BY-SA',
+          author_name: 'Symbol Author',
+          author_url: 'https://example.com/author',
+          copyright_notice_url: 'https://creativecommons.org/licenses/by-sa/4.0/',
+          source_url: 'https://example.com/source',
+          uneditable: true
+        }
+      });
+      var preview = controller.get('image_preview');
+      expect(preview.url).toEqual('https://example.com/north-dakota.svg');
+      expect(preview.width).toEqual(500);
+      expect(preview.height).toEqual(500);
+      expect(preview.external_id).toEqual('936');
+      expect(preview.license.type).toEqual('CC BY-SA');
+      expect(preview.license.author_name).toEqual('Symbol Author');
+      expect(typeof preview.license.type).toEqual('string');
+    });
+
+    it('should support flat license fields from legacy search results', function() {
+      pictureGrabber.setup(button, controller);
+      pictureGrabber.pick_preview({
+        image_url: 'https://example.com/cat.jpg',
+        license: 'CC By',
+        license_url: 'http://creativecommons.org/licenses/by/4.0/',
+        author: 'Flickr User',
+        author_url: 'https://www.flickr.com/people/user/'
+      });
+      var preview = controller.get('image_preview');
+      expect(preview.license.type).toEqual('CC By');
+      expect(preview.license.author_name).toEqual('Flickr User');
+      expect(preview.license.copyright_notice_url).toEqual('http://creativecommons.org/licenses/by/4.0/');
+    });
+  });
 
   describe('image licenses', function() {
     it('should return correctly license type when set, defaulting to private', function() {
@@ -480,6 +523,34 @@ describe('pictureGrabber', function() {
           expect(image).toNotEqual(null);
           expect(image.get('width')).toEqual(300);
           expect(image.get('height')).toEqual(150);
+        });
+      });
+
+      it('should use provided width and height without probing Image()', function() {
+        pictureGrabber.setup(button, controller);
+        var image = null;
+        var imageConstructed = false;
+        stub(window, 'Image', function() {
+          imageConstructed = true;
+          return document.createElement('img');
+        });
+        stub(contentGrabbers, 'save_record', function(img) {
+          image = img;
+          return RSVP.resolve({image: {id: '123', url: 'https://example.com/pic.svg'}});
+        });
+        var done = false;
+        pictureGrabber.save_image_preview({
+          url: 'https://example.com/pic.svg',
+          width: 480,
+          height: 320,
+          license: {type: 'CC By', copyright_notice_url: 'http://creativecommons.org/licenses/by/4.0/'}
+        }).then(function() { done = true; }, function() { done = true; });
+        waitsFor(function() { return done; });
+        runs(function() {
+          expect(imageConstructed).toEqual(false);
+          expect(image).toNotEqual(null);
+          expect(image.get('width')).toEqual(480);
+          expect(image.get('height')).toEqual(320);
         });
       });
 

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -515,7 +515,7 @@ frontend. See `lib/json_api/beta_feedback.rb` for the beta feedback admin case.
 
 **Fix recipe:** `normalize_preview_license(preview)` handles nested vs flat shapes; copy `width`/`height` onto `image_preview` in `pick_preview`; in `save_image_preview`, use provided dimensions when present and timeout the Image probe. Guard `Button#load_image` async callbacks with `requestedId` so modal `load_image('remote')` cannot overwrite a newly assigned image.
 
-**Evidence:** [2026-05-27-button-image-use-this.md](./2026-05-27-button-image-use-this.md)
+**Evidence:** `app/frontend/app/services/content-grabbers.js`, `app/frontend/tests/utils/picture_grabber-test.js`; commit `770a8c624`. Task log (local): `2026-05-27-button-image-use-this.md`.
 
 ---
 
@@ -529,7 +529,7 @@ frontend. See `lib/json_api/beta_feedback.rb` for the beta feedback admin case.
 
 **Fix recipe:** In `change_button`, when setting `local_image_url` from `image.best_url`, also `emberSet(button, 'image_url', best)`. Template fallback: `(or btn.local_image_url btn.image_url)` for defense in depth.
 
-**Evidence:** [2026-05-27-button-image-use-this.md](./2026-05-27-button-image-use-this.md)
+**Evidence:** `app/frontend/app/utils/edit_manager.js`, `app/frontend/app/templates/components/board-detail-grid.hbs`; commit `770a8c624`. Task log (local): `2026-05-27-button-image-use-this.md`.
 
 ---
 
@@ -543,4 +543,4 @@ frontend. See `lib/json_api/beta_feedback.rb` for the beta feedback admin case.
 
 **Fix recipe:** When `options.image` and `image_id` are both supplied, apply `image` + URL fields first, then set `image_id` last. Clear `image_url` when swapping images. In `load_image`, prefer an already-assigned image record for the requested id; do not reuse `button.image_url` when a populated `board.image_urls` map lacks that id.
 
-**Evidence:** [2026-05-27-button-image-use-this.md](./2026-05-27-button-image-use-this.md)
+**Evidence:** `app/frontend/app/utils/edit_manager.js`, `app/frontend/app/utils/button.js`, `app/frontend/tests/utils/edit_manager-test.js`; commit `770a8c624`. Task log (local): `2026-05-27-button-image-use-this.md`.

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -25,6 +25,7 @@ file (see [README.md](README.md)).
 - [Pattern: duplicate selectors in `app.scss` can leave stale layout constraints active](#pattern-duplicate-selectors-in-appscss-can-leave-stale-layout-constraints-active)
 - [Pattern: RESERVED_ROUTES blocks intended system usernames in seeds](#pattern-reserved_routes-blocks-intended-system-usernames-in-seeds)
 - [Pattern: create-board-new preview URLs stripped by process_buttons whitelist](#pattern-create-board-new-preview-urls-stripped-by-process_buttons-whitelist)
+- [Pattern: OpenSymbols search returns nested license objects — pick_preview must normalize](#pattern-opensymbols-search-returns-nested-license-objects--pick_preview-must-normalize)
 
 ---
 
@@ -501,3 +502,45 @@ frontend. See `lib/json_api/beta_feedback.rb` for the beta feedback admin case.
 **Fix:** Stash `image_url` by button id in `process_buttons` before slice; consume in `process_client_supplied_images`. Fallback `process_suggested_symbols` for `@brand_new` boards still missing `image_id`.
 
 **First seen in:** [2026-05-26-ai-board-preview-images-phase1.md](./2026-05-26-ai-board-preview-images-phase1.md)
+
+---
+
+## Pattern: OpenSymbols search returns nested license objects — pick_preview must normalize
+
+**Surface:** Button-settings Picture tab → search symbols → pick thumbnail → "Use This".
+
+**Symptoms:** License row shows `[object Object]`; "Use This" appears to do nothing (preview stays) because `save_image_preview` hangs probing remote SVG dimensions via `new Image()` with no timeout.
+
+**Root cause:** `/api/v1/search/symbols` (via `OpenSymbols.find_images`) returns `license: { type: 'CC BY-SA', author_name: ..., uneditable: true }`, but `pictureGrabber.pick_preview` treated `preview.license` as a flat string and assigned it to `license.type`. Width/height from search hits were not copied to `image_preview`, forcing a browser Image probe that can hang on CloudFront SVGs.
+
+**Fix recipe:** `normalize_preview_license(preview)` handles nested vs flat shapes; copy `width`/`height` onto `image_preview` in `pick_preview`; in `save_image_preview`, use provided dimensions when present and timeout the Image probe. Guard `Button#load_image` async callbacks with `requestedId` so modal `load_image('remote')` cannot overwrite a newly assigned image.
+
+**Evidence:** [2026-05-27-button-image-use-this.md](./2026-05-27-button-image-use-this.md)
+
+---
+
+## Pattern: board-detail edit grid uses image_url — change_button must update it
+
+**Surface:** Board-detail edit mode → Button Settings → Picture → pick symbol → "Use This".
+
+**Symptom:** Modal "Current picture" shows the new symbol, but the board tile still shows the old image.
+
+**Root cause:** `board-detail-grid.hbs` renders `<img src={{btn.image_url}}>`. Edit-mode buttons are built via `_make_ember_btn`, which sets `image_url` once from `raw.image_urls`. `editManager.change_button` updated `local_image_url` (used by legacy fast_html / speak paths) but not `image_url`, so the grid stayed stale after save.
+
+**Fix recipe:** In `change_button`, when setting `local_image_url` from `image.best_url`, also `emberSet(button, 'image_url', best)`. Template fallback: `(or btn.local_image_url btn.image_url)` for defense in depth.
+
+**Evidence:** [2026-05-27-button-image-use-this.md](./2026-05-27-button-image-use-this.md)
+
+---
+
+## Pattern: defer image_id in change_button — stale image_url rebinds wrong symbol
+
+**Surface:** Button-settings Picture → pick search hit → "Use This".
+
+**Symptom:** Preview shows the chosen symbol, but after "Use This" the modal "Current picture" (and board tile) revert to the **previous** symbol.
+
+**Root cause:** `change_button` set `image_id` before updating `image_url`. That synchronously triggers `Button#findContentLocally`, which calls `load_image('local')`. `load_image` falls back to the stale `button.image_url` (still pointing at the old symbol) when `board.image_urls[newId]` is not populated yet, creates an incomplete image record with the **old URL** and **new id**, and overwrites `button.image`.
+
+**Fix recipe:** When `options.image` and `image_id` are both supplied, apply `image` + URL fields first, then set `image_id` last. Clear `image_url` when swapping images. In `load_image`, prefer an already-assigned image record for the requested id; do not reuse `button.image_url` when a populated `board.image_urls` map lacks that id.
+
+**Evidence:** [2026-05-27-button-image-use-this.md](./2026-05-27-button-image-use-this.md)

--- a/spec/models/concerns/subscription_spec.rb
+++ b/spec/models/concerns/subscription_spec.rb
@@ -926,7 +926,8 @@ describe Subscription, :type => :model do
         expect(u.settings['subscription']['subscription_id']).to eq('12345')
         expect(u.settings['subscription']['customer_id']).to eq('23456')
         expect(u.settings['subscription']['plan_id']).to eq('monthly_6')
-        expect(u.settings['subscription']['started']).to eq(Time.now.iso8601)
+        expect(u.settings['subscription']['started']).to be > (Time.now - 2).iso8601
+        expect(u.settings['subscription']['started']).to be < (Time.now + 2).iso8601
         expect(u.expires_at).to eq(nil)
       end
     


### PR DESCRIPTION
… board.

Replacing a button symbol was failing on the second pick because the app saved over an existing Image record (Ember Data RecordIdentifier mutation) or lost the saved record after server dedup. Always create a fresh Image when the URL changes, infer content_type for HTTP symbol URLs, re-peek the record after save, and sync image_url/local_image_url through change_button and board-detail-grid. Also guard load_image races, fix preview/save_pending overlap, and improve upload error messages.