### PR TITLE
fix(board-copy): defer buttonset rebuild to :slow queue to fix copy timeout

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1158,10 +1158,22 @@ class Board < ApplicationRecord
       async_during_bulk_copy = Thread.current[:bulk_copy_in_progress] &&
         ENV['ASYNC_BUTTONSET_DURING_BULK_COPY'].to_s.downcase != 'false'
 
+      # A brand-new board that is a copy of another board (or already references a
+      # downstream hierarchy) rebuilds the entire linked-board graph inline via the
+      # update_for below. The single-board copy path (POST /api/v1/boards ->
+      # Board.process_new) never sets Thread.current[:bulk_copy_in_progress] (only
+      # BoardSetCopier sets it), so without this the rebuild runs inline in the web
+      # request and can exceed the 15s Rack::Timeout, failing the copy with a 500.
+      # Route those to the :slow queue too. Toggle off via ASYNC_BUTTONSET_ON_COPY=false.
+      async_new_copy = is_new_board &&
+        (self.parent_board_id.present? || self.downstream_board_ids.any?) &&
+        ENV['ASYNC_BUTTONSET_ON_COPY'].to_s.downcase != 'false'
+
       # Always check if buttonset exists - create it if missing, update it if content changed
       if !existing_buttonset
-        if async_during_bulk_copy
-          Rails.logger.info("[Board#post_process] Deferring buttonset creation to :slow queue for board #{self.global_id} (bulk copy in progress)")
+        if async_during_bulk_copy || async_new_copy
+          defer_reason = async_during_bulk_copy ? 'bulk copy in progress' : 'new copied board (avoiding inline rebuild timeout)'
+          Rails.logger.info("[Board#post_process] Deferring buttonset creation to :slow queue for board #{self.global_id} (#{defer_reason})")
           BoardDownstreamButtonSet.schedule_for(:slow, :update_for, self.global_id, true)
         else
           # No buttonset exists - create it immediately (whether new board or not)

--- a/app/models/board_downstream_button_set.rb
+++ b/app/models/board_downstream_button_set.rb
@@ -414,7 +414,7 @@ class BoardDownstreamButtonSet < ApplicationRecord
     end
   end
 
-  def self.update_for(board_id, immediate_update=false, traversed_ids=[])
+  def self.update_for(board_id, immediate_update=false, traversed_ids=[], retry_count=0)
     traversed_ids ||= []
     key = "traversed/button_set/#{board_id}"
     cached_traversed = (JSON.parse(RedisInit.default.get(key)) rescue nil) || []
@@ -422,6 +422,19 @@ class BoardDownstreamButtonSet < ApplicationRecord
     traversed_ids = (traversed_ids + cached_traversed).uniq
 
     board = Board.find_by_global_id(board_id)
+    if !board
+      # Deferred rebuilds are enqueued from Board#post_process, which runs in an
+      # after_save callback (before COMMIT). A :slow worker can dequeue this job
+      # before the creating transaction commits, so the board row isn't visible
+      # yet. Re-enqueue a bounded number of times instead of silently leaving the
+      # buttonset unbuilt; give up only if the board never appears (e.g. rolled back).
+      if retry_count < 5
+        BoardDownstreamButtonSet.schedule_for(:slow, :update_for, board_id, immediate_update, traversed_ids, retry_count + 1)
+      else
+        Rails.logger.warn("[BoardDownstreamButtonSet.update_for] board #{board_id} not found after #{retry_count} retries, giving up")
+      end
+      return
+    end
     return if board && traversed_ids.include?(board.global_id)
     board.track_downstream_boards! if board && (!board.settings || !board.settings['full_set_revision'])
     if board

--- a/spec/models/board_downstream_button_set_spec.rb
+++ b/spec/models/board_downstream_button_set_spec.rb
@@ -10,11 +10,20 @@ describe BoardDownstreamButtonSet, :type => :model do
   end
   
   describe "update_for" do
-    it "should do nothing if a matching board does not exist" do
+    it "should not create a buttonset and should re-enqueue a bounded retry if a matching board is not yet visible" do
+      # The board may not be visible yet because the deferred job can run before the
+      # creating transaction commits; re-enqueue rather than silently doing nothing.
       cnt = BoardDownstreamButtonSet.count
+      expect(BoardDownstreamButtonSet).to receive(:schedule_for).with(:slow, :update_for, 'asdf', false, [], 1).once
       res = BoardDownstreamButtonSet.update_for('asdf')
       expect(res).to eq(nil)
       expect(BoardDownstreamButtonSet.count).to eq(cnt)
+    end
+
+    it "should give up (no further re-enqueue) once the retry budget is exhausted" do
+      expect(BoardDownstreamButtonSet).not_to receive(:schedule_for)
+      res = BoardDownstreamButtonSet.update_for('asdf', false, [], 5)
+      expect(res).to eq(nil)
     end
     
     it "should generate a button set for the specified board id" do

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -2359,6 +2359,22 @@ describe Board, :type => :model do
         expect(BoardDownstreamButtonSet).to receive(:schedule_for).with(:slow, :update_for, kind_of(String), true).at_least(:once)
         b.save
       end
