### PR TITLE
docs(infra): remove decommissioned legacy DB + services from INFRASTRUCTURE.md

### DIFF
--- a/INFRASTRUCTURE.md
+++ b/INFRASTRUCTURE.md
@@ -59,18 +59,11 @@ env QUEUES=priority,default,slow INTERVAL=0.1 TERM_CHILD=1 bundle exec rake envi
 |---------|-----|------|-------|
 | lingolinq-n8n | srv-d4kbjqc9c44c73erql8g | Web (Docker) | n8n automation, https://lingolinq-n8n.onrender.com |
 
-### Legacy Services (TO BE SUSPENDED)
-| Service | ID | Type | Notes |
-|---------|-----|------|-------|
-| LingoLinq-AAC (original web) | srv-d473l8s9c44c73dkg2u0 | Web | Replaced by prod/dev/staging. Environment group: evm-d46rgc63jp1c73aorv6g |
-| LingoLinq-AAC (original worker) | srv-d4ocpnje5dus73c5itlg | Worker | Connected to wrong DB (lingolinq-db). Replaced by per-env workers |
-
 ### Databases
 | Database | ID | Used By |
 |----------|----|---------|
 | lingolinq-prod-db | dpg-d64c5i1r0fns73c5jcp0-a | lingolinq-prod + prod-worker |
 | lingolinq-dev-staging-db | dpg-d64c53v5r7bs73acj600-a | lingolinq-dev + lingolinq-staging + dev-worker |
-| lingolinq-db (legacy) | dpg-d46rdsi4d50c7392jsn0-a | Original services only (legacy) |
 
 ### Redis
 | Instance | ID | Plan | Notes |

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -59,18 +59,11 @@ env QUEUES=priority,default,slow INTERVAL=0.1 TERM_CHILD=1 bundle exec rake envi
 |---------|-----|------|-------|
 | lingolinq-n8n | srv-d4kbjqc9c44c73erql8g | Web (Docker) | n8n automation, https://lingolinq-n8n.onrender.com |
 
-### Legacy Services (TO BE SUSPENDED)
-| Service | ID | Type | Notes |
-|---------|-----|------|-------|
-| LingoLinq-AAC (original web) | srv-d473l8s9c44c73dkg2u0 | Web | Replaced by prod/dev/staging. Environment group: evm-d46rgc63jp1c73aorv6g |
-| LingoLinq-AAC (original worker) | srv-d4ocpnje5dus73c5itlg | Worker | Connected to wrong DB (lingolinq-db). Replaced by per-env workers |
-
 ### Databases
 | Database | ID | Used By |
 |----------|----|---------|
 | lingolinq-prod-db | dpg-d64c5i1r0fns73c5jcp0-a | lingolinq-prod + prod-worker |
 | lingolinq-dev-staging-db | dpg-d64c53v5r7bs73acj600-a | lingolinq-dev + lingolinq-staging + dev-worker |
-| lingolinq-db (legacy) | dpg-d46rdsi4d50c7392jsn0-a | Original services only (legacy) |
 
 ### Redis
 | Instance | ID | Plan | Notes |


### PR DESCRIPTION
## What
Removes three now-obsolete rows from both copies of `INFRASTRUCTURE.md` (root and `docs/`):

- **`lingolinq-db (legacy)`** Postgres (`dpg-d46rdsi4d50c7392jsn0-a`) — the "Databases" table row.
- **"Legacy Services (TO BE SUSPENDED)"** section — `LingoLinq-AAC (original web)` (`srv-d473l8s9c44c73dkg2u0`) and `LingoLinq-AAC (original worker)` (`srv-d4ocpnje5dus73c5itlg`).

## Why
All three resources are gone from the live Render account, so the doc no longer matches reality:

- The legacy DB was snapshotted (verified PG17 custom-format dump, all key tables present) and **deleted on 2026-06-03** after it was confirmed orphaned: zero active connections over the prior week, no table writes since the 2026-02 per-env DB split, and not referenced in `render.yaml` (live services use `lingolinq-prod-db` / `lingolinq-dev-staging-db`).
- Both legacy services already return **HTTP 404** from the Render API (deleted earlier).

This was the doc-hygiene follow-up to the hosting-migration Phase 0 cleanup.

## Scope
Documentation only. No code or config changes. `render.yaml` was already correct and is untouched.