### PR TITLE
fix(security): route admin database_contents through model allowlist (#286)

### DIFF
--- a/app/controllers/api/database_contents_controller.rb
+++ b/app/controllers/api/database_contents_controller.rb
@@ -5,11 +5,50 @@ class Api::DatabaseContentsController < ApplicationController
   DEFAULT_LIMIT = 50
   MAX_LIMIT = 500
 
+  # Deny-by-default allowlist for the admin schema explorer. Only the tables
+  # listed here may be browsed; every other table returns 404. Each entry maps a
+  # table to its ActiveRecord model so rows are read through the model layer
+  # (never via raw `SELECT *`), and the model's secure_serialize column is
+  # stripped from the response automatically (see #exposable_columns).
+  #
+  # Tables that hold regulated PII/PHI in non-encrypted columns (users,
+  # log_sessions, contact_messages, devices, ...) or plaintext credentials
+  # (developer_keys) are deliberately omitted. board_locales is also omitted:
+  # it is a search/tsvector table whose search_string and tsv_search_string are
+  # a plaintext, denormalized copy of board content (button labels), so it
+  # carries the same FERPA/HIPAA data that secure_serialize protects with no
+  # admin-browse value. Widen this map only after a privacy review of every
+  # non-encrypted column the candidate table would surface.
+  ALLOWED_MODELS = {
+    'organizations'          => 'Organization',
+    'boards'                 => 'Board',
+    'licenses'               => 'License',
+    'library_caches'         => 'LibraryCache',
+    'word_data'              => 'WordData',
+    'weekly_stats_summaries' => 'WeeklyStatsSummary'
+  }.freeze
+
+  # Plaintext columns stripped in addition to each model's secure_serialize
+  # column. These hold credentials or identifying data that is not encrypted at
+  # rest, so the model layer would otherwise surface them:
+  # - organizations.external_auth_key/shortcut: SAML SSO auth hashes.
+  # - boards.search_string: denormalized board content (button labels), which is
+  #   AAC user vocabulary (FERPA/HIPAA), even though boards.settings is encrypted.
+  # - licenses.metadata/external_reference: License has no secure_serialize;
+  #   metadata is an untyped catch-all and external_reference is a PO/Stripe id.
+  SENSITIVE_COLUMNS = {
+    'organizations' => ['external_auth_key', 'external_auth_shortcut'],
+    'boards'        => ['search_string'],
+    'licenses'      => ['metadata', 'external_reference']
+  }.freeze
+
   # GET /api/v1/database_contents?table=NAME&limit=50&offset=0
-  # Read-only paginated dump of a public table's rows. Admin / admin_support_actions only.
+  # Read-only paginated dump of an allowlisted table's rows. Admin /
+  # admin_support_actions only. Reads route through the model so encrypted
+  # (secure_serialize) and other sensitive columns are never exposed.
   def index
-    table = params[:table].to_s
-    unless allowed_table?(table)
+    model = allowed_model(params[:table].to_s)
+    unless model
       return api_error(404, {error: 'Table not found'})
     end
 
@@ -17,20 +56,21 @@ class Api::DatabaseContentsController < ApplicationController
     limit = [[raw_limit, 1].max, MAX_LIMIT].min
     offset = [params[:offset].to_i, 0].max
 
-    conn = ActiveRecord::Base.connection
-    quoted = conn.quote_table_name(table)
-    columns = conn.columns(table).map(&:name)
+    columns = exposable_columns(model)
 
-    rows_result = conn.exec_query("SELECT * FROM #{quoted} ORDER BY 1 LIMIT #{limit.to_i} OFFSET #{offset.to_i}")
-    total, total_exact = approximate_count(conn, table)
-
-    serialized = rows_result.map do |row|
-      columns.map { |c| serialize_value(row[c]) }
+    records = model.order(model.primary_key).limit(limit).offset(offset)
+    serialized = records.map do |record|
+      attrs = record.attributes
+      columns.map { |c| serialize_value(attrs[c]) }
     end
+
+    total, total_exact = approximate_count(model)
+
+    log_access(model.table_name, limit, offset, serialized.length)
 
     render json: {
       database_contents: {
-        table: table,
+        table: model.table_name,
         columns: columns,
         rows: serialized,
         total: total,
@@ -43,32 +83,45 @@ class Api::DatabaseContentsController < ApplicationController
 
   private
 
-  def allowed_tables
-    @allowed_tables ||= ActiveRecord::Base.connection.exec_query(
-      "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
-    ).map { |r| r['table_name'] }
+  def allowed_model(table)
+    return nil if table.blank?
+    class_name = ALLOWED_MODELS[table]
+    return nil unless class_name
+    # A misconfigured allowlist entry should 404, never raise a 500.
+    class_name.safe_constantize
   end
 
-  def allowed_table?(name)
-    return false if name.blank?
-    return false unless name =~ /\A[a-zA-Z0-9_]+\z/
-    allowed_tables.include?(name)
+  # Columns safe to surface: every DB column minus the model's secure_serialize
+  # column (the encrypted blob) and any explicitly denied plaintext columns.
+  # This is what guarantees encrypted/sensitive data never reaches the response,
+  # even if a new secure column is later added to an allowlisted model.
+  def exposable_columns(model)
+    stripped = []
+    if model.respond_to?(:secure_column) && model.secure_column
+      stripped << model.secure_column.to_s
+    end
+    stripped += (SENSITIVE_COLUMNS[model.table_name] || [])
+    model.column_names - stripped
   end
 
   # Cheap approximate count via pg_class.reltuples for big tables; falls back
-  # to exact COUNT(*) under the threshold so small tables still show truth.
+  # to an exact count under the threshold so small tables still show truth.
   # Returns [count, exact_bool].
   APPROX_COUNT_THRESHOLD = 10_000
-  def approximate_count(conn, table)
+  def approximate_count(model)
+    conn = model.connection
     row = conn.exec_query(
-      "SELECT reltuples::bigint AS estimate FROM pg_class WHERE relname = #{conn.quote(table)} LIMIT 1"
+      "SELECT reltuples::bigint AS estimate FROM pg_class WHERE relname = #{conn.quote(model.table_name)} LIMIT 1"
     ).first
     estimate = row ? row['estimate'].to_i : 0
-    if estimate < APPROX_COUNT_THRESHOLD
-      exact = conn.exec_query("SELECT COUNT(*) AS c FROM #{conn.quote_table_name(table)}").first['c'].to_i
-      [exact, true]
+    # pg_class.reltuples is -1 (or 0) for a table that has never been analyzed,
+    # which can be a huge table with stale stats. Only run the exact COUNT(*)
+    # when the estimate is a real, small, non-negative value; otherwise fall
+    # back to the (possibly unknown) estimate rather than scanning a big table.
+    if estimate >= 0 && estimate < APPROX_COUNT_THRESHOLD
+      [model.count, true]
     else
-      [estimate, false]
+      [[estimate, 0].max, false]
     end
   end
 
@@ -83,6 +136,22 @@ class Api::DatabaseContentsController < ApplicationController
     else
       v.to_s
     end
+  end
+
+  # Record who read which table, for FERPA/HIPAA accounting-of-disclosures.
+  # Only successful, authorized reads of real data reach here (404/403 paths
+  # disclose nothing). Auditing is best-effort: an audit-write failure must
+  # never break a read that the requester is already authorized to perform.
+  def log_access(table, limit, offset, returned)
+    AuditEvent.log_command(@api_user&.global_id || 'unknown', {
+      'type' => 'database_contents',
+      'command' => table,
+      'limit' => limit,
+      'offset' => offset,
+      'returned' => returned
+    })
+  rescue => e
+    Rails.logger.error("database_contents audit log failed: #{e.class}: #{e.message}")
   end
 
   def require_schema_explorer_access

--- a/spec/controllers/api/database_contents_controller_spec.rb
+++ b/spec/controllers/api/database_contents_controller_spec.rb
@@ -1,15 +1,32 @@
 require 'spec_helper'
 
 describe Api::DatabaseContentsController, :type => :controller do
+  def make_admin
+    token_user
+    @user.settings['admin'] = true
+    @user.save
+  end
+
+  # Mirrors the controller's stripping rule so column expectations stay in sync
+  # with ALLOWED_MODELS / SENSITIVE_COLUMNS without duplicating literals.
+  def columns_stripped_for(model)
+    stripped = []
+    if model.respond_to?(:secure_column) && model.secure_column
+      stripped << model.secure_column.to_s
+    end
+    stripped += (Api::DatabaseContentsController::SENSITIVE_COLUMNS[model.table_name] || [])
+    stripped
+  end
+
   describe 'index' do
     it 'should require api token' do
-      get :index, params: {table: 'users'}
+      get :index, params: {table: 'organizations'}
       assert_missing_token
     end
 
     it 'should return forbidden for a non-admin user' do
       token_user
-      get :index, params: {table: 'users'}
+      get :index, params: {table: 'organizations'}
       assert_error('Not authorized', 403)
     end
 
@@ -18,11 +35,12 @@ describe Api::DatabaseContentsController, :type => :controller do
       token_user
       admin_org.add_manager(@user.user_name, true)
 
-      get :index, params: {table: 'users', limit: 5}
+      Organization.create
+      get :index, params: {table: 'organizations', limit: 5}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
       payload = json['database_contents']
-      expect(payload['table']).to eq('users')
+      expect(payload['table']).to eq('organizations')
       expect(payload['columns']).to be_a(Array)
       expect(payload['columns']).to include('id')
       expect(payload['rows']).to be_a(Array)
@@ -32,32 +50,172 @@ describe Api::DatabaseContentsController, :type => :controller do
     end
 
     it 'should return 404 for an unknown table' do
-      token_user
-      @user.settings['admin'] = true
-      @user.save
-
+      make_admin
       get :index, params: {table: 'nope_does_not_exist'}
       expect(response.status).to eq(404)
     end
 
     it 'should reject table names with sql-meta characters' do
-      token_user
-      @user.settings['admin'] = true
-      @user.save
-
-      get :index, params: {table: 'users; DROP TABLE foo'}
+      make_admin
+      get :index, params: {table: 'organizations; DROP TABLE foo'}
       expect(response.status).to eq(404)
     end
 
     it 'should clamp limit to MAX_LIMIT' do
-      token_user
-      @user.settings['admin'] = true
-      @user.save
-
-      get :index, params: {table: 'users', limit: 99999}
+      make_admin
+      get :index, params: {table: 'organizations', limit: 99999}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
       expect(json['database_contents']['limit']).to eq(Api::DatabaseContentsController::MAX_LIMIT)
+    end
+
+    # Deny-by-default: tables that hold regulated PII/PHI or credentials must not
+    # be browsable even by an admin, since this endpoint dumps whole rows.
+    ['users', 'log_sessions', 'contact_messages', 'devices', 'developer_keys', 'audit_events'].each do |table|
+      it "should return 404 for non-allowlisted sensitive table #{table}" do
+        make_admin
+        get :index, params: {table: table}
+        expect(response.status).to eq(404)
+        json = JSON.parse(response.body)
+        expect(json['error']).to eq('Table not found')
+      end
+    end
+
+    it 'should never expose a model secure_serialize column' do
+      make_admin
+      org = Organization.create
+      org.settings['secret_pii_marker'] = 'TOP-SECRET-PII-VALUE'
+      org.save
+
+      get :index, params: {table: 'organizations'}
+      expect(response.successful?).to eq(true)
+      json = JSON.parse(response.body)
+      columns = json['database_contents']['columns']
+      expect(columns).not_to include('settings')
+      expect(columns).to include('id')
+      expect(columns).to include('admin')
+      # The decrypted secret must not surface anywhere in the payload, and the
+      # raw encrypted blob is never serialized either.
+      expect(response.body).not_to include('TOP-SECRET-PII-VALUE')
+      expect(response.body).not_to include('secret_pii_marker')
+    end
+
+    it 'should strip non-encrypted sensitive columns (SSO auth keys)' do
+      make_admin
+      org = Organization.create
+      # Write raw column values, bypassing the callback that derives them.
+      org.update_columns(external_auth_key: 'sso-secret-key-123', external_auth_shortcut: 'sso-shortcut-456')
+
+      get :index, params: {table: 'organizations'}
+      expect(response.successful?).to eq(true)
+      json = JSON.parse(response.body)
+      columns = json['database_contents']['columns']
+      expect(columns).not_to include('external_auth_key')
+      expect(columns).not_to include('external_auth_shortcut')
+      expect(response.body).not_to include('sso-secret-key-123')
+      expect(response.body).not_to include('sso-shortcut-456')
+    end
+
+    # Every allowlisted entry must resolve to a real model and serve a 200,
+    # never raise (which would surface as a 500). Catches a future typo or a
+    # removed model at CI time rather than in production.
+    Api::DatabaseContentsController::ALLOWED_MODELS.each do |table, class_name|
+      it "should resolve allowlisted table #{table} and strip its secure column" do
+        make_admin
+        get :index, params: {table: table, limit: 1}
+        expect(response.successful?).to eq(true)
+        json = JSON.parse(response.body)
+        columns = json['database_contents']['columns']
+        model = class_name.constantize
+        if model.respond_to?(:secure_column) && model.secure_column
+          expect(columns).not_to include(model.secure_column.to_s)
+        end
+        expect(columns).to match_array(model.column_names - columns_stripped_for(model))
+      end
+    end
+
+    it 'should serve a no-secure-column allowlisted table (licenses)' do
+      # Exercises the exposable_columns guard for a model that never calls
+      # secure_serialize, so respond_to?(:secure_column) is false.
+      make_admin
+      expect(License.respond_to?(:secure_column)).to eq(false)
+      get :index, params: {table: 'licenses'}
+      expect(response.successful?).to eq(true)
+      json = JSON.parse(response.body)
+      columns = json['database_contents']['columns']
+      # licenses has no encrypted column, so its plaintext metadata and the
+      # PO/Stripe external_reference must be stripped explicitly.
+      expect(columns).not_to include('metadata')
+      expect(columns).not_to include('external_reference')
+    end
+
+    it 'should strip the plaintext board search_string (AAC vocabulary)' do
+      make_admin
+      org = Organization.create
+      board = Board.create(user: @user)
+      board.update_column(:search_string, 'grandma hospital seizure medication')
+
+      get :index, params: {table: 'boards'}
+      expect(response.successful?).to eq(true)
+      json = JSON.parse(response.body)
+      columns = json['database_contents']['columns']
+      # boards.settings is encrypted (stripped automatically); search_string is a
+      # plaintext denormalized copy of board content and must be stripped too.
+      expect(columns).not_to include('settings')
+      expect(columns).not_to include('search_string')
+      expect(response.body).not_to include('grandma hospital seizure medication')
+    end
+
+    it 'should not allowlist the board_locales search/tsvector table' do
+      make_admin
+      get :index, params: {table: 'board_locales'}
+      expect(response.status).to eq(404)
+    end
+
+    it 'should write an AuditEvent for a successful authorized read' do
+      make_admin
+      Organization.create
+      expect {
+        get :index, params: {table: 'organizations', limit: 5, offset: 0}
+      }.to change { AuditEvent.count }.by(1)
+      expect(response.successful?).to eq(true)
+      event = AuditEvent.last
+      expect(event.user_key).to eq(@user.global_id)
+      expect(event.data['type']).to eq('database_contents')
+      expect(event.data['command']).to eq('organizations')
+      expect(event.data['limit']).to eq(5)
+    end
+
+    it 'should not write an AuditEvent for a non-allowlisted table (no disclosure)' do
+      make_admin
+      expect {
+        get :index, params: {table: 'users'}
+      }.not_to change { AuditEvent.count }
+      expect(response.status).to eq(404)
+    end
+
+    it 'should not write an AuditEvent for an unauthorized request' do
+      token_user
+      expect {
+        get :index, params: {table: 'organizations'}
+      }.not_to change { AuditEvent.count }
+      expect(response.status).to eq(403)
+    end
+
+    it 'should route reads through the model and return only exposable columns' do
+      make_admin
+      org = Organization.create(admin: true)
+
+      get :index, params: {table: 'organizations'}
+      expect(response.successful?).to eq(true)
+      json = JSON.parse(response.body)
+      payload = json['database_contents']
+      # Each row is an array aligned to the columns array, with no secure/sensitive cols.
+      expect(payload['rows']).to be_a(Array)
+      expect(payload['rows'].first).to be_a(Array)
+      expect(payload['rows'].first.length).to eq(payload['columns'].length)
+      expected = Organization.column_names - ['settings', 'external_auth_key', 'external_auth_shortcut']
+      expect(payload['columns']).to match_array(expected)
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes the Section 1 finding in #286. `GET /api/v1/database_contents` read rows via raw `exec_query("SELECT *")`, serializing the underlying column bytes and bypassing the `secure_serialize` (go_secure) decryption/abstraction layer. That exposed encrypted FERPA/HIPAA blobs (e.g. `users.settings`, `log_sessions.data`, `contact_messages.settings`) and every other column of any public table to admin / admin_support_actions users, with no field-level control. Legacy `**`-prefixed rows would have leaked plaintext.

## What changed

- **Deny-by-default `(table -> model)` allowlist** (`ALLOWED_MODELS`). Any table not listed returns 404. `users`, `log_sessions`, `contact_messages`, `devices`, `developer_keys`, and all log/audit tables are no longer browsable.
- **Reads route through the ActiveRecord model**, never raw SQL. `exposable_columns` strips the model's `secure_serialize` column automatically (fail-safe for any future encrypted column) plus an explicit `SENSITIVE_COLUMNS` denylist for plaintext landmines.
- `safe_constantize` so a misconfigured allowlist entry returns 404 instead of a 500.
- **`AuditEvent` logged per successful read** (requester, table, limit, offset, rows returned) for FERPA/HIPAA accounting-of-disclosures. Best-effort / fail-open: an audit-write error never breaks an authorized read. 404/403 paths are not logged (no disclosure).
- `model.count` guarded against never-analyzed large tables (`pg_class.reltuples = -1`).

## Dual-reviewer pass

Ran the senior-dev (`/review-pr`) then red-team (`/adversary-review`) passes. The adversary caught three real plaintext leaks the first two passes missed, all verified against the code before fixing:

- **High** `boards.search_string`: plaintext denormalized board content (button labels = AAC user vocabulary). Now stripped via `SENSITIVE_COLUMNS`.
- **High** `board_locales.search_string` + `tsv_search_string`: same data plus the tsvector. `board_locales` removed from the allowlist entirely (search table, no admin-browse value).
- **Medium** `licenses.metadata` + `external_reference`: plaintext (`License` has no `secure_serialize`). Now stripped.

Audience was verified to be managers of the global admin org (`Organization.admin_manager?`), i.e. LingoLinq staff, so the cross-tenant support view is intended; no audience change was needed.

## Tests

`spec/controllers/api/database_contents_controller_spec.rb`: 27 examples, 0 failures. Covers auth gates, 404 for each sensitive/credential table, proof that decrypted secrets and plaintext sensitive columns never appear in the body, the audit-event write, and column/row shape.

## Follow-up (not in this PR)

The sibling `GET /api/v1/database_schema` (metadata only, lower stakes) has the same no-audit gap. Worth a separate issue rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)