### PR TITLE
Auto-provision default vocab boards on signup and migrate system boar…

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -260,6 +260,7 @@ class Api::UsersController < ApplicationController
       res = Organization.parse_activation_code(user_data['start_code'], user)
       start_progress = res[:progress]
     end
+    UserBoardProvisioner.provision_for(user)
     coppa_pending = user.coppa_parental_consent_pending?
     unless coppa_pending
       UserMailer.schedule_delivery(:confirm_registration, user.global_id)

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -912,6 +912,7 @@ class SessionController < ApplicationController
       error = e.message == 'user_creation_failed' ? 'registration_failed' : e.message
       return api_error 400, {error: error}
     end
+    UserBoardProvisioner.provision_for(user)
     unless user.coppa_parental_consent_pending?
       UserMailer.schedule_delivery(:confirm_registration, user.global_id)
       UserMailer.schedule_delivery(:new_user_registration, user.global_id)

--- a/app/frontend/app/services/app-state.js
+++ b/app/frontend/app/services/app-state.js
@@ -739,7 +739,7 @@ export default Service.extend({
     }
   }),
   domain_board_user_name: computed('domain_settings.board_user_name', function() {
-    return this.get('domain_settings.board_user_name') || 'example';
+    return this.get('domain_settings.board_user_name') || 'lingolinq';
   }),
   darkMode: computed('themeMode', function() {
     return this.get('themeMode') === 'dark';
@@ -3781,7 +3781,8 @@ export default Service.extend({
         user_prefers_native_keyboard = window.user_preferences.any_user.prefer_native_keyboard;
       }
       var native_keyboard_available = capabilities.installed_app && (capabilities.system == 'iOS' || capabilities.system == 'Android') && !buttonTracker.scanning_enabled;
-      var expecting_key = (button.vocalization || '').match(/:native-keyboard/) || (button.load_board && button.load_board.key == 'example/keyboard');
+      var load_key = button.load_board && button.load_board.key;
+      var expecting_key = (button.vocalization || '').match(/:native-keyboard/) || (load_key && load_key.match(/\/keyboard$/));
       if(expecting_key && native_keyboard_available && user_prefers_native_keyboard && window.Keyboard && window.Keyboard.hide) {
         scanner.native_keyboard();
       } else if(this.stashes.get('sticky_board') && this.get('speak_mode')) {

--- a/app/frontend/tests/utils/app_state-test.js
+++ b/app/frontend/tests/utils/app_state-test.js
@@ -1052,7 +1052,7 @@ describe('app_state', function() {
       var key = null;
       app_state.set('sessionUser', EmberObject.create({
         preferences: {
-          home_board: {key: 'example/inflections'}
+          home_board: {key: 'lingolinq/inflections'}
         }
       }));
       stub(app_state.controller, 'transitionToRoute', function(r, k) {
@@ -1061,7 +1061,7 @@ describe('app_state', function() {
       });
       app_state.home_in_speak_mode();
       expect(route).toEqual('board');
-      expect(key).toEqual('example/inflections');
+      expect(key).toEqual('lingolinq/inflections');
     });
 
     it("should fall back to a stashed board when no home board is set", function() {
@@ -1086,10 +1086,10 @@ describe('app_state', function() {
       expect(route).toEqual(null);
       expect(key).toEqual(null);
 
-      stashes.set('root_board_state', {key: 'example/keyboard'});
+      stashes.set('root_board_state', {key: 'lingolinq/keyboard'});
       app_state.home_in_speak_mode();
       expect(route).toEqual('board');
-      expect(key).toEqual('example/keyboard');
+      expect(key).toEqual('lingolinq/keyboard');
     });
   });
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -261,7 +261,7 @@ class Board < ApplicationRecord
   def self.find_suggested(locale='en', limit=10)
     ids = nil
     if locale == 'en'
-      user = User.find_by_path('example')
+      user = SystemBoardSources.owner || User.find_by_path('lingolinq')
       ids = user && self.local_ids(user.settings['starred_board_ids'] || [])
     end
     if ids.blank?

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2378,7 +2378,8 @@ class Board < ApplicationRecord
     # if self.settings && self.settings['images_not_mapped']
       return @button_images if @button_images
       image_ids = self.grid_buttons.map{|b| b['image_id'] }.compact.uniq
-      @button_images = ButtonImage.find_all_by_global_id(image_ids)
+      images = ButtonImage.find_all_by_global_id(image_ids)
+      @button_images = images.sort_by { |i| image_ids.index(i.global_id) || image_ids.length }
     # else
     #   self.button_images
     # end
@@ -2389,7 +2390,8 @@ class Board < ApplicationRecord
   def known_button_sounds
     return @button_sounds if @button_sounds
     sound_ids = (self.grid_buttons || []).map { |b| b['sound_id'] }.compact.uniq
-    @button_sounds = ButtonSound.find_all_by_global_id(sound_ids)
+    sounds = ButtonSound.find_all_by_global_id(sound_ids)
+    @button_sounds = sounds.sort_by { |s| sound_ids.index(s.global_id) || sound_ids.length }
   end
 
   def import_translation(translated_copy, locale, overwrite=false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1728,6 +1728,29 @@ class User < ApplicationRecord
     end
   end
 
+  def copy_board_to_library(library_board, updater_id, symbol_library=nil)
+    original = library_board && Board.find_by_path(library_board['id'])
+    updater = User.find_by_path(updater_id)
+    return false unless original && updater
+
+    existing = self.boards.where(parent_board: original).order('id DESC').first
+    if existing && ((existing.settings['swapped_library'] || 'original') == (symbol_library || 'original'))
+      return true
+    end
+
+    new_board = original.copy_for(self, copier: updater)
+    self.copy_board_links(
+      old_board_id: original.global_id,
+      new_board_id: new_board.global_id,
+      ids_to_copy: [],
+      auth_user: updater,
+      user_for_paper_trail: "user:#{updater.global_id}",
+      copier_id: updater.global_id,
+      swap_library: symbol_library
+    )
+    true
+  end
+
   def copy_to_home_board(home_board, updater_id, symbol_library)
     original = home_board && Board.find_by_path(home_board['id'])
     updater = User.find_by_path(updater_id)
@@ -1982,8 +2005,8 @@ class User < ApplicationRecord
   def self.default_sidebar_boards
     [
       {'name' => "Yes/No", 'key' => 'lingolinq/yesno', 'image' => 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/yes_2.png', 'home_lock' => false},
-      {'name' => "Inflections", 'key' => 'example/inflections', 'image' => 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/verb.png', 'home_lock' => false},
-      {'name' => "Keyboard", 'key' => 'example/keyboard', 'image' => 'https://opensymbols.s3.amazonaws.com/libraries/noun-project/Computer%20Keyboard-19d40c3f5a.svg', 'home_lock' => false},
+      {'name' => "Inflections", 'key' => SystemBoardSources.board_key('inflections'), 'image' => 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/verb.png', 'home_lock' => false},
+      {'name' => "Keyboard", 'key' => SystemBoardSources.board_key('keyboard'), 'image' => 'https://opensymbols.s3.amazonaws.com/libraries/noun-project/Computer%20Keyboard-19d40c3f5a.svg', 'home_lock' => false},
       {'name' => 'Social', 'key' => 'mbaud12/senner-baud-greetings', 'image' => 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/greet_2.png', 'home_lock' => false},
       {'name' => "Alert", 'special' => true, 'alert' => true, 'image' => 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/to%20sound.png'}
     ]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1217,3 +1217,20 @@ unless board_yesno
 else
   puts "  Found existing lingolinq/yesno board"
 end
+
+SystemSidebarBoards.ensure_for(lingolinq_user).each do |board|
+  puts "  Ensured lingolinq/#{board.key.split('/').last} board"
+end
+
+if lingolinq_user && !Board.find_by_path('lingolinq/quick-core-60')
+  if ENV['SEED_IMPORT_OPENAAC_VOCABULARIES'].to_s =~ /^(1|true|yes)$/i
+    puts "  Importing OpenAAC vocabulary boards for lingolinq (this may take a while)..."
+    Rake::Task['openaac:import_vocabularies'].reenable
+    ENV['VOCABULARY_USER_NAME'] = 'lingolinq'
+    Rake::Task['openaac:import_vocabularies'].invoke
+  else
+    puts "  NOTE: lingolinq/quick-core-60 not found."
+    puts "        Run: VOCABULARY_USER_NAME=lingolinq bundle exec rake openaac:import_vocabularies"
+    puts "        Or set SEED_IMPORT_OPENAAC_VOCABULARIES=1 before db:seed to import during seed."
+  end
+end

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -20,6 +20,7 @@ file (see [README.md](README.md)).
 
 ## Index
 
+- [Pattern: `find_all_by_global_id` does not preserve input order](#pattern-find_all_by_global_id-does-not-preserve-input-order)
 - [Pattern: HTML5 drag-and-drop suppressed by nested `<button>` children](#pattern-html5-drag-and-drop-suppressed-by-nested-button-children)
 - [Pattern: "It's broken" symptoms that vanish on re-test = stale Ember dev bundle](#pattern-its-broken-symptoms-that-vanish-on-re-test--stale-ember-dev-bundle)
 - [Pattern: SVG gradient ID refs inside CSS data URIs mangled by Rails Sprockets in production](#pattern-svg-gradient-id-refs-inside-css-data-uris-mangled-by-rails-sprockets-in-production)
@@ -2067,3 +2068,15 @@ query.
 **Fix recipe:** When `options.image` and `image_id` are both supplied, apply `image` + URL fields first, then set `image_id` last. Clear `image_url` when swapping images. In `load_image`, prefer an already-assigned image record for the requested id; do not reuse `button.image_url` when a populated `board.image_urls` map lacks that id.
 
 **Evidence:** `app/frontend/app/utils/edit_manager.js`, `app/frontend/app/utils/button.js`, `app/frontend/tests/utils/edit_manager-test.js`; commit `770a8c624`. Task log (local): `2026-05-27-button-image-use-this.md`.
+
+---
+
+## Pattern: `find_all_by_global_id` does not preserve input order
+
+**Symptom:** RSpec expects `[bi1, bi2]` from `known_button_images` but gets reversed order when DB ids differ from button-list order.
+
+**Root cause:** `GlobalId.find_all_by_global_id` uses `WHERE id IN (...)`; PostgreSQL returns rows in arbitrary/id order, not the caller's id list order.
+
+**Fix recipe:** After lookup, `sort_by { |r| ids.index(r.global_id) || ids.length }` (see `Board.long_query`, `Board#known_button_images`). For specs comparing sorted `global_id` lists, sort **both** sides — lexicographic sort puts `"1_1000"` before `"1_999"`.
+
+**Evidence:** `app/models/concerns/global_id.rb:108-174`, `app/models/board.rb#known_button_images`; task log `2026-05-29-spec-ordering-flakes.md`.

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -58,6 +58,7 @@ file (see [README.md](README.md)).
 - [Pattern: `/api/v1/boards?user_id=X` returns every owned board including sub-board copies — visible-tile counts need root clustering](#pattern-apiv1boardsuser_idx-returns-every-owned-board-including-sub-board-copies--visible-tile-counts-need-root-clustering)
 - [Pattern: create-board-new preview URLs stripped by process_buttons whitelist](#pattern-create-board-new-preview-urls-stripped-by-process_buttons-whitelist)
 - [Pattern: OpenSymbols search returns nested license objects — pick_preview must normalize](#pattern-opensymbols-search-returns-nested-license-objects--pick_preview-must-normalize)
+- [Pattern: Signup default library boards — copy via Progress, not copy_to_home_board](#pattern-signup-default-library-boards--copy-via-progress-not-copy_to_home_board)
 
 ---
 
@@ -2067,3 +2068,17 @@ query.
 **Fix recipe:** When `options.image` and `image_id` are both supplied, apply `image` + URL fields first, then set `image_id` last. Clear `image_url` when swapping images. In `load_image`, prefer an already-assigned image record for the requested id; do not reuse `button.image_url` when a populated `board.image_urls` map lacks that id.
 
 **Evidence:** `app/frontend/app/utils/edit_manager.js`, `app/frontend/app/utils/button.js`, `app/frontend/tests/utils/edit_manager-test.js`; commit `770a8c624`. Task log (local): `2026-05-27-button-image-use-this.md`.
+
+---
+
+## Pattern: Signup default library boards — copy via Progress, not copy_to_home_board
+
+**Surface:** new user registration (email or Google SSO).
+
+**Requirement:** Give every new communicator owned copies of curated vocab boards in **My Boards** without setting `preferences.home_board`.
+
+**Root cause to avoid:** `User#copy_to_home_board` always writes `preferences.home_board` — wrong tool for library-only provisioning.
+
+**Fix recipe:** Add `User#copy_board_to_library` (`copy_for` + `copy_board_links`, no home pref). Schedule two jobs via `Progress.schedule(user, :copy_board_to_library, …, for_user: user)` from `UserBoardProvisioner` after save. Source boards live on the `lingolinq` content user (`SystemBoardSources`); import with `VOCABULARY_USER_NAME=lingolinq bundle exec rake openaac:import_vocabularies`. Gate with `FeatureFlags.signup_default_library_boards_enabled?`.
+
+**Evidence:** `lib/user_board_provisioner.rb`, `lib/system_board_sources.rb`, `app/models/user.rb`; task log `2026-05-28-signup-default-library-boards.md`.

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -24,7 +24,8 @@ module FeatureFlags
               'telemetry_admin_panel',
               'tarheel_reader', 'auth_spa_transition', 'google_sso', 'quick_screen_eval',
               'comprehensive_eval_ai', 'multi_user_board_import', 'customize_menu',
-              'home_tour', 'paste_html_import', 'catalog_board_prefetch']
+              'home_tour', 'paste_html_import', 'catalog_board_prefetch',
+              'signup_default_library_boards']
   ENABLED_FRONTEND_FEATURES = ['subscriptions', 'assessments', 'custom_sidebar', 'snapshots',
               'video_recording', 'goals', 'modeling', 'geo_sidebar', 'edit_before_copying',
               'core_reports', 'lessonpix', 'translation', 'fast_render',
@@ -36,7 +37,8 @@ module FeatureFlags
               'skin_tones', 'lessons', 'profiles', 'other_menu', 'ai_board_generation',
               'google_sso', 'quick_screen_eval', 'multi_user_board_import',
               'customize_menu', # TEMPORARY: ON for everyone during testing — remove from this list when moving to beta-opt-in (see comment above AVAILABLE_FRONTEND_FEATURES)
-              'home_tour'] # TEMPORARY (spike — 2026-05-27): ON for everyone so Traci can validate the Shepherd.js home-page tour in the browser. REMOVE from this list before merging the spike out of traci/styling/styling-updates — the canonical state is AVAILABLE-only (beta opt-in per user).
+              'home_tour', # TEMPORARY (spike — 2026-05-27): ON for everyone so Traci can validate the Shepherd.js home-page tour in the browser. REMOVE from this list before merging the spike out of traci/styling/styling-updates — the canonical state is AVAILABLE-only (beta opt-in per user).
+              'signup_default_library_boards']
   DISABLED_CANARY_FEATURES = []
   FEATURE_DATES = {
     'word_suggestion_images' => 'Jan 21, 2017',
@@ -92,6 +94,12 @@ module FeatureFlags
   def self.feature_enabled_for?(feature, user)
     flags = frontend_flags_for(user)
     !!flags[feature]
+  end
+
+  # Server-side gate for copying default vocab boards into new user libraries.
+  def self.signup_default_library_boards_enabled?(_user = nil)
+    return true if ENV['SIGNUP_DEFAULT_LIBRARY_BOARDS'].to_s =~ /^(1|true|yes)$/i
+    ENABLED_FRONTEND_FEATURES.include?('signup_default_library_boards')
   end
 
   # Check if AI features are allowed for a user's organization.

--- a/lib/system_board_sources.rb
+++ b/lib/system_board_sources.rb
@@ -1,0 +1,13 @@
+# Public/system vocabulary boards owned by the lingolinq content account.
+module SystemBoardSources
+  USER_NAME = ENV.fetch('SYSTEM_BOARD_USER_NAME', 'lingolinq').freeze
+  SIGNUP_LIBRARY_SLUGS = %w[quick-core-60 vocal-flair-60].freeze
+
+  def self.board_key(slug)
+    "#{USER_NAME}/#{slug}"
+  end
+
+  def self.owner
+    User.find_by(user_name: USER_NAME)
+  end
+end

--- a/lib/system_sidebar_boards.rb
+++ b/lib/system_sidebar_boards.rb
@@ -1,0 +1,42 @@
+# Ensures public utility boards used in default sidebars exist on the content account.
+class SystemSidebarBoards
+  UTILITIES = [
+    {slug: 'keyboard', legacy_source: 'example/keyboard', generator: :generate_keyboard},
+    {slug: 'inflections', legacy_source: 'example/inflections', generator: :generate_inflections}
+  ].freeze
+
+  def self.ensure_for(user)
+    return [] unless user
+
+    UTILITIES.map do |spec|
+      ensure_utility_board(user, spec)
+    end.compact
+  end
+
+  def self.ensure_utility_board(user, spec)
+    existing = Board.find_by_path("#{user.user_name}/#{spec[:slug]}") ||
+      Board.find_by(key: spec[:slug], user_id: user.id)
+    return existing if existing
+
+    legacy = Board.find_by_path(spec[:legacy_source])
+    if legacy
+      board = legacy.copy_for(user)
+      board.public = true
+      board.settings['name'] ||= spec[:slug].split(/-/).map(&:capitalize).join(' ')
+      board.save!
+      return board
+    end
+
+    send(spec[:generator], user)
+  end
+
+  def self.generate_keyboard(user)
+    require Rails.root.join('lib', 'templates', 'keyboard_board')
+    KeyboardBoard.generate(user)
+  end
+
+  def self.generate_inflections(user)
+    require Rails.root.join('lib', 'templates', 'inflections_board')
+    InflectionsBoard.generate(user)
+  end
+end

--- a/lib/tasks/openaac.rake
+++ b/lib/tasks/openaac.rake
@@ -4,7 +4,7 @@
 # Run: bundle exec rake openaac:import_vocabularies
 #
 # Optional env:
-#   VOCABULARY_USER_NAME=example   (default: example) - user to own imported boards
+#   VOCABULARY_USER_NAME=lingolinq   (default: lingolinq) - user to own imported boards
 #   ONLY=quick-core-24.obz        - import only this file (for testing)
 #
 namespace :openaac do
@@ -30,7 +30,7 @@ namespace :openaac do
   desc 'Download OBZ files from openboards.s3.amazonaws.com and import via Converters::LingoLinq.from_obz()'
   task import_vocabularies: :environment do
     require Rails.root.join('lib', 'converters', 'lingo_linq')
-    user_name = ENV['VOCABULARY_USER_NAME'] || 'example'
+    user_name = ENV['VOCABULARY_USER_NAME'] || 'lingolinq'
     user = User.find_by(user_name: user_name)
     raise "User not found: #{user_name}. Run db:seed or create the user first." unless user
 

--- a/lib/templates/inflections_board.rb
+++ b/lib/templates/inflections_board.rb
@@ -1,0 +1,56 @@
+module InflectionsBoard
+  IMAGE_URL = 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/verb.png'.freeze
+
+  MODIFIERS = [
+    {id: 1, label: 's', vocalization: ':plural'},
+    {id: 2, label: 'singular', vocalization: ':singular'},
+    {id: 3, label: "'s", vocalization: ":'s"},
+    {id: 4, label: 'ed', vocalization: ':ed'},
+    {id: 5, label: 'ing', vocalization: ':ing'},
+    {id: 6, label: "n't", vocalization: ':verb-negation'},
+    {id: 7, label: 'er', vocalization: ':er'},
+    {id: 8, label: 'est', vocalization: ':est'},
+    {id: 9, label: '.', vocalization: '+.'},
+    {id: 10, label: '?', vocalization: '+?'},
+    {id: 11, label: ',', vocalization: '+,'},
+    {id: 12, label: '!', vocalization: '+!'}
+  ].freeze
+
+  def self.generate(user, board=nil)
+    raise 'missing user' unless user
+
+    buttons = MODIFIERS.map do |spec|
+      {
+        id: spec[:id],
+        label: spec[:label],
+        vocalization: spec[:vocalization],
+        image_url: IMAGE_URL
+      }
+    end
+
+    options = [{
+      name: 'Inflections',
+      grid: {
+        rows: 3,
+        columns: 4,
+        order: [
+          [1, 2, 3, 4],
+          [5, 6, 7, 8],
+          [9, 10, 11, 12]
+        ]
+      },
+      buttons: buttons,
+      public: true
+    }, {
+      user: user,
+      key: 'inflections'
+    }]
+
+    if board
+      board.process(*options)
+      board
+    else
+      Board.process_new(*options)
+    end
+  end
+end

--- a/lib/user_board_provisioner.rb
+++ b/lib/user_board_provisioner.rb
@@ -1,0 +1,33 @@
+# Copies default vocabulary boards into a new user's library on signup.
+class UserBoardProvisioner
+  def self.provision_for(user)
+    return [] unless user && FeatureFlags.signup_default_library_boards_enabled?(user)
+
+    source_user = SystemBoardSources.owner
+    unless source_user
+      Rails.logger.warn("[UserBoardProvisioner] System board owner #{SystemBoardSources::USER_NAME} not found")
+      return []
+    end
+
+    progresses = []
+    SystemBoardSources::SIGNUP_LIBRARY_SLUGS.each do |slug|
+      key = SystemBoardSources.board_key(slug)
+      board = Board.find_by_path(key)
+      unless board&.public?
+        Rails.logger.warn("[UserBoardProvisioner] Skipping missing or non-public board: #{key}")
+        next
+      end
+
+      progress = Progress.schedule(
+        user,
+        :copy_board_to_library,
+        {'id' => board.global_id},
+        source_user.global_id,
+        nil,
+        for_user: user
+      )
+      progresses << progress if progress
+    end
+    progresses
+  end
+end

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -605,6 +605,12 @@ describe Api::UsersController, :type => :controller do
       post :create, params: {:user => {'name' => 'fred'}}
       expect(response).to be_successful
     end
+
+    it "should provision default library boards on signup when enabled" do
+      expect(UserBoardProvisioner).to receive(:provision_for).and_return([])
+      post :create, params: {:user => {'name' => 'fred'}}
+      expect(response).to be_successful
+    end
     
     it "should schedule delivery of a welcome message" do
       expect(UserMailer).to receive(:schedule_delivery).exactly(2).times

--- a/spec/javascripts/utils/app_state_spec.js
+++ b/spec/javascripts/utils/app_state_spec.js
@@ -594,7 +594,7 @@ describe('app_state', function() {
       var key = null;
       app_state.set('sessionUser', Ember.Object.create({
         preferences: {
-          home_board: {key: 'example/inflections'}
+          home_board: {key: 'lingolinq/inflections'}
         }
       }));
       stub(app_state.controller, 'transitionToRoute', function(r, k) {
@@ -603,7 +603,7 @@ describe('app_state', function() {
       });
       app_state.home_in_speak_mode();
       expect(route).toEqual('board');
-      expect(key).toEqual('example/inflections');
+      expect(key).toEqual('lingolinq/inflections');
     });
     
     it("should fall back to a stashed board when no home board is set", function() {
@@ -628,10 +628,10 @@ describe('app_state', function() {
       expect(route).toEqual(null);
       expect(key).toEqual(null);
       
-      stashes.set('root_board_state', {key: 'example/keyboard'});
+      stashes.set('root_board_state', {key: 'lingolinq/keyboard'});
       app_state.home_in_speak_mode();
       expect(route).toEqual('board');
-      expect(key).toEqual('example/keyboard');
+      expect(key).toEqual('lingolinq/keyboard');
     });
   });
 

--- a/spec/lib/system_sidebar_boards_spec.rb
+++ b/spec/lib/system_sidebar_boards_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe SystemSidebarBoards do
+  describe ".ensure_for" do
+    it "generates keyboard and inflections boards for the content user when missing" do
+      user = User.create(user_name: 'lingolinq')
+      boards = described_class.ensure_for(user)
+      expect(boards.length).to eq(2)
+      expect(Board.find_by_path('lingolinq/keyboard')).to_not eq(nil)
+      expect(Board.find_by_path('lingolinq/inflections')).to_not eq(nil)
+      expect(Board.find_by_path('lingolinq/keyboard').public).to eq(true)
+      expect(Board.find_by_path('lingolinq/inflections').public).to eq(true)
+    end
+
+    it "copies from legacy example boards when present" do
+      example_user = User.create(user_name: 'example')
+      source = Board.process_new({name: 'Keyboard', public: true}, {user: example_user, key: 'keyboard'})
+      user = User.create(user_name: 'lingolinq')
+      board = described_class.ensure_utility_board(user, described_class::UTILITIES.first)
+      expect(board.user_id).to eq(user.id)
+      expect(board.parent_board_id).to eq(source.id)
+    end
+
+    it "is idempotent" do
+      user = User.create(user_name: 'lingolinq')
+      first = described_class.ensure_for(user)
+      second = described_class.ensure_for(user)
+      expect(first.map(&:id)).to eq(second.map(&:id))
+    end
+  end
+end

--- a/spec/lib/user_board_provisioner_spec.rb
+++ b/spec/lib/user_board_provisioner_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe UserBoardProvisioner do
+  describe ".provision_for" do
+    it "schedules library copies for default vocab boards when enabled" do
+      source = User.create(user_name: 'lingolinq')
+      user = User.create
+      b1 = Board.process_new({name: 'Quick Core 60', public: true}, {user: source, key: 'quick-core-60'})
+      b2 = Board.process_new({name: 'Vocal Flair 60', public: true}, {user: source, key: 'vocal-flair-60'})
+
+      allow(FeatureFlags).to receive(:signup_default_library_boards_enabled?).and_return(true)
+      expect(Progress).to receive(:schedule).with(
+        user,
+        :copy_board_to_library,
+        {'id' => b1.global_id},
+        source.global_id,
+        nil,
+        for_user: user
+      ).ordered
+      expect(Progress).to receive(:schedule).with(
+        user,
+        :copy_board_to_library,
+        {'id' => b2.global_id},
+        source.global_id,
+        nil,
+        for_user: user
+      ).ordered
+
+      described_class.provision_for(user)
+    end
+
+    it "does nothing when the feature is disabled" do
+      user = User.create
+      allow(FeatureFlags).to receive(:signup_default_library_boards_enabled?).and_return(false)
+      expect(Progress).to_not receive(:schedule)
+      expect(described_class.provision_for(user)).to eq([])
+    end
+
+    it "skips missing boards without raising" do
+      User.create(user_name: 'lingolinq')
+      user = User.create
+      allow(FeatureFlags).to receive(:signup_default_library_boards_enabled?).and_return(true)
+      expect(Progress).to_not receive(:schedule)
+      expect(described_class.provision_for(user)).to eq([])
+    end
+  end
+end

--- a/spec/models/concerns/board_caching_spec.rb
+++ b/spec/models/concerns/board_caching_spec.rb
@@ -109,9 +109,9 @@ describe BoardCaching, :type => :model do
       Worker.process_queues
       Worker.process_queues
       RemoteAction.process_all
-      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
+      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
     end
 
     # if someone downstream-edit-shares a board with me, and someone else on the team creates a new board and links to it, I should see it
@@ -128,9 +128,9 @@ describe BoardCaching, :type => :model do
       RedisInit.permissions.keys.each{|k| RedisInit.permissions.del(k) }
       Worker.process_queues
       Worker.process_queues
-      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
+      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
     end
 
     # if someone shares a board with me and creates a private sub-board, I shouldn't see it
@@ -150,7 +150,7 @@ describe BoardCaching, :type => :model do
       Worker.process_queues
       Worker.process_queues
       Worker.process_queues
-      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
+      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
       expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id])
     end
 
@@ -173,8 +173,8 @@ describe BoardCaching, :type => :model do
       Worker.process_queues
       Worker.process_queues
       Worker.process_queues
-      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
+      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
     end
 
     # if someone downstream-shares a board with me and one of the board's downstream-co-authors creates a private sub-board, I should see it
@@ -202,9 +202,9 @@ describe BoardCaching, :type => :model do
       expect(RemoteAction.where(action: 'update_available_boards', path: u3.global_id).count).to be >= 1
       RemoteAction.process_all
       Worker.process_queues
-      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
+      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
     end
 
     # if someone downstream-shares a board with me and one of the board's downstream-co-authors creates a public board, it shouldn't bother updating
@@ -268,9 +268,9 @@ describe BoardCaching, :type => :model do
       Worker.process_queues
       # Explicitly run update_available_boards - RemoteAction schedules to slow queue
       [u1, u2, u3].each { |usr| usr.reload.update_available_boards }
-      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b3.global_id])
-      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b3.global_id])
-      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b3.global_id])
+      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b3.global_id].sort)
+      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b3.global_id].sort)
+      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b3.global_id].sort)
     end
   
     # if I create a board downstream of a downstream-co-authored board (me not the author) that links
@@ -300,12 +300,12 @@ describe BoardCaching, :type => :model do
       Worker.process_queues
       Worker.process_queues
       RemoteAction.process_all
-      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u2.reload.private_editable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u3.reload.private_editable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u1.reload.private_editable_board_ids.sort).to eq([b.global_id, b2.global_id])
+      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u2.reload.private_editable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u3.reload.private_editable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u1.reload.private_editable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
     end
 
     # if me and someone else supervise each other, we shouldn't get caught in a loop on update
@@ -462,7 +462,7 @@ describe BoardCaching, :type => :model do
       RemoteAction.process_all
       Worker.process_queues
       
-      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
+      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
     end
 
     # if a co-authored board gets a link to a private board by one of the authors, it should update
@@ -491,9 +491,9 @@ describe BoardCaching, :type => :model do
       Worker.process_queues
       Worker.process_queues
       [u1, u2, u3].each { |usr| usr.reload.update_available_boards }
-      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
-      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id])
+      expect(u2.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u3.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
+      expect(u1.reload.private_viewable_board_ids.sort).to eq([b.global_id, b2.global_id].sort)
     end
 
     # if an editable supervisee creates a board I should see it

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3558,6 +3558,32 @@ describe User, :type => :model do
     end
   end
 
+  describe "copy_board_to_library" do
+    it "returns false without a valid original board" do
+      u = User.create
+      expect(u.copy_board_to_library({}, nil, nil)).to eq(false)
+    end
+
+    it "copies a board without setting home_board" do
+      u = User.create
+      owner = User.create
+      b1 = Board.create(user: owner, public: true)
+      expect(u.copy_board_to_library({'id' => b1.global_id}, owner.global_id, nil)).to eq(true)
+      expect(u.settings['preferences']['home_board']).to eq(nil)
+      expect(u.boards.where(parent_board: b1).first).to_not eq(nil)
+    end
+
+    it "returns true when the user already owns a matching copy" do
+      u = User.create
+      owner = User.create
+      b1 = Board.create(user: owner, public: true)
+      existing = b1.copy_for(u)
+      expect(u).to_not receive(:copy_board_links)
+      expect(u.copy_board_to_library({'id' => b1.global_id}, owner.global_id, nil)).to eq(true)
+      expect(u.boards.where(parent_board: b1).first.id).to eq(existing.id)
+    end
+  end
+
   describe "copy_to_home_board" do
     it "should return without an valid original board" do
       u = User.create

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -367,6 +367,22 @@ describe User, :type => :model do
   end
 
   describe "track_boards" do
+    before(:each) do
+      JobStash.delete_all
+      allow(RedisInit).to receive(:any_queue_pressure?).and_return(false)
+    end
+
+    def expect_refresh_stats_scheduled(stash)
+      jobs = Worker.scheduled_actions('slow').select do |job|
+        args = job['args'][2]
+        args &&
+          args['method'] == 'refresh_stats' &&
+          args['arguments'][0] == {'stash' => stash.global_id} &&
+          args['arguments'][1].is_a?(Integer)
+      end
+      expect(jobs.length).to eq(1)
+    end
+
     it "should schedule a background job by default" do
       u = User.create
       u.instance_variable_set('@do_track_boards', true)
@@ -396,7 +412,7 @@ describe User, :type => :model do
       expect(o).to receive(:select).with('id').and_return([b])
       u.track_boards(true)
       s = JobStash.last
-      expect(Worker.scheduled_for?(:slow, Board, :perform_action, {'method' => 'refresh_stats', 'arguments' => [{'stash' => s.global_id}, Time.now.to_i]})).to eq(true)
+      expect_refresh_stats_scheduled(s)
       expect(s.data).to eq([b.global_id])
     end
 
@@ -423,8 +439,8 @@ describe User, :type => :model do
       expect(u.settings['home_board_changed']).to eq(true)
       u.track_boards(true)
       s = JobStash.last
-      expect(Worker.scheduled_for?(:slow, Board, :perform_action, {'method' => 'refresh_stats', 'arguments' => [{'stash' => s.global_id}, Time.now.to_i]})).to eq(true)
       expect(s.data).to eq([b2.global_id])
+      expect_refresh_stats_scheduled(s)
     end
 
     it "should create missing connections" do


### PR DESCRIPTION
…ds to lingolinq.

Copy Quick Core 60 and Vocal Flair 60 into every new user's library via UserBoardProvisioner, using lingolinq as the OpenAAC import owner and content source. Seed lingolinq keyboard/inflections sidebar utilities and point default sidebar references at lingolinq instead of example.