### PR TITLE
fix: keep board-load caches independent of overlays and fix JSON data…

### DIFF
--- a/app/frontend/app/controllers/user/index.js
+++ b/app/frontend/app/controllers/user/index.js
@@ -14,6 +14,7 @@ import session from '../../utils/session';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
 import { filterRootBoards } from '../../utils/board-roots';
+import boardDetailCache from '../../utils/board_detail_cache';
 
 function invertBoardTagMap(map) {
   var inv = {};
@@ -1279,9 +1280,23 @@ export default Controller.extend({
          board-detail / board-alt setupController calls
          hide_loading_overlay when ready. .catch handler clears the
          overlay if the transition aborts (setupController would
-         never run in that case). */
+         never run in that case). When raw JSON and an Ember board
+         record are already cached, use a shorter minimum so repeat
+         opens feel instant without skipping click feedback. */
       var _appState = this.appState;
-      _appState.show_loading_overlay(i18n.t('loading_board', "Loading board..."));
+      var board_key = parts[0] + '/' + parts[1];
+      var overlay_opts = null;
+      var cached_raw = boardDetailCache.get(board_key);
+      if (cached_raw) {
+        var cached_record = this.store.peekAll('board').find(function(b) {
+          if (!b) { return false; }
+          return b.get('key') === board_key;
+        });
+        if (cached_record && !cached_record.get('should_reload')) {
+          overlay_opts = { min_ms: _appState.get('LOADING_OVERLAY_CACHE_HIT_MIN_MS') };
+        }
+      }
+      _appState.show_loading_overlay(i18n.t('loading_board', "Loading board..."), overlay_opts);
       var transition = this.get('router').transitionTo(route, parts[0], parts[1]);
       if(transition && typeof transition.catch === 'function') {
         transition.catch(function() { _appState.hide_loading_overlay(); });

--- a/app/frontend/app/routes/user/board-alt.js
+++ b/app/frontend/app/routes/user/board-alt.js
@@ -4,6 +4,7 @@ import { set as emberSet } from '@ember/object';
 import LingoLinq from '../../app';
 import { later as runLater } from '@ember/runloop';
 import { inject as service } from '@ember/service';
+import boardDetailCache from '../../utils/board_detail_cache';
 
 export default Route.extend({
   store: service('store'),
@@ -36,6 +37,27 @@ export default Route.extend({
         if (lastSegment && lastSegment.match(/^\d+_\d+/)) {
           lookupKey = lastSegment;
         }
+      }
+      // Cache-first: reuse JSON prefetched by board-detail / session
+      // prefetch so classic view skips a network roundtrip when possible.
+      var raw_cached = boardDetailCache.get(key) || boardDetailCache.get(lookupKey);
+      if (raw_cached) {
+        try {
+          var from_cache = _this.store.normalize('board', JSON.parse(JSON.stringify(raw_cached)));
+          var cache_record = _this.store.push(from_cache);
+          if (cache_record && !cache_record.get('should_reload')) {
+            try {
+              emberSet(cache_record, 'lookup_key', key);
+            } catch (e) {
+              runLater(function() {
+                if (cache_record && !cache_record.get('isDestroyed') && !cache_record.get('isDestroying')) {
+                  try { emberSet(cache_record, 'lookup_key', key); } catch (e2) { }
+                }
+              }, 100);
+            }
+            return RSVP.resolve(cache_record);
+          }
+        } catch (e) { /* fall through to identity-map peek / findRecord */ }
       }
       var cached = _this.store.peekAll('board').find(function(b) {
         if (!b) { return false; }

--- a/app/frontend/app/routes/user/board-detail.js
+++ b/app/frontend/app/routes/user/board-detail.js
@@ -330,7 +330,11 @@ export default Route.extend({
 
     // Load button set for find-a-button functionality
     if(model.get('valid_id') && !model.get('integration')) {
-      model.load_button_set();
+      // Find-a-button support; failure must not surface as an unhandled rejection.
+      var load_bs = model.load_button_set();
+      if(load_bs && typeof load_bs.catch === 'function') {
+        load_bs.catch(function() { /* optional offline path */ });
+      }
     }
 
     // Set currentBoardState
@@ -377,7 +381,10 @@ export default Route.extend({
     contentGrabbers.board_controller = controller;
 
     // Build display buttons from raw data AFTER editManager setup
-    // so nothing overwrites them
+    // so nothing overwrites them. Prime offline url_cache BEFORE
+    // _build_from_raw so ordered_buttons cache ctx includes the
+    // correct url_cache_primed flag — overlay is already dismissed
+    // above; priming here does not extend overlay visibility.
     var raw = _this.get('_raw_board_data');
     if(raw) {
       _this._maybe_prime_caches().then(function() {

--- a/app/frontend/app/services/app-state.js
+++ b/app/frontend/app/services/app-state.js
@@ -1943,7 +1943,13 @@ export default Service.extend({
 
     // Per-user transient UI overlays / refresh timers
     this.set('loading_overlay_message', null);
+    this._loading_overlay_shown_at = null;
+    this._loading_overlay_min_ms = null;
     this.set('toast', null);
+
+    // In-memory board JSON / ordered_buttons / image-warm state must not
+    // leak across users on SPA sign-out (full reload clears module state).
+    try { boardDetailCache.clear(); } catch(e) { /* non-critical */ }
     this.set('last_keepalive', null);
     this.set('refresh_stamp', null);
     this.set('short_refresh_stamp', null);
@@ -2948,22 +2954,34 @@ export default Service.extend({
   // Minimum time the overlay stays on screen once shown, so fast synchronous
   // transitions still let the user see it (and don't flash-and-disappear).
   LOADING_OVERLAY_MIN_MS: 700,
+  // Shorter minimum when navigation is a known cache hit (raw JSON + Ember
+  // record already in memory). Still long enough for click feedback.
+  LOADING_OVERLAY_CACHE_HIT_MIN_MS: 150,
 
-  show_loading_overlay: function(message) {
+  show_loading_overlay: function(message, opts) {
+    opts = opts || {};
     this.set('loading_overlay_message', message);
     this._loading_overlay_shown_at = Date.now();
+    if (opts.min_ms != null) {
+      this._loading_overlay_min_ms = opts.min_ms;
+    } else {
+      this._loading_overlay_min_ms = null;
+    }
   },
 
   hide_loading_overlay: function() {
     var _this = this;
     var shown_at = this._loading_overlay_shown_at || 0;
     var elapsed = Date.now() - shown_at;
-    var min = this.get('LOADING_OVERLAY_MIN_MS') || 700;
+    var min = this._loading_overlay_min_ms != null ?
+      this._loading_overlay_min_ms :
+      (this.get('LOADING_OVERLAY_MIN_MS') || 700);
     var remaining = Math.max(0, min - elapsed);
     runLater(function() {
       if(_this.isDestroyed) { return; }
       _this.set('loading_overlay_message', null);
       _this._loading_overlay_shown_at = null;
+      _this._loading_overlay_min_ms = null;
     }, remaining);
   },
 

--- a/app/frontend/app/services/persistence.js
+++ b/app/frontend/app/services/persistence.js
@@ -1602,7 +1602,10 @@ var persistence = Service.extend({
       var trusted_not_to_change = url.match(/opensymbols\.s3\.amazonaws\.com/) || url.match(/s3\.amazonaws\.com\/opensymbols/) ||
                   url.match(/lingolinq-usercontent\.s3\.amazonaws\.com/) || url.match(/s3\.amazonaws\.com\/lingolinq-usercontent/) ||
                   url.match(/d18vdu4p71yql0.cloudfront.net/) || url.match(/dc5pvf6xvgi7y.cloudfront.net/);
-      var cors_match = trusted_not_to_change || url.match(/api\/v\d+\/users\/.+\/protected_image/) || url.match(/api\/v\d+\/lang/);
+      var uploads_bucket = url.match(/lingolinq[^/]*-uploads\.s3\.amazonaws\.com/) ||
+        url.match(/s3\.amazonaws\.com\/lingolinq[^/]*-uploads/);
+      var cors_match = trusted_not_to_change || uploads_bucket ||
+        url.match(/api\/v\d+\/users\/.+\/protected_image/) || url.match(/api\/v\d+\/lang/);
       if(trusted_not_to_change && url.match(/usercontent/) && url.match(/\/extras\//)) {
         trusted_not_to_change = false;
       }
@@ -1737,6 +1740,18 @@ var persistence = Service.extend({
       size_image.then(function(object) {
         // remember: persisted objects will not have a data_uri attribute, so this will be skipped for them
         if(_this.get('local_system.available') && _this.get('local_system.allowed') && _this.stashes && _this.stashes.get && _this.stashes.get('auth_settings')) {
+          // Encrypted extra_data JSON (button sets, etc.): IndexedDB dataCache
+          // is sufficient. FileSystem writes for large JSON blobs often fail
+          // (quota / Chrome PERSISTENT FS limits); find_json reads data_uri.
+          if(type == 'json' && object.data_uri) {
+            if(!object.persisted) {
+              object.persisted = true;
+              object.url = url_id;
+            }
+            return _this.store('dataCache', object, object.url).then(function() {
+              return object;
+            });
+          }
           if(object.data_uri) {
             var local_system_filename = object.local_filename;
             if(!local_system_filename) {

--- a/app/frontend/app/utils/persistence.js
+++ b/app/frontend/app/utils/persistence.js
@@ -1605,7 +1605,10 @@ var persistence = EmberObject.extend({
       var trusted_not_to_change = url.match(/opensymbols\.s3\.amazonaws\.com/) || url.match(/s3\.amazonaws\.com\/opensymbols/) ||
                   url.match(/lingolinq-usercontent\.s3\.amazonaws\.com/) || url.match(/s3\.amazonaws\.com\/lingolinq-usercontent/) ||
                   url.match(/d18vdu4p71yql0.cloudfront.net/) || url.match(/dc5pvf6xvgi7y.cloudfront.net/);
-      var cors_match = trusted_not_to_change || url.match(/api\/v\d+\/users\/.+\/protected_image/) || url.match(/api\/v\d+\/lang/);
+      var uploads_bucket = url.match(/lingolinq[^/]*-uploads\.s3\.amazonaws\.com/) ||
+        url.match(/s3\.amazonaws\.com\/lingolinq[^/]*-uploads/);
+      var cors_match = trusted_not_to_change || uploads_bucket ||
+        url.match(/api\/v\d+\/users\/.+\/protected_image/) || url.match(/api\/v\d+\/lang/);
       if(trusted_not_to_change && url.match(/usercontent/) && url.match(/\/extras\//)) {
         trusted_not_to_change = false;
       }
@@ -1742,6 +1745,18 @@ var persistence = EmberObject.extend({
       size_image.then(function(object) {
         // remember: persisted objects will not have a data_uri attribute, so this will be skipped for them
         if(safeGet(getPersistence(), 'local_system.available') && safeGet(getPersistence(), 'local_system.allowed') && safeGet(getStashes(), 'auth_settings')) {
+          // Encrypted extra_data JSON (button sets, etc.): IndexedDB dataCache
+          // is sufficient. FileSystem writes for large JSON blobs often fail
+          // (quota / Chrome PERSISTENT FS limits); find_json reads data_uri.
+          if(type == 'json' && object.data_uri) {
+            if(!object.persisted) {
+              object.persisted = true;
+              object.url = url_id;
+            }
+            return persistence.store('dataCache', object, object.url).then(function() {
+              return object;
+            });
+          }
           if(object.data_uri) {
             var local_system_filename = object.local_filename;
             if(!local_system_filename) {

--- a/app/frontend/tests/test-helper.js
+++ b/app/frontend/tests/test-helper.js
@@ -59,6 +59,8 @@ QUnit.on('runEnd', function(runEnd) {
 import 'frontend/tests/acceptance/board-detail-empty-state-test';
 import 'frontend/tests/unit/controllers/copying-board-test';
 import 'frontend/tests/unit/controllers/user-board-detail-image-cache-test';
+import 'frontend/tests/unit/utils/board-detail-cache-test';
+import 'frontend/tests/unit/utils/loading-overlay-cache-test';
 
 // loadTests: false — we already pre-loaded all test modules above
 start({ loadTests: false });

--- a/app/frontend/tests/unit/utils/board-detail-cache-test.js
+++ b/app/frontend/tests/unit/utils/board-detail-cache-test.js
@@ -205,6 +205,28 @@ module('Unit | Utility | board-detail-cache', function() {
     });
   });
 
+  test('get_ordered_buttons returns null when url_cache_primed context differs', function(assert) {
+    boardDetailCache.clear();
+    var raw = { key: 'user/board-a', id: '1_1', buttons: [] };
+    boardDetailCache.set(raw);
+    var grid = [[{ id: 'btn-1' }]];
+    boardDetailCache.set_ordered_buttons('user/board-a', grid, {
+      skin: 'default',
+      preferred_symbols: null,
+      edit_mode: false,
+      label_locale: 'en',
+      url_cache_primed: false
+    });
+    var hit = boardDetailCache.get_ordered_buttons('user/board-a', {
+      skin: 'default',
+      preferred_symbols: null,
+      edit_mode: false,
+      label_locale: 'en',
+      url_cache_primed: true
+    });
+    assert.notOk(hit, 'url_cache_primed mismatch invalidates ordered_buttons cache');
+  });
+
   test('prefetch_lingolinq_catalog warms images for root only', function(assert) {
     boardDetailCache.clear();
     var origAjax = persistence.ajax;

--- a/app/frontend/tests/unit/utils/loading-overlay-cache-test.js
+++ b/app/frontend/tests/unit/utils/loading-overlay-cache-test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+import boardDetailCache from 'frontend/utils/board_detail_cache';
+
+module('Unit | loading overlay and board cache', function(hooks) {
+  setupTest(hooks);
+
+  test('show and hide loading overlay do not read or write boardDetailCache', function(assert) {
+    boardDetailCache.clear();
+    boardDetailCache.set({ key: 'user/board-a', id: '1_1', buttons: [] });
+    var getCalls = 0;
+    var setCalls = 0;
+    var origGet = boardDetailCache.get;
+    var origSet = boardDetailCache.set;
+    boardDetailCache.get = function() {
+      getCalls++;
+      return origGet.apply(this, arguments);
+    };
+    boardDetailCache.set = function() {
+      setCalls++;
+      return origSet.apply(this, arguments);
+    };
+
+    var appState = this.owner.lookup('service:app-state');
+    run(function() {
+      appState.show_loading_overlay('Loading board...');
+      appState.hide_loading_overlay();
+    });
+
+    boardDetailCache.get = origGet;
+    boardDetailCache.set = origSet;
+    assert.equal(getCalls, 0, 'overlay show/hide does not call cache get');
+    assert.equal(setCalls, 0, 'overlay show/hide does not call cache set');
+    assert.ok(boardDetailCache.get('user/board-a'), 'cache entry survives overlay lifecycle');
+  });
+
+  test('show_loading_overlay accepts shorter min_ms for cache-hit navigation', function(assert) {
+    var appState = this.owner.lookup('service:app-state');
+    run(function() {
+      appState.show_loading_overlay('Loading board...', { min_ms: 0 });
+      appState.hide_loading_overlay();
+    });
+    assert.equal(appState._loading_overlay_min_ms, 0, 'stores per-show minimum until hide completes');
+    run(function() {
+      assert.strictEqual(appState._loading_overlay_min_ms, null, 'clears per-show minimum after hide');
+      assert.strictEqual(appState.get('loading_overlay_message'), null, 'clears overlay message');
+    });
+  });
+
+  test('clear_user_state wipes boardDetailCache', function(assert) {
+    boardDetailCache.clear();
+    boardDetailCache.set({ key: 'user/board-a', id: '1_1', buttons: [] });
+    assert.ok(boardDetailCache.get('user/board-a'), 'precondition: cache populated');
+
+    var appState = this.owner.lookup('service:app-state');
+    run(function() {
+      appState.clear_user_state();
+    });
+
+    assert.notOk(boardDetailCache.get('user/board-a'), 'clear_user_state empties boardDetailCache');
+  });
+});

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -2024,6 +2024,38 @@ query.
 
 ---
 
+## Pattern: loading overlays are UX-only — keep them off the cache path
+
+**Surface:** global `show_loading_overlay` / `hide_loading_overlay`, board open from My Boards, board-detail route.
+
+**Finding:** Overlays only set `loading_overlay_message` and timing fields. All board JSON (`board_detail_cache`), Ember Data peek/push, `prime_caches`, and ordered-buttons caching run independently. Overlay hide in `setupController` does not invalidate caches.
+
+**Smoothness fixes (2026-05-28):**
+- Shorter overlay minimum (150ms) when raw JSON + Ember record are already cached (`open_board_in_user_view`).
+- `boardDetailCache.clear()` in `clear_user_state` on SPA sign-out.
+- Classic `board-alt` route reads `boardDetailCache` before `findRecord`.
+- `_maybe_prime_caches()` already awaited before `_build_from_raw` so `url_cache_primed` in ordered-buttons ctx is correct on first build.
+
+**Do not:** tie overlay dismissal to image warm or `/tree` completion — conflicts with lazy descendant image prefetch.
+
+**First seen in:** [2026-05-28-loading-overlay-cache-evaluation](./2026-05-28-loading-overlay-cache-evaluation.md)
+
+---
+
+## Pattern: extra_data JSON must not use FileSystem writes on web
+
+**Surface:** `persistence.store_url_now` caching `BoardDownstreamButtonSet` S3 URLs (`lingolinq-*-uploads`, `/extras…/data-….json`).
+
+**Symptom:** Console error `saving to data cache failed for https://…/BoardDownstreamButtonSet/…/data-….json` via `LingoLinq.track_error` (unhandled RSVP rejection).
+
+**Root cause:** After fetching encrypted JSON via the search proxy, `store_url_now` attempted a Chrome PERSISTENT FileSystem write when `local_system.allowed` was true. Large encrypted button-set payloads often fail that write (quota / FS limits). Images/sounds need FileSystem; JSON extra_data does not — `find_json` resolves via `data_uri` in IndexedDB `dataCache`.
+
+**Fix recipe:** In `store_url_now`, when `type == 'json'` and `object.data_uri` is set, skip `write_file` and `store('dataCache', …)` with `data_uri` retained. Add uploads buckets to `cors_match` so dev/prod S3 can be fetched directly when CORS allows.
+
+**Evidence:** `app/frontend/app/services/persistence.js`, `app/frontend/app/utils/persistence.js`; task log `2026-05-28-loading-overlay-cache-evaluation.md`.
+
+---
+
 ## Pattern: defer image_id in change_button — stale image_url rebinds wrong symbol
 
 **Surface:** Button-settings Picture → pick search hit → "Use This".


### PR DESCRIPTION
…Cache saves

Evaluated the loading overlay system against all board-load cache layers and confirmed overlays are UX-only—they never read or write cache state. Applied low-risk consolidation so caching stays effective without tying work to overlay timing.

Overlay and cache:
- Use a 150ms overlay minimum when raw JSON + Ember record are already cached (700ms remains for network paths)
- Clear boardDetailCache on SPA sign-out via clear_user_state
- Let classic board-alt reuse board_detail_cache before findRecord
- Document that prime_caches already runs before _build_from_raw

Persistence (BoardDownstreamButtonSet extra_data):
- Skip FileSystem writes for type=json; persist encrypted button-set JSON in IndexedDB dataCache via data_uri (fixes "saving to data cache failed" on web)
- Add lingolinq-*-uploads S3 hosts to cors_match for direct fetch when allowed
- Catch load_button_set rejections on board-detail so failures stay non-fatal

Tests and docs:
- Add loading-overlay-cache and url_cache_primed unit tests; register in test-helper
- Record patterns in LEARNINGS.md

Verified: npx ember test — 1372 passed, 0 failed