### PR TITLE
Add Vocal Flair 84 to signup default library boards

### DIFF
--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -2482,7 +2482,7 @@ when you change a positioned element's `position` responsively, check whether an
 
 **Root cause to avoid:** `User#copy_to_home_board` always writes `preferences.home_board` — wrong tool for library-only provisioning.
 
-**Fix recipe:** Add `User#copy_board_to_library` (`copy_for` + `copy_board_links`, no home pref). Schedule two jobs via `Progress.schedule(user, :copy_board_to_library, …, for_user: user)` from `UserBoardProvisioner` after save. Source boards live on the `lingolinq` content user (`SystemBoardSources`); import with `VOCABULARY_USER_NAME=lingolinq bundle exec rake openaac:import_vocabularies`. Gate with `FeatureFlags.signup_default_library_boards_enabled?`.
+**Fix recipe:** Add `User#copy_board_to_library` (`copy_for` + `copy_board_links`, no home pref). Schedule one Progress job per slug in `SystemBoardSources::SIGNUP_LIBRARY_SLUGS` via `Progress.schedule(user, :copy_board_to_library, …, for_user: user)` from `UserBoardProvisioner` after save. Source boards live on the `lingolinq` content user (`SystemBoardSources`); import with `VOCABULARY_USER_NAME=lingolinq bundle exec rake openaac:import_vocabularies`. Gate with `FeatureFlags.signup_default_library_boards_enabled?`.
 
 **Evidence:** `lib/user_board_provisioner.rb`, `lib/system_board_sources.rb`, `app/models/user.rb`; task log `2026-05-28-signup-default-library-boards.md`.
 

--- a/lib/system_board_sources.rb
+++ b/lib/system_board_sources.rb
@@ -1,7 +1,7 @@
 # Public/system vocabulary boards owned by the lingolinq content account.
 module SystemBoardSources
   USER_NAME = ENV.fetch('SYSTEM_BOARD_USER_NAME', 'lingolinq').freeze
-  SIGNUP_LIBRARY_SLUGS = %w[quick-core-60 vocal-flair-60].freeze
+  SIGNUP_LIBRARY_SLUGS = %w[quick-core-60 vocal-flair-60 vocal-flair-84].freeze
 
   def self.board_key(slug)
     "#{USER_NAME}/#{slug}"

--- a/spec/lib/user_board_provisioner_spec.rb
+++ b/spec/lib/user_board_provisioner_spec.rb
@@ -7,6 +7,7 @@ describe UserBoardProvisioner do
       user = User.create
       b1 = Board.process_new({name: 'Quick Core 60', public: true}, {user: source, key: 'quick-core-60'})
       b2 = Board.process_new({name: 'Vocal Flair 60', public: true}, {user: source, key: 'vocal-flair-60'})
+      b3 = Board.process_new({name: 'Vocal Flair 84', public: true}, {user: source, key: 'vocal-flair-84'})
 
       allow(FeatureFlags).to receive(:signup_default_library_boards_enabled?).and_return(true)
       expect(Progress).to receive(:schedule).with(
@@ -21,6 +22,14 @@ describe UserBoardProvisioner do
         user,
         :copy_board_to_library,
         {'id' => b2.global_id},
+        source.global_id,
+        nil,
+        for_user: user
+      ).ordered
+      expect(Progress).to receive(:schedule).with(
+        user,
+        :copy_board_to_library,
+        {'id' => b3.global_id},
         source.global_id,
         nil,
         for_user: user


### PR DESCRIPTION
## Summary
- Add `vocal-flair-84` to `SystemBoardSources::SIGNUP_LIBRARY_SLUGS` so new users receive a third default vocabulary board on signup (alongside Quick Core 60 and Vocal Flair 60).
- Update `UserBoardProvisioner` spec to expect a third scheduled `copy_board_to_library` Progress job.
- Clarify LEARNINGS doc that provisioning schedules one job per slug in `SIGNUP_LIBRARY_SLUGS`.

## Test plan
- [x] `bundle exec rspec spec/lib/user_board_provisioner_spec.rb`
- [x] Confirm `lingolinq/vocal-flair-84` exists and is public on staging (import with `VOCABULARY_USER_NAME=lingolinq ONLY=vocal-flair-84.obz bundle exec rake openaac:import_vocabularies` if missing)
- [ ] Register a test user on staging and verify Quick Core 60, Vocal Flair 60, and Vocal Flair 84 appear in My Boards after background jobs complete
- [ ] Confirm signup still does not set `preferences.home_board`


Made with [Cursor](https://cursor.com)