### PR TITLE
feat(seed): demo org rooms + 3-month report history (with prod password guard)

### DIFF
--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -2522,3 +2522,29 @@ when you change a positioned element's `position` responsively, check whether an
 **Fix recipe:** After lookup, `sort_by { |r| ids.index(r.global_id) || ids.length }` (see `Board.long_query`, `Board#known_button_images`). For specs comparing sorted `global_id` lists, sort **both** sides — lexicographic sort puts `"1_1000"` before `"1_999"`.
 
 **Evidence:** `app/models/concerns/global_id.rb:108-174`, `app/models/board.rb#known_button_images`; task log `2026-05-29-spec-ordering-flakes.md`.
+
+---
+
+## Pattern: Org/room reports read from WeeklyStatsSummary, not raw logs
+
+**Surface:** seed/demo data, org portal reports, room (OrganizationUnit) stats.
+
+**Root cause:** `Organization.usage_stats` (used by the org portal AND `units_controller#stats`) sources word clouds / total words / modeled words from `WeeklyStatsSummary` rows over an **8-week** window; only the session timeline comes from raw `LogSession` (4 months), and room `user_weeks` from raw logs (12 weeks). `LogSession` schedules summary builds **async** (`after_save :schedule_summary`), so freshly-created logs have no summaries until a worker runs. `lib/seed_reporting_logs.rb` actively *deletes* summaries (fine for the individual `/user/stats` page, which recomputes live, but leaves org/room reports empty).
+
+**Fix recipe:** After seeding sessions, build summaries synchronously: collect distinct weekyears via `WeeklyStatsSummary.date_to_weekyear(started_at.utc.beginning_of_week(:sunday))` and call `WeeklyStatsSummary.update_now(user_id, weekyear)` per week. For supervisor modeling frequency in room reports, seed `daily_use` logs (`LogSession.process_daily_use`) with `models`/`modeled` per `DAILY_EVENT_TYPES`.
+
+**Gotcha:** `UserLink.links_for(record)` caches in Redis keyed by `record.updated_at`. `OrganizationUnit#assert_supervision!` reads `links_for(self)`; each `add_supervisor`/`add_communicator` bumps the unit's `updated_at` via `UserLink#touch_connections` but only in the DB. Reload the unit (`unit.reload`) before `assert_supervision!` or it reads a stale empty link set and wires nothing.
+
+**Evidence:** `app/models/organization.rb:1085` (`usage_stats`), `app/controllers/api/units_controller.rb:68` (`stats`), `app/models/log_session.rb:18,883`, `app/models/weekly_stats_summary.rb:192,197`, `app/models/user_link.rb:19,94`; impl `lib/seed_organization.rb` (`seed_room`, `seed_communicator_history`).
+
+---
+
+## Gotcha: organizations.admin has a UNIQUE index — normal orgs must be NULL
+
+**Symptom:** `PG::UniqueViolation ... index_organizations_on_admin ... Key (admin)=(f) already exists` when seeding a second org.
+
+**Root cause:** `t.index ["admin"], unique: true` (`db/schema.rb`). Postgres unique indexes allow unlimited NULLs but only one row per concrete value: `admin = true` is the single super-admin org, and `admin = false` is a *second* singleton slot already claimed by the demo org from `db/seeds.rb`. Every normal/seeded district must use `admin = nil`.
+
+**Fix recipe:** Never set `org.admin = false` for normal orgs; leave it NULL. `Organization.admin` is `where(admin: true).first`, so NULL orgs behave identically to "not admin".
+
+**Evidence:** `db/schema.rb` (`index_organizations_on_admin`), `app/models/organization.rb:125`, `db/seeds.rb:489`; fix `lib/seed_organization.rb:37`.

--- a/lib/seed_organization.rb
+++ b/lib/seed_organization.rb
@@ -10,7 +10,12 @@ def seed_organization(org_name: "Sample Organization",
                       manager_count: 2,
                       supervisor_count: 5,
                       user_count: 10,
-                      eval_count: 3)
+                      eval_count: 3,
+                      room_names: ["Washington", "Adams", "Jefferson"],
+                      students_per_room: 3,
+                      seed_reports: true,
+                      report_weeks: 13,
+                      sessions_per_week: 2)
   puts "\n" + "=" * 60
   puts "Seeding Organization: #{org_name}"
   puts "=" * 60
