### PR TITLE
Fix email delivery configuration

### DIFF
--- a/app/frontend/app/index.html
+++ b/app/frontend/app/index.html
@@ -414,7 +414,7 @@
         if (typeof window.domain_settings === 'undefined') {
           window.domain_settings = {
             app_name: 'LingoLinq',
-            company_name: 'Someone',
+            company_name: 'Lingolinq',
             logo_url: '/images/LL_Logo_Line_Bright.png',
             full_domain: true,
             support_url: 'https://lingolinq.zendesk.com',

--- a/app/mailers/mailer_helper.rb
+++ b/app/mailers/mailer_helper.rb
@@ -5,7 +5,7 @@ module MailerHelper
   end
 
   def email_signature
-    "-The #{JsonApi::Json.current_domain['settings']['company_name']} Team"
+    "The Lingolinq Team"
   end
 
   def app_name

--- a/app/mailers/mailer_helper.rb
+++ b/app/mailers/mailer_helper.rb
@@ -5,7 +5,7 @@ module MailerHelper
   end
 
   def email_signature
-    "The Lingolinq Team"
+    "The #{company_name} Team"
   end
 
   def app_name

--- a/config/initializers/amazon_ses.rb
+++ b/config/initializers/amazon_ses.rb
@@ -18,5 +18,5 @@ Aws::Rails.add_action_mailer_delivery_method(
     ENV['SES_KEY'] || ENV['AWS_KEY'],
     ENV['SES_SECRET'] || ENV['AWS_SECRET']
   ),
-  region: ENV['SES_REGION']
+  region: ENV['SES_REGION'] || ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION']
 )

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -76,6 +76,7 @@ file (see [README.md](README.md)).
 - [Pattern: endpoint-specific 401 auth without changing legacy `require_api_token`](#pattern-endpoint-specific-401-auth-without-changing-legacy-require_api_token)
 - [Pattern: activation location logging must tolerate missing hit history](#pattern-activation-location-logging-must-tolerate-missing-hit-history)
 - [Pattern: retranslate existing board language must force default update](#pattern-retranslate-existing-board-language-must-force-default-update)
+- [Gotcha: SES region config may be `AWS_REGION`, not `SES_REGION`](#gotcha-ses-region-config-may-be-aws_region-not-ses_region)
 
 ---
 
@@ -2915,3 +2916,15 @@ Reduced-motion users get the hover depth with zero movement; everyone else gets 
 **Fix recipe:** Only from the explicit Re-Translate UI, open the existing button-set review modal with `force_update_default: true` and pass the original source locale (`translations.default || board.locale`) as `source_locale`; keep normal Start Translation and Switch Existing Translation unchanged. The server will then apply reviewed labels/vocalizations to the visible board text and propagate the override to selected linked boards. For read-only boards, keep the translate modal reachable and show a `Translate a Copy` action that calls the existing application `copy_board` flow with `translate_locale`; `copying-board` then opens the review modal against the copied board.
 
 **Evidence:** `app/frontend/app/components/translation-select.js`, `app/frontend/app/templates/components/translation-select.hbs`, `app/models/board.rb` (`translate_set`); task log `2026-06-01-translate-modal-retranslate.md`.
+
+---
+
+## Gotcha: SES region config may be `AWS_REGION`, not `SES_REGION`
+
+**Surface:** registration emails and any mail delivered through `config/initializers/amazon_ses.rb`.
+
+**Root cause pattern:** local/Render env may provide standard AWS keys like `AWS_REGION` while the app-specific SES initializer reads only `SES_REGION`. Credentials can be present and `op run` can be working, but SES still fails before delivery with `Aws::Errors::MissingRegionError`.
+
+**Fix recipe:** Keep `SES_REGION` as the explicit override, but fall back to `AWS_REGION` and `AWS_DEFAULT_REGION`. For diagnosis, check the running app process env in a sanitized way and use read-only `Aws::SES::Client#get_send_quota` before sending a real email.
+
+**Evidence:** `config/initializers/amazon_ses.rb`; task log `2026-06-02-registration-email-sending-investigation.md`.

--- a/lib/json_api/json.rb
+++ b/lib/json_api/json.rb
@@ -96,7 +96,7 @@ module JsonApi::Json
         'settings' => domain
       }
       domain_overrides['settings']['app_name'] ||= "LingoLinq"
-      domain_overrides['settings']['company_name'] ||= "Someone"
+      domain_overrides['settings']['company_name'] ||= "Lingolinq"
       # Org host_settings replace default_domain; merge COPPA from ENV unless org set it explicitly.
       s = domain_overrides['settings']
       if s['coppa_parental_consent'].nil?
@@ -139,7 +139,7 @@ module JsonApi::Json
       'css' => nil,
       'settings' => {
         'app_name' => ENV['APP_NAME'] || "LingoLinq",
-        'company_name' => ENV['COMPANY_NAME'] || "Someone",
+        'company_name' => ENV['COMPANY_NAME'] || "Lingolinq",
         'logo_url' => "/images/logo-new.png",
         'ios_store_url' => ENV['IOS_STORE_URL'],
         'play_store_url' => ENV['PLAY_STORE_URL'],

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -505,7 +505,7 @@ describe ApplicationController, :type => :controller do
       expect(assigns[:domain_overrides]).to_not eq(nil)
       expect(assigns[:domain_overrides]['host']).to eq('test.host')
       expect(assigns[:domain_overrides]['settings']['app_name']).to eq('LingoLinq')
-      expect(assigns[:domain_overrides]['settings']['company_name']).to eq('Someone')
+      expect(assigns[:domain_overrides]['settings']['company_name']).to eq('Lingolinq')
     end
 
     it "should load org-set settings" do
@@ -522,7 +522,7 @@ describe ApplicationController, :type => :controller do
       expect(assigns[:domain_overrides]['host']).to eq('bacon.com')
       expect(assigns[:domain_overrides]['css']).to eq('asdf')
       expect(assigns[:domain_overrides]['settings']['app_name']).to eq('bacon')
-      expect(assigns[:domain_overrides]['settings']['company_name']).to eq('Someone')
+      expect(assigns[:domain_overrides]['settings']['company_name']).to eq('Lingolinq')
     end
   end
 

--- a/spec/lib/json_api/json_spec.rb
+++ b/spec/lib/json_api/json_spec.rb
@@ -171,7 +171,7 @@ describe JsonApi::Json do
       host = JsonApi::Json.load_domain('bacon.com')
       expect(host).to_not eq(nil)
       expect(host['host']).to eq('bacon.com')
-      expect(host['settings']['company_name']).to eq('Someone')
+      expect(host['settings']['company_name']).to eq('Lingolinq')
     end
 
     it 'fills coppa_parental_consent from ENV when org host_settings omit it' do
@@ -231,7 +231,7 @@ describe JsonApi::Json do
       default = JsonApi::Json.default_domain
       expect(default['css']).to eq(nil)
       expect(default['settings']['app_name']).to eq('LingoLinq')
-      expect(default['settings']['company_name']).to eq('Someone')
+      expect(default['settings']['company_name']).to eq('Lingolinq')
       expect(default['settings']['full_domain']).to eq(true)
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -53,7 +53,7 @@ describe UserMailer, :type => :mailer do
       expect(m.to).to eq(["bob@example.com"])
       html = message_body(m, :html)
       expect(html).to match(/Welcome to LingoLinq!/)
-      expect(html).to match("-The Someone Team")
+      expect(html).to match("The Lingolinq Team")
       expect(html).to match(/<b>#{u.user_name}<\/b>/)
       text = message_body(m, :text)
       expect(text).to match(/Welcome to LingoLinq!/)
@@ -77,7 +77,7 @@ describe UserMailer, :type => :mailer do
       m = UserMailer.confirm_registration(u.global_id)
       expect(m.subject).to eq("Cheddar - Welcome!")
       html = message_body(m, :html)
-      expect(html).to match("-The Cheddarific Team")
+      expect(html).to match("The Cheddarific Team")
     end
   end
 


### PR DESCRIPTION
## Summary
- Fix SES email delivery by allowing the mailer config to use the standard AWS region environment variable.
- Update shared email signatures to say "The Lingolinq Team" instead of using the placeholder company name.
- Document the SES region gotcha for future email delivery investigations.

## Test plan
- `ruby -c config/initializers/amazon_ses.rb`
- `ruby -c app/mailers/mailer_helper.rb`
- ReadLints on the changed Ruby helper and docs files
- Read-only SES `get_send_quota` check succeeded locally after applying the region fallback


Made with [Cursor](https://cursor.com)