### PR TITLE
feat: prefetch lingolinq public board trees in session cache

### DIFF
--- a/app/frontend/app/utils/board_detail_cache.js
+++ b/app/frontend/app/utils/board_detail_cache.js
@@ -26,6 +26,10 @@ var TTL_MS = 5 * 60 * 1000;
 var MAX_PREFETCH = 20;
 var WARM_BATCH = 20;
 var WARM_BATCH_GAP_MS = 80;
+var CATALOG_TREE_GAP_MS = 400;
+var CATALOG_ROOTS_PER_PAGE = 50;
+var CATALOG_ROOT_CAP = 100;
+var CATALOG_ACCOUNT = 'lingolinq';
 
 // key (e.g. "user_name/boardname") → entry
 var _by_key = {};
@@ -177,6 +181,47 @@ function _warm_urls_batched(urls) {
   });
 }
 
+function _push_board_to_store(raw) {
+  try {
+    if (typeof window !== 'undefined' && LingoLinq && LingoLinq.store) {
+      var norm = LingoLinq.store.normalize('board', JSON.parse(JSON.stringify(raw)));
+      LingoLinq.store.push(norm);
+    }
+  } catch (e) { /* ignore */ }
+}
+
+function _catalog_prefetch_enabled(user) {
+  try {
+    if (typeof window !== 'undefined' && LingoLinq && LingoLinq.appState) {
+      return !!LingoLinq.appState.get('feature_flags.catalog_board_prefetch');
+    }
+    if (user && user.get) {
+      var flags = user.get('feature_flags');
+      if (flags && flags.catalog_board_prefetch) { return true; }
+    }
+  } catch (e) { /* app may not be booted yet */ }
+  return false;
+}
+
+function _ingest_tree_response(cache, data, warm_opts, options) {
+  options = options || {};
+  if (!data || !data.root || !data.root.board) { return false; }
+  var root_raw = normalize_board_payload(data.root);
+  if (!root_raw) { return false; }
+  cache.set(root_raw);
+  if (options.warm_root_images !== false) {
+    cache.warm_images(root_raw, warm_opts);
+  }
+  _push_board_to_store(root_raw);
+  (data.descendants || []).forEach(function(wrapped) {
+    var sub_raw = normalize_board_payload(wrapped);
+    if (!sub_raw) { return; }
+    cache.set(sub_raw);
+    _push_board_to_store(sub_raw);
+  });
+  return true;
+}
+
 function _collect_linked_lookups(raw) {
   var lookups = [];
   var seen = {};
@@ -277,6 +322,8 @@ export default {
     _inflight = {};
     _warmed = {};
     _warmed_urls = {};
+    this._prefetched_user_ids = {};
+    this._prefetched_catalog_user_ids = {};
   },
 
   // Warm the browser image cache for every button image URL on the
@@ -428,59 +475,127 @@ export default {
     var home_key = user.get('preferences.home_board.key');
     var home_id = user.get('preferences.home_board.id');
     var lookup = home_key || home_id;
-    if (!lookup) { return; }
     var _this = this;
     var warm_opts = {
       skin: user.get('preferences.skin'),
       preferred_symbols: user.get('preferences.preferred_symbols')
     };
+    var start_catalog_prefetch = function() {
+      _this.prefetch_lingolinq_catalog(user, warm_opts);
+    };
     // Defer slightly so this doesn't compete with the post-login UI
     // render. By the time the user finishes reading the dashboard,
     // the tree is cached and Boards-tab navigation is instant.
     runLater(function() {
+      if (!lookup) {
+        start_catalog_prefetch();
+        return;
+      }
       persistence.ajax('/api/v1/boards/' + lookup + '/tree', { type: 'GET' }).then(function(data) {
-        if (!data || !data.root || !data.root.board) { return; }
-        var root_raw = normalize_board_payload(data.root);
-        if (!root_raw) { return; }
-        _this.set(root_raw);
-        _this.warm_images(root_raw, warm_opts);
-        // Try to push root into Ember Data store too so the route's
-        // cache-hit check (which requires `cached_record`) passes
-        // when the user navigates to it. The store may not be the
-        // same one as the route uses — fall back silently if so.
-        try {
-          if (typeof window !== 'undefined' && LingoLinq && LingoLinq.store) {
-            var rootNorm = LingoLinq.store.normalize('board', JSON.parse(JSON.stringify(root_raw)));
-            LingoLinq.store.push(rootNorm);
-          }
-        } catch (e) { /* ignore */ }
-        // Cache + push every descendant — JSON only. We intentionally
-        // DO NOT warm-prefetch descendant images here: for a home
-        // board with many sub-boards (e.g. Quick Core 112 with ~95
-        // descendants × ~100 buttons each), warm_images() per
-        // descendant flooded the browser request queue with 8k+
-        // pending image requests, blocking everything else (including
-        // the Board Details modal's canvas image loads). Sub-board
-        // images now load lazily when the user actually navigates
-        // into that sub-board — the JSON cache still keeps the
-        // navigation fast; only the image fetch is deferred.
-        (data.descendants || []).forEach(function(wrapped) {
-          var sub_raw = normalize_board_payload(wrapped);
-          if (!sub_raw) { return; }
-          _this.set(sub_raw);
-          try {
-            if (typeof window !== 'undefined' && LingoLinq && LingoLinq.store) {
-              var subNorm = LingoLinq.store.normalize('board', JSON.parse(JSON.stringify(sub_raw)));
-              LingoLinq.store.push(subNorm);
-            }
-          } catch (e) { /* ignore */ }
-        });
+        _ingest_tree_response(_this, data, warm_opts);
       }, function() {
         // Allow a retry on the next observer fire — the network may
         // have been unavailable at session-start.
         delete _this._prefetched_user_ids[user_id];
-      });
+      }).then(start_catalog_prefetch, start_catalog_prefetch);
     }, 400);
