### PR TITLE
Melissa/fix/registration form flow with google

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -739,6 +739,15 @@ class SessionController < ApplicationController
       'popout_id' => params['popout_id'],
       'app' => ActiveModel::Type::Boolean.new.cast(params['app'] || false)
     }
+    if flow == 'register'
+      registration_type = params['registration_type'].to_s.strip
+      allowed_registration_types = %w[communicator therapist parent teacher other]
+      registration_type = 'communicator' unless allowed_registration_types.include?(registration_type)
+      config['registration_type'] = registration_type
+      config['user_name'] = params['user_name'].to_s.strip
+      config['terms_agree'] = ActiveModel::Type::Boolean.new.cast(params['terms_agree'])
+      config['product_improvement_opt_in'] = ActiveModel::Type::Boolean.new.cast(params['product_improvement_opt_in'])
+    end
     return_origin = params['return_origin'].to_s.strip
     origin = GoogleOAuth.frontend_origin(request, return_origin.present? ? { 'return_origin' => return_origin } : nil)
     config['return_origin'] = origin if origin.present?
@@ -768,6 +777,12 @@ class SessionController < ApplicationController
       return redirect_to google_auth_error_redirect('unverified_email', config), allow_other_host: true
     end
 
+    if config['flow'] == 'register'
+      nonce = GoSecure.nonce('google_link')
+      GoogleOAuth.store_link(nonce, google_link_config(profile, config, [], 'signup_complete'))
+      return redirect_to google_frontend_redirect("/register?google_signup=#{nonce}", config), allow_other_host: true
+    end
+
     linked_users = User.find_all_by_google_sub(profile[:sub]).reject(&:google_sso_blocked?)
     unlinked_candidates = google_unlinked_email_candidates(profile, linked_users)
     if linked_users.length > 1
@@ -788,10 +803,6 @@ class SessionController < ApplicationController
       nonce = GoSecure.nonce('google_link')
       GoogleOAuth.store_link(nonce, google_link_config(profile, config, candidates, 'email_match', single_candidate: true))
       return redirect_to google_frontend_redirect("/login?google_link=#{nonce}", config), allow_other_host: true
-    elsif config['flow'] == 'register'
-      nonce = GoSecure.nonce('google_link')
-      GoogleOAuth.store_link(nonce, google_link_config(profile, config, [], 'signup_complete'))
-      return redirect_to google_frontend_redirect("/register?google_signup=#{nonce}", config), allow_other_host: true
     end
 
     nonce = GoSecure.nonce('google_link')
@@ -881,7 +892,11 @@ class SessionController < ApplicationController
     end
     render json: {
       email: link['email'],
-      name: link['name']
+      name: link['name'],
+      user_name: link['user_name'],
+      registration_type: link['registration_type'] || 'communicator',
+      terms_agree: !!link['terms_agree'],
+      product_improvement_opt_in: !!link['product_improvement_opt_in']
     }
   end
 
@@ -904,9 +919,10 @@ class SessionController < ApplicationController
     begin
       user = User.create_from_google_signup!(
         profile,
-        user_name: params['user_name'],
-        registration_type: params['registration_type'],
-        terms_agree: params['terms_agree']
+        user_name: params['user_name'].presence || link['user_name'],
+        registration_type: params['registration_type'].presence || link['registration_type'],
+        terms_agree: params['terms_agree'].presence || link['terms_agree'],
+        product_improvement_opt_in: params['product_improvement_opt_in'].presence || link['product_improvement_opt_in']
       )
     rescue GoogleOAuth::Error => e
       error = e.message == 'user_creation_failed' ? 'registration_failed' : e.message
@@ -991,7 +1007,11 @@ class SessionController < ApplicationController
       'device_id' => config['device_id'],
       'popout_id' => config['popout_id'],
       'app' => config['app'],
-      'return_origin' => config['return_origin']
+      'return_origin' => config['return_origin'],
+      'registration_type' => config['registration_type'],
+      'user_name' => config['user_name'],
+      'terms_agree' => config['terms_agree'],
+      'product_improvement_opt_in' => config['product_improvement_opt_in']
     }
     link['single_candidate'] = true if single_candidate
     if unlinked_candidates.any?

