### PR TITLE
fix(security): redact secure_serialize columns in /database admin dump

### DIFF
--- a/app/controllers/api/database_contents_controller.rb
+++ b/app/controllers/api/database_contents_controller.rb
@@ -9,6 +9,25 @@ class Api::DatabaseContentsController < ApplicationController
   # never leaves the model layer through this raw SELECT * dump.
   REDACTED_PLACEHOLDER = '[redacted: secured]'
 
+  # PaperTrail snapshot columns embed the raw ciphertext of a secured column for
+  # any paper-trailed secured model (e.g. User/Board settings), so the versions
+  # audit table re-exposes the same encrypted blobs even though it has no
+  # secure_serialize of its own. Redact those snapshot columns by table name.
+  SNAPSHOT_REDACTED_COLUMNS = { 'versions' => %w[object object_changes] }.freeze
+
+  # Plaintext columns holding live credentials or impersonation tokens that are
+  # NOT secure_serialize'd, so model introspection cannot find them. Redacted by
+  # table name. A broader sensitive-plaintext-column audit is tracked as a
+  # follow-up to #286.
+  SENSITIVE_PLAINTEXT_COLUMNS = {
+    'developer_keys' => %w[secret key],
+    'purchase_tokens' => %w[token],
+    'organizations' => %w[external_auth_key],
+    'supervisor_relationships' => %w[consent_response_token],
+    'beta_feedback_recordings' => %w[token],
+    'external_nonces' => %w[nonce]
+  }.freeze
+
   # GET /api/v1/database_contents?table=NAME&limit=50&offset=0
   # Read-only paginated dump of a public table's rows. Admin / admin_support_actions only.
   def index
@@ -24,7 +43,9 @@ class Api::DatabaseContentsController < ApplicationController
     conn = ActiveRecord::Base.connection
     quoted = conn.quote_table_name(table)
     columns = conn.columns(table).map(&:name)
-    redacted = self.class.secured_columns_by_table[table] || []
+    redacted = ((self.class.secured_columns_by_table[table] || []) +
+                SNAPSHOT_REDACTED_COLUMNS.fetch(table, []) +
+                SENSITIVE_PLAINTEXT_COLUMNS.fetch(table, [])) & columns
 
     rows_result = conn.exec_query("SELECT * FROM #{quoted} ORDER BY 1 LIMIT #{limit.to_i} OFFSET #{offset.to_i}")
     total, total_exact = approximate_count(conn, table)

--- a/app/controllers/api/database_contents_controller.rb
+++ b/app/controllers/api/database_contents_controller.rb
@@ -5,6 +5,10 @@ class Api::DatabaseContentsController < ApplicationController
   DEFAULT_LIMIT = 50
   MAX_LIMIT = 500
 
+  # Emitted in place of any secure_serialize column so the encrypted-at-rest blob
+  # never leaves the model layer through this raw SELECT * dump.
+  REDACTED_PLACEHOLDER = '[redacted: secured]'
+
   # GET /api/v1/database_contents?table=NAME&limit=50&offset=0
   # Read-only paginated dump of a public table's rows. Admin / admin_support_actions only.
   def index
@@ -20,18 +24,20 @@ class Api::DatabaseContentsController < ApplicationController
     conn = ActiveRecord::Base.connection
     quoted = conn.quote_table_name(table)
     columns = conn.columns(table).map(&:name)
+    redacted = self.class.secured_columns_by_table[table] || []
 
     rows_result = conn.exec_query("SELECT * FROM #{quoted} ORDER BY 1 LIMIT #{limit.to_i} OFFSET #{offset.to_i}")
     total, total_exact = approximate_count(conn, table)
 
     serialized = rows_result.map do |row|
-      columns.map { |c| serialize_value(row[c]) }
+      columns.map { |c| redacted.include?(c) ? REDACTED_PLACEHOLDER : serialize_value(row[c]) }
     end
 
     render json: {
       database_contents: {
         table: table,
         columns: columns,
+        redacted_columns: redacted,
         rows: serialized,
         total: total,
         total_exact: total_exact,
@@ -39,6 +45,23 @@ class Api::DatabaseContentsController < ApplicationController
         offset: offset
       }
     }