+
+      it "builds the buttonset on the :slow queue after a deferred copy is processed (not left missing)" do
+        u = User.create
+        parent = Board.create(:user => u)
+        b = Board.new(:user => u)
+        b.parent_board_id = parent.id
+        b.settings = {'name' => "copied board", 'buttons' => [{'id' => 1, 'label' => "hi"}]}
+        b.save
+        # Deferred, so nothing was built inline in the request.
+        b.reload
+        expect(b.board_downstream_button_set).to eq(nil)
+        # The worker drains the :slow queue and the buttonset gets built (no permanent gap).
+        Worker.process_queues
+        b.reload
+        expect(b.board_downstream_button_set).not_to eq(nil)
+      end
     end
 
     it "should search for a better default icon if the default icon is being used" do

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -2309,6 +2309,58 @@ describe Board, :type => :model do
   end
   
   describe "post_process" do
+    context "buttonset creation for new copied boards" do
+      it "defers buttonset creation to the :slow queue for a brand-new copied board instead of rebuilding it inline" do
+        u = User.create
+        parent = Board.create(:user => u)
+        Worker.process_queues
+        b = Board.new(:user => u)
+        b.parent_board_id = parent.id
+        b.settings = {'name' => "copied board", 'buttons' => []}
+        # The crux of the fix: a new copy must NOT rebuild the downstream button set
+        # inline in the request (that inline traversal is what exceeded the 15s
+        # Rack::Timeout and failed the copy with a 500). It must defer to :slow.
+        expect(BoardDownstreamButtonSet).not_to receive(:update_for)
+        expect(BoardDownstreamButtonSet).to receive(:schedule_for).with(:slow, :update_for, kind_of(String), true).at_least(:once)
+        b.save
+      end
+
+      it "still builds the buttonset inline for a brand-new board with no downstream hierarchy" do
+        u = User.create
+        b = Board.new(:user => u)
+        b.settings = {'name' => "standalone board", 'buttons' => []}
+        # A from-scratch board with no links is cheap; keep the immediate inline build.
+        expect(BoardDownstreamButtonSet).to receive(:update_for).with(kind_of(String), true)
+        expect(BoardDownstreamButtonSet).not_to receive(:schedule_for).with(:slow, :update_for, anything, true)
+        b.save
+      end
+
+      it "builds the buttonset inline for a copy when ASYNC_BUTTONSET_ON_COPY is disabled (kill switch)" do
+        ENV['ASYNC_BUTTONSET_ON_COPY'] = 'false'
+        u = User.create
+        parent = Board.create(:user => u)
+        b = Board.new(:user => u)
+        b.parent_board_id = parent.id
+        b.settings = {'name' => "copied board", 'buttons' => []}
+        expect(BoardDownstreamButtonSet).to receive(:update_for).with(kind_of(String), true)
+        b.save
+      ensure
+        ENV.delete('ASYNC_BUTTONSET_ON_COPY')
+      end
+
+      it "defers when a brand-new board already references a downstream hierarchy even without a parent_board_id" do
+        u = User.create
+        b = Board.new(:user => u)
+        b.settings = {'name' => "links out", 'buttons' => []}
+        # Exercise the downstream_board_ids branch of the guard (not the parent_board_id one).
+        allow(b).to receive(:downstream_board_ids).and_return(['1_999'])
+        expect(b.parent_board_id).to be_nil
+        expect(BoardDownstreamButtonSet).not_to receive(:update_for)
+        expect(BoardDownstreamButtonSet).to receive(:schedule_for).with(:slow, :update_for, kind_of(String), true).at_least(:once)
+        b.save
+      end
+    end
+
     it "should search for a better default icon if the default icon is being used" do
       u = User.create
       b = Board.create(:user => u)


### PR DESCRIPTION
## Problem

Copying a board on staging failed with HTTP 500. Root cause: `Board#post_process` rebuilt the entire downstream button set inline in the web request via `BoardDownstreamButtonSet.update_for`, which traverses the full linked-board graph (per-board, per-locale inflection lookups) and exceeded the ~15s Rack::Timeout (`config/initializers/rack_timeout.rb`). The existing `:slow`-queue deferral only fired for `BoardSetCopier` bulk copies (`Thread.current[:bulk_copy_in_progress]`); the single-board copy path (`POST /api/v1/boards` -> `Board.process_new`) never set that flag, so it always ran inline.

Diagnosed from Render staging logs (request `772c8433`, 2026-05-27 23:53 UTC).

## Fix

- `Board#post_process`: also defer the buttonset rebuild to the `:slow` queue when a board is brand-new AND a copy (`parent_board_id` present) or already references a downstream hierarchy. Cheap from-scratch boards still build inline. Kill switch: `ASYNC_BUTTONSET_ON_COPY=false` (mirrors the existing `ASYNC_BUTTONSET_DURING_BULK_COPY`).
- `BoardDownstreamButtonSet.update_for`: re-enqueue a bounded retry (max 5) when the board is not yet visible, instead of silently no-opping. This closes an enqueue-before-commit race (the deferred job is scheduled from an `after_save` callback, before COMMIT) that could otherwise leave the buttonset permanently missing. This also self-heals the pre-existing bulk-copy path.

## Testing

New specs: defer-on-copy, inline-for-standalone, kill-switch, downstream-only branch, re-enqueue-on-missing, give-up-at-cap, and an integration spec that drains the `:slow` queue after a deferred copy and asserts the buttonset is actually built.

`bundle exec rspec spec/models/board_spec.rb spec/models/board_downstream_button_set_spec.rb` (relevant groups): 32 examples, 0 failures.

## Reviews

- Senior-dev pass (`/review-pr`): approve with comments, both addressed.
- Adversary pass (`/adversary-review`): one High (the commit-timing race), now fixed by the bounded re-enqueue, plus an integration spec proving the buttonset is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