--- a/app/frontend/app/components/bound-select.js
+++ b/app/frontend/app/components/bound-select.js
@@ -122,19 +122,27 @@ export default Component.extend({
     if (!list) { return; }
     const search = list.querySelector('.bound-select__search-input');
     if (search && typeof search.focus === 'function') {
-      search.focus();
+      this._focusWithoutScrolling(search);
       return;
     }
     const selected = list.querySelector('.bound-select__option--selected');
     const target = selected || list.querySelector('.bound-select__option');
-    if (target && typeof target.focus === 'function') { target.focus(); }
+    if (target && typeof target.focus === 'function') { this._focusWithoutScrolling(target); }
   },
 
   /** Return focus to the trigger so Tab nav resumes from the dropdown. */
   _focusTrigger() {
     if (!this.element) { return; }
     const trigger = this.element.querySelector('.bound-select__trigger');
-    if (trigger && typeof trigger.focus === 'function') { trigger.focus(); }
+    if (trigger && typeof trigger.focus === 'function') { this._focusWithoutScrolling(trigger); }
+  },
+
+  _focusWithoutScrolling(element) {
+    try {
+      element.focus({ preventScroll: true });
+    } catch (e) {
+      element.focus();
+    }
   },
 
   actions: {

--- a/app/frontend/app/components/login-form.js
+++ b/app/frontend/app/components/login-form.js
@@ -24,6 +24,15 @@ export default Component.extend({
     this.set('google_link_nonce', null);
     try { sessionStorage.removeItem('google_link_nonce'); } catch (e) { /* ignore */ }
   },
+  expireGoogleLinkSession: function() {
+    this.clearGoogleLinkSession();
+    this.set('google_link_state', null);
+    this.set('google_link_password', null);
+    this.set('google_link_selected_user_name', null);
+    this.set('google_link_error', null);
+    this.set('google_link_linking_another', false);
+    this.set('login_error', i18n.t('google_link_session_expired', "This Google sign-in session expired. Please try again."));
+  },
   syncGoogleReturnParams: function() {
     if(typeof window === 'undefined') { return; }
     var params = new URLSearchParams(window.location.search || '');
@@ -201,8 +210,7 @@ export default Component.extend({
     this.persistence.ajax('/auth/google/link?nonce=' + encodeURIComponent(nonce), { type: 'GET', dataType: 'json' }).then(function(res) {
       if (_this.isDestroyed || _this.isDestroying) { return; }
       if(!res || typeof res !== 'object' || res.error || !res.mode) {
-        _this.set('google_link_state', { loading: false, error: true, candidates: [] });
-        _this.set('login_error', i18n.t('google_link_session_expired', "This Google sign-in session expired. Please try again."));
+        _this.expireGoogleLinkSession();
         return;
       }
       var candidates = res.candidates || [];
@@ -223,8 +231,7 @@ export default Component.extend({
       }
     }, function() {
       if (_this.isDestroyed || _this.isDestroying) { return; }
-      _this.set('google_link_state', { loading: false, error: true, candidates: [] });
-      _this.set('login_error', i18n.t('google_link_session_expired', "This Google sign-in session expired. Please try again."));
+      _this.expireGoogleLinkSession();
     });
   },
   googleLoginStartUrl: function(flow) {
@@ -376,7 +383,7 @@ export default Component.extend({
   googleLinkStepLoading: computed('google_link_state', 'google_link_nonce', function() {
     if(!this.get('google_link_nonce')) { return false; }
     var state = this.get('google_link_state');
-    return !state || !!state.loading || !state.mode;
+    return !state || !!state.loading || (!state.mode && !state.error);
   }),
   googleLinkMode: computed('google_link_state.mode', 'google_link_state.loading', function() {
     var state = this.get('google_link_state');

--- a/app/frontend/app/controllers/register.js
+++ b/app/frontend/app/controllers/register.js
@@ -4,6 +4,7 @@ import LingoLinq from '../app';
 import { computed, observer } from '@ember/object';
 import persistence from '../utils/persistence';
 import capabilities from '../utils/capabilities';
+import i18n from '../utils/i18n';
 
 // TODO: Maybe a pretty img they can send/embed to share with users
 
@@ -14,30 +15,31 @@ export default Controller.extend({
   session: service('session'),
   title: "Register",
   queryParams: ['code', 'v', 'google_signup'],
+  registrationStep: 'role',
+  birth_month: '',
+  birth_year: '',
+  productImprovementOptIn: false,
   googleSignupProfile: null,
   googleSignupBusy: false,
   googleSignupError: null,
   googleSignupUserName: '',
-  googleSignupRegistrationType: 'individual',
+  googleSignupRegistrationType: 'communicator',
   googleSignupTerms: false,
-  googleSignupTelemetryOptIn: false,
-  googleSignupCommsLogOptIn: false,
+  googleSignupProductImprovementOptIn: false,
   showGoogleSignup: computed('google_signup', 'googleSignupProfile', function() {
     return !!(this.get('google_signup') && this.get('googleSignupProfile'));
   }),
-  googleSignupSubmitDisabled: computed('googleSignupBusy', 'googleSignupUserName', 'googleSignupTerms', 'showCoppaConsent', 'coppa_age_group', 'age_attested', function() {
+  googleSignupUserNameMissing: computed('googleSignupUserName', function() {
+    return (this.get('googleSignupUserName') || '').trim().length === 0;
+  }),
+  googleSignupUserNameInvalid: computed('googleSignupUserName', function() {
+    return !!(this.get('googleSignupUserName') || '').match(/[\s\.'"]/);
+  }),
+  googleSignupSubmitDisabled: computed('googleSignupBusy', 'googleSignupTerms', 'googleSignupUserNameMissing', 'googleSignupUserNameInvalid', function() {
     if(this.get('googleSignupBusy')) { return true; }
     if(!this.get('googleSignupTerms')) { return true; }
-    if((this.get('googleSignupUserName') || '').trim().length === 0) { return true; }
-    if(this.get('showCoppaConsent')) {
-      if(!this.get('coppa_age_group')) { return true; }
-      if(this.get('coppa_age_group') === 'under_13') { return true; }
-    } else {
-      // Mainline (non-COPPA) path: require explicit 13+ attestation.
-      // When `showCoppaConsent` is true the radio-button flow above
-      // already gates age, so don't double-require this checkbox.
-      if(!this.get('age_attested')) { return true; }
-    }
+    if(this.get('googleSignupUserNameMissing')) { return true; }
+    if(this.get('googleSignupUserNameInvalid')) { return true; }
     return false;
   }),
   registration_types: LingoLinq.registrationTypes,
@@ -48,6 +50,50 @@ export default Controller.extend({
   role_categories: LingoLinq.roleCategories,
   supporter_types: LingoLinq.supporterTypes,
   registration_role: '',
+  birthMonths: [
+    {name: i18n.t('birth_month_placeholder', "Month"), id: ''},
+    {name: i18n.t('month_january', "January"), id: '1'},
+    {name: i18n.t('month_february', "February"), id: '2'},
+    {name: i18n.t('month_march', "March"), id: '3'},
+    {name: i18n.t('month_april', "April"), id: '4'},
+    {name: i18n.t('month_may', "May"), id: '5'},
+    {name: i18n.t('month_june', "June"), id: '6'},
+    {name: i18n.t('month_july', "July"), id: '7'},
+    {name: i18n.t('month_august', "August"), id: '8'},
+    {name: i18n.t('month_september', "September"), id: '9'},
+    {name: i18n.t('month_october', "October"), id: '10'},
+    {name: i18n.t('month_november', "November"), id: '11'},
+    {name: i18n.t('month_december', "December"), id: '12'}
+  ],
+  birthYears: computed(function() {
+    var currentYear = (new Date()).getFullYear();
+    var years = [{name: i18n.t('birth_year_placeholder', "Year"), id: ''}];
+    for(var year = currentYear; year >= currentYear - 120; year--) {
+      years.push({name: year.toString(), id: year.toString()});
+    }
+    return years;
+  }),
+  showRoleStep: computed('registrationStep', function() {
+    return this.get('registrationStep') === 'role';
+  }),
+  showCommunicatorAgeStep: computed('registrationStep', function() {
+    return this.get('registrationStep') === 'communicator_age';
+  }),
+  showUnder13Step: computed('registrationStep', function() {
+    return this.get('registrationStep') === 'under_13';
+  }),
+  showAccountStep: computed('registrationStep', function() {
+    return this.get('registrationStep') === 'account';
+  }),
+  showSupporterTypeStep: computed('registrationStep', function() {
+    return this.get('registrationStep') === 'supporter_type';
+  }),
+  birthDateComplete: computed('birth_month', 'birth_year', function() {
+    return !!(this.get('birth_month') && this.get('birth_year'));
+  }),
+  communicatorAgeRequired: computed('triedToSave', 'birthDateComplete', 'registrationStep', function() {
+    return this.get('triedToSave') && this.get('registrationStep') === 'communicator_age' && !this.get('birthDateComplete');
+  }),
   roleIncomplete: computed('triedToSave', 'registration_role', 'model.preferences.registration_type', function() {
     if(!this.get('triedToSave')) { return false; }
     var role = this.get('registration_role');
@@ -56,6 +102,21 @@ export default Controller.extend({
       return ['therapist', 'parent', 'teacher', 'other'].indexOf(this.get('model.preferences.registration_type')) === -1;
     }
     return false;
+  }),
+  selectedRoleSignupHeading: computed('model.preferences.registration_type', function() {
+    switch(this.get('model.preferences.registration_type')) {
+      case 'parent':
+        return i18n.t('register_signup_as_parent_today', "Sign up as a parent today!");
+      case 'teacher':
+        return i18n.t('register_signup_as_teacher_today', "Sign up as a teacher today!");
+      case 'therapist':
+        return i18n.t('register_signup_as_therapist_today', "Sign up as a therapist today!");
+      case 'other':
+        return i18n.t('register_signup_as_other_supporter_today', "Sign up as another supporter today!");
+      case 'communicator':
+      default:
+        return i18n.t('register_signup_as_communicator_today', "Sign up as a communicator today!");
+    }
   }),
   triedToSave: false,
   badEmail: computed('model.email', 'triedToSave', function() {
@@ -67,13 +128,17 @@ export default Controller.extend({
     var password2 = this.get('model.password2');
     return (this.get('triedToSave') || password == password2) && password.length < 6;
   }),
-  noName: computed('model.name', 'model.user_name', 'triedToSave', function() {
-    var name = this.get('model.name');
-    var user_name = this.get('model.user_name');
-    return this.get('triedToSave') && !name && !user_name;
-  }),
   noSpacesName: computed('model.user_name', function() {
     return !!(this.get('model.user_name') || '').match(/[\s\.'"]/);
+  }),
+  userNameBlank: computed('model.user_name', function() {
+    return (this.get('model.user_name') || '').trim().length === 0;
+  }),
+  userNameMissing: computed('triedToSave', 'userNameBlank', function() {
+    return this.get('triedToSave') && this.get('userNameBlank');
+  }),
+  userNameUnavailable: computed('user.user_name_check.exists', function() {
+    return !!this.get('user.user_name_check.exists');
   }),
   showCoppaConsent: computed('appState.domain_settings', function() {
     var ds = this.get('appState.domain_settings');
@@ -81,24 +146,19 @@ export default Controller.extend({
   }),
   coppa_age_group: null,
   parent_consent_email: '',
-  coppaAgeRequired: computed('triedToSave', 'coppa_age_group', 'showCoppaConsent', function() {
-    if(!this.get('showCoppaConsent')) { return false; }
-    return this.get('triedToSave') && !this.get('coppa_age_group');
-  }),
-  coppaParentEmailMissing: computed('triedToSave', 'coppa_age_group', 'parent_consent_email', 'showCoppaConsent', function() {
-    if(!this.get('showCoppaConsent') || this.get('coppa_age_group') !== 'under_13') { return false; }
+  coppaParentEmailMissing: computed('triedToSave', 'coppa_age_group', 'parent_consent_email', function() {
+    if(this.get('coppa_age_group') !== 'under_13') { return false; }
     return this.get('triedToSave') && !(this.get('parent_consent_email') || '').trim();
   }),
-  coppaParentEmailSameAsAccount: computed('triedToSave', 'coppa_age_group', 'parent_consent_email', 'model.email', 'showCoppaConsent', function() {
-    if(!this.get('showCoppaConsent') || this.get('coppa_age_group') !== 'under_13') { return false; }
+  coppaParentEmailSameAsAccount: computed('triedToSave', 'coppa_age_group', 'parent_consent_email', 'model.email', function() {
+    if(this.get('coppa_age_group') !== 'under_13') { return false; }
     if(!this.get('triedToSave')) { return false; }
     var pe = (this.get('parent_consent_email') || '').trim().toLowerCase();
     var ce = (this.get('model.email') || '').trim().toLowerCase();
     return !!(pe && ce && pe === ce);
   }),
-  coppaBlocksSave: computed('triedToSave', 'showCoppaConsent', 'coppa_age_group', 'parent_consent_email', 'model.email', function() {
-    if(!this.get('triedToSave') || !this.get('showCoppaConsent')) { return false; }
-    if(!this.get('coppa_age_group')) { return true; }
+  coppaBlocksSave: computed('triedToSave', 'coppa_age_group', 'parent_consent_email', 'model.email', function() {
+    if(!this.get('triedToSave')) { return false; }
     if(this.get('coppa_age_group') !== 'under_13') { return false; }
     var pe = (this.get('parent_consent_email') || '').trim();
     var ce = (this.get('model.email') || '').trim().toLowerCase();
@@ -106,62 +166,26 @@ export default Controller.extend({
     if(pe.toLowerCase() === ce) { return true; }
     return false;
   }),
-  // Mainline 13+ attestation. Required only when the COPPA flow is
-  // OFF (domains without parental-consent UI). The COPPA-enabled path
-  // already handles age via the radio-group at register.hbs:144-178,
-  // so we don't double-gate. `age_attested` is checkbox-bound;
-  // `ageAttestationRequired` shows the inline error message when the
-  // user tried to submit without checking.
   age_attested: false,
-  // Combined consent — the single checkbox on the register form now
-  // confirms BOTH age (13+) and ToS agreement. Reading returns true
-  // only when both underlying flags are set; writing mirrors the new
-  // value into both, so all existing validation gates (ageBlocksSave,
-  // googleSignupSubmitDisabled, the submit path that reads
-  // model.terms_agree) continue to work unchanged. The Google-signup
-  // variant has its own pair (age_attested + googleSignupTerms).
-  combined_consent: computed('age_attested', 'model.terms_agree', {
-    get() {
-      return !!this.get('age_attested') && !!this.get('model.terms_agree');
-    },
-    set(key, value) {
-      var v = !!value;
-      this.set('age_attested', v);
-      this.set('model.terms_agree', v);
-      return v;
-    }
-  }),
-  combined_google_consent: computed('age_attested', 'googleSignupTerms', {
-    get() {
-      return !!this.get('age_attested') && !!this.get('googleSignupTerms');
-    },
-    set(key, value) {
-      var v = !!value;
-      this.set('age_attested', v);
-      this.set('googleSignupTerms', v);
-      return v;
-    }
-  }),
-  ageAttestationRequired: computed('triedToSave', 'age_attested', 'showCoppaConsent', function() {
-    if(this.get('showCoppaConsent')) { return false; }
-    return this.get('triedToSave') && !this.get('age_attested');
-  }),
-  ageBlocksSave: computed('triedToSave', 'showCoppaConsent', 'age_attested', function() {
-    if(!this.get('triedToSave') || this.get('showCoppaConsent')) { return false; }
-    return !this.get('age_attested');
-  }),
   googleSsoEnabled: computed('appState.feature_flags.google_sso', function() {
     return !!this.get('appState.feature_flags.google_sso');
   }),
-  googleRegisterAllowed: computed('model.terms_agree', 'showCoppaConsent', 'coppa_age_group', 'googleSsoEnabled', function() {
+  googleRegisterAllowed: computed('model.terms_agree', 'googleSsoEnabled', 'registrationStep', 'coppa_age_group', 'roleIncomplete', 'persistence.online', 'userNameBlank', 'noSpacesName', 'userNameUnavailable', function() {
     if(!this.get('googleSsoEnabled')) { return false; }
+    if(!this.persistence.get('online')) { return false; }
     if(!this.get('model.terms_agree')) { return false; }
-    if(this.get('showCoppaConsent') && this.get('coppa_age_group') === 'under_13') { return false; }
-    if(this.get('showCoppaConsent') && !this.get('coppa_age_group')) { return false; }
+    if(this.get('userNameBlank')) { return false; }
+    if(this.get('noSpacesName') || this.get('userNameUnavailable')) { return false; }
+    if(this.get('registrationStep') !== 'account') { return false; }
+    if(this.get('coppa_age_group') === 'under_13') { return false; }
+    if(this.get('roleIncomplete')) { return false; }
     return true;
   }),
   googleRegisterDisabled: computed('googleRegisterAllowed', function() {
     return !this.get('googleRegisterAllowed');
+  }),
+  accountStepEmailSignupDisabled: computed('registering.saving', 'model.terms_agree', 'userNameBlank', 'noSpacesName', 'userNameUnavailable', function() {
+    return !!(this.get('registering.saving') || !this.get('model.terms_agree') || this.get('userNameBlank') || this.get('noSpacesName') || this.get('userNameUnavailable'));
   }),
   clear_start_code_ref: observer('model.start_code', 'start_code_ref', function() {
     if(this.get('model.start_code') && this.get('model.start_code') != this.get('start_code_ref.code')) {
@@ -189,6 +213,10 @@ export default Controller.extend({
       if(_this.isDestroyed || _this.isDestroying) { return; }
       _this.set('googleSignupProfile', res);
       _this.set('googleSignupBusy', false);
+      _this.set('googleSignupRegistrationType', res.registration_type || 'communicator');
+      _this.set('googleSignupTerms', !!res.terms_agree);
+      _this.set('googleSignupProductImprovementOptIn', !!res.product_improvement_opt_in);
+      _this.set('googleSignupUserName', res.user_name || '');
       if(res.name && !_this.get('googleSignupUserName')) {
         _this.set('googleSignupUserName', '');
       }
@@ -198,11 +226,38 @@ export default Controller.extend({
       _this.set('googleSignupError', true);
     });
   },
+  _classifyCommunicatorAge: function() {
+    var month = parseInt(this.get('birth_month'), 10);
+    var year = parseInt(this.get('birth_year'), 10);
+    if(!month || !year) { return null; }
+    var today = new Date();
+    var cutoffYear = today.getFullYear() - 13;
+    var cutoffMonth = today.getMonth() + 1;
+    // With month/year only, treat the cutoff month as under 13 until the
+    // exact birthday is known. This keeps Google off the ambiguous edge.
+    if(year > cutoffYear || (year === cutoffYear && month >= cutoffMonth)) {
+      return 'under_13';
+    }
+    return 'over_13';
+  },
+  _setProductImprovementPrefs: function(value) {
+    var enabled = !!value;
+    this.set('user.preferences.cookies', enabled);
+    this.set('model.preferences.cookies', enabled);
+    this.set('model.preferences.telemetry_opt_in', enabled);
+    this.set('model.preferences.comms_log_opt_in', enabled);
+  },
   actions: {
+    go_to_step: function(step) {
+      this.set('triedToSave', false);
+      this.set('registrationStep', step);
+    },
     select_registration_role: function(val) {
       this.set('registration_role', val);
+      this.set('triedToSave', false);
       if(val === 'communicator') {
         this.set('model.preferences.registration_type', 'communicator');
+        this.set('registrationStep', 'communicator_age');
       } else if(val === 'supporter') {
         // 'supporter' is a UI grouping; the persisted registration_type must be
         // a supporter sub-type (therapist/parent/teacher/other) so the backend
@@ -211,6 +266,9 @@ export default Controller.extend({
         if(['therapist', 'parent', 'teacher', 'other'].indexOf(this.get('model.preferences.registration_type')) === -1) {
           this.set('model.preferences.registration_type', null);
         }
+        this.set('coppa_age_group', null);
+        this.set('parent_consent_email', '');
+        this.set('registrationStep', 'supporter_type');
       } else {
         this.set('model.preferences.registration_type', null);
       }
@@ -218,6 +276,19 @@ export default Controller.extend({
     select_supporter_type: function(type) {
       this.set('registration_role', 'supporter');
       this.set('model.preferences.registration_type', type);
+      this.set('registrationStep', 'account');
+    },
+    continue_communicator_age: function() {
+      this.set('triedToSave', true);
+      var ageGroup = this._classifyCommunicatorAge();
+      if(!ageGroup) { return; }
+      this.set('coppa_age_group', ageGroup);
+      this.set('triedToSave', false);
+      this.set('registrationStep', ageGroup === 'under_13' ? 'under_13' : 'account');
+    },
+    toggle_product_improvement: function(value) {
+      this.set('productImprovementOptIn', !!value);
+      this._setProductImprovementPrefs(value);
     },
     allow_start_code: function() {
       this.set('start_code', !this.get('start_code'));
@@ -226,6 +297,10 @@ export default Controller.extend({
       if(!this.get('googleRegisterAllowed') || !this.persistence.get('online')) { return; }
       var url = '/auth/google/start?flow=register&device_id=' + encodeURIComponent(capabilities.device_id());
       url = url + '&return_origin=' + encodeURIComponent(window.location.origin);
+      url = url + '&registration_type=' + encodeURIComponent(this.get('model.preferences.registration_type') || 'communicator');
+      url = url + '&user_name=' + encodeURIComponent((this.get('model.user_name') || '').trim());
+      url = url + '&terms_agree=' + encodeURIComponent(this.get('model.terms_agree') ? 'true' : 'false');
+      url = url + '&product_improvement_opt_in=' + encodeURIComponent(this.get('productImprovementOptIn') ? 'true' : 'false');
       if(capabilities.installed_app) {
         url = url + '&app=true&popout_id=' + encodeURIComponent((new Date()).getTime() + 'T' + Math.round(Math.random() * 999999));
         window.open(url, '_blank');
@@ -243,10 +318,9 @@ export default Controller.extend({
         data: {
           nonce: _this.get('google_signup'),
           user_name: (_this.get('googleSignupUserName') || '').trim(),
-          registration_type: _this.get('googleSignupRegistrationType') || 'individual',
+          registration_type: _this.get('googleSignupRegistrationType') || 'communicator',
           terms_agree: _this.get('googleSignupTerms') ? 'true' : 'false',
-          telemetry_opt_in: _this.get('googleSignupTelemetryOptIn') ? 'true' : 'false',
-          comms_log_opt_in: _this.get('googleSignupCommsLogOptIn') ? 'true' : 'false'
+          product_improvement_opt_in: _this.get('googleSignupProductImprovementOptIn') ? 'true' : 'false'
         }
       }).then(function(res) {
         if(_this.isDestroyed || _this.isDestroying) { return; }

--- a/app/frontend/app/routes/register.js
+++ b/app/frontend/app/routes/register.js
@@ -19,6 +19,11 @@ export default Route.extend({
     controller.set('model', model);
     controller.set('user', model);
     controller.set('coppaWaitingParent', false);
+    controller.set('registrationStep', 'role');
+    controller.set('registration_role', '');
+    controller.set('birth_month', '');
+    controller.set('birth_year', '');
+    controller.set('productImprovementOptIn', false);
     controller.set('coppa_age_group', null);
     controller.set('parent_consent_email', '');
     if(model.get('reg_params.code') && model.get('reg_params.v')) {
@@ -41,24 +46,21 @@ export default Route.extend({
       controller.set('triedToSave', true);
       if(!user.get('terms_agree')) { return; }
       if(!_this.persistence.get('online')) { return; }
-      if(controller.get('badEmail') || controller.get('passwordMismatch') || controller.get('shortPassword') || controller.get('noName')|| controller.get('noSpacesName') || controller.get('coppaBlocksSave') || controller.get('ageBlocksSave') || controller.get('roleIncomplete')) {
+      if(controller.get('badEmail') || controller.get('passwordMismatch') || controller.get('shortPassword') || controller.get('userNameMissing') || controller.get('noSpacesName') || controller.get('userNameUnavailable') || controller.get('coppaBlocksSave') || controller.get('roleIncomplete')) {
         return;
       }
-      if(controller.get('showCoppaConsent')) {
-        if(controller.get('coppa_age_group') === 'under_13') {
-          user.set('coppa_under_13', true);
-          user.set('parent_consent_email', (controller.get('parent_consent_email') || '').trim());
-        } else {
-          user.set('coppa_under_13', false);
-          user.set('parent_consent_email', null);
-        }
+      if(controller.get('coppa_age_group') === 'under_13') {
+        user.set('coppa_under_13', true);
+        user.set('parent_consent_email', (controller.get('parent_consent_email') || '').trim());
       } else {
         user.set('coppa_under_13', false);
         user.set('parent_consent_email', null);
       }
       controller.set('registering', {saving: true});
-      user.set('preferences.telemetry_opt_in', controller.get('model.preferences.telemetry_opt_in') || false);
-      user.set('preferences.comms_log_opt_in', controller.get('model.preferences.comms_log_opt_in') || false);
+      var productImprovementOptIn = !!controller.get('productImprovementOptIn');
+      user.set('preferences.cookies', productImprovementOptIn);
+      user.set('preferences.telemetry_opt_in', productImprovementOptIn);
+      user.set('preferences.comms_log_opt_in', productImprovementOptIn);
       user.save().then(function(user) {
         controller.set('start_code', null);
         user.set('password', null);

--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -38028,6 +38028,84 @@ a.la-footer-bottom-a11y-wcag {
   max-width: 560px;
 }
 
+.register-step-copy {
+  margin: 0 0 18px;
+  color: #4f5c6f;
+  font-size: 16px;
+  line-height: 1.45;
+}
+
+.register-role-heading {
+  margin: 0 0 18px;
+  color: $la-navy;
+  font-size: 22px;
+  line-height: 1.25;
+  font-weight: 700;
+}
+
+.register-role-options {
+  display: grid;
+  gap: $aac-spacing-12;
+  margin-bottom: $aac-spacing-16;
+}
+
+.register-choice-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 64px;
+  padding: $aac-spacing-16 $aac-spacing-20;
+  border-radius: 14px;
+  border: 1px solid rgba($brand-smart-blue, 0.22);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(241, 246, 255, 0.9) 100%);
+  color: $brand-smart-blue;
+  font-size: 18px;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.7),
+    0 2px 8px rgba($la-navy, 0.12);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    border-color: rgba($brand-smart-blue, 0.55);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.78),
+      0 4px 14px rgba($la-navy, 0.16);
+    transform: translateY(-1px);
+    outline: none;
+  }
+}
+
+.register-date-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: $aac-spacing-12;
+}
+
+.register-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 0 0 $aac-spacing-14;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: $brand-smart-blue;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline;
+    outline: none;
+  }
+}
+
 /* Supporter sub-type buttons — revealed under the role dropdown when
    "Supporter" is selected. Modern glassy pill buttons (2 per row), with a
    brand-smart-blue active state for the chosen type. */
@@ -38036,6 +38114,10 @@ a.la-footer-bottom-a11y-wcag {
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 10px;
+}
+
+.register-supporter-types--large {
+  margin-bottom: $aac-spacing-16;
 }
 .register-supporter-type {
   flex: 1 1 calc(50% - 4px);
@@ -38070,6 +38152,27 @@ a.la-footer-bottom-a11y-wcag {
     0 0 0 2px rgba($brand-smart-blue, 0.18);
 }
 
+.register-footer-link {
+  margin: 18px 0 0;
+  color: $brand-blue-black;
+  font-size: 15px;
+  text-align: center;
+
+  a {
+    color: $brand-smart-blue;
+    font-weight: 700;
+    text-decoration: underline;
+  }
+}
+
+.register-help-text {
+  margin: $aac-spacing-8 0 $aac-spacing-12;
+  color: #5a6578;
+  font-size: 14px;
+  line-height: 1.4;
+  text-align: center;
+}
+
 .register-card {
   margin-top: $aac-spacing-24;
   background:
@@ -38085,7 +38188,7 @@ a.la-footer-bottom-a11y-wcag {
     0 8px 24px rgba(0, 0, 0, 0.07),
     0 24px 48px -12px rgba(0, 0, 0, 0.08);
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 
   /* Auth header/divider: match about page design */
   .la-section-header {
@@ -38374,6 +38477,10 @@ a.la-footer-bottom-a11y-wcag {
   transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease, border-color 0.2s ease, color 0.2s ease;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
   text-align: center;
+
+  &.register-btn--wide {
+    width: 100%;
+  }
 
   &:hover:not(:disabled):not(.register-btn--disabled) {
     background: color.adjust(rgba($brand-charcoal-dark, 1), $lightness: 8%);

--- a/app/frontend/app/templates/add-supervisor.hbs
+++ b/app/frontend/app/templates/add-supervisor.hbs
@@ -19,14 +19,14 @@
         <div class="form-group">
           <label for="add_supervisee_key" class="col-sm-3 control-label">{{t "Supervisor" key="supervisor"}}</label>
           <div class="col-sm-6">
-            <Input @value={{this.supervisor_key}} class="form-control" id="add_supervisee_key" placeholder="User name" />
+            <Input @value={{this.supervisor_key}} class="form-control" id="add_supervisee_key" placeholder="User name" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
           </div>
         </div>
       {{else if this.start_code}}
         <div class="form-group">
           <label for="add_start_code_key" class="col-sm-3 control-label">{{t "Start Code" key="start_code"}}</label>
           <div class="col-sm-6">
-            <Input @value={{this.start_code_key}} class="form-control" id="add_start_code" placeholder="start code" />
+            <Input @value={{this.start_code_key}} class="form-control" id="add_start_code" placeholder="start code" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
           </div>
           <div class="col-sm-9 col-sm-offset-3">
             <p class='form-control-static'><em>{{t "In addition to adding supervision access, start codes may update some of your settings based on the pre-set configuration by the supervisor, so make sure to check with them before entering a start code." key="start_code_warning"}}</em></p>
@@ -36,12 +36,12 @@
         <div class="form-group">
           <label for="supervisor_name" class="col-sm-3 control-label">{{t "Supervisor" key="supervisor"}}</label>
           <div class="col-sm-6">
-            <Input @value={{this.model.supervisor.name}} class="form-control" id="supervisor_name" placeholder="Full name" />
+            <Input @value={{this.model.supervisor.name}} class="form-control" id="supervisor_name" placeholder="Full name" autocomplete="name" />
           </div>
         </div>
         <div class="form-group">
           <div class="col-sm-6 col-sm-offset-3">
-            <Input @value={{this.model.supervisor.user_name}} class="form-control" placeholder="User name" />
+            <Input @value={{this.model.supervisor.user_name}} class="form-control" placeholder="User name" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
             {{#if this.model.supervisor.user_name_check.checking}}
             {{else if this.model.supervisor.user_name_check.exists}}
               <span class='text-danger'>{{t "\"%{user_name}\" already exists" user_name=this.model.supervisor.user_name}}</span>
@@ -50,12 +50,12 @@
         </div>
         <div class="form-group">
           <div class="col-sm-6 col-sm-offset-3">
-            <Input @value={{this.model.supervisor.email}} class="form-control" placeholder="Email address" />
+            <Input @type="email" @value={{this.model.supervisor.email}} class="form-control" placeholder="Email address" autocomplete="email" inputmode="email" />
           </div>
         </div>
         <div class="form-group">
           <div class="col-sm-6 col-sm-offset-3">
-            <Input @type="password" @value={{this.model.supervisor.password}} class="form-control" placeholder="Password" />
+            <Input @type="password" @value={{this.model.supervisor.password}} class="form-control" placeholder="Password" autocomplete="new-password" />
           </div>
         </div>
       {{/if}}

--- a/app/frontend/app/templates/components/add-supervisor.hbs
+++ b/app/frontend/app/templates/components/add-supervisor.hbs
@@ -29,37 +29,37 @@
             <p class="md-modal-hint" style="font-style: italic;">{{t "Enter their email address. They'll receive a consent request and must approve before access is granted." key="consent_request_intro"}}</p>
             <div class="md-add-supervisor__field">
               <label for="owner_email" class="md-add-supervisor__label">{{t "Email" key="email"}}</label>
-              <Input @value={{this.owner_email}} class="md-add-supervisor__input" id="owner_email" placeholder={{t "Supervisor's email address" key="supervisor_email_placeholder"}} />
+              <Input @type="email" @value={{this.owner_email}} class="md-add-supervisor__input" id="owner_email" placeholder={{t "Supervisor's email address" key="supervisor_email_placeholder"}} autocomplete="email" inputmode="email" />
             </div>
           {{/if}}
         {{else if this.existing_user}}
           <div class="md-add-supervisor__field">
             <label for="add_supervisee_key" class="md-add-supervisor__label">{{t "Supervisor" key="supervisor"}}</label>
-            <Input @value={{this.supervisor_key}} class="md-add-supervisor__input" id="add_supervisee_key" placeholder="User name" />
+            <Input @value={{this.supervisor_key}} class="md-add-supervisor__input" id="add_supervisee_key" placeholder="User name" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
           </div>
         {{else if this.start_code}}
           <div class="md-add-supervisor__field">
             <label for="add_start_code_key" class="md-add-supervisor__label">{{t "Start Code" key="start_code"}}</label>
-            <Input @value={{this.start_code_key}} class="md-add-supervisor__input" id="add_start_code" placeholder="start code" />
+            <Input @value={{this.start_code_key}} class="md-add-supervisor__input" id="add_start_code" placeholder="start code" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
             <p class="md-modal-hint" style="font-style: italic;">{{t "Start codes may also update some of your settings — check with the supervisor before entering one." key="start_code_warning"}}</p>
           </div>
         {{else}}
           <div class="md-add-supervisor__field">
             <label for="supervisor_name" class="md-add-supervisor__label">{{t "Supervisor" key="supervisor"}}</label>
-            <Input @value={{this.model.supervisor.name}} class="md-add-supervisor__input" id="supervisor_name" placeholder="Full name" />
+            <Input @value={{this.model.supervisor.name}} class="md-add-supervisor__input" id="supervisor_name" placeholder="Full name" autocomplete="name" />
           </div>
           <div class="md-add-supervisor__field">
-            <Input @value={{this.model.supervisor.user_name}} class="md-add-supervisor__input" placeholder="User name" />
+            <Input @value={{this.model.supervisor.user_name}} class="md-add-supervisor__input" placeholder="User name" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
             {{#if this.model.supervisor.user_name_check.checking}}
             {{else if this.model.supervisor.user_name_check.exists}}
               <span class="md-add-supervisor__error">{{t "\"%{user_name}\" already exists" user_name=this.model.supervisor.user_name}}</span>
             {{/if}}
           </div>
           <div class="md-add-supervisor__field">
-            <Input @value={{this.model.supervisor.email}} class="md-add-supervisor__input" placeholder="Email address" />
+            <Input @type="email" @value={{this.model.supervisor.email}} class="md-add-supervisor__input" placeholder="Email address" autocomplete="email" inputmode="email" />
           </div>
           <div class="md-add-supervisor__field">
-            <Input @type="password" @value={{this.model.supervisor.password}} class="md-add-supervisor__input" placeholder="Password" />
+            <Input @type="password" @value={{this.model.supervisor.password}} class="md-add-supervisor__input" placeholder="Password" autocomplete="new-password" />
           </div>
         {{/if}}
         {{#unless this.start_code}}

--- a/app/frontend/app/templates/components/eval-status.hbs
+++ b/app/frontend/app/templates/components/eval-status.hbs
@@ -17,11 +17,11 @@
           <div class="la-eval-status-form">
             <div class="la-eval-status-field">
               <label class="la-eval-status-field__label" for="eval_reset_user_name">{{t "Current User Name" key="current_user_name"}}</label>
-              <Input type="text" id="eval_reset_user_name" @value={{this.reset_user_name}} class="la-eval-status-field__input" />
+              <Input type="text" id="eval_reset_user_name" @value={{this.reset_user_name}} class="la-eval-status-field__input" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
             </div>
             <div class="la-eval-status-field">
               <label class="la-eval-status-field__label" for="eval_reset_email">{{t "New Email Address" key="new_email"}}</label>
-              <Input type="text" id="eval_reset_email" @value={{this.reset_email}} class="la-eval-status-field__input" />
+              <Input type="email" id="eval_reset_email" @value={{this.reset_email}} class="la-eval-status-field__input" autocomplete="email" inputmode="email" />
               {{#if this.status.reset_email_used}}
                 <p class="la-eval-status-error" role="alert">{{t "Must be a different email address than last time" key="must_be_different_email"}}</p>
               {{/if}}
@@ -44,7 +44,7 @@
             </div>
             <div class="la-eval-status-field">
               <label class="la-eval-status-field__label" for="eval_reset_password">{{t "New Password" key="new_password"}}</label>
-              <Input type="password" id="eval_reset_password" placeholder="(optional)" @value={{this.reset_password}} class="la-eval-status-field__input" />
+              <Input type="password" id="eval_reset_password" placeholder="(optional)" @value={{this.reset_password}} class="la-eval-status-field__input" autocomplete="new-password" />
             </div>
           </div>
         {{else}}
@@ -57,14 +57,14 @@
         <div class="la-eval-status-form">
           <div class="la-eval-status-field">
             <label class="la-eval-status-field__label" for="eval_transfer_user_name">{{t "New User Name" key="new_user_name"}}</label>
-            <Input type="text" id="eval_transfer_user_name" @value={{this.transfer_user_name}} class="la-eval-status-field__input" />
+            <Input type="text" id="eval_transfer_user_name" @value={{this.transfer_user_name}} class="la-eval-status-field__input" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" />
             {{#if this.status.transfer_bad_credentials}}
               <p class="la-eval-status-error" role="alert">{{t "No account found with that user name and password" key="no_account_found"}}</p>
             {{/if}}
           </div>
           <div class="la-eval-status-field">
             <label class="la-eval-status-field__label" for="eval_transfer_password">{{t "New Password" key="new_password"}}</label>
-            <Input type="password" id="eval_transfer_password" @value={{this.transfer_password}} class="la-eval-status-field__input" />
+            <Input type="password" id="eval_transfer_password" @value={{this.transfer_password}} class="la-eval-status-field__input" autocomplete="current-password" />
           </div>
         </div>
       {{else if this.choice.extend}}

--- a/app/frontend/app/templates/modals.legacy/eval-status.hbs
+++ b/app/frontend/app/templates/modals.legacy/eval-status.hbs
@@ -17,11 +17,11 @@
           <div class="la-eval-status-form">
             <div class="la-eval-status-field">
               <label class="la-eval-status-field__label">{{t "Current User Name" key="current_user_name"}}</label>
-              <Input type="text" @value={{this.reset_user_name}} class="la-eval-status-field__input" />
+              <Input type="text" @value={{this.reset_user_name}} class="la-eval-status-field__input" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
             </div>
             <div class="la-eval-status-field">
               <label class="la-eval-status-field__label">{{t "New Email Address" key="new_email"}}</label>
-              <Input type="text" @value={{this.reset_email}} class="la-eval-status-field__input" />
+              <Input type="email" @value={{this.reset_email}} class="la-eval-status-field__input" autocomplete="email" inputmode="email" />
               {{#if this.status.reset_email_used}}
                 <p class="la-eval-status-error">{{t "Must be a different email address than last time" key="must_be_different_email"}}</p>
               {{/if}}
@@ -44,7 +44,7 @@
             </div>
             <div class="la-eval-status-field">
               <label class="la-eval-status-field__label">{{t "New Password" key="new_password"}}</label>
-              <Input type="password" placeholder="(optional)" @value={{this.reset_password}} class="la-eval-status-field__input" />
+              <Input type="password" placeholder="(optional)" @value={{this.reset_password}} class="la-eval-status-field__input" autocomplete="new-password" />
             </div>
           </div>
         {{else}}
@@ -57,14 +57,14 @@
         <div class="la-eval-status-form">
           <div class="la-eval-status-field">
             <label class="la-eval-status-field__label">{{t "New User Name" key="new_user_name"}}</label>
-            <Input type="text" @value={{this.transfer_user_name}} class="la-eval-status-field__input" />
+            <Input type="text" @value={{this.transfer_user_name}} class="la-eval-status-field__input" autocomplete="username" autocapitalize="off" autocorrect="off" spellcheck="false" />
             {{#if this.status.transfer_bad_credentials}}
               <p class="la-eval-status-error">{{t "No account found with that user name and password" key="no_account_found"}}</p>
             {{/if}}
           </div>
           <div class="la-eval-status-field">
             <label class="la-eval-status-field__label">{{t "New Password" key="new_password"}}</label>
-            <Input type="password" @value={{this.transfer_password}} class="la-eval-status-field__input" />
+            <Input type="password" @value={{this.transfer_password}} class="la-eval-status-field__input" autocomplete="current-password" />
           </div>
         </div>
       {{else if this.choice.extend}}

--- a/app/frontend/app/templates/new-user.hbs
+++ b/app/frontend/app/templates/new-user.hbs
@@ -8,13 +8,13 @@
       <div class="form-group">
         <label for="name" class="col-sm-4 control-label">{{t "Full Name" key="full_name"}}</label>
         <div class="col-sm-6">
-          <Input @value={{this.model.user.name}} class="form-control" id="name" placeholder="Full name" />
+          <Input @value={{this.model.user.name}} class="form-control" id="name" placeholder="Full name" autocomplete="name" />
         </div>
       </div>
       <div class="form-group">
         <label for="user_name" class="col-sm-4 control-label">{{t "User Name" key="uesr_name"}}</label>
         <div class="col-sm-6">
-          <Input @value={{this.model.user.user_name}} class="form-control" placeholder="User name" />
+          <Input @value={{this.model.user.user_name}} class="form-control" placeholder="User name" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
           {{#if this.model.user.user_name_check.checking}}
           {{else if this.model.user.user_name_check.exists}}
             <span class='text-danger'>{{t "%{user_name} already exists" user_name=this.model.user.user_name}}</span>
@@ -24,13 +24,13 @@
       <div class="form-group">
         <label for="email" class="col-sm-4 control-label">{{t "Email" key="email"}}</label>
         <div class="col-sm-6">
-          <Input @value={{this.model.user.email}} class="form-control" placeholder="Email address" />
+          <Input @type="email" @value={{this.model.user.email}} class="form-control" placeholder="Email address" autocomplete="email" inputmode="email" />
         </div>
       </div>
       <div class="form-group">
         <label for="name" class="col-sm-4 control-label">{{t "Password" key="password"}}</label>
         <div class="col-sm-6">
-          <Input @type="password" @value={{this.model.user.password}} class="form-control" placeholder="Password" />
+          <Input @type="password" @value={{this.model.user.password}} class="form-control" placeholder="Password" autocomplete="new-password" />
         </div>
       </div>
       <div class="form-group">

--- a/app/frontend/app/templates/register.hbs
+++ b/app/frontend/app/templates/register.hbs
@@ -16,7 +16,7 @@
           <hr class="la-about-hero-separator" aria-hidden="true">
         </div>
         <p>{{t "We emailed the parent or guardian address you provided. They must approve your account before you can sign in. Ask them to check their inbox (and spam folder)." key="coppa_waiting_parent_body"}}</p>
-        <p><LinkTo @route="login" class="register-btn">{{t "Back to login" key="coppa_waiting_parent_login"}}</LinkTo></p>
+        <p class="register-footer-link"><LinkTo @route="login">{{t "Back to login" key="coppa_waiting_parent_login"}}</LinkTo></p>
       {{else if this.showGoogleSignup}}
         <div class="la-section-header">
           <div class="la-hero-title-wrap">
@@ -25,71 +25,26 @@
           <hr class="la-about-hero-separator" aria-hidden="true">
         </div>
         <p class="google-link-context">{{t "Signed in to Google as %{email}" email=this.googleSignupProfile.email key="google_signed_in_as"}}</p>
-        <p>{{t "Choose a username and role, then agree to the terms to finish creating your account." key="google_signup_complete_body"}}</p>
+        <p>{{t "Choose the username you want for your LingoLinq account, then finish creating your account." key="google_signup_complete_body_username_required"}}</p>
         <div class="form-group">
           <label for="google_signup_user_name">{{t "Username" key="username"}}</label>
-          <Input @value={{this.googleSignupUserName}} class="form-control" id="google_signup_user_name" placeholder="User name" />
-        </div>
-        <div class="form-group">
-          <label for="google_signup_registration_type">{{t "Type" key="type"}}</label>
-          {{bound-select select_class="form-control" select_id="google_signup_registration_type" content=this.registration_types selection=this.googleSignupRegistrationType action=(action (mut this.googleSignupRegistrationType)) }}
-        </div>
-        {{#if this.showCoppaConsent}}
-          <div class="form-group">
-            <fieldset>
-              <legend class="sr-only">{{t "How old is the person creating this account?" key="coppa_age_gate_prompt"}}</legend>
-              <span id="google-signup-coppa-age-prompt">{{t "How old is the person creating this account?" key="coppa_age_gate_prompt"}}</span>
-              <div class="checkbox big_checkbox" style="margin-top: 0.5rem;">
-                <label>
-                  <input type="radio" name="google_signup_coppa_age" checked={{is-equal this.coppa_age_group "over_13"}} onclick={{action (mut this.coppa_age_group) "over_13"}} />
-                  {{t "13 or older" key="coppa_age_13_or_older"}}
-                </label>
-              </div>
-              <div class="checkbox big_checkbox">
-                <label>
-                  <input type="radio" name="google_signup_coppa_age" checked={{is-equal this.coppa_age_group "under_13"}} onclick={{action (mut this.coppa_age_group) "under_13"}} />
-                  {{t "Under 13" key="coppa_age_under_13"}}
-                </label>
-              </div>
-            </fieldset>
-          </div>
-        {{/if}}
-        <div class="register-checkboxes">
-          <div class="checkbox big_checkbox">
-            <label>
-              <Input @type="checkbox" @checked={{this.googleSignupTelemetryOptIn}} />
-              {{t "I agree to allow anonymous usage and performance data (telemetry) to be collected to help improve LingoLinq." key="telemetry_opt_in"}}
-            </label>
-          </div>
-          <div class="checkbox big_checkbox">
-            <label>
-              <Input @type="checkbox" @checked={{this.googleSignupCommsLogOptIn}} />
-              {{t "I agree to allow anonymized communication logs to be reviewed for troubleshooting and app improvement. Logs are fully stripped of names and personal profiles before any engineer reviews them." key="comms_log_opt_in"}}
-            </label>
-          </div>
-          {{!-- Combined age + ToS consent. One checkbox covers both
-               the 13+ attestation and Terms of Use agreement; the
-               `combined_google_consent` setter on the controller
-               mirrors the new value into `age_attested` and
-               `googleSignupTerms` so all existing submit gates stay
-               intact. Drops the age clause when the COPPA radio
-               flow above already gates age. --}}
-          {{#if this.showCoppaConsent}}
-            <div class="checkbox big_checkbox">
-              <label>
-                <Input @type="checkbox" @checked={{this.googleSignupTerms}} />
-                {{t "I have read and agree to the " key="register_consent_terms_prefix"}}<a href="/terms" target="_blank" rel="noopener">{{t "Terms of Use and License Agreement" key="terms_of_use_and_license"}}</a>{{t ", and am capable of binding to a legal contract." key="register_consent_terms_suffix"}}
-              </label>
-            </div>
-          {{else}}
-            <div class="checkbox big_checkbox">
-              <label>
-                <Input @type="checkbox" @checked={{this.combined_google_consent}} />
-                {{t "I am at least 13 years old, have read and agree to the " key="register_consent_combined_prefix"}}<a href="/terms" target="_blank" rel="noopener">{{t "Terms of Use and License Agreement" key="terms_of_use_and_license"}}</a>{{t ", and am capable of binding to a legal contract." key="register_consent_combined_suffix"}}
-              </label>
-            </div>
+          <Input @value={{this.googleSignupUserName}} class="form-control" id="google_signup_user_name" placeholder={{t "choose a username" key="choose_a_username"}} autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
+          {{#if this.googleSignupUserNameMissing}}
+            <span class="text-danger">{{t "username required" key="username_required"}}</span>
+          {{else if this.googleSignupUserNameInvalid}}
+            <span class='text-danger'>{{t "user names can't have spaces, dots or quotes" key="no_spaces_user_name"}}</span>
           {{/if}}
         </div>
+        {{#unless this.googleSignupTerms}}
+          <div class="register-checkboxes">
+            <div class="checkbox big_checkbox">
+              <div id="google_signup_terms_label">
+                <Input @type="checkbox" @checked={{this.googleSignupTerms}} aria-labelledby="google_signup_terms_label" />
+                {{t "By checking this box, I agree to the LingoLinq " key="register_terms_privacy_prefix"}}<a href="/terms" target="_blank" rel="noopener">{{t "Terms of Service" key="terms_of_service"}}</a>{{t " and " key="and_spaced"}}<a href="/privacy" target="_blank" rel="noopener">{{t "Privacy Policy" key="privacy_policy"}}</a>{{t "." key="period"}}
+              </div>
+            </div>
+          </div>
+        {{/unless}}
         <div class="register-btn-wrap">
           <button type="button" disabled={{this.googleSignupSubmitDisabled}} class="register-btn" {{action "saveGoogleSignup"}}>
             {{#if this.googleSignupBusy}}
@@ -113,230 +68,323 @@
           <p>{{t "Checking..." key="checking"}}</p>
         {{else if this.googleSignupError}}
           <p class="register-error">{{t "This Google sign-in session expired. Please try again." key="google_link_session_expired"}}</p>
-          <p><LinkTo @route="login" class="register-btn">{{t "Back to login" key="coppa_waiting_parent_login"}}</LinkTo></p>
+          <p class="register-footer-link"><LinkTo @route="login">{{t "Back to login" key="coppa_waiting_parent_login"}}</LinkTo></p>
         {{/if}}
       {{else}}
-      <div class="la-section-header">
-        <div class="la-hero-title-wrap">
-          <h2 class="la-hero-title"><span class="la-hero-title__prefix">{{t "Create a " key="create_account_prefix"}}</span><span class="hero-gradient">{{t "LingoLinq" key="app_name"}}</span><span class="la-hero-title__prefix">{{t " Account" key="create_account_suffix"}}</span></h2>
-        </div>
-        <hr class="la-about-hero-separator" aria-hidden="true">
-      </div>
-      <form novalidate autocomplete="off" {{action "saveProfile" on="submit"}}>
-      {{#if this.start_code_ref}}
-        <div class="register-invite">
-          <div class="register-invite-icon">
-            {{#if this.start_code_ref.image_url}}
-              <img src={{this.start_code_ref.image_url}} alt="">
+        <form novalidate autocomplete="off" {{action "saveProfile" on="submit"}}>
+          <div class="la-section-header">
+            <div class="la-hero-title-wrap">
+              <h2 class="la-hero-title"><span class="la-hero-title__prefix">{{t "Create a " key="create_account_prefix"}}</span><span class="hero-gradient">{{t "LingoLinq" key="app_name"}}</span><span class="la-hero-title__prefix">{{t " Account" key="create_account_suffix"}}</span></h2>
+            </div>
+            <hr class="la-about-hero-separator" aria-hidden="true">
+          </div>
+
+          {{#if this.start_code_ref}}
+            <div class="register-invite">
+              <div class="register-invite-icon">
+                {{#if this.start_code_ref.image_url}}
+                  <img src={{this.start_code_ref.image_url}} alt="">
+                {{else}}
+                  <span class="glyphicon glyphicon-paperclip"></span>
+                {{/if}}
+              </div>
+              <div class="register-invite-info">
+                <h4>
+                  {{t "Invited By" key="invited_by"}}
+                  {{#if this.start_code_ref.organization}}
+                    {{t "Organization - " key="organization_dash"}}
+                  {{else}}
+                    {{t "Supervisor - " key="supervisor_dash"}}
+                  {{/if}}
+                  <em>{{this.start_code_ref.name}}</em>
+                </h4>
+                <p>{{t "When you sign up using the provided start code, you will automatically be connected to the organization or user that invited you to join. Some default settings such as home board may also be set automatically for you." key="auto_start_code_explainer"}}</p>
+              </div>
+            </div>
+          {{/if}}
+
+          {{#if this.showRoleStep}}
+            <p class="register-step-copy">{{t "Choose the role that best describes who this account is for." key="register_choose_role_intro"}}</p>
+            <div class="register-role-options">
+              <button type="button" class="register-choice-card" {{action "select_registration_role" "communicator"}}>
+                <span>{{t "Communicator" key="registration_role_communicator_short"}}</span>
+                <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+              </button>
+              <button type="button" class="register-choice-card" {{action "select_registration_role" "supporter"}}>
+                <span>{{t "Supporter" key="registration_role_supporter"}}</span>
+                <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+              </button>
+            </div>
+
+            {{#if this.start_code}}
+              <div class="form-group">
+                <label for="start_code_role">{{t "Start Code" key="start_code"}}</label>
+                <Input @value={{this.model.start_code}} class="form-control" id="start_code_role" placeholder={{t "optional, if provided" key="optional_if_provided"}} />
+              </div>
             {{else}}
-              <span class="glyphicon glyphicon-paperclip"></span>
+              <button type="button" class="register-start-code-link" {{action "allow_start_code"}}>
+                {{t "I have a start code" key="have_a_start_code"}}
+              </button>
             {{/if}}
-          </div>
-          <div class="register-invite-info">
-            <h4>
-              {{t "Invited By" key="invited_by"}}
-              {{#if this.start_code_ref.organization}}
-                {{t "Organization - " key="organization_dash"}}
-              {{else}}
-                {{t "Supervisor - " key="supervisor_dash"}}
+
+          {{else if this.showCommunicatorAgeStep}}
+            <button type="button" class="register-back-link" {{action "go_to_step" "role"}}>
+              <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
+              {{t "Choose a different role" key="choose_different_role"}}
+            </button>
+            <p class="register-step-copy">{{t "First, we need your date of birth to help us give you the best experience." key="register_birthdate_intro"}}</p>
+            <div class="form-group">
+              <label>{{t "Date of birth" key="date_of_birth"}}</label>
+              <div class="register-date-row">
+                {{bound-select select_class="form-control" select_id="birth_month" content=this.birthMonths selection=this.birth_month action=(action (mut this.birth_month)) }}
+                {{bound-select select_class="form-control" select_id="birth_year" content=this.birthYears selection=this.birth_year action=(action (mut this.birth_year)) }}
+              </div>
+              {{#if this.communicatorAgeRequired}}
+                <span class="text-danger">{{t "Please choose a birth month and year." key="birthdate_required"}}</span>
               {{/if}}
-              <em>{{this.start_code_ref.name}}</em>
-            </h4>
-            <p>{{t "When you sign up using the provided start code, you will automatically be connected to the organization or user that invited you to join. Some default settings such as home board may also be set automatically for you." key="auto_start_code_explainer"}}</p>
-          </div>
-        </div>
-      {{/if}}
-      <div class="form-group">
-        <label for="name">{{t "Name" key="name"}}</label>
-        <Input @type="text" @value={{this.model.name}} class="form-control" id="name" placeholder="Full Name" autocomplete="name" />
-      </div>
-      <div class="form-group">
-        <label for="user_name">{{t "Username" key="username"}}</label>
-        <Input @type="text" @value={{this.model.user_name}} class="form-control" id="user_name" placeholder="User name (optional, we can pick for you)" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
-        {{#if this.noSpacesName}}
-          <span class='text-danger'>{{t "user names can't have spaces, dots or quotes" key="no_spaces_user_name"}}</span>
-        {{else if this.user.user_name_check.checking}}
-        {{else if this.user.user_name_check.exists}}
-          <span class='text-danger'>{{t "%{user_name} already exists" user_name=this.user.user_name}}</span>
-        {{else if this.noName}}
-          <span class='text-danger'>{{t "name or username is required" key="name_or_username_required"}}</span>
-        {{/if}}
-      </div>
-      <div class="form-group">
-        <label for="email">{{t "Email" key="email"}}</label>
-        <Input @type="email" @value={{this.model.email}} class="form-control" id="email" placeholder="" autocomplete="email" inputmode="email" />
-        {{#if this.badEmail}}
-          <span class='text-danger'>{{t "email required" key="email_required"}}</span>
-        {{/if}}
-      </div>
-      {{#if this.showCoppaConsent}}
-        <div class="form-group">
-          <fieldset>
-            <legend class="sr-only">{{t "How old is the person creating this account?" key="coppa_age_gate_prompt"}}</legend>
-            <span id="coppa-age-prompt">{{t "How old is the person creating this account?" key="coppa_age_gate_prompt"}}</span>
-            <div class="checkbox big_checkbox" style="margin-top: 0.5rem;">
-              <label>
-                <input type="radio" name="coppa_age" checked={{is-equal this.coppa_age_group "over_13"}} onclick={{action (mut this.coppa_age_group) "over_13"}} />
-                {{t "13 or older" key="coppa_age_13_or_older"}}
-              </label>
             </div>
-            <div class="checkbox big_checkbox">
-              <label>
-                <input type="radio" name="coppa_age" checked={{is-equal this.coppa_age_group "under_13"}} onclick={{action (mut this.coppa_age_group) "under_13"}} />
-                {{t "Under 13" key="coppa_age_under_13"}}
-              </label>
+            <div class="register-btn-wrap">
+              <button type="button" class="register-btn register-btn--wide" {{action "continue_communicator_age"}}>
+                {{t "Next" key="next"}}
+              </button>
             </div>
-            {{#if this.coppaAgeRequired}}
-              <span class="text-danger">{{t "Please select an age option." key="coppa_age_required"}}</span>
+
+          {{else if this.showSupporterTypeStep}}
+            <button type="button" class="register-back-link" {{action "go_to_step" "role"}}>
+              <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
+              {{t "Choose a different role" key="choose_different_role"}}
+            </button>
+            <p class="register-step-copy">{{t "What kind of supporter account are you creating?" key="supporter_type_prompt"}}</p>
+            <div class="register-supporter-types register-supporter-types--large" role="radiogroup" aria-label={{t "What kind of supporter are you?" key="supporter_type_group"}}>
+              {{#each this.supporter_types as |st|}}
+                <button type="button" role="radio"
+                  aria-checked={{if (is-equal this.model.preferences.registration_type st.id) "true" "false"}}
+                  class="register-supporter-type {{if (is-equal this.model.preferences.registration_type st.id) 'register-supporter-type--active'}}"
+                  {{action "select_supporter_type" st.id}}>{{st.name}}</button>
+              {{/each}}
+            </div>
+            {{#if this.start_code}}
+              <div class="form-group">
+                <label for="start_code_supporter">{{t "Start Code" key="start_code"}}</label>
+                <Input @value={{this.model.start_code}} class="form-control" id="start_code_supporter" placeholder={{t "optional, if provided" key="optional_if_provided"}} />
+              </div>
+            {{else}}
+              <button type="button" class="register-start-code-link" {{action "allow_start_code"}}>
+                {{t "I have a start code" key="have_a_start_code"}}
+              </button>
             {{/if}}
-          </fieldset>
-        </div>
-        {{#if (is-equal this.coppa_age_group "under_13")}}
-          <div class="form-group">
-            <label for="parent_consent_email">{{t "Parent or guardian email" key="coppa_parent_email_label"}}</label>
-            <Input @value={{this.parent_consent_email}} class="form-control" id="parent_consent_email" placeholder={{t "Parent's email address (must differ from account email)" key="coppa_parent_email_placeholder"}} />
-            {{#if this.coppaParentEmailMissing}}
-              <span class="text-danger">{{t "Parent or guardian email is required for users under 13." key="coppa_parent_email_required"}}</span>
+
+          {{else if this.showUnder13Step}}
+            <button type="button" class="register-back-link" {{action "go_to_step" "communicator_age"}}>
+              <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
+              {{t "Change date of birth" key="change_date_of_birth"}}
+            </button>
+            <h3 class="register-role-heading">{{this.selectedRoleSignupHeading}}</h3>
+            <p class="register-step-copy">{{t "A parent or guardian needs to approve this account before it can be used." key="under_13_parent_approval_intro"}}</p>
+            <div class="form-group">
+              <label for="parent_consent_email">{{t "Parent or guardian email" key="coppa_parent_email_label"}}</label>
+              <Input @value={{this.parent_consent_email}} class="form-control" id="parent_consent_email" placeholder={{t "Parent's email address (must differ from account email)" key="coppa_parent_email_placeholder"}} autocomplete="email" inputmode="email" />
+              {{#if this.coppaParentEmailMissing}}
+                <span class="text-danger">{{t "Parent or guardian email is required for users under 13." key="coppa_parent_email_required"}}</span>
+              {{/if}}
+              {{#if this.coppaParentEmailSameAsAccount}}
+                <span class="text-danger">{{t "Parent email must be different from the account email." key="coppa_parent_email_must_differ"}}</span>
+              {{/if}}
+            </div>
+            <div class="form-group">
+              <label for="user_name_under_13">{{t "Username" key="username"}}</label>
+              <Input @type="text" @value={{this.model.user_name}} class="form-control" id="user_name_under_13" placeholder={{t "choose a username" key="choose_a_username"}} autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
+              {{#if this.userNameMissing}}
+                <span class='text-danger'>{{t "username required" key="username_required"}}</span>
+              {{else if this.noSpacesName}}
+                <span class='text-danger'>{{t "user names can't have spaces, dots or quotes" key="no_spaces_user_name"}}</span>
+              {{else if this.user.user_name_check.exists}}
+                <span class='text-danger'>{{t "%{user_name} already exists" user_name=this.user.user_name}}</span>
+              {{/if}}
+            </div>
+            <div class="form-group">
+              <label for="email_under_13">{{t "Email" key="email"}}</label>
+              <Input @type="email" @value={{this.model.email}} class="form-control" id="email_under_13" autocomplete="email" inputmode="email" />
+              {{#if this.badEmail}}
+                <span class='text-danger'>{{t "email required" key="email_required"}}</span>
+              {{/if}}
+            </div>
+            <div class="form-group">
+              <label for="password_under_13">{{t "Password" key="password"}}</label>
+              {{password-field id="password_under_13" class="form-control" value=this.model.password placeholder=(t "at least 6 characters" key="at_least_6_characters") autocomplete="new-password"}}
+              {{#if this.shortPassword}}
+                <span class='text-danger'>{{t "password must be at least 6 characters" key="min_password_lower"}}</span>
+              {{/if}}
+            </div>
+            {{#if this.start_code}}
+              <div class="form-group">
+                <label for="start_code_under_13">{{t "Start Code" key="start_code"}}</label>
+                <Input @value={{this.model.start_code}} class="form-control" id="start_code_under_13" placeholder={{t "optional, if provided" key="optional_if_provided"}} />
+              </div>
+            {{else}}
+              <button type="button" class="register-start-code-link" {{action "allow_start_code"}}>
+                {{t "I have a start code" key="have_a_start_code"}}
+              </button>
             {{/if}}
-            {{#if this.coppaParentEmailSameAsAccount}}
-              <span class="text-danger">{{t "Parent email must be different from the account email." key="coppa_parent_email_must_differ"}}</span>
+            <div class="register-checkboxes">
+              <div class="checkbox big_checkbox">
+                <div id="under_13_terms_label">
+                  <Input @type="checkbox" @checked={{this.model.terms_agree}} aria-labelledby="under_13_terms_label" />
+                  {{t "By checking this box, I agree to the LingoLinq " key="register_terms_privacy_prefix"}}<a href="/terms" target="_blank" rel="noopener">{{t "Terms of Service" key="terms_of_service"}}</a>{{t " and " key="and_spaced"}}<a href="/privacy" target="_blank" rel="noopener">{{t "Privacy Policy" key="privacy_policy"}}</a>{{t "." key="period"}}
+                </div>
+              </div>
+            </div>
+            <div class="register-btn-wrap">
+              {{#if (persistence-online)}}
+                <button type="submit" disabled={{this.accountStepEmailSignupDisabled}} class="register-btn register-btn--wide">
+                  {{#if this.registering.initializing}}
+                    {{t "Handling Start Code..." key="processing_start_code"}}
+                  {{else if this.registering.saving}}
+                    {{t "Signing Up..." key="signing_up"}}
+                  {{else}}
+                    {{t "Sign Up" key="sign_up"}}
+                  {{/if}}
+                </button>
+              {{else}}
+                <button type='submit' disabled='true' class="register-btn register-btn--disabled register-btn--wide">
+                  {{t "Not Online" key="not_online"}}
+                </button>
+              {{/if}}
+            </div>
+            {{#unless this.model.terms_agree}}
+              <p class="register-help-text">{{t "Agree to the Terms of Service before continuing with email." key="email_terms_required_hint"}}</p>
+            {{/unless}}
+            {{#if this.userNameBlank}}
+              <p class="register-help-text">{{t "Choose a username before continuing with email." key="email_username_required_hint"}}</p>
             {{/if}}
-          </div>
-        {{/if}}
-      {{/if}}
-      <div class="form-group">
-        <label for="password">{{t "Password" key="password"}}</label>
-        {{password-field id="password" class="form-control" value=this.model.password placeholder="at least 6 characters" autocomplete="new-password"}}
-        {{#if this.shortPassword}}
-          <span class='text-danger'>{{t "password must be at least 6 characters" key="min_password_lower"}}</span>
-        {{/if}}
-      </div>
-      <div class="form-group">
-        <label for="registration_type">{{t "Role" key="role"}}</label>
-        {{bound-select select_class="form-control" select_id="registration_type" content=this.role_categories selection=this.registration_role action=(action "select_registration_role") }}
-        {{#if (is-equal this.registration_role "supporter")}}
-          {{!-- Supporter sub-type: stores the specific registration_type
-               (therapist/parent/teacher/other) so the backend maps
-               role=supporter. UI-grouped under "Supporter" above. --}}
-          <div class="register-supporter-types" role="radiogroup" aria-label={{t "What kind of supporter are you?" key="supporter_type_group"}}>
-            {{#each this.supporter_types as |st|}}
-              <button type="button" role="radio"
-                aria-checked={{if (is-equal this.model.preferences.registration_type st.id) "true" "false"}}
-                class="register-supporter-type {{if (is-equal this.model.preferences.registration_type st.id) 'register-supporter-type--active'}}"
-                {{action "select_supporter_type" st.id}}>{{st.name}}</button>
-            {{/each}}
-          </div>
-        {{/if}}
-        {{#if this.roleIncomplete}}
-          <span class='text-danger'>{{t "Please choose your role" key="role_required"}}</span>
-        {{/if}}
-      </div>
-      <div class="form-group">
-        {{#unless this.start_code}}
-          <button type="button" class="register-start-code-link" {{action "allow_start_code"}}>
-            {{t "I have a start code" key="have_a_start_code"}}
-          </button>
-        {{else}}
-          <label for="start_code">{{t "Start Code" key="start_code"}}</label>
-          <Input @value={{this.model.start_code}} class="form-control" placeholder="optional, if provided" />
-        {{/unless}}
-      </div>
-      <div class="register-checkboxes">
-        <div class="checkbox big_checkbox">
-          <label>
-            <Input @type="checkbox" @checked={{this.user.preferences.cookies}} />
-            {{t "Send usage data to %app_name% for analytics, error tracking and feature improvements" key="allow_cookies"}}
-          </label>
-        </div>
-        <div class="checkbox big_checkbox">
-          <label>
-            <Input @type="checkbox" @checked={{this.model.preferences.telemetry_opt_in}} />
-            {{t "I agree to allow anonymous usage and performance data (telemetry) to be collected to help improve LingoLinq." key="telemetry_opt_in"}}
-          </label>
-        </div>
-        <div class="checkbox big_checkbox">
-          <label>
-            <Input @type="checkbox" @checked={{this.model.preferences.comms_log_opt_in}} />
-            {{t "I agree to allow anonymized communication logs to be reviewed for troubleshooting and app improvement. Logs are fully stripped of names and personal profiles before any engineer reviews them." key="comms_log_opt_in"}}
-          </label>
-        </div>
-        {{!-- Combined age + ToS consent. One checkbox covers both
-             the 13+ attestation and Terms of Use agreement; the
-             `combined_consent` setter on the controller mirrors the
-             new value into `age_attested` and `model.terms_agree` so
-             all existing submit gates stay intact. Drops the age
-             clause when the COPPA radio flow above already gates
-             age. --}}
-        {{#if this.showCoppaConsent}}
-          <div class="checkbox big_checkbox">
-            <label>
-              <Input @type="checkbox" @checked={{this.model.terms_agree}} />
-              {{t "I have read and agree to the " key="register_consent_terms_prefix"}}<a href="/terms" target="_blank" rel="noopener">{{t "Terms of Use and License Agreement" key="terms_of_use_and_license"}}</a>{{t ", and am capable of binding to a legal contract." key="register_consent_terms_suffix"}}
-            </label>
-          </div>
-        {{else}}
-          <div class="checkbox big_checkbox">
-            <label>
-              <Input @type="checkbox" @checked={{this.combined_consent}} />
-              {{t "I am at least 13 years old, have read and agree to the " key="register_consent_combined_prefix"}}<a href="/terms" target="_blank" rel="noopener">{{t "Terms of Use and License Agreement" key="terms_of_use_and_license"}}</a>{{t ", and am capable of binding to a legal contract." key="register_consent_combined_suffix"}}
-            </label>
-          </div>
-        {{/if}}
-        {{#if this.ageAttestationRequired}}
-          <span class='text-danger register-checkboxes__error'>{{t "You must confirm your age and agree to the Terms of Use to create an account." key="combined_consent_required_message"}}</span>
-        {{/if}}
-      </div>
-      <div class="register-btn-wrap">
-      {{#if this.googleSsoEnabled}}
-        {{!-- Sign-up-with-Google button per Google's Identity Branding
-             Guidelines (https://developers.google.com/identity/branding-guidelines):
-             white field, 1px #dadce0 border, 18px 4-color "G" logo on
-             the left, Roboto-family Medium 14px label. --}}
-        <button type="button" disabled={{this.googleRegisterDisabled}} class="register-btn register-btn--google" {{action "continue_with_google"}}>
-          <span class="register-btn--google__icon" aria-hidden="true">
-            <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
-              <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.874 2.684-6.615z" fill="#4285F4"/>
-              <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z" fill="#34A853"/>
-              <path d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/>
-              <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
-            </svg>
-          </span>
-          <span class="register-btn--google__label">{{t "Continue with Google" key="continue_with_google"}}</span>
-        </button>
-        <div class="login-google-divider">
-          <span>{{t "or" key="google_or_divider"}}</span>
-        </div>
-      {{/if}}
-      {{#if (persistence-online)}}
-        <button type="submit" disabled={{this.registering.saving}} class="register-btn">
-          {{#if this.registering.initializing}}
-            {{t "Handling Start Code..." key="processing_start_code"}}
-          {{else if this.registering.saving}}
-            {{t "Signing Up..." key="signing_up"}}
-          {{else}}
-            {{t "Sign Up" key="sign_up"}}
+
+          {{else if this.showAccountStep}}
+            {{#if (is-equal this.registration_role "supporter")}}
+              <button type="button" class="register-back-link" {{action "go_to_step" "supporter_type"}}>
+                <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
+                {{t "Change supporter type" key="change_supporter_type"}}
+              </button>
+            {{else}}
+              <button type="button" class="register-back-link" {{action "go_to_step" "communicator_age"}}>
+                <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
+                {{t "Change date of birth" key="change_date_of_birth"}}
+              </button>
+            {{/if}}
+            <h3 class="register-role-heading">{{this.selectedRoleSignupHeading}}</h3>
+            <div class="form-group">
+              <label for="user_name_account">{{t "Username" key="username"}}</label>
+              <Input @type="text" @value={{this.model.user_name}} class="form-control" id="user_name_account" placeholder={{t "choose a username" key="choose_a_username"}} autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" />
+              {{#if this.userNameMissing}}
+                <span class='text-danger'>{{t "username required" key="username_required"}}</span>
+              {{else if this.noSpacesName}}
+                <span class='text-danger'>{{t "user names can't have spaces, dots or quotes" key="no_spaces_user_name"}}</span>
+              {{else if this.user.user_name_check.exists}}
+                <span class='text-danger'>{{t "%{user_name} already exists" user_name=this.user.user_name}}</span>
+              {{/if}}
+            </div>
+            <div class="register-checkboxes">
+              <div class="checkbox big_checkbox">
+                <div id="account_terms_label">
+                  <Input @type="checkbox" @checked={{this.model.terms_agree}} aria-labelledby="account_terms_label" />
+                  {{t "By checking this box, I agree to the LingoLinq " key="register_terms_privacy_prefix"}}<a href="/terms" target="_blank" rel="noopener">{{t "Terms of Service" key="terms_of_service"}}</a>{{t " and " key="and_spaced"}}<a href="/privacy" target="_blank" rel="noopener">{{t "Privacy Policy" key="privacy_policy"}}</a>{{t "." key="period"}}
+                </div>
+              </div>
+              <div class="checkbox big_checkbox">
+                <label>
+                  <Input @type="checkbox" @checked={{this.productImprovementOptIn}} />
+                  {{t "Help improve LingoLinq by sharing usage, performance, and anonymized troubleshooting data." key="product_improvement_opt_in"}}
+                </label>
+              </div>
+            </div>
+            {{#if this.googleSsoEnabled}}
+              <div class="register-btn-wrap">
+                <button type="button" disabled={{this.googleRegisterDisabled}} class="register-btn register-btn--google" {{action "continue_with_google"}}>
+                  <span class="register-btn--google__icon" aria-hidden="true">
+                    <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.874 2.684-6.615z" fill="#4285F4"/>
+                      <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z" fill="#34A853"/>
+                      <path d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/>
+                      <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
+                    </svg>
+                  </span>
+                  <span class="register-btn--google__label">{{t "Continue with Google" key="continue_with_google"}}</span>
+                </button>
+              </div>
+              {{#unless this.model.terms_agree}}
+                <p class="register-help-text">{{t "Agree to the Terms of Service before continuing with Google." key="google_terms_required_hint"}}</p>
+              {{/unless}}
+              {{#if this.userNameBlank}}
+                <p class="register-help-text">{{t "Choose a username before continuing with Google." key="google_username_required_hint"}}</p>
+              {{/if}}
+              <div class="login-google-divider">
+                <span>{{t "or sign up with email" key="or_sign_up_with_email"}}</span>
+              </div>
+            {{/if}}
+            <div class="form-group">
+              <label for="email_account">{{t "Email" key="email"}}</label>
+              <Input @type="email" @value={{this.model.email}} class="form-control" id="email_account" autocomplete="email" inputmode="email" />
+              {{#if this.badEmail}}
+                <span class='text-danger'>{{t "email required" key="email_required"}}</span>
+              {{/if}}
+            </div>
+            <div class="form-group">
+              <label for="password_account">{{t "Password" key="password"}}</label>
+              {{password-field id="password_account" class="form-control" value=this.model.password placeholder=(t "at least 6 characters" key="at_least_6_characters") autocomplete="new-password"}}
+              {{#if this.shortPassword}}
+                <span class='text-danger'>{{t "password must be at least 6 characters" key="min_password_lower"}}</span>
+              {{/if}}
+            </div>
+            {{#if this.start_code}}
+              <div class="form-group">
+                <label for="start_code_account">{{t "Start Code" key="start_code"}}</label>
+                <Input @value={{this.model.start_code}} class="form-control" id="start_code_account" placeholder={{t "optional, if provided" key="optional_if_provided"}} />
+              </div>
+            {{else}}
+              <button type="button" class="register-start-code-link" {{action "allow_start_code"}}>
+                {{t "I have a start code" key="have_a_start_code"}}
+              </button>
+            {{/if}}
+            <div class="register-btn-wrap">
+              {{#if (persistence-online)}}
+                <button type="submit" disabled={{this.accountStepEmailSignupDisabled}} class="register-btn register-btn--wide">
+                  {{#if this.registering.initializing}}
+                    {{t "Handling Start Code..." key="processing_start_code"}}
+                  {{else if this.registering.saving}}
+                    {{t "Signing Up..." key="signing_up"}}
+                  {{else}}
+                    {{t "Sign Up" key="sign_up"}}
+                  {{/if}}
+                </button>
+              {{else}}
+                <button type='submit' disabled='true' class="register-btn register-btn--disabled register-btn--wide">
+                  {{t "Not Online" key="not_online"}}
+                </button>
+              {{/if}}
+            </div>
+            {{#unless this.model.terms_agree}}
+              <p class="register-help-text">{{t "Agree to the Terms of Service before continuing with email." key="email_terms_required_hint"}}</p>
+            {{/unless}}
+            {{#if this.userNameBlank}}
+              <p class="register-help-text">{{t "Choose a username before continuing with email." key="email_username_required_hint"}}</p>
+            {{/if}}
           {{/if}}
-        </button>
-      {{else}}
-        <button type='submit' disabled='true' class="register-btn register-btn--disabled">
-          {{t "Not Online" key="not_online"}}
-        </button>
-      {{/if}}
-      </div>
-      {{#if this.registering.error}}
-        <p class='register-error'>
-          {{#if this.registering.error.email_blocked}}
-            {{t "The email address provided has been blocked, please try a different address" key="email_blocked"}}
-          {{else if this.registering.error.progress}}
-            {{t "User initialization failed. Please contact support." key="user_init_failed"}}
-          {{else if this.registering.error.start_code}}
-            {{t "Please re-check the start code" key="check_start_code"}}
-          {{else}}
-            {{t "There was an unexpected error while registering" key="error_registering"}}
+
+          {{#if this.registering.error}}
+            <p class='register-error'>
+              {{#if this.registering.error.email_blocked}}
+                {{t "The email address provided has been blocked, please try a different address" key="email_blocked"}}
+              {{else if this.registering.error.progress}}
+                {{t "User initialization failed. Please contact support." key="user_init_failed"}}
+              {{else if this.registering.error.start_code}}
+                {{t "Please re-check the start code" key="check_start_code"}}
+              {{else}}
+                {{t "There was an unexpected error while registering" key="error_registering"}}
+              {{/if}}
+            </p>
           {{/if}}
-        </p>
-      {{/if}}
-      </form>
+
+          <p class="register-footer-link">{{t "Already have a LingoLinq account?" key="already_have_lingolinq_account"}} <LinkTo @route="login">{{t "Log in" key="log_in"}}</LinkTo></p>
+        </form>
       {{/if}}
     {{else}}
       <div class="la-section-header">

--- a/app/frontend/app/templates/user/edit.hbs
+++ b/app/frontend/app/templates/user/edit.hbs
@@ -11,19 +11,19 @@
     <div class="form-group">
       <label for="name" class="col-sm-3 control-label">{{t "Name" key="name"}}</label>
       <div class="col-sm-5">
-        <Input @value={{this.model.name}} class="form-control" id="name" placeholder="Full Name" />
+        <Input @value={{this.model.name}} class="form-control" id="name" placeholder="Full Name" autocomplete="name" />
       </div>
     </div>
     <div class="form-group">
       <label for="email" class="col-sm-3 control-label">{{t "Email" key="email"}}</label>
       <div class="col-sm-5">
-        <Input @value={{this.model.email}} class="form-control" id="email" placeholder="" />
+        <Input @type="email" @value={{this.model.email}} class="form-control" id="email" placeholder="" autocomplete="email" inputmode="email" />
       </div>
     </div>
     <div class="form-group">
       <label for="cell_phone" class="col-sm-3 control-label">{{t "Cell Phone" key="cell_phone"}}</label>
       <div class="col-sm-5">
-        <Input @value={{this.model.cell_phone}} class="form-control" id="cell_phone" placeholder="optional, for alerts" />
+        <Input @type="tel" @value={{this.model.cell_phone}} class="form-control" id="cell_phone" placeholder="optional, for alerts" autocomplete="tel" inputmode="tel" />
       </div>
     </div>
   {{/preference-box}}
@@ -79,7 +79,7 @@
             {{qr-code text=this.status_2fa.uri size=300}}
             </div>
             <span style='display: inline-block; width: 200px;'>
-              <Input type="number" class="form-control" @value={{this.code_2fa}} placeholder="# # # # # #" />
+              <Input type="number" class="form-control" @value={{this.code_2fa}} placeholder="# # # # # #" autocomplete="one-time-code" />
             </span>
             {{#if this.status_2fa.error}}
               <p class='text-danger'>{{t "Invalid code, please check again" key="invalid_code_please_try_again"}}</p>
@@ -118,19 +118,19 @@
     <div class="form-group">
       <label for="description" class="col-sm-3 control-label">{{t "Short Bio" key="one_liner"}}</label>
       <div class="col-sm-5">
-        <Input @value={{this.model.description}} class="form-control" id="description" placeholder="a short bio" />
+        <Input @value={{this.model.description}} class="form-control" id="description" placeholder="a short bio" autocomplete="off" />
       </div>
     </div>
     <div class="form-group">
       <label for="url" class="col-sm-3 control-label">{{t "URL" key="url"}}</label>
       <div class="col-sm-5">
-        <Input @value={{this.model.details_url}} class="form-control" id="url" placeholder="https://" />
+        <Input @type="url" @value={{this.model.details_url}} class="form-control" id="url" placeholder="https://" autocomplete="url" inputmode="url" />
       </div>
     </div>
     <div class="form-group">
       <label for="location" class="col-sm-3 control-label">{{t "Location" key="location"}}</label>
       <div class="col-sm-5">
-        <Input @value={{this.model.location}} class="form-control" id="location" placeholder="City, State, Whatever" />
+        <Input @value={{this.model.location}} class="form-control" id="location" placeholder="City, State, Whatever" autocomplete="off" />
       </div>
     </div>
     <div class="form-group">
@@ -328,9 +328,9 @@
           <label class="col-sm-3 control-label" for='valet_password'>{{t "Classroom Password" key="classroom_password"}}</label>
           <div class="col-sm-3">
             {{#if this.model.valet_password_set}}
-              <Input @type="password" @value={{this.model.valet_password}} class="form-control" id="valet_password" placeholder="enter to change" />
+              <Input @type="password" @value={{this.model.valet_password}} class="form-control" id="valet_password" placeholder="enter to change" autocomplete="new-password" />
             {{else}}
-              <Input @type="password" @value={{this.model.valet_password}} class="form-control" id="valet_password" placeholder="required" />
+              <Input @type="password" @value={{this.model.valet_password}} class="form-control" id="valet_password" placeholder="required" autocomplete="new-password" />
             {{/if}}
           </div>
           <div class="col-sm-2">
@@ -382,9 +382,9 @@
           <label class="col-sm-3 control-label" for='valet_password'>{{t "Valet Password" key="valet_password"}}</label>
           <div class="col-sm-3">
             {{#if this.model.valet_password_set}}
-              <Input @type="password" @value={{this.model.valet_password}} class="form-control" id="valet_password" placeholder="enter to change" />
+              <Input @type="password" @value={{this.model.valet_password}} class="form-control" id="valet_password" placeholder="enter to change" autocomplete="new-password" />
             {{else}}
-              <Input @type="password" @value={{this.model.valet_password}} class="form-control" id="valet_password" placeholder="required" />
+              <Input @type="password" @value={{this.model.valet_password}} class="form-control" id="valet_password" placeholder="required" autocomplete="new-password" />
             {{/if}}
           </div>
           <div class="col-sm-2">

--- a/app/frontend/app/templates/user/password_reset.hbs
+++ b/app/frontend/app/templates/user/password_reset.hbs
@@ -9,12 +9,12 @@
     <div class="form-group">
       <label for="password" class="col-sm-2 control-label">{{t "Password" key="password"}}</label>
       <div class="col-sm-4">
-        <Input @type="password" @value={{this.model.password}} class="form-control" id="password" placeholder="new password" />
+        <Input @type="password" @value={{this.model.password}} class="form-control" id="password" placeholder="new password" autocomplete="new-password" />
       </div>
     </div>
     <div class="form-group">
       <div class="col-sm-4 col-sm-offset-2">
-        <Input @type="password" @value={{this.model.password2}} class="form-control" id="password2" title="Repeat password" placeholder="new password again" />
+        <Input @type="password" @value={{this.model.password2}} class="form-control" id="password2" title="Repeat password" placeholder="new password again" autocomplete="new-password" />
         {{#if this.badPassword.mismatch}}
           {{t "Passwords do not match" key="passwords_dont_match"}}
         {{else}}

--- a/app/frontend/tests/controllers/register-test.js
+++ b/app/frontend/tests/controllers/register-test.js
@@ -9,11 +9,124 @@ import {
   stub
 } from 'frontend/tests/helpers/jasmine';
 import { queryLog } from 'frontend/tests/helpers/ember_helper';
+import EmberObject from '@ember/object';
 
 describe('RegisterController', 'controller:register', function() {
+  var testOwner;
+
+  beforeEach(function() {
+    testOwner = this.owner;
+  });
+
   it("should exist", function() {
     expect(this).not.toEqual(null);
     expect(this).not.toEqual(window);
+  });
+
+  it("moves communicators through the birthdate step before account details", function() {
+    var controller = testOwner.lookup('controller:register');
+    controller.set('model', EmberObject.create({ preferences: {} }));
+    controller.send('select_registration_role', 'communicator');
+
+    expect(controller.get('registrationStep')).toEqual('communicator_age');
+    expect(controller.get('model.preferences.registration_type')).toEqual('communicator');
+
+    controller.set('birth_month', '1');
+    controller.set('birth_year', ((new Date()).getFullYear() - 20).toString());
+    controller.send('continue_communicator_age');
+
+    expect(controller.get('coppa_age_group')).toEqual('over_13');
+    expect(controller.get('registrationStep')).toEqual('account');
+  });
+
+  it("routes under-13 communicators to the parent approval step", function() {
+    var controller = testOwner.lookup('controller:register');
+    controller.set('model', EmberObject.create({ preferences: {} }));
+    controller.send('select_registration_role', 'communicator');
+    controller.set('birth_month', '1');
+    controller.set('birth_year', (new Date()).getFullYear().toString());
+    controller.send('continue_communicator_age');
+
+    expect(controller.get('coppa_age_group')).toEqual('under_13');
+    expect(controller.get('registrationStep')).toEqual('under_13');
+    controller.set('triedToSave', true);
+    expect(controller.get('coppaParentEmailMissing')).toEqual(true);
+  });
+
+  it("stores supporter subtypes without persisting the supporter grouping", function() {
+    var controller = testOwner.lookup('controller:register');
+    controller.set('model', EmberObject.create({ preferences: {} }));
+    controller.send('select_registration_role', 'supporter');
+
+    expect(controller.get('registrationStep')).toEqual('supporter_type');
+    expect(controller.get('model.preferences.registration_type')).toEqual(null);
+
+    controller.send('select_supporter_type', 'teacher');
+    expect(controller.get('registrationStep')).toEqual('account');
+    expect(controller.get('registration_role')).toEqual('supporter');
+    expect(controller.get('model.preferences.registration_type')).toEqual('teacher');
+  });
+
+  it("shows role-specific signup heading copy", function() {
+    var controller = testOwner.lookup('controller:register');
+    controller.set('model', EmberObject.create({ preferences: { registration_type: 'parent' } }));
+    expect(controller.get('selectedRoleSignupHeading')).toEqual("Sign up as a parent today!");
+
+    controller.set('model.preferences.registration_type', 'teacher');
+    expect(controller.get('selectedRoleSignupHeading')).toEqual("Sign up as a teacher today!");
+
+    controller.set('model.preferences.registration_type', 'other');
+    expect(controller.get('selectedRoleSignupHeading')).toEqual("Sign up as another supporter today!");
+
+    controller.set('model.preferences.registration_type', 'communicator');
+    expect(controller.get('selectedRoleSignupHeading')).toEqual("Sign up as a communicator today!");
+  });
+
+  it("maps the optional product improvement checkbox to existing preferences", function() {
+    var prefs = {};
+    var controller = testOwner.lookup('controller:register');
+    controller.set('model', EmberObject.create({ preferences: prefs }));
+    controller.set('user', EmberObject.create({ preferences: prefs }));
+
+    controller.send('toggle_product_improvement', true);
+    expect(controller.get('model.preferences.cookies')).toEqual(true);
+    expect(controller.get('model.preferences.telemetry_opt_in')).toEqual(true);
+    expect(controller.get('model.preferences.comms_log_opt_in')).toEqual(true);
+
+    controller.send('toggle_product_improvement', false);
+    expect(controller.get('model.preferences.cookies')).toEqual(false);
+    expect(controller.get('model.preferences.telemetry_opt_in')).toEqual(false);
+    expect(controller.get('model.preferences.comms_log_opt_in')).toEqual(false);
+  });
+
+  it("requires username before Google completion can submit", function() {
+    var controller = testOwner.lookup('controller:register');
+    controller.set('googleSignupBusy', false);
+    controller.set('googleSignupTerms', true);
+    controller.set('googleSignupUserName', '');
+
+    expect(controller.get('googleSignupSubmitDisabled')).toEqual(true);
+
+    controller.set('googleSignupUserName', 'chosen-name');
+    expect(controller.get('googleSignupSubmitDisabled')).toEqual(false);
+
+    controller.set('googleSignupUserName', 'chosen name');
+    expect(controller.get('googleSignupSubmitDisabled')).toEqual(true);
+  });
+
+  it("requires username on staged email signup steps", function() {
+    var controller = testOwner.lookup('controller:register');
+    controller.set('model', EmberObject.create({ preferences: {}, terms_agree: true, user_name: '' }));
+    controller.set('user', EmberObject.create({ user_name_check: { exists: false } }));
+    controller.set('registrationStep', 'account');
+    controller.set('triedToSave', true);
+
+    expect(controller.get('userNameMissing')).toEqual(true);
+    expect(controller.get('accountStepEmailSignupDisabled')).toEqual(true);
+
+    controller.set('model.user_name', 'chosen-name');
+    expect(controller.get('userNameMissing')).toEqual(false);
+    expect(controller.get('accountStepEmailSignupDisabled')).toEqual(false);
   });
 });
 // import Ember from 'ember';

--- a/app/models/concerns/google_authentication.rb
+++ b/app/models/concerns/google_authentication.rb
@@ -42,26 +42,30 @@ module GoogleAuthentication
       user
     end
 
-    def create_from_google_signup!(profile, user_name:, registration_type:, terms_agree:)
+    def create_from_google_signup!(profile, user_name:, registration_type:, terms_agree:, product_improvement_opt_in: false)
       raise GoogleOAuth::Error, 'terms_required' unless ActiveModel::Type::Boolean.new.cast(terms_agree)
       user_name = user_name.to_s.strip
       raise GoogleOAuth::Error, 'username_required' if user_name.blank?
+      product_improvement_opt_in = ActiveModel::Type::Boolean.new.cast(product_improvement_opt_in)
 
       email = profile[:email].to_s.strip
       name = profile[:name].presence || email.split('@').first
       password = GoSecure.nonce('google_pw')
-      user = User.process_new({
+      params = {
         'name' => name,
-        'user_name' => user_name,
         'email' => email,
         'password' => password,
         'terms_agree' => true,
         'preferences' => {
-          'registration_type' => registration_type.presence || 'individual',
-          'cookies' => false,
-          'google_signup' => true
+          'registration_type' => registration_type.presence || 'communicator',
+          'cookies' => product_improvement_opt_in,
+          'google_signup' => true,
+          'telemetry_opt_in' => product_improvement_opt_in,
+          'comms_log_opt_in' => product_improvement_opt_in
         }
-      }, { pending: true, allow_password_change: true })
+      }
+      params['user_name'] = user_name
+      user = User.process_new(params, { pending: true, allow_password_change: true })
       raise GoogleOAuth::Error, 'user_creation_failed' if !user || user.errored?
       user.link_google!(profile[:sub], email: email, name: name)
       user

--- a/app/models/concerns/processable.rb
+++ b/app/models/concerns/processable.rb
@@ -176,7 +176,9 @@ module Processable
   end
   
   def generate_user_name(suggestion=nil, downcased=true)
+    suggestion = nil if suggestion.respond_to?(:blank?) && suggestion.blank?
     suggestion ||= self.user_name || (self.settings && self.settings['name'])
+    suggestion = nil if suggestion.respond_to?(:blank?) && suggestion.blank?
     suggestion ||= (self.settings && self.settings['email'] && self.settings['email'].split(/@/)[0])
     suggestion ||= "person"
     suggestion = suggestion.downcase if downcased

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1081,7 +1081,7 @@ class User < ApplicationRecord
       'goal_notifications', 'word_suggestion_images', 'hidden_buttons',
       'speak_on_speak_mode', 'ever_synced', 'folder_icons', 'folder_display_style', 'allow_log_reports', 'allow_log_publishing',
       'symbol_background', 'disable_button_help', 'click_buttons', 'prevent_hide_buttons',
-      'new_index', 'debounce', 'cookies', 'preferred_symbols', 'tag_ids', 'vibrate_buttons',
+      'new_index', 'debounce', 'cookies', 'telemetry_opt_in', 'comms_log_opt_in', 'preferred_symbols', 'tag_ids', 'vibrate_buttons',
       'highlighted_buttons', 'never_delete', 'dim_header', 'inflections_overlay',
       'highlight_popup_text', 'phrase_categories', 'high_contrast', 'swipe_pages',
       'hide_pin_hint', 'battery_sounds', 'auto_inflections', 'private_logging',

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -96,6 +96,13 @@ file (see [README.md](README.md)).
 - [Pattern: the speak row's left "stack" mirrors the right `actions-wrap--stacked` — build symmetric, use `flex: 1`](#pattern-the-speak-rows-left-stack-mirrors-the-right-actions-wrap--stacked--build-symmetric-use-flex-1)
 - [Pattern: a child pinned by `parent > * { z-index: 1 }` traps ALL its descendants below higher-z siblings — raise the ROW, not the menu](#pattern-a-child-pinned-by-parent---z-index-1--traps-all-its-descendants-below-higher-z-siblings--raise-the-row-not-the-menu)
 - [Pattern: auth-page (login/register) "content cut off / bg not full height" — page-bg must be a transparent box; mesh goes on the fixed full-viewport `#within_ember`](#pattern-auth-page-loginregister-content-cut-off--bg-not-full-height--page-bg-must-be-a-transparent-box-mesh-goes-on-the-fixed-full-viewport-within_ember)
+- [Pattern: blank username suggestions must be discarded before `clean_path`](#pattern-blank-username-suggestions-must-be-discarded-before-clean_path)
+
+## Pattern: blank username suggestions must be discarded before `clean_path`
+
+`Processable#generate_user_name` treats an explicit suggestion as authoritative unless it is blanked out first. Passing `''` from signup/default-generation paths reaches `clean_path('')`, which pads to `___` instead of falling back to email or `"person"`. Normalize blank suggestions to `nil` before choosing the fallback source, and keep a regression spec in `spec/models/concerns/processable_spec.rb`.
+
+**First seen in:** [2026-06-03-staged-registration-flow.md](./2026-06-03-staged-registration-flow.md)
 
 ## Pattern: Word prediction locale has three layers — display locale, board locale, cache/sync locale
 
@@ -3037,3 +3044,13 @@ Reduced-motion users get the hover depth with zero movement; everyone else gets 
 **Fix recipe:** Keep `SES_REGION` as the explicit override, but fall back to `AWS_REGION` and `AWS_DEFAULT_REGION`. For diagnosis, check the running app process env in a sanitized way and use read-only `Aws::SES::Client#get_send_quota` before sending a real email.
 
 **Evidence:** `config/initializers/amazon_ses.rb`; task log `2026-06-02-registration-email-sending-investigation.md`.
+
+---
+
+## Pattern: autocomplete tokens should follow credential intent, not nearby labels
+
+**Surface:** profile/preferences and account-management forms with mixed profile fields, username lookups, password resets, and delegated account creation.
+
+**Fix recipe:** Use semantic tokens for real user details (`name`, `email`, `tel`, `url`), `current-password` only for credentials that authenticate an existing account, and `new-password` for credential creation/reset/update. For username lookup, start-code, free-form bio, and profile location fields, prefer `autocomplete="off"` plus autocapitalize/autocorrect/spellcheck off where typing exact identifiers matters, so browsers do not inject saved usernames/password-adjacent values into unrelated profile fields.
+
+**Evidence:** `app/frontend/app/templates/user/edit.hbs`; task log `2026-06-03-profile-autocomplete-field-types.md`.

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -2245,6 +2245,50 @@ describe SessionController, :type => :controller do
       expect(response.location).not_to include('google_link')
     end
 
+    it "keeps register flow on signup_complete even when the Google account matches existing users" do
+      linked = User.process_new({
+        'user_name' => 'linked_register_google_user',
+        'name' => 'Linked Register Google User',
+        'email' => 'google@example.com',
+        'password' => 'secret123',
+        'terms_agree' => true
+      }, { pending: true })
+      linked.link_google!(google_profile[:sub], email: google_profile[:email], name: google_profile[:name])
+      email_match = User.process_new({
+        'user_name' => 'register_email_match',
+        'name' => 'Register Email Match',
+        'email' => 'google@example.com',
+        'password' => 'secret456',
+        'terms_agree' => true
+      }, { pending: true })
+      allow(GoogleOAuth).to receive(:fetch_state).and_return({
+        'flow' => 'register',
+        'device_id' => 'dev1',
+        'return_origin' => 'http://localhost:8184',
+        'registration_type' => 'teacher',
+        'user_name' => 'new_google_username',
+        'terms_agree' => true,
+        'product_improvement_opt_in' => true
+      })
+      allow(GoogleOAuth).to receive(:clear_state)
+      allow(GoogleOAuth).to receive(:exchange_code).and_return({
+        'sub' => google_profile[:sub],
+        'email' => google_profile[:email],
+        'email_verified' => true,
+        'name' => google_profile[:name]
+      })
+      expect(GoogleOAuth).to receive(:store_link) do |_nonce, link|
+        expect(link['mode']).to eq('signup_complete')
+        expect(link['user_name']).to eq('new_google_username')
+        expect(link['registration_type']).to eq('teacher')
+        expect(link['candidate_user_ids']).to eq([])
+      end
+
+      get :google_callback, params: { state: 'abc', code: 'xyz' }
+      expect(response.location).to match(%r{http://localhost:8184/register\?google_signup=})
+      expect(response.location).not_to include('/login?google_link=')
+    end
+
     it "redirects zero-candidate login to manual_link on the frontend origin" do
       allow(GoogleOAuth).to receive(:fetch_state).and_return({
         'flow' => 'login',
@@ -2403,6 +2447,59 @@ describe SessionController, :type => :controller do
       user = User.find_by(user_name: 'google_signup_user')
       expect(user).not_to eq(nil)
       expect(user.google_linked?).to eq(true)
+    end
+
+    it "creates accounts from signup_complete with the username stored before Google redirect" do
+      link = {
+        'mode' => 'signup_complete',
+        'sub' => 'google-sub-generated-signup',
+        'email' => 'generated-signup@gmail.com',
+        'name' => 'Generated Signup',
+        'flow' => 'register',
+        'device_id' => 'dev1',
+        'app' => false,
+        'user_name' => 'chosen_google_signup',
+        'registration_type' => 'teacher',
+        'terms_agree' => true,
+        'product_improvement_opt_in' => true
+      }
+      allow(GoogleOAuth).to receive(:fetch_link).and_return(link)
+      expect(GoogleOAuth).to receive(:clear_link).with('signup-generated-nonce')
+      post :google_signup_complete, params: {
+        nonce: 'signup-generated-nonce',
+        terms_agree: 'true'
+      }
+      json = assert_success_json
+      expect(json['token']).not_to eq(nil)
+      user = User.find_by(user_name: 'chosen_google_signup')
+      expect(user).not_to eq(nil)
+      expect(user.settings['preferences']['registration_type']).to eq('teacher')
+      expect(user.settings['preferences']['role']).to eq('supporter')
+      expect(user.settings['preferences']['cookies']).to eq(true)
+      expect(user.settings['preferences']['telemetry_opt_in']).to eq(true)
+      expect(user.settings['preferences']['comms_log_opt_in']).to eq(true)
+      expect(user.google_linked?).to eq(true)
+    end
+
+    it "requires a username for signup_complete" do
+      link = {
+        'mode' => 'signup_complete',
+        'sub' => 'google-sub-blank-username',
+        'email' => 'blank-google-signup@gmail.com',
+        'name' => 'Blank Google Signup',
+        'flow' => 'register',
+        'device_id' => 'dev1',
+        'app' => false,
+        'registration_type' => 'teacher',
+        'terms_agree' => true
+      }
+      allow(GoogleOAuth).to receive(:fetch_link).and_return(link)
+      post :google_signup_complete, params: {
+        nonce: 'signup-blank-username',
+        user_name: '',
+        terms_agree: 'true'
+      }
+      assert_error('username_required', 400)
     end
 
     it "requires terms for signup_complete" do

--- a/spec/models/concerns/processable_spec.rb
+++ b/spec/models/concerns/processable_spec.rb
@@ -104,6 +104,11 @@ describe Processable, :type => :model do
       u = User.new(:settings => {'name' => 'Bob Jones'})
       expect(u.generate_user_name).to eq('bob-jones')
     end
+
+    it "should ignore blank name suggestions and fall back to email" do
+      u = User.new(:settings => {'name' => '', 'email' => 'blank_name@example.com'})
+      expect(u.generate_user_name('')).to eq('blank_name')
+    end
     
     it "should not generate an existing user name" do
       User.create(:user_name => "franklin")


### PR DESCRIPTION
This branch makes account registration clearer and easier to follow.

It changes signup from one long form into a step-by-step flow:

First choose whether the account is for a communicator or a supporter.
Communicators enter birth month/year so the app can handle child accounts correctly.
Supporters choose their role, like parent, teacher, therapist, or other supporter.
The final step clearly says what kind of account they are creating.
It also improves Google signup:

Users must choose their own username before continuing.
If they are creating a new account with Google, the app now keeps them in the new-account flow instead of sending them to the “choose an existing account” screen.
If an old Google sign-in session expires, the login page no longer gets stuck on “Checking...”.
It makes requirements clearer:

Terms must be accepted before signup.
A username is required for both Google signup and email signup.
The page now explains what still needs to be done before each button can be used.
It keeps child-account safety behavior:

Under-13 communicator accounts still require a parent or guardian email.
Google signup is not offered for under-13 communicator accounts.
It also includes a few polish fixes:

Dropdowns no longer push the form around when opened.
The auto-generated username bug that could create ___ was fixed.
Browser autofill hints were improved on related account forms.