+  end
+
+  # table_name => [secure_serialize column names], by introspecting every model
+  # that declares a secure column (go_secure sets the class-level secure_column
+  # accessor). Memoized per process. Drives redaction so the secure_serialize
+  # decryption layer is never bypassed in the clear by the raw SELECT * dump.
+  def self.secured_columns_by_table
+    @secured_columns_by_table ||= begin
+      Rails.application.eager_load! unless Rails.application.config.eager_load
+      map = Hash.new { |h, k| h[k] = [] }
+      ActiveRecord::Base.descendants.each do |model|
+        next unless model.respond_to?(:secure_column) && model.secure_column
+        next unless (model.table_exists? rescue false)
+        map[model.table_name] << model.secure_column.to_s
+      end
+      map.transform_values(&:uniq)
+    end
   end
 
   private

--- a/spec/controllers/api/database_contents_controller_spec.rb
+++ b/spec/controllers/api/database_contents_controller_spec.rb
@@ -31,6 +31,53 @@ describe Api::DatabaseContentsController, :type => :controller do
       expect(payload['total']).to be_a(Integer)
     end
 
+    it 'redacts secure_serialize columns so raw secured values never leak' do
+      admin_org = Organization.create(admin: true)
+      token_user
+      admin_org.add_manager(@user.user_name, true)
+      @user.settings['secret_marker'] = 'TOP-SECRET-PII-MARKER-12345'
+      @user.save!
+
+      raw_settings = ActiveRecord::Base.connection.exec_query(
+        "SELECT settings FROM users WHERE id = #{@user.id.to_i}"
+      ).first['settings']
+
+      get :index, params: {table: 'users', limit: 50}
+      expect(response.successful?).to eq(true)
+      json = JSON.parse(response.body)
+      payload = json['database_contents']
+
+      settings_idx = payload['columns'].index('settings')
+      expect(settings_idx).to be_present
+      expect(payload['redacted_columns']).to include('settings')
+
+      # Every secured cell is redacted, and the encrypted blob never appears.
+      payload['rows'].each do |row|
+        expect(row[settings_idx]).to eq(Api::DatabaseContentsController::REDACTED_PLACEHOLDER)
+      end
+      expect(response.body).not_to include(raw_settings)
+      expect(response.body).not_to include('TOP-SECRET-PII-MARKER-12345')
+
+      # Non-secured columns are untouched: the explorer still works.
+      id_idx = payload['columns'].index('id')
+      uname_idx = payload['columns'].index('user_name')
+      row = payload['rows'].find { |r| r[id_idx].to_s == @user.id.to_s }
+      expect(row).to be_present
+      expect(row[uname_idx]).to eq(@user.user_name)
+    end
+
+    it 'reports no redacted columns for a table with no secure_serialize column' do
+      token_user
+      @user.settings['admin'] = true
+      @user.save
+
+      # versions has no secure_serialize column; redacted_columns should be empty.
+      get :index, params: {table: 'versions', limit: 5}
+      expect(response.successful?).to eq(true)
+      json = JSON.parse(response.body)
+      expect(json['database_contents']['redacted_columns']).to eq([])
+    end
+
     it 'should return 404 for an unknown table' do
       token_user
       @user.settings['admin'] = true

--- a/spec/controllers/api/database_contents_controller_spec.rb
+++ b/spec/controllers/api/database_contents_controller_spec.rb
@@ -66,13 +66,68 @@ describe Api::DatabaseContentsController, :type => :controller do
       expect(row[uname_idx]).to eq(@user.user_name)
     end
 
-    it 'reports no redacted columns for a table with no secure_serialize column' do
+    it 'redacts PaperTrail snapshot columns so secured blobs never leak via versions' do
       token_user
       @user.settings['admin'] = true
       @user.save
 
