### PR TITLE
Gate Paste HTML import behind paste_html_import feature flag

### DIFF
--- a/app/frontend/app/components/create-board-new.js
+++ b/app/frontend/app/components/create-board-new.js
@@ -225,6 +225,10 @@ export default Component.extend({
     return !!this.appState.get('feature_flags.ai_board_generation');
   }),
 
+  paste_html_import_enabled: computed('appState.feature_flags.paste_html_import', function() {
+    return !!this.appState.get('feature_flags.paste_html_import');
+  }),
+
   /** Mirror the live board-detail page's text-position class on the
    *  preview grid so the mockup honors the user's saved preference
    *  (top / bottom / text_only). Defaults to 'top' when unset, matching

--- a/app/frontend/app/components/new-board.js
+++ b/app/frontend/app/components/new-board.js
@@ -107,6 +107,10 @@ export default Component.extend({
     return !!this.appState.get('feature_flags.ai_board_generation');
   }),
 
+  paste_html_import_enabled: computed('appState.feature_flags.paste_html_import', function() {
+    return !!this.appState.get('feature_flags.paste_html_import');
+  }),
+
   willDestroy() {
     // Stop recording before teardown (don't use send() - component is being destroyed)
     var speech = this.get('speech');

--- a/app/frontend/app/templates/components/create-board-new.hbs
+++ b/app/frontend/app/templates/components/create-board-new.hbs
@@ -46,9 +46,11 @@
             </button>
             <input type="file" name="board_upload" id="board_upload" tabindex="-1">
           </span>
-          <button type="button" class="btn btn-default" {{action "importFromHtml"}}>
-            {{t "Paste HTML" key="paste_html"}}
-          </button>
+          {{#if this.paste_html_import_enabled}}
+            <button type="button" class="btn btn-default" {{action "importFromHtml"}}>
+              {{t "Paste HTML" key="paste_html"}}
+            </button>
+          {{/if}}
           {{#if this.ai_board_generation_enabled}}
             {{!-- Generate with AI sits on the same row as Import /
                  Paste, but absolute-positioned to be centered on the
@@ -130,9 +132,11 @@
             </button>
             <input type="file" name="board_upload" id="board_upload" tabindex="-1">
           </span>
-          <button type="button" class="la-btn la-btn--ghost" {{action "importFromHtml"}}>
-            {{t "Paste HTML" key="paste_html"}}
-          </button>
+          {{#if this.paste_html_import_enabled}}
+            <button type="button" class="la-btn la-btn--ghost" {{action "importFromHtml"}}>
+              {{t "Paste HTML" key="paste_html"}}
+            </button>
+          {{/if}}
           {{#if this.ai_board_generation_enabled}}
             {{!-- Same-row, page-centered Generate with AI button. See
                  .nb-generate-ai-btn positioning rules in app.scss. --}}

--- a/app/frontend/app/templates/components/new-board.hbs
+++ b/app/frontend/app/templates/components/new-board.hbs
@@ -11,9 +11,11 @@
           </button>
           <input type="file" name="board_upload" id="board_upload" tabindex="-1">
         </span>
-        <button type="button" class="btn btn-default" {{action "importFromHtml"}}>
-          {{t "Paste HTML" key="paste_html"}}
-        </button>
+        {{#if this.paste_html_import_enabled}}
+          <button type="button" class="btn btn-default" {{action "importFromHtml"}}>
+            {{t "Paste HTML" key="paste_html"}}
+          </button>
+        {{/if}}
         {{#if this.ai_board_generation_enabled}}
           <button type="button" class="btn btn-default" {{action "generateWithAi"}}>
             {{t "Generate with AI" key="generate_with_ai"}}
@@ -40,9 +42,11 @@
           </button>
           <input type="file" name="board_upload" id="board_upload" tabindex="-1">
         </span>
-        <button type="button" class="la-btn la-btn--ghost" {{action "importFromHtml"}}>
-          {{t "Paste HTML" key="paste_html"}}
-        </button>
+        {{#if this.paste_html_import_enabled}}
+          <button type="button" class="la-btn la-btn--ghost" {{action "importFromHtml"}}>
+            {{t "Paste HTML" key="paste_html"}}
+          </button>
+        {{/if}}
         {{#if this.ai_board_generation_enabled}}
           <button type="button" class="la-btn la-btn--ghost" {{action "generateWithAi"}}>
             {{t "Generate with AI" key="generate_with_ai"}}

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -14,7 +14,7 @@ module FeatureFlags
               'ai_compliance_logging', 'supervisor_consent_flow', 'product_telemetry',
               'telemetry_admin_panel',
               'tarheel_reader', 'auth_spa_transition', 'google_sso', 'quick_screen_eval',
-              'comprehensive_eval_ai', 'multi_user_board_import']
+              'comprehensive_eval_ai', 'multi_user_board_import', 'paste_html_import']
   ENABLED_FRONTEND_FEATURES = ['subscriptions', 'assessments', 'custom_sidebar', 'snapshots',
               'video_recording', 'goals', 'modeling', 'geo_sidebar', 'edit_before_copying',
               'core_reports', 'lessonpix', 'translation', 'fast_render',


### PR DESCRIPTION
Hide the Paste HTML button on create-board flows until the import experience is improved. Import Board(s) and Generate with AI are unchanged. The flag is available but not globally enabled; turn it on per user via settings feature_flags.paste_html_import or canary.