+  },
+
+  // After the home board tree is cached, prefetch full JSON trees for
+  // every public root board on the official lingolinq account so
+  // home-board picker / catalog navigation is instant in-session.
+  prefetch_lingolinq_catalog: function(user, warm_opts) {
+    if (!user || !user.get) { return RSVP.resolve(); }
+    if (!_catalog_prefetch_enabled(user)) { return RSVP.resolve(); }
+    var user_id = user.get('id');
+    if (!user_id) { return RSVP.resolve(); }
+    this._prefetched_catalog_user_ids = this._prefetched_catalog_user_ids || {};
+    if (this._prefetched_catalog_user_ids[user_id]) { return RSVP.resolve(); }
+    this._prefetched_catalog_user_ids[user_id] = true;
+
+    var _this = this;
+    warm_opts = warm_opts || {
+      skin: user.get('preferences.skin'),
+      preferred_symbols: user.get('preferences.preferred_symbols')
+    };
+    var ingested_count = 0;
+    var root_keys = [];
+
+    var collect_roots = function(list_url) {
+      if (typeof document !== 'undefined' && document.hidden) {
+        return RSVP.resolve();
+      }
+      return persistence.ajax(list_url, { type: 'GET' }).then(function(data) {
+        (data.board || []).forEach(function(b) {
+          if (b && b.key && root_keys.length < CATALOG_ROOT_CAP) {
+            root_keys.push(b.key);
+          }
+        });
+        if (data.meta && data.meta.more && data.meta.next_url && root_keys.length < CATALOG_ROOT_CAP) {
+          return collect_roots(data.meta.next_url);
+        }
+      });
+    };
+
+    var locale = user.get('preferences.locale');
+    var list_query = '/api/v1/boards?user_id=' + encodeURIComponent(CATALOG_ACCOUNT) +
+      '&public=true&sort=home_popularity&copies=false&per_page=' + CATALOG_ROOTS_PER_PAGE;
+    if (locale) {
+      list_query += '&locale=' + encodeURIComponent(locale);
+    }
+
+    var process_next_root = function(index) {
+      if (typeof document !== 'undefined' && document.hidden) {
+        return RSVP.resolve();
+      }
+      if (index >= root_keys.length) { return RSVP.resolve(); }
+      var key = root_keys[index];
+      var existing = _lookup(key);
+      if (existing && _is_fresh(existing) && existing.raw) {
+        return new RSVP.Promise(function(resolve) {
+          runLater(function() {
+            process_next_root(index + 1).then(resolve, resolve);
+          }, CATALOG_TREE_GAP_MS);
+        });
+      }
+      return persistence.ajax('/api/v1/boards/' + key + '/tree', { type: 'GET' }).then(function(data) {
+        if (_ingest_tree_response(_this, data, warm_opts)) {
+          ingested_count++;
+        }
+      }, function() {
+        /* swallow per-board errors */
+      }).then(function() {
+        return new RSVP.Promise(function(resolve) {
+          runLater(function() {
+            process_next_root(index + 1).then(resolve, resolve);
+          }, CATALOG_TREE_GAP_MS);
+        });
+      });
+    };
+
+    return new RSVP.Promise(function(resolve) {
+      runLater(function() {
+        collect_roots(list_query).then(function() {
+          if (!root_keys.length) {
+            delete _this._prefetched_catalog_user_ids[user_id];
+            return;
+          }
+          return process_next_root(0).then(function() {
+            if (!ingested_count) {
+              delete _this._prefetched_catalog_user_ids[user_id];
+            }
+          });
+        }, function() {
+          if (!ingested_count) {
+            delete _this._prefetched_catalog_user_ids[user_id];
+          }
+        }).then(function() {
+          resolve();
+        }, function() {
+          resolve();
+        });
+      }, CATALOG_TREE_GAP_MS);
+    });
   },
 
   // BFS-walk the reachable board tree starting from `raw`, fetching

