### PR TITLE
Add phased background board prefetch for online navigation and offline sync

### DIFF
--- a/app/frontend/app/services/app-state.js
+++ b/app/frontend/app/services/app-state.js
@@ -139,6 +139,18 @@ export default Service.extend({
     }
     
     this.setup();
+    if (typeof document !== 'undefined' && !isTesting() && !this._visibilityPrefetchBound) {
+      this._visibilityPrefetchBound = true;
+      var _this = this;
+      document.addEventListener('visibilitychange', function() {
+        if (document.hidden || _this.isDestroyed || _this.isDestroying) { return; }
+        if (!_this.get('persistence.online')) { return; }
+        var user = _this.get('currentUser');
+        if (user && user.get && user.get('id') && boardDetailCache && boardDetailCache.prefetch_for_user) {
+          try { boardDetailCache.prefetch_for_user(user); } catch(e) { /* non-critical */ }
+        }
+      });
+    }
     // Defer refresh timers to ensure all services are initialized
     // This prevents errors if window.persistence isn't ready yet
     var _this = this;

--- a/app/frontend/app/services/app-state.js
+++ b/app/frontend/app/services/app-state.js
@@ -2591,6 +2591,13 @@ export default Service.extend({
       try { boardDetailCache.prefetch_for_user(user); } catch(e) { /* non-critical */ }
     }
   }),
+  on_online_board_prefetch: observer('persistence.online', function() {
+    if(!this.get('persistence.online')) { return; }
+    var user = this.get('currentUser');
+    if(user && user.get && user.get('id') && boardDetailCache && boardDetailCache.prefetch_for_user) {
+      try { boardDetailCache.prefetch_for_user(user); } catch(e) { /* non-critical */ }
+    }
+  }),
   speak_mode_handlers: observer(
     'speak_mode',
     'currentUser.id',

--- a/app/frontend/app/services/persistence.js
+++ b/app/frontend/app/services/persistence.js
@@ -18,6 +18,7 @@ import contentGrabbers from '../utils/content_grabbers';
 import Utils from '../utils/misc';
 import modal from '../utils/modal';
 import capabilities from '../utils/capabilities';
+import boardPrefetchPlanner from '../utils/board_prefetch_planner';
 import { observer } from '@ember/object';
 import { computed } from '@ember/object';
 
@@ -2248,7 +2249,8 @@ var persistence = Service.extend({
             });
           }
         }
-        // TODO: also download all the user's personally-created boards
+        // Phased board sync (owned + public roots) handled in sync_boards
+        // when background_board_prefetch is enabled.
 
         var sync_log = [];
 
