### PR TITLE
fix(boards): drop eager-load before id-only selects in #index (LINGOLINQ-RAILS-J)

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -43,6 +43,11 @@ class Api::BoardsController < ApplicationController
     # extra SELECT per board (~25 at default per_page). Verified by the
     # regression spec in spec/controllers/api/boards_controller_spec.rb.
     # See docs/task-management/2026-05-27-boards-index-n-plus-one.md.
+    # NOTE: id-only partial selects off this relation (the two
+    # `.except(:includes)` sites below, ~line 173 and ~307) drop this
+    # eager-load so the :parent_board preloader does not read an unselected
+    # parent_board_id FK (LINGOLINQ-RAILS-J). If you ever switch this to a
+    # `references`/`eager_load`-backed join, update those two sites too.
     boards = boards.includes(:board_content, :parent_board)
     other_boards = nil
     other_searchable_board_ids = nil
@@ -163,7 +168,14 @@ class Api::BoardsController < ApplicationController
           locs = locs.where(locale: [params['locale'], params['locale'].split(/-|_/)[0]])
         end
         if params['user_id']
-          board_ids = boards.select('id, board_content_id').limit(500).map(&:id)
+          # `.except(:includes)`: `boards` carries `includes(:board_content,
+          # :parent_board)` for the full serialization path below. A partial
+          # `select('id, board_content_id')` omits `parent_board_id`, so the
+          # preloader raises MissingAttributeError when it reads the
+          # :parent_board foreign key off these records. We only want the ids
+          # here, so drop the eager-load entirely (also avoids a wasted
+          # preload over up to 500 discarded records). See LINGOLINQ-RAILS-J.
+          board_ids = boards.except(:includes).select('id, board_content_id').limit(500).map(&:id)
           locs = locs.where(board_id: board_ids)
         end
         board_ids = []
@@ -292,7 +304,12 @@ class Api::BoardsController < ApplicationController
       if !params['q'].blank? && !params['public']
         limited_boards = boards
         if params['allow_job'] #&& boards.limit(26).select('id').length > 25
-          progress = Progress.schedule(Board, :long_query, params['q'], params['locale'], boards.select('id, board_content_id').map(&:global_id) + (other_searchable_board_ids || []), for_user: @api_user)
+          # `.except(:includes)`: see the note above. The partial select omits
+          # `parent_board_id`, which the `includes(:parent_board)` preloader
+          # needs, so loading these records raised MissingAttributeError and
+          # 500'd the request (LINGOLINQ-RAILS-J). We only need the global_ids
+          # to hand off to the background long_query job.
+          progress = Progress.schedule(Board, :long_query, params['q'], params['locale'], boards.except(:includes).select('id, board_content_id').map(&:global_id) + (other_searchable_board_ids || []), for_user: @api_user)
           boards = []
         else
           # For private user searches this will limit to the user's first 25 boards

--- a/spec/controllers/api/boards_controller_spec.rb
+++ b/spec/controllers/api/boards_controller_spec.rb
@@ -351,7 +351,41 @@ describe Api::BoardsController, :type => :controller do
       expect(json['board'].length).to eq(1)
       expect(json['board'][0]['id']).to eq(b2.global_id)
     end
-    
+
+    it "should not 500 on a private query search with allow_job (regression: LINGOLINQ-RAILS-J)" do
+      # The index relation eager-loads `includes(:board_content, :parent_board)`
+      # for the full serialization path. The allow_job branch builds the
+      # candidate id list with a partial `select('id, board_content_id')` that
+      # omits `parent_board_id`; the :parent_board preloader then raised
+      # ActiveModel::MissingAttributeError ("missing attribute 'parent_board_id'
+      # for Board"), 500ing the request. A child board exercises the
+      # parent_board association so the preloader has linkage to resolve.
+      token_user
+      parent = Board.create(:user => @user, :settings => {'name' => "prologue parent"})
+      child = Board.create(:user => @user, :parent_board => parent, :settings => {'name' => "prologue child"})
+      get :index, params: {:user_id => @user.global_id, :q => "pro", :allow_job => true}
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+      # allow_job offloads the heavy search to a background job and returns an
+      # empty board list with a progress handle in meta.
+      expect(json['board']).to eq([])
+      expect(json['meta']['progress']).to_not eq(nil)
+    end
+
+    it "should not 500 on a public query search scoped to a user_id (regression: LINGOLINQ-RAILS-J twin)" do
+      # The public+user_id branch builds its candidate id list with the same
+      # partial `select('id, board_content_id')` off the includes-carrying
+      # relation, so it had the identical MissingAttributeError defect as the
+      # allow_job branch. This covers the second `.except(:includes)` site.
+      token_user
+      @user.settings['public'] = true
+      @user.save
+      parent = Board.create(:user => @user, :public => true, :settings => {'name' => "prologue parent"})
+      child = Board.create(:user => @user, :public => true, :parent_board => parent, :settings => {'name' => "prologue child"})
+      get :index, params: {:user_id => @user.global_id, :public => true, :q => "pro"}
+      expect(response).to be_successful
+    end
+
     it "should allow sorting by popularity or home_popularity" do
       u = User.create(:settings => {:public => true})
       b = Board.create(:user => u, :public => true)


### PR DESCRIPTION
## What

Fixes the live staging 500 on `GET /api/v1/boards` (Sentry **LINGOLINQ-RAILS-J**): `ActiveModel::MissingAttributeError: missing attribute 'parent_board_id' for Board`, first seen 2026-05-29 22:58 UTC.

## User impact

Board search fires two queries. The public/online catalog query was fine; the **"Your Boards" personal query** (`user_id: 'self', allow_job: true` in `controllers/search.js:80`) routed into the broken branch and 500'd. So a logged-in user searching boards got online results but their own matching boards failed to load. The board picker used when linking a board to a button (`content-grabbers.js` also sends `allow_job`) was affected the same way.

## Root cause

PR #303 added `:parent_board` to the index eager-load (`boards.includes(:board_content, :parent_board)`) to fix a real N+1 in `lib/json_api/board.rb` (`build_json` reads `board.parent_board` per result). Correct fix for that problem, but two branches in the same action harvest IDs with a partial `select('id, board_content_id')` that omits `parent_board_id`. With `:parent_board` now eager-loaded, ActiveRecord's `belongs_to` preloader reads the `parent_board_id` foreign key off those partial records and raises, because the column was never selected. `board_content` survived only because `board_content_id` was in the select.

Both broken branches are gated behind a search query (`q` present), which is why empty browse lists never hit it.

## Fix

`.except(:includes)` on the two id-only extraction sites so the preloader is not invoked on records that are immediately discarded (also drops a wasted preload over up to 500 throwaway rows). The full serialization path keeps `includes(:parent_board)`, so PR #303's N+1 fix is preserved. A guard comment at the eager-load site warns against a future `references`/`eager_load` refactor reopening this.

Not related to lite serialization (PR #294): `#index` never passes `as_lite`, and the `tree_lite_serialization` kill switch does not touch this path.

## Tests

- Two regression specs (the `allow_job` private path and the public+`user_id` twin), each verified to reproduce the exact `MissingAttributeError` against the unfixed line and pass with the fix.
- Full `#index` suite green (37 examples, 0 failures).

## Review

Cleared the dual-reviewer gate: `/review-pr` (Approve) and `/adversary-review` (Ship, all findings Low).

Fixes LINGOLINQ-RAILS-J

🤖 Generated with [Claude Code](https://claude.com/claude-code)