--- a/app/frontend/tests/unit/utils/board-detail-cache-test.js
+++ b/app/frontend/tests/unit/utils/board-detail-cache-test.js
@@ -1,5 +1,8 @@
 import { module, test } from 'qunit';
+import RSVP from 'rsvp';
 import boardDetailCache from 'frontend/utils/board_detail_cache';
+import persistence from 'frontend/utils/persistence';
+import LingoLinq from 'frontend/app';
 
 module('Unit | Utility | board-detail-cache', function() {
   test('set skips re-caching a fresh entry unless force is true', function(assert) {
@@ -82,6 +85,179 @@ module('Unit | Utility | board-detail-cache', function() {
       window.Image = OriginalImage;
       assert.equal(loadCount, 0, 'does not create Image() for an already-warmed URL');
       done();
+    });
+  });
+
+  test('prefetch_lingolinq_catalog lists roots then fetches each tree', function(assert) {
+    boardDetailCache.clear();
+    var calls = [];
+    var origAjax = persistence.ajax;
+    var origAppState = LingoLinq.appState;
+
+    persistence.ajax = function(url, opts) {
+      calls.push({ url: url, type: opts && opts.type });
+      if (url.indexOf('user_id=lingolinq') !== -1) {
+        return RSVP.resolve({
+          board: [
+            { key: 'lingolinq/board-a', id: '1_1' },
+            { key: 'lingolinq/board-b', id: '1_2' }
+          ],
+          meta: { more: false }
+        });
+      }
+      if (url.indexOf('/tree') !== -1) {
+        var key = url.split('/boards/')[1].split('/tree')[0];
+        return RSVP.resolve({
+          root: { board: { key: key, id: '1_root', buttons: [] } },
+          descendants: key.indexOf('board-a') !== -1 ?
+            [{ board: { key: 'lingolinq/sub-a', id: '1_sub', buttons: [] } }] : []
+        });
+      }
+      return RSVP.reject({ error: 'unexpected url' });
+    };
+
+    LingoLinq.appState = {
+      get: function(path) {
+        if (path === 'feature_flags.catalog_board_prefetch') { return true; }
+        return null;
+      }
+    };
+
+    var user = {
+      get: function(k) {
+        if (k === 'id') { return '2_99'; }
+        if (k === 'preferences.skin') { return 'default'; }
+        if (k === 'preferences.preferred_symbols') { return 'original'; }
+        if (k === 'preferences.locale') { return 'en'; }
+        return null;
+      }
+    };
+
+    return boardDetailCache.prefetch_lingolinq_catalog(user).then(function() {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+
+      assert.ok(calls.some(function(c) { return c.url.indexOf('user_id=lingolinq') !== -1; }), 'lists lingolinq roots');
+      var treeCalls = calls.filter(function(c) { return c.url.indexOf('/tree') !== -1; });
+      assert.equal(treeCalls.length, 2, 'fetches a tree per root');
+      assert.ok(treeCalls[0].url.indexOf('board-a') !== -1, 'first tree is board-a');
+      assert.ok(treeCalls[1].url.indexOf('board-b') !== -1, 'second tree is board-b');
+      assert.ok(boardDetailCache.get('lingolinq/sub-a'), 'caches descendants as JSON only');
+    }, function(err) {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      throw err;
+    });
+  });
+
+  test('prefetch_lingolinq_catalog skips roots already fresh in cache', function(assert) {
+    boardDetailCache.clear();
+    var calls = [];
+    var origAjax = persistence.ajax;
+    var origAppState = LingoLinq.appState;
+
+    boardDetailCache.set({ key: 'lingolinq/board-a', id: '1_1', buttons: [] });
+
+    persistence.ajax = function(url) {
+      calls.push(url);
+      if (url.indexOf('user_id=lingolinq') !== -1) {
+        return RSVP.resolve({
+          board: [
+            { key: 'lingolinq/board-a', id: '1_1' },
+            { key: 'lingolinq/board-b', id: '1_2' }
+          ],
+          meta: { more: false }
+        });
+      }
+      if (url.indexOf('board-b/tree') !== -1) {
+        return RSVP.resolve({
+          root: { board: { key: 'lingolinq/board-b', id: '1_2', buttons: [] } },
+          descendants: []
+        });
+      }
+      return RSVP.reject({ error: 'unexpected url' });
+    };
+
+    LingoLinq.appState = {
+      get: function(path) {
+        if (path === 'feature_flags.catalog_board_prefetch') { return true; }
+        return null;
+      }
+    };
+
+    var user = {
+      get: function(k) {
+        if (k === 'id') { return '2_99'; }
+        return null;
+      }
+    };
+
+    return boardDetailCache.prefetch_lingolinq_catalog(user).then(function() {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      var treeCalls = calls.filter(function(u) { return u.indexOf('/tree') !== -1; });
+      assert.equal(treeCalls.length, 1, 'only fetches uncached root');
+      assert.ok(treeCalls[0].indexOf('board-b') !== -1, 'skipped cached board-a');
+    }, function(err) {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      throw err;
+    });
+  });
+
+  test('prefetch_lingolinq_catalog warms images for root only', function(assert) {
+    boardDetailCache.clear();
+    var origAjax = persistence.ajax;
+    var origAppState = LingoLinq.appState;
+    var warmCalls = [];
+    var origWarm = boardDetailCache.warm_images;
+
+    boardDetailCache.warm_images = function(raw) {
+      warmCalls.push(raw && raw.key);
+      return RSVP.resolve();
+    };
+
+    persistence.ajax = function(url) {
+      if (url.indexOf('user_id=lingolinq') !== -1) {
+        return RSVP.resolve({
+          board: [{ key: 'lingolinq/board-a', id: '1_1' }],
+          meta: { more: false }
+        });
+      }
+      if (url.indexOf('/tree') !== -1) {
+        return RSVP.resolve({
+          root: { board: { key: 'lingolinq/board-a', id: '1_1', buttons: [] } },
+          descendants: [{ board: { key: 'lingolinq/sub-a', id: '1_sub', buttons: [] } }]
+        });
+      }
+      return RSVP.reject({ error: 'unexpected url' });
+    };
+
+    LingoLinq.appState = {
+      get: function(path) {
+        if (path === 'feature_flags.catalog_board_prefetch') { return true; }
+        return null;
+      }
+    };
+
+    var user = {
+      get: function(k) {
+        if (k === 'id') { return '2_99'; }
+        return null;
+      }
+    };
+
+    return boardDetailCache.prefetch_lingolinq_catalog(user).then(function() {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      boardDetailCache.warm_images = origWarm;
+      assert.equal(warmCalls.length, 1, 'warms root images once');
+      assert.equal(warmCalls[0], 'lingolinq/board-a', 'does not warm descendant images');
+    }, function(err) {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      boardDetailCache.warm_images = origWarm;
+      throw err;
     });
   });
 });

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -527,6 +527,20 @@ frontend. See `lib/json_api/beta_feedback.rb` for the beta feedback admin case.
 
 **Root cause:** `board-detail-grid.hbs` renders `<img src={{btn.image_url}}>`. Edit-mode buttons are built via `_make_ember_btn`, which sets `image_url` once from `raw.image_urls`. `editManager.change_button` updated `local_image_url` (used by legacy fast_html / speak paths) but not `image_url`, so the grid stayed stale after save.
 