@@ -3075,8 +3077,10 @@ var persistence = Service.extend({
 
     var sync_all_boards = get_sounds.then(function(soundRes) {
       var _sync = _this;
+      var startBoardSync = function(listData) {
       return new RSVP.Promise(function(resolve, reject) {
         var to_visit_boards = [];
+        var backgroundPrefetch = user && boardPrefetchPlanner.backgroundBoardPrefetchEnabled(user);
         if(user.get('preferences.home_board.id')) {
           var board = user.get('preferences.home_board');
           board.depth = 0;
@@ -3090,8 +3094,25 @@ var persistence = Service.extend({
             }
           });
         }
-        // A user without a home board should also sync starred boards, by default
-        if(user.get('preferences.sync_starred_boards') === true || (!user.get('preferences.home_board.id') && user.get('preferences.sync_starred_boards') !== false)) {
+        if(backgroundPrefetch) {
+          var phased = boardPrefetchPlanner.buildPhasedLookups(user, {
+            ownedBoards: listData && listData.ownedBoards,
+            catalogBoards: listData && listData.catalogBoards,
+            globalBoards: listData && listData.globalBoards,
+            includeLiked: true
+          });
+          to_visit_boards = to_visit_boards.concat(
+            boardPrefetchPlanner.lookupsToSyncSeeds(phased.phase2, 'starred board', 0)
+          );
+          to_visit_boards = to_visit_boards.concat(
+            boardPrefetchPlanner.lookupsToSyncSeeds(phased.phase3, 'owned root', 0)
+          );
+          if(boardPrefetchPlanner.publicPrefetchEnabled(user)) {
+            to_visit_boards = to_visit_boards.concat(
+              boardPrefetchPlanner.lookupsToSyncSeeds(phased.phase4, 'public root', 0)
+            );
+          }
+        } else if(user.get('preferences.sync_starred_boards') === true || (!user.get('preferences.home_board.id') && user.get('preferences.sync_starred_boards') !== false)) {
           var sync_all = user.get('preferences.sync_starred_boards') === true;
           user.get('stats.starred_board_refs').forEach(function(ref) {
             if(sync_all || !ref.suggested) {
@@ -3153,7 +3174,7 @@ var persistence = Service.extend({
               var content_promises = 0;
               var safely_cached = !!safely_cached_boards[board.id];
               // force a reload of the buttonset if the board changed
-              if((next.depth == 0 && next.visit_source == 'home board') || (next.depth == 1 && next.visit_source == 'sidebar board') || (next.depth == 0 && next.visit_source == 'starred board')) {
+              if((next.depth == 0 && next.visit_source == 'home board') || (next.depth == 1 && next.visit_source == 'sidebar board') || (next.depth == 0 && next.visit_source == 'starred board') || (next.depth == 0 && next.visit_source == 'owned root') || (next.depth == 0 && next.visit_source == 'public root')) {
                 // Confirm if the button set is stored locally
                 _sync.find('buttonset', board.get('id')).then(function(bs) {
                   if(bs.full_set_revision != local_full_set_revision && !bs.buttons && !safely_cached) {
@@ -3479,6 +3500,23 @@ var persistence = Service.extend({
           reject.apply(null, arguments);
         });
       });
+      };
+
+      if(user && boardPrefetchPlanner.backgroundBoardPrefetchEnabled(user)) {
+        return boardPrefetchPlanner.fetchBoardListsForPrefetch(
+          _this.ajax.bind(_this),
+          user,
+          {
+            includeOwned: true,
+            includePublic: boardPrefetchPlanner.publicPrefetchEnabled(user)
+          }
+        ).then(function(listData) {
+          return startBoardSync(listData);
+        }, function() {
+          return startBoardSync(null);
+        });
+      }
+      return startBoardSync(null);
     });
 
     return sync_all_boards.then(function(full_set_revisions) {

--- a/app/frontend/app/utils/board_detail_cache.js
+++ b/app/frontend/app/utils/board_detail_cache.js
@@ -18,6 +18,7 @@
 // and on entering edit mode so editors never read stale state.
 
 import persistence from './persistence';
+import boardPrefetchPlanner from './board_prefetch_planner';
 import { later as runLater } from '@ember/runloop';
 import RSVP from 'rsvp';
 import LingoLinq from '../app';
@@ -26,10 +27,7 @@ var TTL_MS = 5 * 60 * 1000;
 var MAX_PREFETCH = 20;
 var WARM_BATCH = 20;
 var WARM_BATCH_GAP_MS = 80;
-var CATALOG_TREE_GAP_MS = 400;
-var CATALOG_ROOTS_PER_PAGE = 50;
-var CATALOG_ROOT_CAP = 100;
-var CATALOG_ACCOUNT = 'lingolinq';
+var TREE_GAP_MS = 400;
 
 // key (e.g. "user_name/boardname") → entry
 var _by_key = {};
@@ -190,17 +188,57 @@ function _push_board_to_store(raw) {
   } catch (e) { /* ignore */ }
 }
 
-function _catalog_prefetch_enabled(user) {
+function _is_online() {
   try {
-    if (typeof window !== 'undefined' && LingoLinq && LingoLinq.appState) {
-      return !!LingoLinq.appState.get('feature_flags.catalog_board_prefetch');
+    if (!persistence) { return false; }
+    if (typeof persistence.get === 'function') {
+      return !!persistence.get('online');
     }
-    if (user && user.get) {
-      var flags = user.get('feature_flags');
-      if (flags && flags.catalog_board_prefetch) { return true; }
+    return !!persistence.online;
+  } catch (e) { return false; }
+}
+
+function _document_hidden() {
+  return typeof document !== 'undefined' && document.hidden;
+}
+
+function _process_roots_sequentially(cache, rootKeys, warm_opts, gapMs) {
+  if (!rootKeys || !rootKeys.length) { return RSVP.resolve(true); }
+  var index = 0;
+  var anyIngested = false;
+
+  var processNext = function() {
+    if (_document_hidden() || !_is_online()) {
+      return RSVP.resolve(anyIngested);
     }
-  } catch (e) { /* app may not be booted yet */ }
-  return false;
+    if (index >= rootKeys.length) {
+      return RSVP.resolve(true);
+    }
+    var key = rootKeys[index++];
+    var existing = _lookup(key);
+    if (existing && _is_fresh(existing) && existing.raw) {
+      return new RSVP.Promise(function(resolve) {
+        runLater(function() {
+          processNext().then(resolve, resolve);
+        }, gapMs);
+      });
+    }
+    return persistence.ajax('/api/v1/boards/' + key + '/tree', { type: 'GET' }).then(function(data) {
+      if (_ingest_tree_response(cache, data, warm_opts)) {
+        anyIngested = true;
+      }
+    }, function() {
+      /* swallow per-board errors */
+    }).then(function() {
+      return new RSVP.Promise(function(resolve) {
+        runLater(function() {
+          processNext().then(resolve, resolve);
+        }, gapMs);
+      });
+    });
+  };
+
+  return processNext();
 }
 
 function _ingest_tree_response(cache, data, warm_opts, options) {
@@ -324,6 +362,8 @@ export default {
     _warmed_urls = {};
     this._prefetched_user_ids = {};
     this._prefetched_catalog_user_ids = {};
+    this._prefetch_phase_done = {};
+    this._prefetch_pipeline_running = {};
   },
 
   // Warm the browser image cache for every button image URL on the
@@ -451,150 +491,197 @@ export default {
     });
   },
 
-  // Session-start prefetch: called when a user logs in (or session is
-  // restored on app boot). Fires a one-shot /tree fetch for the user's
-  // home board so by the time the user navigates to Boards / clicks a
-  // sub-board, every board JSON and every image URL is already in
-  // cache.
-  //
-  // Industry-standard pattern: prefetch the user's known data envelope
-  // at session start (Slack, Notion, Linear all do this), so subsequent
-  // navigation is instant rather than slow on first hit.
-  //
-  // - Tracked per user id so we don't re-prefetch on every observer
-  //   fire (currentUser can flicker during session restore).
-  // - Fire-and-forget; returns nothing. Doesn't block any caller.
-  // - Skips silently if no home board is configured.
-  prefetch_for_user: function(user) {
-    if (!user || !user.get) { return; }
-    var user_id = user.get('id');
-    if (!user_id) { return; }
-    this._prefetched_user_ids = this._prefetched_user_ids || {};
-    if (this._prefetched_user_ids[user_id]) { return; }
-    this._prefetched_user_ids[user_id] = true;
-    var home_key = user.get('preferences.home_board.key');
-    var home_id = user.get('preferences.home_board.id');
-    var lookup = home_key || home_id;
+  _run_prefetch_pipeline: function(user, warm_opts) {
     var _this = this;
-    var warm_opts = {
-      skin: user.get('preferences.skin'),
-      preferred_symbols: user.get('preferences.preferred_symbols')
-    };
-    var start_catalog_prefetch = function() {
-      _this.prefetch_lingolinq_catalog(user, warm_opts);
-    };
-    // Defer slightly so this doesn't compete with the post-login UI
-    // render. By the time the user finishes reading the dashboard,
-    // the tree is cached and Boards-tab navigation is instant.
-    runLater(function() {
-      if (!lookup) {
-        start_catalog_prefetch();
-        return;
-      }
-      persistence.ajax('/api/v1/boards/' + lookup + '/tree', { type: 'GET' }).then(function(data) {
-        _ingest_tree_response(_this, data, warm_opts);
-      }, function() {
-        // Allow a retry on the next observer fire — the network may
-        // have been unavailable at session-start.
-        delete _this._prefetched_user_ids[user_id];
-      }).then(start_catalog_prefetch, start_catalog_prefetch);
-    }, 400);
-  },
-
-  // After the home board tree is cached, prefetch full JSON trees for
-  // every public root board on the official lingolinq account so
-  // home-board picker / catalog navigation is instant in-session.
-  prefetch_lingolinq_catalog: function(user, warm_opts) {
-    if (!user || !user.get) { return RSVP.resolve(); }
-    if (!_catalog_prefetch_enabled(user)) { return RSVP.resolve(); }
     var user_id = user.get('id');
-    if (!user_id) { return RSVP.resolve(); }
-    this._prefetched_catalog_user_ids = this._prefetched_catalog_user_ids || {};
-    if (this._prefetched_catalog_user_ids[user_id]) { return RSVP.resolve(); }
-    this._prefetched_catalog_user_ids[user_id] = true;
-
-    var _this = this;
     warm_opts = warm_opts || {
       skin: user.get('preferences.skin'),
       preferred_symbols: user.get('preferences.preferred_symbols')
     };
-    var ingested_count = 0;
-    var root_keys = [];
+    _this._prefetch_phase_done = _this._prefetch_phase_done || {};
+    var phaseDone = _this._prefetch_phase_done[user_id] || {};
+    _this._prefetch_phase_done[user_id] = phaseDone;
 
-    var collect_roots = function(list_url) {
-      if (typeof document !== 'undefined' && document.hidden) {
-        return RSVP.resolve();
-      }
-      return persistence.ajax(list_url, { type: 'GET' }).then(function(data) {
-        (data.board || []).forEach(function(b) {
-          if (b && b.key && root_keys.length < CATALOG_ROOT_CAP) {
-            root_keys.push(b.key);
-          }
-        });
-        if (data.meta && data.meta.more && data.meta.next_url && root_keys.length < CATALOG_ROOT_CAP) {
-          return collect_roots(data.meta.next_url);
+    var chain = RSVP.resolve();
+
+    if (!phaseDone.phase1) {
+      chain = chain.then(function() {
+        if (_document_hidden() || !_is_online()) { return RSVP.resolve(); }
+        var lookups = boardPrefetchPlanner.collectHomeLookups(user);
+        if (!lookups.length) {
+          phaseDone.phase1 = true;
+          return RSVP.resolve();
         }
+        return _process_roots_sequentially(_this, lookups, warm_opts, TREE_GAP_MS).then(function() {
+          phaseDone.phase1 = true;
+        }, function() {
+          delete phaseDone.phase1;
+        });
       });
-    };
-
-    var locale = user.get('preferences.locale');
-    var list_query = '/api/v1/boards?user_id=' + encodeURIComponent(CATALOG_ACCOUNT) +
-      '&public=true&sort=home_popularity&copies=false&per_page=' + CATALOG_ROOTS_PER_PAGE;
-    if (locale) {
-      list_query += '&locale=' + encodeURIComponent(locale);
     }
 
-    var process_next_root = function(index) {
-      if (typeof document !== 'undefined' && document.hidden) {
-        return RSVP.resolve();
-      }
-      if (index >= root_keys.length) { return RSVP.resolve(); }
-      var key = root_keys[index];
-      var existing = _lookup(key);
-      if (existing && _is_fresh(existing) && existing.raw) {
-        return new RSVP.Promise(function(resolve) {
-          runLater(function() {
-            process_next_root(index + 1).then(resolve, resolve);
-          }, CATALOG_TREE_GAP_MS);
-        });
-      }
-      return persistence.ajax('/api/v1/boards/' + key + '/tree', { type: 'GET' }).then(function(data) {
-        if (_ingest_tree_response(_this, data, warm_opts)) {
-          ingested_count++;
-        }
-      }, function() {
-        /* swallow per-board errors */
-      }).then(function() {
-        return new RSVP.Promise(function(resolve) {
-          runLater(function() {
-            process_next_root(index + 1).then(resolve, resolve);
-          }, CATALOG_TREE_GAP_MS);
-        });
-      });
-    };
-
-    return new RSVP.Promise(function(resolve) {
-      runLater(function() {
-        collect_roots(list_query).then(function() {
-          if (!root_keys.length) {
-            delete _this._prefetched_catalog_user_ids[user_id];
-            return;
+    if (boardPrefetchPlanner.backgroundBoardPrefetchEnabled(user)) {
+      if (!phaseDone.phase2) {
+        chain = chain.then(function() {
+          if (_document_hidden() || !_is_online()) { return RSVP.resolve(); }
+          var seen = {};
+          boardPrefetchPlanner.collectHomeLookups(user).forEach(function(l) { seen[l] = true; });
+          var lookups = boardPrefetchPlanner.collectLikedLookups(user, seen);
+          if (!lookups.length) {
+            phaseDone.phase2 = true;
+            return RSVP.resolve();
           }
-          return process_next_root(0).then(function() {
-            if (!ingested_count) {
-              delete _this._prefetched_catalog_user_ids[user_id];
+          return _process_roots_sequentially(_this, lookups, warm_opts, TREE_GAP_MS).then(function() {
+            phaseDone.phase2 = true;
+          }, function() {
+            delete phaseDone.phase2;
+          });
+        });
+      }
+
+      if (!phaseDone.phase3) {
+        chain = chain.then(function() {
+          if (_document_hidden() || !_is_online()) { return RSVP.resolve(); }
+          return boardPrefetchPlanner.fetchBoardListsForPrefetch(
+            persistence.ajax.bind(persistence),
+            user,
+            { includeOwned: true, includePublic: false }
+          ).then(function(listData) {
+            var phased = boardPrefetchPlanner.buildPhasedLookups(user, {
+              ownedBoards: listData.ownedBoards,
+              includeLiked: false
+            });
+            if (!phased.phase3.length) {
+              phaseDone.phase3 = true;
+              return RSVP.resolve();
             }
+            return _process_roots_sequentially(_this, phased.phase3, warm_opts, TREE_GAP_MS).then(function() {
+              phaseDone.phase3 = true;
+            }, function() {
+              delete phaseDone.phase3;
+            });
+          }, function() {
+            delete phaseDone.phase3;
+          });
+        });
+      }
+    }
+
+    if (boardPrefetchPlanner.publicPrefetchEnabled(user) && !phaseDone.phase4) {
+      chain = chain.then(function() {
+        if (_document_hidden() || !_is_online()) { return RSVP.resolve(); }
+        return boardPrefetchPlanner.fetchBoardListsForPrefetch(
+          persistence.ajax.bind(persistence),
+          user,
+          { includeOwned: false, includePublic: true }
+        ).then(function(listData) {
+          var seen = {};
+          var phased = boardPrefetchPlanner.buildPhasedLookups(user, {
+            catalogBoards: listData.catalogBoards,
+            globalBoards: listData.globalBoards,
+            includeLiked: false
+          });
+          phased.phase1.concat(phased.phase2, phased.phase3).forEach(function(l) { seen[l] = true; });
+          var publicLookups = boardPrefetchPlanner.collectPublicLookups(
+            user,
+            listData.catalogBoards,
+            listData.globalBoards,
+            seen
+          );
+          if (!publicLookups.length) {
+            phaseDone.phase4 = true;
+            return RSVP.resolve();
+          }
+          return _process_roots_sequentially(_this, publicLookups, warm_opts, TREE_GAP_MS).then(function() {
+            phaseDone.phase4 = true;
+          }, function() {
+            delete phaseDone.phase4;
           });
         }, function() {
-          if (!ingested_count) {
-            delete _this._prefetched_catalog_user_ids[user_id];
-          }
-        }).then(function() {
-          resolve();
-        }, function() {
-          resolve();
+          delete phaseDone.phase4;
         });
-      }, CATALOG_TREE_GAP_MS);
+      });
+    }
+
+    return chain;
+  },
+
+  // Session-start prefetch: called when a user logs in (or session is
+  // restored on app boot). Runs a phased pipeline — home board first,
+  // then liked boards, all owned roots, and public boards when the
+  // background_board_prefetch flag is enabled.
+  //
+  // - Phase completion tracked per user so reconnect resumes incomplete
+  //   phases without re-fetching finished work.
+  // - Fire-and-forget; returns nothing. Doesn't block any caller.
+  prefetch_for_user: function(user) {
+    if (!user || !user.get) { return; }
+    var user_id = user.get('id');
+    if (!user_id) { return; }
+    if (!_is_online()) { return; }
+    if (_document_hidden()) { return; }
+
+    var _this = this;
+    _this._prefetch_pipeline_running = _this._prefetch_pipeline_running || {};
+    if (_this._prefetch_pipeline_running[user_id]) { return; }
+    _this._prefetch_pipeline_running[user_id] = true;
+
+    var warm_opts = {
+      skin: user.get('preferences.skin'),
+      preferred_symbols: user.get('preferences.preferred_symbols')
+    };
+
+    runLater(function() {
+      _this._run_prefetch_pipeline(user, warm_opts).then(function() {
+        delete _this._prefetch_pipeline_running[user_id];
+      }, function() {
+        delete _this._prefetch_pipeline_running[user_id];
+      });
+    }, 400);
+  },
+
+  // Legacy entry point kept for tests. Prefetches LingoLinq catalog +
+  // global public roots when public prefetch is enabled.
+  prefetch_lingolinq_catalog: function(user, warm_opts) {
+    if (!user || !user.get) { return RSVP.resolve(); }
+    if (!boardPrefetchPlanner.publicPrefetchEnabled(user)) { return RSVP.resolve(); }
+    var user_id = user.get('id');
+    if (!user_id) { return RSVP.resolve(); }
+    if (!_is_online()) { return RSVP.resolve(); }
+
+    var _this = this;
+    _this._prefetched_catalog_user_ids = _this._prefetched_catalog_user_ids || {};
+    if (_this._prefetched_catalog_user_ids[user_id]) { return RSVP.resolve(); }
+    _this._prefetched_catalog_user_ids[user_id] = true;
+
+    warm_opts = warm_opts || {
+      skin: user.get('preferences.skin'),
+      preferred_symbols: user.get('preferences.preferred_symbols')
+    };
+
+    return boardPrefetchPlanner.fetchBoardListsForPrefetch(
+      persistence.ajax.bind(persistence),
+      user,
+      { includeOwned: false, includePublic: true }
+    ).then(function(listData) {
+      var seen = {};
+      var publicLookups = boardPrefetchPlanner.collectPublicLookups(
+        user,
+        listData.catalogBoards,
+        listData.globalBoards,
+        seen
+      );
+      if (!publicLookups.length) {
+        delete _this._prefetched_catalog_user_ids[user_id];
+        return RSVP.resolve();
+      }
+      return _process_roots_sequentially(_this, publicLookups, warm_opts, TREE_GAP_MS).then(function() {
+        /* done */
+      }, function() {
+        delete _this._prefetched_catalog_user_ids[user_id];
+      });
+    }, function() {
+      delete _this._prefetched_catalog_user_ids[user_id];
     });
   },
 

--- a/app/frontend/app/utils/board_detail_cache.js
+++ b/app/frontend/app/utils/board_detail_cache.js
@@ -202,14 +202,21 @@ function _document_hidden() {
   return typeof document !== 'undefined' && document.hidden;
 }
 
+function _complete_phase_if_done(phaseDone, phaseKey, completed) {
+  if (completed === true) {
+    phaseDone[phaseKey] = true;
+  } else if (completed === false) {
+    delete phaseDone[phaseKey];
+  }
+}
+
 function _process_roots_sequentially(cache, rootKeys, warm_opts, gapMs) {
   if (!rootKeys || !rootKeys.length) { return RSVP.resolve(true); }
   var index = 0;
-  var anyIngested = false;
 
   var processNext = function() {
     if (_document_hidden() || !_is_online()) {
-      return RSVP.resolve(anyIngested);
+      return RSVP.resolve(false);
     }
     if (index >= rootKeys.length) {
       return RSVP.resolve(true);
@@ -224,9 +231,7 @@ function _process_roots_sequentially(cache, rootKeys, warm_opts, gapMs) {
       });
     }
     return persistence.ajax('/api/v1/boards/' + key + '/tree', { type: 'GET' }).then(function(data) {
-      if (_ingest_tree_response(cache, data, warm_opts)) {
-        anyIngested = true;
-      }
+      _ingest_tree_response(cache, data, warm_opts);
     }, function() {
       /* swallow per-board errors */
     }).then(function() {
@@ -512,8 +517,8 @@ export default {
           phaseDone.phase1 = true;
           return RSVP.resolve();
         }
-        return _process_roots_sequentially(_this, lookups, warm_opts, TREE_GAP_MS).then(function() {
-          phaseDone.phase1 = true;
+        return _process_roots_sequentially(_this, lookups, warm_opts, TREE_GAP_MS).then(function(completed) {
+          _complete_phase_if_done(phaseDone, 'phase1', completed);
         }, function() {
           delete phaseDone.phase1;
         });
@@ -531,8 +536,8 @@ export default {
             phaseDone.phase2 = true;
             return RSVP.resolve();
           }
-          return _process_roots_sequentially(_this, lookups, warm_opts, TREE_GAP_MS).then(function() {
-            phaseDone.phase2 = true;
+          return _process_roots_sequentially(_this, lookups, warm_opts, TREE_GAP_MS).then(function(completed) {
+            _complete_phase_if_done(phaseDone, 'phase2', completed);
           }, function() {
             delete phaseDone.phase2;
           });
@@ -555,8 +560,8 @@ export default {
               phaseDone.phase3 = true;
               return RSVP.resolve();
             }
-            return _process_roots_sequentially(_this, phased.phase3, warm_opts, TREE_GAP_MS).then(function() {
-              phaseDone.phase3 = true;
+            return _process_roots_sequentially(_this, phased.phase3, warm_opts, TREE_GAP_MS).then(function(completed) {
+              _complete_phase_if_done(phaseDone, 'phase3', completed);
             }, function() {
               delete phaseDone.phase3;
             });
@@ -592,8 +597,8 @@ export default {
             phaseDone.phase4 = true;
             return RSVP.resolve();
           }
-          return _process_roots_sequentially(_this, publicLookups, warm_opts, TREE_GAP_MS).then(function() {
-            phaseDone.phase4 = true;
+          return _process_roots_sequentially(_this, publicLookups, warm_opts, TREE_GAP_MS).then(function(completed) {
+            _complete_phase_if_done(phaseDone, 'phase4', completed);
           }, function() {
             delete phaseDone.phase4;
           });

--- a/app/frontend/app/utils/board_prefetch_planner.js
+++ b/app/frontend/app/utils/board_prefetch_planner.js
@@ -37,9 +37,11 @@ export function collectLikedLookups(user, seen) {
   if (!user || !user.get) { return []; }
   seen = seen || {};
   var refs = user.get('stats.starred_board_refs') || [];
+  var syncAll = user.get('preferences.sync_starred_boards') === true;
   var result = [];
   refs.forEach(function(ref) {
     if (!ref) { return; }
+    if (!syncAll && ref.suggested) { return; }
     if (ref.style && ref.style.options) {
       ref.style.options.forEach(function(opt) {
         if (opt && opt.key) {

--- a/app/frontend/app/utils/board_prefetch_planner.js
+++ b/app/frontend/app/utils/board_prefetch_planner.js
@@ -1,0 +1,247 @@
+// Shared phased board-root enumeration for session prefetch
+// (board_detail_cache) and offline sync (persistence.sync_boards).
+
+import RSVP from 'rsvp';
+import filterRootBoards from './board-roots';
+import LingoLinq from '../app';
+
+export var OWNED_ROOT_CAP = 200;
+export var CATALOG_ROOT_CAP = 100;
+export var GLOBAL_PUBLIC_ROOT_CAP = 50;
+export var CATALOG_ROOTS_PER_PAGE = 50;
+export var CATALOG_ACCOUNT = 'lingolinq';
+
+function _seenFromList(list) {
+  var seen = {};
+  (list || []).forEach(function(l) {
+    if (l) { seen[l] = true; }
+  });
+  return seen;
+}
+
+function _addUnique(result, seen, lookup, cap) {
+  if (!lookup || seen[lookup] || (cap && result.length >= cap)) { return; }
+  seen[lookup] = true;
+  result.push(lookup);
+}
+
+export function collectHomeLookups(user) {
+  if (!user || !user.get) { return []; }
+  var hb = user.get('preferences.home_board');
+  if (!hb) { return []; }
+  var lookup = hb.key || hb.id;
+  return lookup ? [lookup] : [];
+}
+
+export function collectLikedLookups(user, seen) {
+  if (!user || !user.get) { return []; }
+  seen = seen || {};
+  var refs = user.get('stats.starred_board_refs') || [];
+  var result = [];
+  refs.forEach(function(ref) {
+    if (!ref) { return; }
+    if (ref.style && ref.style.options) {
+      ref.style.options.forEach(function(opt) {
+        if (opt && opt.key) {
+          _addUnique(result, seen, opt.key);
+        }
+      });
+    } else if (ref.key) {
+      _addUnique(result, seen, ref.key);
+    } else if (ref.id) {
+      _addUnique(result, seen, ref.id);
+    }
+  });
+  return result;
+}
+
+export function collectOwnedRootLookups(user, boardsFromApi, seen) {
+  if (!user || !user.get || !boardsFromApi) { return []; }
+  seen = seen || {};
+  var userId = user.get('id');
+  var roots = filterRootBoards(boardsFromApi, userId);
+  var result = [];
+  roots.forEach(function(b) {
+    var lookup = (b && (b.key || b.id)) || null;
+    _addUnique(result, seen, lookup, OWNED_ROOT_CAP);
+  });
+  return result;
+}
+
+export function collectPublicLookups(user, catalogBoards, globalBoards, seen) {
+  seen = seen || {};
+  var result = [];
+  var catalogCount = 0;
+  (catalogBoards || []).forEach(function(b) {
+    if (b && b.key) {
+      var before = result.length;
+      _addUnique(result, seen, b.key);
+      if (result.length > before) { catalogCount++; }
+      if (catalogCount >= CATALOG_ROOT_CAP) { return; }
+    }
+  });
+  var globalCount = 0;
+  (globalBoards || []).forEach(function(b) {
+    if (b && b.key) {
+      var before = result.length;
+      _addUnique(result, seen, b.key);
+      if (result.length > before) { globalCount++; }
+      if (globalCount >= GLOBAL_PUBLIC_ROOT_CAP) { return; }
+    }
+  });
+  return result;
+}
+
+export function buildPhasedLookups(user, opts) {
+  opts = opts || {};
+  var seen = {};
+  var phase1 = collectHomeLookups(user);
+  Object.assign(seen, _seenFromList(phase1));
+
+  var phase2 = [];
+  if (opts.includeLiked !== false) {
+    phase2 = collectLikedLookups(user, seen);
+    Object.assign(seen, _seenFromList(phase2));
+  }
+
+  var phase3 = [];
+  if (opts.ownedBoards) {
+    phase3 = collectOwnedRootLookups(user, opts.ownedBoards, seen);
+    Object.assign(seen, _seenFromList(phase3));
+  }
+
+  var phase4 = [];
+  if (opts.catalogBoards || opts.globalBoards) {
+    phase4 = collectPublicLookups(user, opts.catalogBoards, opts.globalBoards, seen);
+  }
+
+  return { phase1: phase1, phase2: phase2, phase3: phase3, phase4: phase4 };
+}
+
+function _flagFromAppState(flagName) {
+  try {
+    if (typeof window !== 'undefined' && LingoLinq && LingoLinq.appState) {
+      return !!LingoLinq.appState.get('feature_flags.' + flagName);
+    }
+  } catch (e) { /* app may not be booted */ }
+  return false;
+}
+
+function _flagFromUser(user, flagName) {
+  if (user && user.get) {
+    var flags = user.get('feature_flags');
+    if (flags && flags[flagName]) { return true; }
+  }
+  return false;
+}
+
+export function catalogPrefetchEnabled(user) {
+  return _flagFromAppState('catalog_board_prefetch') || _flagFromUser(user, 'catalog_board_prefetch');
+}
+
+export function backgroundBoardPrefetchEnabled(user) {
+  return _flagFromAppState('background_board_prefetch') || _flagFromUser(user, 'background_board_prefetch');
+}
+
+export function publicPrefetchEnabled(user) {
+  return backgroundBoardPrefetchEnabled(user) || catalogPrefetchEnabled(user);
+}
+
+function paginateBoardList(ajax, listUrl, cap) {
+  var boards = [];
+  var collect = function(url) {
+    return ajax(url, { type: 'GET' }).then(function(data) {
+      (data.board || []).forEach(function(b) {
+        if (b && boards.length < cap) {
+          boards.push(b);
+        }
+      });
+      if (data.meta && data.meta.more && data.meta.next_url && boards.length < cap) {
+        return collect(data.meta.next_url);
+      }
+    });
+  };
+  return collect(listUrl).then(function() {
+    return boards;
+  });
+}
+
+export function fetchOwnedBoards(ajax, userId) {
+  var url = '/api/v1/boards?user_id=' + encodeURIComponent(userId) +
+    '&per_page=' + CATALOG_ROOTS_PER_PAGE;
+  return paginateBoardList(ajax, url, OWNED_ROOT_CAP * 3);
+}
+
+export function fetchCatalogBoards(ajax, locale) {
+  var url = '/api/v1/boards?user_id=' + encodeURIComponent(CATALOG_ACCOUNT) +
+    '&public=true&sort=home_popularity&copies=false&per_page=' + CATALOG_ROOTS_PER_PAGE;
+  if (locale) {
+    url += '&locale=' + encodeURIComponent(locale);
+  }
+  return paginateBoardList(ajax, url, CATALOG_ROOT_CAP);
+}
+
+export function fetchGlobalPublicBoards(ajax, locale) {
+  var url = '/api/v1/boards?q=&sort=popularity&per_page=' + CATALOG_ROOTS_PER_PAGE;
+  if (locale) {
+    url += '&locale=' + encodeURIComponent(locale);
+  }
+  return paginateBoardList(ajax, url, GLOBAL_PUBLIC_ROOT_CAP);
+}
+
+export function fetchBoardListsForPrefetch(ajax, user, opts) {
+  opts = opts || {};
+  var locale = (user && user.get && user.get('preferences.locale')) || 'en';
+  var userId = user && user.get && user.get('id');
+  var result = { ownedBoards: [], catalogBoards: [], globalBoards: [] };
+  var promises = [];
+
+  if (opts.includeOwned && userId) {
+    promises.push(fetchOwnedBoards(ajax, userId).then(function(boards) {
+      result.ownedBoards = boards;
+    }));
+  }
+  if (opts.includePublic) {
+    promises.push(fetchCatalogBoards(ajax, locale).then(function(boards) {
+      result.catalogBoards = boards;
+    }));
+    promises.push(fetchGlobalPublicBoards(ajax, locale).then(function(boards) {
+      result.globalBoards = boards;
+    }));
+  }
+
+  return RSVP.all(promises).then(function() {
+    return result;
+  });
+}
+
+export function lookupsToSyncSeeds(lookups, visitSource, depth) {
+  depth = depth === undefined ? 0 : depth;
+  return (lookups || []).map(function(lookup) {
+    if (lookup && lookup.indexOf('/') !== -1) {
+      return { key: lookup, depth: depth, visit_source: visitSource };
+    }
+    return { id: lookup, depth: depth, visit_source: visitSource };
+  });
+}
+
+export default {
+  OWNED_ROOT_CAP: OWNED_ROOT_CAP,
+  CATALOG_ROOT_CAP: CATALOG_ROOT_CAP,
+  GLOBAL_PUBLIC_ROOT_CAP: GLOBAL_PUBLIC_ROOT_CAP,
+  CATALOG_ROOTS_PER_PAGE: CATALOG_ROOTS_PER_PAGE,
+  CATALOG_ACCOUNT: CATALOG_ACCOUNT,
+  collectHomeLookups: collectHomeLookups,
+  collectLikedLookups: collectLikedLookups,
+  collectOwnedRootLookups: collectOwnedRootLookups,
+  collectPublicLookups: collectPublicLookups,
+  buildPhasedLookups: buildPhasedLookups,
+  catalogPrefetchEnabled: catalogPrefetchEnabled,
+  backgroundBoardPrefetchEnabled: backgroundBoardPrefetchEnabled,
+  publicPrefetchEnabled: publicPrefetchEnabled,
+  fetchOwnedBoards: fetchOwnedBoards,
+  fetchCatalogBoards: fetchCatalogBoards,
+  fetchGlobalPublicBoards: fetchGlobalPublicBoards,
+  fetchBoardListsForPrefetch: fetchBoardListsForPrefetch,
+  lookupsToSyncSeeds: lookupsToSyncSeeds
+};

--- a/app/frontend/app/utils/persistence.js
+++ b/app/frontend/app/utils/persistence.js
@@ -17,6 +17,7 @@ import contentGrabbers from './content_grabbers';
 import Utils from './misc';
 import modal from './modal';
 import capabilities from './capabilities';
+import boardPrefetchPlanner from './board_prefetch_planner';
 import { observer } from '@ember/object';
 import { computed } from '@ember/object';
 
@@ -2245,7 +2246,8 @@ var persistence = EmberObject.extend({
             });
           }
         }
-        // TODO: also download all the user's personally-created boards
+        // Phased board sync (owned + public roots) handled in sync_boards
+        // when background_board_prefetch is enabled.
 
         var sync_log = [];
 
@@ -3048,8 +3050,10 @@ var persistence = EmberObject.extend({
     });
 
     var sync_all_boards = get_sounds.then(function() {
-      return new RSVP.Promise(function(resolve, reject) {
+      var startBoardSync = function(listData) {
+        return new RSVP.Promise(function(resolve, reject) {
         var to_visit_boards = [];
+        var backgroundPrefetch = user && boardPrefetchPlanner.backgroundBoardPrefetchEnabled(user);
         if(user.get('preferences.home_board.id')) {
           var board = user.get('preferences.home_board');
           board.depth = 0;
@@ -3063,8 +3067,25 @@ var persistence = EmberObject.extend({
             }
           });
         }
-        // A user without a home board should also sync starred boards, by default
-        if(user.get('preferences.sync_starred_boards') === true || (!user.get('preferences.home_board.id') && user.get('preferences.sync_starred_boards') !== false)) {
+        if(backgroundPrefetch) {
+          var phased = boardPrefetchPlanner.buildPhasedLookups(user, {
+            ownedBoards: listData && listData.ownedBoards,
+            catalogBoards: listData && listData.catalogBoards,
+            globalBoards: listData && listData.globalBoards,
+            includeLiked: true
+          });
+          to_visit_boards = to_visit_boards.concat(
+            boardPrefetchPlanner.lookupsToSyncSeeds(phased.phase2, 'starred board', 0)
+          );
+          to_visit_boards = to_visit_boards.concat(
+            boardPrefetchPlanner.lookupsToSyncSeeds(phased.phase3, 'owned root', 0)
+          );
+          if(boardPrefetchPlanner.publicPrefetchEnabled(user)) {
+            to_visit_boards = to_visit_boards.concat(
+              boardPrefetchPlanner.lookupsToSyncSeeds(phased.phase4, 'public root', 0)
+            );
+          }
+        } else if(user.get('preferences.sync_starred_boards') === true || (!user.get('preferences.home_board.id') && user.get('preferences.sync_starred_boards') !== false)) {
           var sync_all = user.get('preferences.sync_starred_boards') === true;
           user.get('stats.starred_board_refs').forEach(function(ref) {
             if(sync_all || !ref.suggested) {
@@ -3126,7 +3147,7 @@ var persistence = EmberObject.extend({
               var content_promises = 0;
               var safely_cached = !!safely_cached_boards[board.id];
               // force a reload of the buttonset if the board changed
-              if((next.depth == 0 && next.visit_source == 'home board') || (next.depth == 1 && next.visit_source == 'sidebar board') || (next.depth == 0 && next.visit_source == 'starred board')) {
+              if((next.depth == 0 && next.visit_source == 'home board') || (next.depth == 1 && next.visit_source == 'sidebar board') || (next.depth == 0 && next.visit_source == 'starred board') || (next.depth == 0 && next.visit_source == 'owned root') || (next.depth == 0 && next.visit_source == 'public root')) {
                 // Confirm if the button set is stored locally
                 persistence.find('buttonset', board.get('id')).then(function(bs) {
                   if(bs.full_set_revision != local_full_set_revision && !bs.buttons && !safely_cached) {
@@ -3451,6 +3472,23 @@ var persistence = EmberObject.extend({
           reject.apply(null, arguments);
         });
       });
+      };
+
+      if(user && boardPrefetchPlanner.backgroundBoardPrefetchEnabled(user)) {
+        return boardPrefetchPlanner.fetchBoardListsForPrefetch(
+          persistence.ajax.bind(persistence),
+          user,
+          {
+            includeOwned: true,
+            includePublic: boardPrefetchPlanner.publicPrefetchEnabled(user)
+          }
+        ).then(function(listData) {
+          return startBoardSync(listData);
+        }, function() {
+          return startBoardSync(null);
+        });
+      }
+      return startBoardSync(null);
     });
 
     return sync_all_boards.then(function(full_set_revisions) {

--- a/app/frontend/tests/test-helper.js
+++ b/app/frontend/tests/test-helper.js
@@ -60,6 +60,7 @@ import 'frontend/tests/acceptance/board-detail-empty-state-test';
 import 'frontend/tests/unit/controllers/copying-board-test';
 import 'frontend/tests/unit/controllers/user-board-detail-image-cache-test';
 import 'frontend/tests/unit/utils/board-detail-cache-test';
+import 'frontend/tests/unit/utils/board-prefetch-planner-test';
 import 'frontend/tests/unit/utils/loading-overlay-cache-test';
 
 // loadTests: false — we already pre-loaded all test modules above

--- a/app/frontend/tests/unit/utils/board-detail-cache-test.js
+++ b/app/frontend/tests/unit/utils/board-detail-cache-test.js
@@ -485,4 +485,90 @@ module('Unit | Utility | board-detail-cache', function() {
       throw err;
     });
   });
+
+  test('prefetch pipeline does not mark phase done when interrupted mid-phase', function(assert) {
+    boardDetailCache.clear();
+    var done = assert.async();
+    var treeCount = 0;
+    var origAjax = persistence.ajax;
+    var origAppState = LingoLinq.appState;
+    var origGet = persistence.get;
+    var origHidden = Object.getOwnPropertyDescriptor(document, 'hidden');
+
+    persistence.get = function(key) {
+      if (key === 'online') { return true; }
+      if (origGet) { return origGet.call(persistence, key); }
+      return true;
+    };
+
+    LingoLinq.appState = {
+      get: function(path) {
+        if (path === 'feature_flags.background_board_prefetch') { return true; }
+        return null;
+      }
+    };
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: function() { return treeCount >= 1; }
+    });
+
+    persistence.ajax = function(url) {
+      if (url.indexOf('/tree') !== -1) {
+        treeCount++;
+        var key = url.split('/boards/')[1].split('/tree')[0];
+        return RSVP.resolve({
+          root: { board: { key: key, id: '1_x', buttons: [] } },
+          descendants: []
+        });
+      }
+      if (url.indexOf('user_id=1_50') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
+      if (url.indexOf('user_id=lingolinq') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
+      if (url.indexOf('q=&') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
+      return RSVP.reject({ error: 'unexpected ' + url });
+    };
+
+    var user = {
+      get: function(k) {
+        if (k === 'id') { return '1_50'; }
+        if (k === 'preferences.home_board') { return { key: 'user/home', id: '1_1' }; }
+        if (k === 'preferences.skin') { return 'default'; }
+        if (k === 'preferences.preferred_symbols') { return 'original'; }
+        if (k === 'preferences.locale') { return 'en'; }
+        if (k === 'stats.starred_board_refs') {
+          return [{ key: 'user/liked-a' }, { key: 'user/liked-b' }];
+        }
+        return null;
+      }
+    };
+
+    boardDetailCache._run_prefetch_pipeline(user, { skin: 'default', preferred_symbols: 'original' }).then(function() {
+      var phaseDone = boardDetailCache._prefetch_phase_done['1_50'] || {};
+      assert.ok(phaseDone.phase1, 'phase1 marked done when home tree finishes');
+      assert.notOk(phaseDone.phase2, 'phase2 stays incomplete when tab hidden mid-phase');
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      persistence.get = origGet;
+      if (origHidden) {
+        Object.defineProperty(document, 'hidden', origHidden);
+      } else {
+        delete document.hidden;
+      }
+      done();
+    }, function(err) {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      persistence.get = origGet;
+      if (origHidden) {
+        Object.defineProperty(document, 'hidden', origHidden);
+      }
+      throw err;
+    });
+  });
 });

--- a/app/frontend/tests/unit/utils/board-detail-cache-test.js
+++ b/app/frontend/tests/unit/utils/board-detail-cache-test.js
@@ -105,6 +105,9 @@ module('Unit | Utility | board-detail-cache', function() {
           meta: { more: false }
         });
       }
+      if (url.indexOf('q=&sort=popularity') !== -1 || url.indexOf('q=&') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
       if (url.indexOf('/tree') !== -1) {
         var key = url.split('/boards/')[1].split('/tree')[0];
         return RSVP.resolve({
@@ -168,6 +171,9 @@ module('Unit | Utility | board-detail-cache', function() {
           ],
           meta: { more: false }
         });
+      }
+      if (url.indexOf('q=&sort=popularity') !== -1 || url.indexOf('q=&') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
       }
       if (url.indexOf('board-b/tree') !== -1) {
         return RSVP.resolve({
@@ -246,6 +252,9 @@ module('Unit | Utility | board-detail-cache', function() {
           meta: { more: false }
         });
       }
+      if (url.indexOf('q=&sort=popularity') !== -1 || url.indexOf('q=&') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
       if (url.indexOf('/tree') !== -1) {
         return RSVP.resolve({
           root: { board: { key: 'lingolinq/board-a', id: '1_1', buttons: [] } },
@@ -279,6 +288,200 @@ module('Unit | Utility | board-detail-cache', function() {
       persistence.ajax = origAjax;
       LingoLinq.appState = origAppState;
       boardDetailCache.warm_images = origWarm;
+      throw err;
+    });
+  });
+
+  test('prefetch pipeline runs home then liked then owned when background flag enabled', function(assert) {
+    boardDetailCache.clear();
+    var done = assert.async();
+    var treeOrder = [];
+    var origAjax = persistence.ajax;
+    var origAppState = LingoLinq.appState;
+    var origGet = persistence.get;
+
+    persistence.get = function(key) {
+      if (key === 'online') { return true; }
+      if (origGet) { return origGet.call(persistence, key); }
+      return true;
+    };
+
+    LingoLinq.appState = {
+      get: function(path) {
+        if (path === 'feature_flags.background_board_prefetch') { return true; }
+        return null;
+      }
+    };
+
+    persistence.ajax = function(url) {
+      if (url.indexOf('/tree') !== -1) {
+        var key = url.split('/boards/')[1].split('/tree')[0];
+        treeOrder.push(key);
+        return RSVP.resolve({
+          root: { board: { key: key, id: '1_x', buttons: [] } },
+          descendants: []
+        });
+      }
+      if (url.indexOf('user_id=1_50') !== -1) {
+        return RSVP.resolve({
+          board: [{ key: 'user/owned', id: '1_20' }],
+          meta: { more: false }
+        });
+      }
+      if (url.indexOf('user_id=lingolinq') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
+      if (url.indexOf('q=&') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
+      return RSVP.reject({ error: 'unexpected ' + url });
+    };
+
+    var user = {
+      get: function(k) {
+        if (k === 'id') { return '1_50'; }
+        if (k === 'preferences.home_board') { return { key: 'user/home', id: '1_1' }; }
+        if (k === 'preferences.skin') { return 'default'; }
+        if (k === 'preferences.preferred_symbols') { return 'original'; }
+        if (k === 'preferences.locale') { return 'en'; }
+        if (k === 'stats.starred_board_refs') { return [{ key: 'user/liked' }]; }
+        return null;
+      }
+    };
+
+    boardDetailCache._run_prefetch_pipeline(user, { skin: 'default', preferred_symbols: 'original' }).then(function() {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      persistence.get = origGet;
+      assert.deepEqual(treeOrder, ['user/home', 'user/liked', 'user/owned'], 'runs phased trees in order');
+      done();
+    }, function(err) {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      persistence.get = origGet;
+      throw err;
+    });
+  });
+
+  test('prefetch pipeline skips extended phases when background flag off', function(assert) {
+    boardDetailCache.clear();
+    var done = assert.async();
+    var treeOrder = [];
+    var origAjax = persistence.ajax;
+    var origAppState = LingoLinq.appState;
+    var origGet = persistence.get;
+
+    persistence.get = function(key) {
+      if (key === 'online') { return true; }
+      if (origGet) { return origGet.call(persistence, key); }
+      return true;
+    };
+
+    LingoLinq.appState = { get: function() { return null; } };
+
+    persistence.ajax = function(url) {
+      if (url.indexOf('/tree') !== -1) {
+        var key = url.split('/boards/')[1].split('/tree')[0];
+        treeOrder.push(key);
+        return RSVP.resolve({
+          root: { board: { key: key, id: '1_x', buttons: [] } },
+          descendants: []
+        });
+      }
+      return RSVP.reject({ error: 'unexpected ' + url });
+    };
+
+    var user = {
+      get: function(k) {
+        if (k === 'id') { return '1_50'; }
+        if (k === 'preferences.home_board') { return { key: 'user/home', id: '1_1' }; }
+        if (k === 'preferences.skin') { return 'default'; }
+        if (k === 'preferences.preferred_symbols') { return 'original'; }
+        if (k === 'stats.starred_board_refs') { return [{ key: 'user/liked' }]; }
+        return null;
+      }
+    };
+
+    boardDetailCache._run_prefetch_pipeline(user, { skin: 'default', preferred_symbols: 'original' }).then(function() {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      persistence.get = origGet;
+      assert.deepEqual(treeOrder, ['user/home'], 'only home phase when flag off');
+      done();
+    }, function(err) {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      persistence.get = origGet;
+      throw err;
+    });
+  });
+
+  test('prefetch pipeline skips roots already fresh in cache', function(assert) {
+    boardDetailCache.clear();
+    var done = assert.async();
+    var treeOrder = [];
+    var origAjax = persistence.ajax;
+    var origAppState = LingoLinq.appState;
+    var origGet = persistence.get;
+
+    boardDetailCache.set({ key: 'user/liked', id: '1_2', buttons: [] });
+
+    persistence.get = function(key) {
+      if (key === 'online') { return true; }
+      if (origGet) { return origGet.call(persistence, key); }
+      return true;
+    };
+
+    LingoLinq.appState = {
+      get: function(path) {
+        if (path === 'feature_flags.background_board_prefetch') { return true; }
+        return null;
+      }
+    };
+
+    persistence.ajax = function(url) {
+      if (url.indexOf('/tree') !== -1) {
+        var key = url.split('/boards/')[1].split('/tree')[0];
+        treeOrder.push(key);
+        return RSVP.resolve({
+          root: { board: { key: key, id: '1_x', buttons: [] } },
+          descendants: []
+        });
+      }
+      if (url.indexOf('user_id=1_50') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
+      if (url.indexOf('user_id=lingolinq') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
+      if (url.indexOf('q=&') !== -1) {
+        return RSVP.resolve({ board: [], meta: { more: false } });
+      }
+      return RSVP.reject({ error: 'unexpected ' + url });
+    };
+
+    var user = {
+      get: function(k) {
+        if (k === 'id') { return '1_50'; }
+        if (k === 'preferences.home_board') { return { key: 'user/home', id: '1_1' }; }
+        if (k === 'preferences.skin') { return 'default'; }
+        if (k === 'preferences.preferred_symbols') { return 'original'; }
+        if (k === 'preferences.locale') { return 'en'; }
+        if (k === 'stats.starred_board_refs') { return [{ key: 'user/liked' }]; }
+        return null;
+      }
+    };
+
+    boardDetailCache._run_prefetch_pipeline(user, { skin: 'default', preferred_symbols: 'original' }).then(function() {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      persistence.get = origGet;
+      assert.deepEqual(treeOrder, ['user/home'], 'skips cached liked board');
+      done();
+    }, function(err) {
+      persistence.ajax = origAjax;
+      LingoLinq.appState = origAppState;
+      persistence.get = origGet;
       throw err;
     });
   });

--- a/app/frontend/tests/unit/utils/board-prefetch-planner-test.js
+++ b/app/frontend/tests/unit/utils/board-prefetch-planner-test.js
@@ -1,0 +1,77 @@
+import { module, test } from 'qunit';
+import boardPrefetchPlanner from 'frontend/utils/board_prefetch_planner';
+
+function mockUser(attrs) {
+  attrs = attrs || {};
+  return {
+    get: function(k) {
+      if (k === 'id') { return attrs.id || '1_50'; }
+      if (k === 'preferences.home_board') { return attrs.home_board || null; }
+      if (k === 'stats.starred_board_refs') { return attrs.starred_board_refs || []; }
+      return null;
+    }
+  };
+}
+
+module('Unit | Utility | board-prefetch-planner', function() {
+  test('collectLikedLookups expands style.options and excludes home', function(assert) {
+    var user = mockUser({
+      home_board: { key: 'user/home', id: '1_1' },
+      starred_board_refs: [
+        { key: 'user/home', id: '1_1' },
+        {
+          key: 'user/style-board',
+          style: {
+            options: [
+              { key: 'user/style-a' },
+              { key: 'user/style-b' }
+            ]
+          }
+        },
+        { key: 'user/liked-z' }
+      ]
+    });
+    var seen = {};
+    boardPrefetchPlanner.collectHomeLookups(user).forEach(function(l) { seen[l] = true; });
+    var liked = boardPrefetchPlanner.collectLikedLookups(user, seen);
+    assert.deepEqual(liked, ['user/style-a', 'user/style-b', 'user/liked-z'], 'expands options and skips home');
+  });
+
+  test('collectOwnedRootLookups filters to root tiles only', function(assert) {
+    var user = mockUser({ id: '1_50' });
+    var boards = [
+      { id: '1_10', key: 'user/root-a', copy_id: null },
+      { id: '1_11', key: 'user/sub-copy', copy_id: '1_10' }
+    ];
+    var roots = boardPrefetchPlanner.collectOwnedRootLookups(user, boards, {});
+    assert.equal(roots.length, 1, 'one root tile');
+    assert.equal(roots[0], 'user/root-a');
+  });
+
+  test('buildPhasedLookups dedupes across phases', function(assert) {
+    var user = mockUser({
+      home_board: { key: 'user/home', id: '1_1' },
+      starred_board_refs: [{ key: 'user/home' }, { key: 'user/liked' }]
+    });
+    var phased = boardPrefetchPlanner.buildPhasedLookups(user, {
+      ownedBoards: [
+        { id: '1_1', key: 'user/home' },
+        { id: '1_2', key: 'user/mine-b' }
+      ],
+      catalogBoards: [{ key: 'lingolinq/cat' }],
+      globalBoards: [{ key: 'lingolinq/cat' }, { key: 'other/public' }],
+      includeLiked: true
+    });
+    assert.deepEqual(phased.phase1, ['user/home']);
+    assert.deepEqual(phased.phase2, ['user/liked']);
+    assert.deepEqual(phased.phase3, ['user/mine-b']);
+    assert.deepEqual(phased.phase4, ['lingolinq/cat', 'other/public']);
+  });
+
+  test('lookupsToSyncSeeds produces sync queue entries', function(assert) {
+    var seeds = boardPrefetchPlanner.lookupsToSyncSeeds(['user/a', '1_99'], 'owned root', 0);
+    assert.equal(seeds.length, 2);
+    assert.deepEqual(seeds[0], { key: 'user/a', depth: 0, visit_source: 'owned root' });
+    assert.deepEqual(seeds[1], { id: '1_99', depth: 0, visit_source: 'owned root' });
+  });
+});

--- a/app/frontend/tests/unit/utils/board-prefetch-planner-test.js
+++ b/app/frontend/tests/unit/utils/board-prefetch-planner-test.js
@@ -7,6 +7,7 @@ function mockUser(attrs) {
     get: function(k) {
       if (k === 'id') { return attrs.id || '1_50'; }
       if (k === 'preferences.home_board') { return attrs.home_board || null; }
+      if (k === 'preferences.sync_starred_boards') { return attrs.sync_starred_boards; }
       if (k === 'stats.starred_board_refs') { return attrs.starred_board_refs || []; }
       return null;
     }
@@ -35,6 +36,32 @@ module('Unit | Utility | board-prefetch-planner', function() {
     boardPrefetchPlanner.collectHomeLookups(user).forEach(function(l) { seen[l] = true; });
     var liked = boardPrefetchPlanner.collectLikedLookups(user, seen);
     assert.deepEqual(liked, ['user/style-a', 'user/style-b', 'user/liked-z'], 'expands options and skips home');
+  });
+
+  test('collectLikedLookups skips suggested refs unless sync_starred_boards is true', function(assert) {
+    var user = mockUser({
+      starred_board_refs: [
+        { key: 'user/suggested-pick', suggested: true },
+        { key: 'user/real-like' }
+      ]
+    });
+    assert.deepEqual(
+      boardPrefetchPlanner.collectLikedLookups(user, {}),
+      ['user/real-like'],
+      'excludes suggested home-board picker refs by default'
+    );
+    var syncAllUser = mockUser({
+      sync_starred_boards: true,
+      starred_board_refs: [
+        { key: 'user/suggested-pick', suggested: true },
+        { key: 'user/real-like' }
+      ]
+    });
+    assert.deepEqual(
+      boardPrefetchPlanner.collectLikedLookups(syncAllUser, {}),
+      ['user/suggested-pick', 'user/real-like'],
+      'includes suggested refs when sync_starred_boards is true'
+    );
   });
 
   test('collectOwnedRootLookups filters to root tiles only', function(assert) {

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -20,6 +20,7 @@ file (see [README.md](README.md)).
 
 ## Index
 
+- [Pattern: phased board prefetch — shared planner, dual persistence files](#pattern-phased-board-prefetch--shared-planner-dual-persistence-files)
 - [Pattern: `find_all_by_global_id` does not preserve input order](#pattern-find_all_by_global_id-does-not-preserve-input-order)
 - [Pattern: HTML5 drag-and-drop suppressed by nested `<button>` children](#pattern-html5-drag-and-drop-suppressed-by-nested-button-children)
 - [Pattern: "It's broken" symptoms that vanish on re-test = stale Ember dev bundle](#pattern-its-broken-symptoms-that-vanish-on-re-test--stale-ember-dev-bundle)
@@ -74,6 +75,18 @@ file (see [README.md](README.md)).
 - [Pattern: async store/query callbacks must guard `isDestroyed`/`isDestroying` before `set`](#pattern-async-storequery-callbacks-must-guard-isdestroyedisdestroying-before-set)
 - [Pattern: per-element responsive show/hide rules must sit AFTER that element's base `display` rule — don't consolidate when bases are scattered](#pattern-per-element-responsive-showhide-rules-must-sit-after-that-elements-base-display-rule--dont-consolidate-when-bases-are-scattered)
 - [Pattern: a glow/halo `::before` that "leaks to the whole container" at one breakpoint = the host lost `position` (static re-anchors the absolute pseudo)](#pattern-a-glowhalo-before-that-leaks-to-the-whole-container-at-one-breakpoint--the-host-lost-position-static-re-anchors-the-absolute-pseudo)
+
+## Pattern: phased board prefetch — shared planner, dual persistence files
+
+**Surface:** session navigation cache (`board_detail_cache.js`) and offline IndexedDB sync (`sync_boards`).
+
+**Approach:** [`board_prefetch_planner.js`](../../app/frontend/app/utils/board_prefetch_planner.js) enumerates roots in priority order (home → liked → owned → public). Session cache runs `/tree` per root via `_run_prefetch_pipeline`; offline sync seeds the BFS queue with the same lookups via `lookupsToSyncSeeds`.
+
+**Gotcha:** `sync_boards` exists in **both** [`app/utils/persistence.js`](../../app/frontend/app/utils/persistence.js) and [`app/services/persistence.js`](../../app/frontend/app/services/persistence.js). Runtime sync uses `window.persistence` (the service). Any offline-sync change must be applied to **both** files or offline behavior won't match.
+
+**Flags:** Phase 1 (home) is unconditional; phases 2–4 run when `background_board_prefetch` is enabled (shipped in `ENABLED_FRONTEND_FEATURES`). Phase 4 also honors legacy `catalog_board_prefetch`.
+
+**First seen in:** [2026-05-30-phased-online-board-caching.md](./2026-05-30-phased-online-board-caching.md)
 
 ## Pattern: HTML5 drag-and-drop suppressed by nested `<button>` children
 

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -25,6 +25,7 @@ module FeatureFlags
               'tarheel_reader', 'auth_spa_transition', 'google_sso', 'quick_screen_eval',
               'comprehensive_eval_ai', 'multi_user_board_import', 'customize_menu',
               'home_tour', 'paste_html_import', 'catalog_board_prefetch',
+              'background_board_prefetch',
               'portrait_orientation_overlay', 'signup_default_library_boards']
   ENABLED_FRONTEND_FEATURES = ['subscriptions', 'assessments', 'custom_sidebar', 'snapshots',
               'video_recording', 'goals', 'modeling', 'geo_sidebar', 'edit_before_copying',
@@ -39,6 +40,7 @@ module FeatureFlags
               'customize_menu', # TEMPORARY: ON for everyone during testing — remove from this list when moving to beta-opt-in (see comment above AVAILABLE_FRONTEND_FEATURES)
               'home_tour', # TEMPORARY (spike — 2026-05-27): ON for everyone so Traci can validate the Shepherd.js home-page tour in the browser. REMOVE from this list before merging the spike out of traci/styling/styling-updates — the canonical state is AVAILABLE-only (beta opt-in per user).
               'portrait_orientation_overlay', # TEMPORARY (2026-05-29): ON for everyone so Traci can view the ≤640px landscape-orientation overlay + immersive tool consolidation in the browser. REMOVE from this list before merging out of traci/styling/styling-updates — canonical state is AVAILABLE-only (beta opt-in per user).
+              'background_board_prefetch',
               'signup_default_library_boards']
   DISABLED_CANARY_FEATURES = []
   FEATURE_DATES = {


### PR DESCRIPTION
## Summary
- Adds a shared `board_prefetch_planner` and phased pipeline that prefetches board trees in priority order: home → liked → owned roots → public (catalog + global search).
- Session navigation uses background `/tree` fetches (fire-and-forget, rate-limited, pauses when tab hidden); offline sync seeds the same roots into the existing BFS queue in both persistence modules.
- Enables `background_board_prefetch` globally so extended prefetch is default behavior for all users.

## Test plan
- [ ] Log in and confirm dashboard loads normally with no blocking wait for prefetch
- [ ] Open home board and sub-boards — navigation should be instant once prefetch completes (Network tab shows background `/tree` calls)
- [ ] Like a board, wait for background prefetch, open it — should cache-hit without extra round-trip
- [ ] Trigger offline sync while online — owned/public roots should appear in sync progress over time
- [ ] Confirm prefetch pauses when tab is backgrounded and resumes on reconnect (`persistence.online`)


Made with [Cursor](https://cursor.com)