@@ -34,7 +39,12 @@ def seed_organization(org_name: "Sample Organization",
       'email' => "support@#{org_name.downcase.gsub(/\s+/, '')}.com",
       'name' => org_name
     }
-    org.admin = false
+    # Normal orgs MUST leave admin as NULL. The organizations table has a UNIQUE
+    # index on `admin`, so only one row may hold `true` (the super-admin org) and
+    # only one may hold `false`. Postgres allows unlimited NULLs, so NULL is the
+    # correct value for every seeded district; using `false` collides with the
+    # demo org seeded by db/seeds.rb (PG::UniqueViolation on index_organizations_on_admin).
+    org.admin = nil
     org.save!
     puts "✓ Created organization: #{org_name} (ID: #{org.id})"
   else
@@ -409,6 +419,32 @@ def seed_organization(org_name: "Sample Organization",
     end
   end
 
+  # ---- 3-month session history + weekly summaries for org communicators ----
+  # Org-portal and room reports read word clouds / totals from WeeklyStatsSummary
+  # over an 8-week window and the session timeline from raw logs over ~4 months,
+  # so we spread sessions across `report_weeks` and build the summaries that the
+  # reports actually read (see Organization.usage_stats / WeeklyStatsSummary).
+  if seed_reports && defined?(build_reporting_events)
+    puts "\nSeeding 3-month report history for org communicators..."
+    users.each do |user|
+      seed_communicator_history(user, org_name: org_name, weeks_back: report_weeks, sessions_per_week: sessions_per_week)
+    end
+  elsif seed_reports
+    puts "\n(Skipping report history: load lib/seed_reporting_logs.rb first, e.g. run via `rake db:seed_organization`.)"
+  end
+
+  # ---- Rooms (OrganizationUnit) each with a teacher, an SLP, and students ----
+  rooms = []
+  if room_names.any?
+    puts "\nCreating rooms (teacher + SLP + students) with cumulative reports..."
+    room_names.each do |room_name|
+      rooms << seed_room(org, org_name: org_name, room_name: room_name,
+                         students_per_room: students_per_room,
+                         seed_reports: seed_reports, report_weeks: report_weeks,
+                         sessions_per_week: sessions_per_week)
+    end
+  end
+
   puts "\n" + "=" * 60
   puts "Organization Seeding Complete!"
   puts "=" * 60
@@ -425,11 +461,188 @@ def seed_organization(org_name: "Sample Organization",
   puts "  Regular Users: #{users.count}"
   puts "  Eval Users: #{eval_users.count}"
   puts "\nUsage logs: session, note, assessment (per user) + eval, journal, profile, daily_use, modeling_activities (one each)" if users.any? && supervisors.any?
-  puts "\nLogin Credentials:"
-  puts "  Manager: #{managers.first.user_name} / password123"
-  puts "  Supervisor: #{supervisors.first.user_name} / password123"
-  puts "  User: #{users.first.user_name} / password123"
+  if rooms.any?
+    puts "\nRooms (each with a teacher, an SLP, and #{students_per_room} students):"
+    rooms.compact.each do |unit|
+      puts "  #{unit.settings['name']}: #{unit.all_user_ids.count} members (global_id #{unit.global_id})"
+    end
+    puts "  Report history: ~#{report_weeks} weeks x #{sessions_per_week} sessions/student + supervisor modeling" if seed_reports
+  end
+  puts "\nLogin Credentials (everyone uses password123):"
+  puts "  Manager: #{managers.first.user_name}"
+  puts "  Supervisor: #{supervisors.first.user_name}"
+  puts "  User: #{users.first.user_name}"
+  if rooms.compact.any?
+    slug = org_name.downcase.gsub(/\s+/, '')
+    sample_room = room_names.first.downcase.gsub(/\s+/, '')
+    puts "  Room teacher: #{slug}_#{sample_room}_teacher"
+    puts "  Room SLP: #{slug}_#{sample_room}_slp"
+    puts "  Room student: #{slug}_#{sample_room}_student_1"
+  end
   puts "=" * 60
 
   org
+end
+
+# ---------------------------------------------------------------------------
+# Room (OrganizationUnit) + reporting helpers
+# ---------------------------------------------------------------------------
+
+# Create (or reuse) a room with a dedicated teacher (supervisor, edit access),
+# SLP (supervisor, edit access), and N students (communicators). Members must be
+# org members first (org.supervisor? / org.managed_user? are enforced by the unit),
+# so we attach them to the org here too. assert_supervision! wires each supervisor
+# to each student synchronously so room/individual reports link up immediately.
+def seed_room(org, org_name:, room_name:, students_per_room:, seed_reports: true, report_weeks: 13, sessions_per_week: 2)
+  slug = org_name.downcase.gsub(/\s+/, '')
+  room_slug = "#{slug}_#{room_name.downcase.gsub(/\s+/, '')}"
+
+  unit = OrganizationUnit.all.detect { |u| u.organization_id == org.id && u.settings && u.settings['name'] == room_name }
+  unless unit
+    unit = OrganizationUnit.process_new({ 'name' => room_name }, { organization: org })
+  end
+  puts "  ✓ Room: #{room_name} (#{unit.global_id})"
+
+  teacher = seed_org_supervisor(org, "#{room_slug}_teacher", "#{room_name} Teacher")
+  unit.add_supervisor(teacher.user_name, true) unless unit.supervisor?(teacher)
+  puts "    ✓ Teacher: #{teacher.user_name}"
+
+  slp = seed_org_supervisor(org, "#{room_slug}_slp", "#{room_name} SLP")
+  unit.add_supervisor(slp.user_name, true) unless unit.supervisor?(slp)
+  puts "    ✓ SLP: #{slp.user_name}"
+
+  students = []
+  students_per_room.times do |i|
+    student = seed_org_communicator(org, "#{room_slug}_student_#{i + 1}", "#{room_name} Student #{i + 1}")
+    unit.add_communicator(student.user_name) unless unit.communicator?(student)
+    students << student
+    puts "    ✓ Student: #{student.user_name}"
+  end
+
+  # Link supervisors -> communicators within the room (normally async).
+  # Reload first: each add_* above bumped the unit's updated_at in the DB
+  # (UserLink#touch_connections), and UserLink.links_for caches by updated_at,
+  # so without a reload assert_supervision! would read a stale (empty) link set
+  # and wire nothing.
+  unit.reload
+  unit.assert_supervision!
+
+  if seed_reports && defined?(build_reporting_events)
+    students.each { |s| seed_communicator_history(s, org_name: org_name, weeks_back: report_weeks, sessions_per_week: sessions_per_week) }
+    [teacher, slp].each { |sup| seed_supervisor_modeling(sup, weeks_back: report_weeks) }
+  end
+
+  unit
+end
+
+# Find or create a user, attach as a non-pending org supervisor (premium).
+def seed_org_supervisor(org, user_name, display_name)
+  user = User.find_by(user_name: user_name) || User.process_new({
+    name: display_name, user_name: user_name,
+    email: "#{user_name}@example.com", public: false, password: 'password123'
+  }, { is_admin: false })
+  org.add_supervisor(user.user_name, false, true) unless org.supervisor?(user) # pending=false, premium=true
+  user.reload
+end
+
+# Find or create a user, attach as a non-pending sponsored org communicator.
+def seed_org_communicator(org, user_name, display_name)
+  user = User.find_by(user_name: user_name) || User.process_new({
+    name: display_name, user_name: user_name,
+    email: "#{user_name}@example.com", public: false, password: 'password123'
+  }, { is_admin: false })
+  org.add_user(user.user_name, false, true, false) unless org.managed_user?(user) # pending=false, sponsored=true
+  user.reload
+end
+
+# Spread realistic word/heat-map session logs across `weeks_back` weeks for a
+# communicator, then build the WeeklyStatsSummary rows that org/room reports read
+# from. Reuses build_reporting_events / REPORTING_SEED_WORDS / HEAT_MAP_POSITIONS
+# from lib/seed_reporting_logs.rb (loaded by the rake task).
+def seed_communicator_history(user, org_name:, weeks_back: 13, sessions_per_week: 2)
+  return 0 unless defined?(build_reporting_events)
+
+  user.settings['preferences'] ||= {}
+  unless user.settings['preferences']['logging']
+    user.settings['preferences']['logging'] = true
+    user.settings['preferences']['geo_logging'] = true
+    user.save!
+  end
+
+  device = Device.find_or_create_by!(user_id: user.id, developer_key_id: 0, device_key: "seed_history_#{user.id}") do |d|
+    d.settings ||= {}
+    d.settings['name'] = "Seed device for #{user.user_name}"
+  end
+
+  word_events = REPORTING_SEED_WORDS.flat_map { |word, count| [word] * count }
+  position_idx = 0
+  created = 0
+
+  weeks_back.times do |w|
+    sessions_per_week.times do |s|
+      # vary the day-of-week and hour so heat maps and time-of-day charts fill in
+      day_offset = (w * 7) + (s * 3) + 1
+      hour = 8 + ((s * 4 + w) % 9)
+      d = day_offset.days.ago.to_date
+      base_time = Time.zone.local(d.year, d.month, d.day, hour, 0, 0)
+      events = build_reporting_events(word_events, '1_1', base_time.to_i, position_idx)
+      position_idx += events.count { |e| e['type'] == 'button' }
+      begin
+        LogSession.process_new(
+          { 'events' => events },
+          { user: user, author: user, device: device, ip_address: '127.0.0.1' }
+        )
+        created += 1
+      rescue => e
+        puts "    ⚠ session #{d} for #{user.user_name}: #{e.message}"
+      end
+    end
+  end
+
+  # Build the weekly summaries synchronously (reports read these, and the async
+  # job that normally builds them is not guaranteed to have run during a seed).
+  weekyears = LogSession.where(user_id: user.id, log_type: 'session')
+                        .where.not(started_at: nil).pluck(:started_at)
+                        .map { |t| WeeklyStatsSummary.date_to_weekyear(t.utc.beginning_of_week(:sunday)) }.uniq
+  weekyears.each do |wy|
+    begin
+      WeeklyStatsSummary.update_now(user.id, wy)
+    rescue => e
+      puts "    ⚠ summary #{wy} for #{user.user_name}: #{e.message}"
+    end
+  end
+
+  puts "    ✓ #{user.user_name}: #{created} sessions / #{weekyears.count} weekly summaries"
+  created
+end
+
+# Seed supervisor daily_use modeling activity across `weeks_back` weeks so room
+# reports show modeling frequency / average activity level for the teacher & SLP.
+def seed_supervisor_modeling(supervisor, weeks_back: 13)
+  model_words = %w[more want help go stop like that look different again]
+  device = Device.find_or_create_by!(user_id: supervisor.id, developer_key_id: 0, device_key: "seed_model_#{supervisor.id}") do |d|
+    d.settings ||= {}
+    d.settings['name'] = "Seed device for #{supervisor.user_name}"
+  end
+
+  events = []
+  weeks_back.times do |w|
+    [1, 3, 5].each do |dow| # three active modeling days per week
+      date = ((w * 7) + dow).days.ago.to_date.to_s
+      events << {
+        'date' => date,
+        'active' => true,
+        'activity_level' => 3 + (w % 3),
+        'models' => 4 + (w % 5),
+        'modeled' => model_words.sample(3)
+      }
+    end
+  end
+
+  begin
+    LogSession.process_daily_use({ 'events' => events }, { author: supervisor, device: device, user: supervisor })
+    puts "    ✓ modeling history: #{supervisor.user_name} (#{events.count} active days)"
+  rescue => e
+    puts "    ⚠ supervisor modeling #{supervisor.user_name}: #{e.message}"
+  end
 end

--- a/lib/seed_organization.rb
+++ b/lib/seed_organization.rb
@@ -15,7 +15,14 @@ def seed_organization(org_name: "Sample Organization",
                       students_per_room: 3,
                       seed_reports: true,
                       report_weeks: 13,
-                      sessions_per_week: 2)
+                      sessions_per_week: 2,
+                      password: nil)
+  # All seeded accounts share one password. In production/staging this MUST be
+  # supplied via SEED_ORG_PASSWORD (no weak default is allowed to reach a
+  # shared/internet-facing DB); dev/test fall back to a known demo password.
+  # Mirrors the seed_password guard in db/seeds.rb.
+  password ||= seed_org_password
+
   puts "\n" + "=" * 60
   puts "Seeding Organization: #{org_name}"
   puts "=" * 60
@@ -71,7 +78,7 @@ def seed_organization(org_name: "Sample Organization",
         user_name: user_name,
         email: "manager#{manager_num}@#{org_name.downcase.gsub(/\s+/, '')}.com",
         public: false,
-        password: 'password123',
+        password: password,
         description: "Manager #{manager_num} for #{org_name}",
         location: "Organization Location"
       }, {
@@ -100,7 +107,7 @@ def seed_organization(org_name: "Sample Organization",
         user_name: user_name,
         email: "supervisor#{supervisor_num}@#{org_name.downcase.gsub(/\s+/, '')}.com",
         public: false,
-        password: 'password123',
+        password: password,
         description: "Supervisor #{supervisor_num} for #{org_name}",
         location: "Organization Location"
       }, {
@@ -131,7 +138,7 @@ def seed_organization(org_name: "Sample Organization",
         user_name: user_name,
         email: "user#{user_num}@#{org_name.downcase.gsub(/\s+/, '')}.com",
         public: false,
-        password: 'password123',
+        password: password,
         description: "User #{user_num} in #{org_name}",
         location: "Organization Location"
       }, {
@@ -160,7 +167,7 @@ def seed_organization(org_name: "Sample Organization",
         user_name: user_name,
         email: "eval#{eval_num}@#{org_name.downcase.gsub(/\s+/, '')}.com",
         public: false,
-        password: 'password123',
+        password: password,
         description: "Evaluation account #{eval_num} for #{org_name}",
         location: "Organization Location"
       }, {
@@ -282,6 +289,8 @@ def seed_organization(org_name: "Sample Organization",
     puts "\nCreating usage logs for communicator users..."
     users.each_with_index do |user, idx|
       user_device = ensure_device.call(user)
+      # Idempotency: these variety logs are additive, so skip users already seeded.
+      next if user_device.settings && user_device.settings['variety_seeded']
       base_ts = (3 + idx).days.ago.to_f
       begin
         # 1) Session log (button + utterance events)
@@ -315,6 +324,8 @@ def seed_organization(org_name: "Sample Organization",
           },
           { user: user, author: supervisors.first, device: supervisor_device }
         )
+        user_device.settings['variety_seeded'] = true
+        user_device.save!
         puts "  ✓ Logs for #{user.user_name} (session, note, assessment)"
       rescue => e
         puts "  ⚠ Logs for #{user.user_name}: #{e.message}"
@@ -324,7 +335,7 @@ def seed_organization(org_name: "Sample Organization",
     # Seed one of each remaining log type (eval, journal, profile, daily_use, modeling_activities)
     first_user = users.first
     first_user_device = ensure_device.call(first_user)
-    if first_user && supervisors.any?
+    if first_user && supervisors.any? && !(first_user_device.settings && first_user_device.settings['extras_seeded'])
       puts "\nCreating one of each additional log type..."
       begin
         # 4) Eval (evaluation session)
@@ -416,6 +427,8 @@ def seed_organization(org_name: "Sample Organization",
       rescue => e
         puts "  ⚠ modeling_activities: #{e.message}"
       end
+      first_user_device.settings['extras_seeded'] = true
+      first_user_device.save!
     end
   end
 
@@ -439,7 +452,7 @@ def seed_organization(org_name: "Sample Organization",
     puts "\nCreating rooms (teacher + SLP + students) with cumulative reports..."
     room_names.each do |room_name|
       rooms << seed_room(org, org_name: org_name, room_name: room_name,
-                         students_per_room: students_per_room,
+                         students_per_room: students_per_room, password: password,
                          seed_reports: seed_reports, report_weeks: report_weeks,
                          sessions_per_week: sessions_per_week)
     end
@@ -468,7 +481,8 @@ def seed_organization(org_name: "Sample Organization",
     end
     puts "  Report history: ~#{report_weeks} weeks x #{sessions_per_week} sessions/student + supervisor modeling" if seed_reports
   end
-  puts "\nLogin Credentials (everyone uses password123):"
+  puts "\nLogin Credentials (every seeded account uses the same password,"
+  puts "set via SEED_ORG_PASSWORD; defaults to 'password123' in dev/test only):"
   puts "  Manager: #{managers.first.user_name}"
   puts "  Supervisor: #{supervisors.first.user_name}"
   puts "  User: #{users.first.user_name}"
@@ -488,12 +502,24 @@ end
 # Room (OrganizationUnit) + reporting helpers
 # ---------------------------------------------------------------------------
 
+# Resolve the shared password for all seeded accounts. In production/staging a
+# strong SEED_ORG_PASSWORD MUST be supplied so a weak, source-controlled default
+# can never land loginable supervisor/student accounts on a shared or
+# internet-facing database. Dev/test fall back to a known demo password.
+# Mirrors db/seeds.rb's seed_password guard.
+def seed_org_password
+  if (Rails.env.production? || ENV['RAILS_ENV'] == 'staging') && ENV['SEED_ORG_PASSWORD'].blank?
+    raise "Cannot seed organization: set SEED_ORG_PASSWORD (strong credentials) in production/staging."
+  end
+  ENV['SEED_ORG_PASSWORD'].presence || 'password123'
+end
+
 # Create (or reuse) a room with a dedicated teacher (supervisor, edit access),
 # SLP (supervisor, edit access), and N students (communicators). Members must be
 # org members first (org.supervisor? / org.managed_user? are enforced by the unit),
 # so we attach them to the org here too. assert_supervision! wires each supervisor
 # to each student synchronously so room/individual reports link up immediately.
-def seed_room(org, org_name:, room_name:, students_per_room:, seed_reports: true, report_weeks: 13, sessions_per_week: 2)
+def seed_room(org, org_name:, room_name:, students_per_room:, password:, seed_reports: true, report_weeks: 13, sessions_per_week: 2)
   slug = org_name.downcase.gsub(/\s+/, '')
   room_slug = "#{slug}_#{room_name.downcase.gsub(/\s+/, '')}"
 
@@ -503,17 +529,17 @@ def seed_room(org, org_name:, room_name:, students_per_room:, seed_reports: true
   end
   puts "  ✓ Room: #{room_name} (#{unit.global_id})"
 
-  teacher = seed_org_supervisor(org, "#{room_slug}_teacher", "#{room_name} Teacher")
+  teacher = seed_org_supervisor(org, "#{room_slug}_teacher", "#{room_name} Teacher", password)
   unit.add_supervisor(teacher.user_name, true) unless unit.supervisor?(teacher)
   puts "    ✓ Teacher: #{teacher.user_name}"
 
-  slp = seed_org_supervisor(org, "#{room_slug}_slp", "#{room_name} SLP")
+  slp = seed_org_supervisor(org, "#{room_slug}_slp", "#{room_name} SLP", password)
   unit.add_supervisor(slp.user_name, true) unless unit.supervisor?(slp)
   puts "    ✓ SLP: #{slp.user_name}"
 
   students = []
   students_per_room.times do |i|
-    student = seed_org_communicator(org, "#{room_slug}_student_#{i + 1}", "#{room_name} Student #{i + 1}")
+    student = seed_org_communicator(org, "#{room_slug}_student_#{i + 1}", "#{room_name} Student #{i + 1}", password)
     unit.add_communicator(student.user_name) unless unit.communicator?(student)
     students << student
     puts "    ✓ Student: #{student.user_name}"
@@ -535,21 +561,25 @@ def seed_room(org, org_name:, room_name:, students_per_room:, seed_reports: true
   unit
 end
 
-# Find or create a user, attach as a non-pending org supervisor (premium).
-def seed_org_supervisor(org, user_name, display_name)
+# Find or create a user, attach as a non-pending org supervisor.
+# premium=false on purpose: each premium seat counts against
+# total_supervisor_licenses, and add_supervisor raises once they run out, which
+# would abort the seed partway through. Supervision/reporting works fine without
+# a premium seat, so room teachers/SLPs stay non-premium and never exhaust the budget.
+def seed_org_supervisor(org, user_name, display_name, password)
   user = User.find_by(user_name: user_name) || User.process_new({
     name: display_name, user_name: user_name,
-    email: "#{user_name}@example.com", public: false, password: 'password123'
+    email: "#{user_name}@example.com", public: false, password: password
   }, { is_admin: false })
-  org.add_supervisor(user.user_name, false, true) unless org.supervisor?(user) # pending=false, premium=true
+  org.add_supervisor(user.user_name, false, false) unless org.supervisor?(user) # pending=false, premium=false
   user.reload
 end
 
 # Find or create a user, attach as a non-pending sponsored org communicator.
-def seed_org_communicator(org, user_name, display_name)
+def seed_org_communicator(org, user_name, display_name, password)
   user = User.find_by(user_name: user_name) || User.process_new({
     name: display_name, user_name: user_name,
-    email: "#{user_name}@example.com", public: false, password: 'password123'
+    email: "#{user_name}@example.com", public: false, password: password
   }, { is_admin: false })
   org.add_user(user.user_name, false, true, false) unless org.managed_user?(user) # pending=false, sponsored=true
   user.reload
@@ -572,6 +602,15 @@ def seed_communicator_history(user, org_name:, weeks_back: 13, sessions_per_week
   device = Device.find_or_create_by!(user_id: user.id, developer_key_id: 0, device_key: "seed_history_#{user.id}") do |d|
     d.settings ||= {}
     d.settings['name'] = "Seed device for #{user.user_name}"
+  end
+
+  # Idempotency: session history is purely additive (each run creates new
+  # LogSessions and re-inflates the weekly summaries), so stamp the seed device
+  # and no-op on subsequent runs. Without this, re-seeding a shared DB silently
+  # doubles every student's totals.
+  if device.settings && device.settings['history_seeded']
+    puts "    • #{user.user_name}: report history already seeded, skipping"
+    return 0
   end
 
   word_events = REPORTING_SEED_WORDS.flat_map { |word, count| [word] * count }
@@ -612,12 +651,19 @@ def seed_communicator_history(user, org_name:, weeks_back: 13, sessions_per_week
     end
   end
 
+  device.settings['history_seeded'] = true
+  device.save!
+
   puts "    ✓ #{user.user_name}: #{created} sessions / #{weekyears.count} weekly summaries"
   created
 end
 
 # Seed supervisor daily_use modeling activity across `weeks_back` weeks so room
 # reports show modeling frequency / average activity level for the teacher & SLP.
+# Idempotent by design: process_daily_use keeps a single daily_use LogSession per
+# author and merges by date (replacing, not appending), so re-runs overwrite the
+# same days rather than accumulating. Values are derived deterministically (no
+# random sampling) so a re-run reproduces the exact same history.
 def seed_supervisor_modeling(supervisor, weeks_back: 13)
   model_words = %w[more want help go stop like that look different again]
   device = Device.find_or_create_by!(user_id: supervisor.id, developer_key_id: 0, device_key: "seed_model_#{supervisor.id}") do |d|
@@ -627,14 +673,15 @@ def seed_supervisor_modeling(supervisor, weeks_back: 13)
 
   events = []
   weeks_back.times do |w|
-    [1, 3, 5].each do |dow| # three active modeling days per week
+    [1, 3, 5].each_with_index do |dow, i| # three active modeling days per week
       date = ((w * 7) + dow).days.ago.to_date.to_s
+      offset = (w + i) % model_words.length
       events << {
         'date' => date,
         'active' => true,
         'activity_level' => 3 + (w % 3),
         'models' => 4 + (w % 5),
-        'modeled' => model_words.sample(3)
+        'modeled' => model_words.rotate(offset).first(3)
       }
     end
   end

--- a/lib/tasks/seed_organization.rake
+++ b/lib/tasks/seed_organization.rake
@@ -20,10 +20,12 @@ namespace :db do
       user_count: ENV['USER_COUNT']&.to_i || 10,
       eval_count: ENV['EVAL_COUNT']&.to_i || 3,
       room_names: room_names,
-      students_per_room: ENV['STUDENTS_PER_ROOM']&.to_i || 3,
+      # Clamp the loop-size knobs so a fat-fingered ENV value can't spin up an
+      # unbounded number of records on a shared DB.
+      students_per_room: (ENV['STUDENTS_PER_ROOM']&.to_i || 3).clamp(0, 50),
       seed_reports: ENV['SEED_REPORTS'] != 'false',
-      report_weeks: ENV['REPORT_WEEKS']&.to_i || 13,
-      sessions_per_week: ENV['SESSIONS_PER_WEEK']&.to_i || 2
+      report_weeks: (ENV['REPORT_WEEKS']&.to_i || 13).clamp(1, 52),
+      sessions_per_week: (ENV['SESSIONS_PER_WEEK']&.to_i || 2).clamp(1, 20)
     )
   end
 

--- a/lib/tasks/seed_organization.rake
+++ b/lib/tasks/seed_organization.rake
@@ -1,7 +1,15 @@
 namespace :db do
   desc "Seed a sample organization with users and relationships"
   task seed_organization: :environment do
+    # seed_reporting_logs.rb provides build_reporting_events + word/heat-map data
+    # that the room/communicator report history reuses.
+    load Rails.root.join('lib', 'seed_reporting_logs.rb')
     load Rails.root.join('lib', 'seed_organization.rb')
+    room_names = if ENV['ROOM_NAMES']
+      ENV['ROOM_NAMES'].split(',').map(&:strip).reject(&:empty?)
+    else
+      ["Washington", "Adams", "Jefferson"]
+    end
     seed_organization(
       org_name: ENV['ORG_NAME'] || "Sample Organization",
       total_licenses: ENV['TOTAL_LICENSES']&.to_i || 50,
@@ -10,7 +18,12 @@ namespace :db do
       manager_count: ENV['MANAGER_COUNT']&.to_i || 2,
       supervisor_count: ENV['SUPERVISOR_COUNT']&.to_i || 5,
       user_count: ENV['USER_COUNT']&.to_i || 10,
-      eval_count: ENV['EVAL_COUNT']&.to_i || 3
+      eval_count: ENV['EVAL_COUNT']&.to_i || 3,
+      room_names: room_names,
+      students_per_room: ENV['STUDENTS_PER_ROOM']&.to_i || 3,
+      seed_reports: ENV['SEED_REPORTS'] != 'false',
+      report_weeks: ENV['REPORT_WEEKS']&.to_i || 13,
+      sessions_per_week: ENV['SESSIONS_PER_WEEK']&.to_i || 2
     )
   end
 


### PR DESCRIPTION
## What

Extends `rake db:seed_organization` so a single command builds a full demo that exercises the **whole org portal**, including the **rooms** (OrganizationUnit) feature and cumulative reports.

- **Fixes the seed crash** you hit: normal seeded orgs now set `organizations.admin = nil` instead of `false`. That column has a UNIQUE index (only one `true` and one `false` row allowed; NULL is unlimited), and `false` collided with `db/seeds.rb`'s demo org (`PG::UniqueViolation on index_organizations_on_admin`).
- **Rooms**: default Washington / Adams / Jefferson, each with a dedicated **teacher + SLP** (org supervisors with edit access) and **students** (sponsored communicators). Supervisor to communicator links are wired via `assert_supervision!` (after a `unit.reload` to dodge a `UserLink.links_for` cache-by-`updated_at` staleness bug).
- **3 months of reports**: ~13 weeks x N sessions/student of word-cloud + heat-map logs, plus **synchronously generated `WeeklyStatsSummary` rows**. This matters because the org portal AND room reports read word/total/model data from summaries (8-week window), not raw logs, and the summary job is async. Generic org communicators get the same history so the portal shows a full quarter of trends.
- **Supervisor modeling history** (`daily_use`) so room modeling-frequency / activity-level charts populate.
- New ENV knobs: `ROOM_NAMES`, `STUDENTS_PER_ROOM`, `SEED_REPORTS`, `REPORT_WEEKS`, `SESSIONS_PER_WEEK`.

## Security / safety (from adversary review)

- **Production/staging password guard**: all seeded accounts share one password, which in production/staging MUST be supplied via `SEED_ORG_PASSWORD` (raises if blank; mirrors the existing `db/seeds.rb` `seed_password` pattern). Dev/test fall back to `password123`. Prevents an accidental run from planting known-weak credentials on accounts wired to student data (FERPA/COPPA).
- **Idempotent**: seed-device stamps make re-runs true no-ops. Verified two runs against a fresh org produce identical log/summary/unit/link counts.
- **Non-premium room supervisors** so seeding can't exhaust `total_supervisor_licenses` mid-run.
- Loop-size ENV vars are clamped.

## Testing

- Smoke-tested end-to-end against the disposable test DB: rooms created, each student linked to teacher + SLP, `WeeklyStatsSummary` rows generated, session + modeling logs present.
- Idempotency verified (run twice, counts identical).
- Two-pass adversary review: initial pass flagged 1 Critical + 1 High + 1 Medium; all resolved; re-review verdict clean (no Critical/High remaining).

## Usage (staging)

```
SEED_ORG_PASSWORD=<strong-pw> \
ORG_NAME="Maple Grove School District" \
ROOM_NAMES="Washington,Adams,Jefferson" STUDENTS_PER_ROOM=3 \
REPORT_WEEKS=13 SESSIONS_PER_WEEK=2 \
bundle exec rake db:seed_organization
```

Seed tooling only; no production runtime code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)