-      # versions has no secure_serialize column; redacted_columns should be empty.
-      get :index, params: {table: 'versions', limit: 5}
+      raw_settings = ActiveRecord::Base.connection.exec_query(
+        "SELECT settings FROM users WHERE id = #{@user.id.to_i}"
+      ).first['settings']
+
+      # A version row embeds the secured ciphertext in its snapshot, the way
+      # paper_trail records User/Board :settings changes.
+      PaperTrail::Version.create!(
+        item_type: 'User', item_id: @user.id, event: 'update',
+        object: {'settings' => raw_settings, 'marker' => 'VERSIONS-LEAK-MARKER-99'}.to_yaml
+      )
+
+      get :index, params: {table: 'versions', limit: 100}
+      expect(response.successful?).to eq(true)
+      json = JSON.parse(response.body)
+      payload = json['database_contents']
+
+      expect(payload['redacted_columns']).to include('object')
+      obj_idx = payload['columns'].index('object')
+      payload['rows'].each do |row|
+        expect(row[obj_idx]).to eq(Api::DatabaseContentsController::REDACTED_PLACEHOLDER)
+      end
+      expect(response.body).not_to include(raw_settings)
+      expect(response.body).not_to include('VERSIONS-LEAK-MARKER-99')
+    end
+
+    it 'redacts sensitive plaintext credential columns that are not secure_serialize' do
+      token_user
+      @user.settings['admin'] = true
+      @user.save
+
+      ActiveRecord::Base.connection.exec_query(
+        "INSERT INTO developer_keys (secret, key, created_at, updated_at) " \
+        "VALUES ('LIVE-OAUTH-SECRET-XYZ', 'CLIENT-KEY-ABC', now(), now())"
+      )
+
+      get :index, params: {table: 'developer_keys', limit: 50}
+      expect(response.successful?).to eq(true)
+      json = JSON.parse(response.body)
+      payload = json['database_contents']
+
+      expect(payload['redacted_columns']).to include('secret')
+      expect(payload['redacted_columns']).to include('key')
+      secret_idx = payload['columns'].index('secret')
+      payload['rows'].each do |row|
+        expect(row[secret_idx]).to eq(Api::DatabaseContentsController::REDACTED_PLACEHOLDER)
+      end
+      expect(response.body).not_to include('LIVE-OAUTH-SECRET-XYZ')
+      expect(response.body).not_to include('CLIENT-KEY-ABC')
+    end
+
+    it 'reports no redacted columns for a table with no secured or snapshot column' do
+      token_user
+      @user.settings['admin'] = true
+      @user.save
+
+      # schema_migrations has no secure_serialize and no snapshot column.
+      get :index, params: {table: 'schema_migrations', limit: 5}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
       expect(json['database_contents']['redacted_columns']).to eq([])


### PR DESCRIPTION
## Summary

The `/api/v1/database_contents` admin schema explorer ran `SELECT *` via `exec_query` and serialized every cell raw (`app/controllers/api/database_contents_controller.rb`), **bypassing the `secure_serialize` (go_secure) decryption layer**. That emitted the encrypted-at-rest blobs for ~30 models (`users.settings`, `log_sessions.data`, `contact_messages.settings`, `boards.settings`, `organizations.settings`, `api_calls.data`, etc.) in the clear to an admin API. FERPA/HIPAA-implicated.

This is the **Scot-owned High** finding in Section 1 of #286.

## Fix

- **Redact, do not decrypt.** Decrypting would worsen the leak. Instead, introspect `Model.secure_column` (go_secure sets a class-level accessor) to build a memoized `table_name => [secured columns]` map, and replace those cells with `[redacted: secured]`.
- Add `redacted_columns` to the payload (additive; `rows` shape unchanged, so the frontend schema explorer is unaffected).
- Non-secured columns are untouched, so the explorer remains useful.

## Why no feature flag

The CLAUDE.md feature-flag rule exists because AAC users are disruption-sensitive. This hardens an **admin-only internal API**, not an AAC-user-facing surface, so no flag is warranted.

## Residual (out of scope for this finding)

Plaintext PII columns that are sensitive-by-design but not `secure_serialize`'d (e.g. emails) remain visible to admins. That is pre-existing admin visibility; a column allow-list is a separate follow-up.

## Test plan

- [x] `bundle exec rspec spec/controllers/api/database_contents_controller_spec.rb` (8 examples, 0 failures)
- [x] New test proves: `redacted_columns` includes `settings`, every `settings` cell == `[redacted: secured]`, the raw ciphertext never appears in the response body, and a non-secured column (`user_name`) still shows its real value
- [x] New test proves a table with no secured column returns `redacted_columns: []`

## Reviewer note

Dual-reviewer (`/review-pr` Codex + `/adversary-review` Claude) per #286 Phase 1 governance, since this touches security + user-data flows. Do not merge until both pass. Refs #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)