+---
+
+## Pattern: large background prefetches must keep descendant images lazy
+
+**Surface:** session-start board prefetch in `app/frontend/app/utils/board_detail_cache.js` for home and catalog trees.
+
+**Symptom:** prefetch appears to speed up navigation but can flood browser requests and delay interactive UI when every descendant image is warmed up front.
+
+**Root cause:** `/tree` returns root plus many descendants. Warming every descendant image immediately multiplies requests by depth and board size; this can saturate the browser queue and starve foreground actions.
+
+**Fix:** ingest all descendant JSON into `board_detail_cache`, but warm images for root boards only during background prefetch; let descendant images load lazily on actual navigation.
+
+**First seen in:** [2026-05-27-lingolinq-catalog-prefetch](./2026-05-27-lingolinq-catalog-prefetch.md)
+
 **Fix recipe:** In `change_button`, when setting `local_image_url` from `image.best_url`, also `emberSet(button, 'image_url', best)`. Template fallback: `(or btn.local_image_url btn.image_url)` for defense in depth.
 
 **Evidence:** `app/frontend/app/utils/edit_manager.js`, `app/frontend/app/templates/components/board-detail-grid.hbs`; commit `770a8c624`. Task log (local): `2026-05-27-button-image-use-this.md`.

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -14,7 +14,8 @@ module FeatureFlags
               'ai_compliance_logging', 'supervisor_consent_flow', 'product_telemetry',
               'telemetry_admin_panel',
               'tarheel_reader', 'auth_spa_transition', 'google_sso', 'quick_screen_eval',
-              'comprehensive_eval_ai', 'multi_user_board_import', 'paste_html_import']
+              'comprehensive_eval_ai', 'multi_user_board_import', 'paste_html_import',
+              'catalog_board_prefetch']
   ENABLED_FRONTEND_FEATURES = ['subscriptions', 'assessments', 'custom_sidebar', 'snapshots',
               'video_recording', 'goals', 'modeling', 'geo_sidebar', 'edit_before_copying',
               'core_reports', 'lessonpix', 'translation', 'fast_render',


### PR DESCRIPTION
After home-board prefetch, add a background catalog prefetch for public root boards owned by `lingolinq`, caching their `/tree` JSON with serial throttling and cache-skip checks to keep navigation fast without flooding image requests. Also harden board-detail cache tests by replacing timeout-based waits with promise-based completion.