### PR TITLE
Fix keyboard control vocalizations and default locale

### DIFF
--- a/app/frontend/app/models/board.js
+++ b/app/frontend/app/models/board.js
@@ -504,7 +504,7 @@ LingoLinq.Board = DS.Model.extend({
   },
   translated_buttons: function(label_locale, vocalization_locale) {
     var res = [];
-    var trans = this.get('translations') || {};
+    var trans = this.get('translations');
     var buttons = this.get('buttons') || [];
     if(!trans) { return buttons; }
     var current_locale = this.get('locale') || 'en';
@@ -517,6 +517,7 @@ LingoLinq.Board = DS.Model.extend({
     var _this = this;
     buttons.forEach(function(button) {
       var b = $.extend({}, button);
+      var has_special_vocalization = !!(button.vocalization && String(button.vocalization).match(/^[:+]/));
       var label_trans = _this._translation_entry(trans, button.id, label_locale);
       var vocalization_trans = _this._translation_entry(trans, button.id, vocalization_locale);
       if(label_trans && label_trans.label) {
@@ -527,7 +528,9 @@ LingoLinq.Board = DS.Model.extend({
           b.label = label_trans.label;
         }
       }
-      if(vocalization_root !== current_root) {
+      if(has_special_vocalization) {
+        b.vocalization = button.vocalization;
+      } else if(vocalization_root !== current_root) {
         if(vocalization_trans && (vocalization_trans.vocalization || vocalization_trans.label)) {
           b.vocalization = (vocalization_trans.vocalization || vocalization_trans.label);
         } else if(vocalization_root !== current_root) {
@@ -542,7 +545,12 @@ LingoLinq.Board = DS.Model.extend({
       }
       // When label and speak locales match, ensure TTS follows the
       // translated label instead of a stale English vocalization field.
-      if(label_locale === vocalization_locale && b.label && (!b.vocalization || b.vocalization === button.vocalization || b.vocalization === button.label)) {
+      var should_follow_translated_label = !has_special_vocalization &&
+        label_locale === vocalization_locale &&
+        b.label &&
+        b.label !== button.label &&
+        (!b.vocalization || b.vocalization === button.vocalization || b.vocalization === button.label);
+      if(should_follow_translated_label) {
         b.vocalization = b.label;
       }
       if(level && level < 10) {

--- a/app/frontend/app/routes/user/board-detail.js
+++ b/app/frontend/app/routes/user/board-detail.js
@@ -339,17 +339,22 @@ export default Route.extend({
 
     // Set currentBoardState
     var board_langs = (model.get('locales') || []);
+    var model_locale = model.get('locale') || 'en';
+    var board_key = model.get('key') || '';
+    var user_locale = _this.appState.get('currentUser.preferences.locale') ||
+      _this.appState.get('sessionUser.preferences.locale');
+    var keyboard_default_locale = (board_key.match(/\/keyboard$/) && !user_locale) ? 'en' : model_locale;
     _this.appState.set('currentBoardState', {
       id: model.get('global_id') || model.get('id'),
-      key: model.get('key'),
+      key: board_key,
       parent_id: model.get('parent_board_id'),
       name: model.get('name'),
       has_fallbacks: model.get('has_fallbacks'),
-      default_locale: model.get('locale'),
+      default_locale: keyboard_default_locale,
       copy_version: model.get('copy_version'),
       integration_name: model.get('integration') && model.get('integration_name'),
       parent_key: model.get('parent_board_key'),
-      text_direction: i18n.text_direction(model.get('locale')),
+      text_direction: i18n.text_direction(keyboard_default_locale),
       translatable: board_langs.length > 1
     });
 
@@ -359,19 +364,19 @@ export default Route.extend({
     var has_locale_override = _this.stashes.get('override_label_locale') || _this.stashes.get('override_vocalization_locale');
     ['label_locale', 'vocalization_locale'].forEach(function(loc_type) {
       if(!has_locale_override) {
-        _this.appState.set(loc_type, model.get('locale'));
+        _this.appState.set(loc_type, keyboard_default_locale);
       } else if(_this.stashes.get(loc_type)) {
         var preferred = _this.stashes.get(loc_type);
         var stripped = preferred.split(/-|_/)[0];
         if(stripped_langs.indexOf(stripped) == -1) {
-          _this.appState.set(loc_type, model.get('locale'));
+          _this.appState.set(loc_type, keyboard_default_locale);
         } else if(board_langs.indexOf(preferred) == -1) {
           _this.appState.set(loc_type, stripped);
         } else {
           _this.appState.set(loc_type, _this.stashes.get(loc_type));
         }
       } else {
-        _this.appState.set(loc_type, model.get('locale'));
+        _this.appState.set(loc_type, keyboard_default_locale);
       }
     });
 

--- a/app/frontend/tests/models/board-test.js
+++ b/app/frontend/tests/models/board-test.js
@@ -738,6 +738,24 @@ describe('Board', function() {
       ]);
     });
 
+    it('should preserve keyboard control vocalizations', function() {
+      var b = LingoLinq.store.createRecord('board', { locale: 'en' });
+      b.set('buttons', [
+        {id: 'a', label: 'a', vocalization: '+a'},
+        {id: 'space', label: 'space', vocalization: ':space'},
+        {id: 'shift', label: 'shift', vocalization: ':shift'}
+      ]);
+      b.set('translations', {
+        current_label: 'en',
+        current_vocalization: 'en'
+      });
+
+      var buttons = b.translated_buttons('en', 'en');
+      expect(buttons[0].vocalization).toEqual('+a');
+      expect(buttons[1].vocalization).toEqual(':space');
+      expect(buttons[2].vocalization).toEqual(':shift');
+    });
+
     it('should return translated for the specified locales', function() {
       var b = LingoLinq.store.createRecord('board');
       expect(b.translated_buttons()).toEqual([]);

--- a/app/frontend/tests/utils/utterance-test.js
+++ b/app/frontend/tests/utils/utterance-test.js
@@ -237,7 +237,20 @@ describe('utterance', function() {
       var b = {label: "occupy", vocalization: "+w&&+a"};
       var res = utterance.add_button(b);
       expect(res.label).toEqual('wa');
-    })
+    });
+
+    it("should capitalize keyboard letters and complete them with space", function() {
+      app_state.set('shift', true);
+      utterance.add_button({label: "a", vocalization: "+a"});
+      expect(app_state.get('button_list')[0].label).toEqual("A");
+      expect(app_state.get('button_list')[0].vocalization).toEqual("A");
+
+      utterance.add_button({label: "space", vocalization: ":space"});
+      expect(app_state.get('button_list').length).toEqual(1);
+      expect(app_state.get('button_list')[0].label).toEqual("A ");
+      expect(app_state.get('button_list')[0].vocalization).toEqual("A ");
+      expect(app_state.get('button_list')[0].in_progress).toEqual(false);
+    });
   });
 
   describe("speak_button", function() {

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -96,6 +96,13 @@ file (see [README.md](README.md)).
 - [Pattern: the speak row's left "stack" mirrors the right `actions-wrap--stacked` — build symmetric, use `flex: 1`](#pattern-the-speak-rows-left-stack-mirrors-the-right-actions-wrap--stacked--build-symmetric-use-flex-1)
 - [Pattern: a child pinned by `parent > * { z-index: 1 }` traps ALL its descendants below higher-z siblings — raise the ROW, not the menu](#pattern-a-child-pinned-by-parent---z-index-1--traps-all-its-descendants-below-higher-z-siblings--raise-the-row-not-the-menu)
 - [Pattern: auth-page (login/register) "content cut off / bg not full height" — page-bg must be a transparent box; mesh goes on the fixed full-viewport `#within_ember`](#pattern-auth-page-loginregister-content-cut-off--bg-not-full-height--page-bg-must-be-a-transparent-box-mesh-goes-on-the-fixed-full-viewport-within_ember)
+- [Pattern: keyboard control vocalizations must survive translation overlay](#pattern-keyboard-control-vocalizations-must-survive-translation-overlay)
+
+## Pattern: keyboard control vocalizations must survive translation overlay
+
+Keyboard boards use vocalizations as control protocols: `+a` composes spelling, `:space` completes the in-progress word, and `:shift` toggles capitalization. `Board#translated_buttons` must not replace those `:`/`+` vocalizations with visible labels when label and vocalization locales match, or controls start speaking words like “space”/“shift” and letters stop composing. If `lingolinq/keyboard` has stale locale metadata, default it back to English when no user locale or Switch Languages override exists, and repair the content board through `SystemSidebarBoards.ensure_for`.
+
+**First seen in:** [2026-06-03-keyboard-shift-space-default-language.md](./2026-06-03-keyboard-shift-space-default-language.md)
 
 ## Pattern: Word prediction locale has three layers — display locale, board locale, cache/sync locale
 

--- a/lib/system_sidebar_boards.rb
+++ b/lib/system_sidebar_boards.rb
@@ -16,7 +16,7 @@ class SystemSidebarBoards
   def self.ensure_utility_board(user, spec)
     existing = Board.find_by_path("#{user.user_name}/#{spec[:slug]}") ||
       Board.find_by(key: spec[:slug], user_id: user.id)
-    return existing if existing
+    return repair_utility_board(existing, spec) if existing
 
     legacy = Board.find_by_path(spec[:legacy_source])
     if legacy
@@ -28,6 +28,14 @@ class SystemSidebarBoards
     end
 
     send(spec[:generator], user)
+  end
+
+  def self.repair_utility_board(board, spec)
+    if spec[:slug] == 'keyboard' && board.settings['locale'] != 'en'
+      board.settings['locale'] = 'en'
+      board.save!
+    end
+    board
   end
 
   def self.generate_keyboard(user)

--- a/lib/templates/keyboard_board.rb
+++ b/lib/templates/keyboard_board.rb
@@ -33,6 +33,7 @@ module KeyboardBoard
       },
       buttons: buttons,
       public: true,
+      locale: 'en',
       word_suggestions: true
     }, {
       :user => user,

--- a/spec/javascripts/models/board_spec.js
+++ b/spec/javascripts/models/board_spec.js
@@ -92,6 +92,36 @@ describe('Board', function() {
       expect(board.get('labels')).toEqual("hat, car");
     });
   });
+
+  describe("translated_buttons", function() {
+    it("preserves keyboard control vocalizations", function() {
+      var board = LingoLinq.store.createRecord('board', {
+        locale: 'en',
+        buttons: [
+          {id: 'a', label: 'a', vocalization: '+a'},
+          {id: 'space', label: 'space', vocalization: ':space'},
+          {id: 'shift', label: 'shift', vocalization: ':shift'}
+        ]
+      });
+
+      var buttons = board.translated_buttons('en', 'en');
+      expect(buttons[0].vocalization).toEqual('+a');
+      expect(buttons[1].vocalization).toEqual(':space');
+      expect(buttons[2].vocalization).toEqual(':shift');
+    });
+
+    it("preserves ordinary explicit vocalizations when the label is unchanged", function() {
+      var board = LingoLinq.store.createRecord('board', {
+        locale: 'en',
+        buttons: [
+          {id: 'cat', label: 'cat', vocalization: 'kitty'}
+        ]
+      });
+
+      var buttons = board.translated_buttons('en', 'en');
+      expect(buttons[0].vocalization).toEqual('kitty');
+    });
+  });
   
 //   star_or_unstar: function(star) {
 //     var _this = this;

--- a/spec/javascripts/utils/utterance_spec.js
+++ b/spec/javascripts/utils/utterance_spec.js
@@ -172,6 +172,19 @@ describe('utterance', function() {
       res = utterance.add_button(b);
       res.label.should == "tries";
     });
+
+    it("should capitalize keyboard letters and complete them with space", function() {
+      app_state.set('shift', true);
+      utterance.add_button({label: "a", vocalization: "+a"});
+      expect(app_state.get('button_list')[0].label).toEqual("A");
+      expect(app_state.get('button_list')[0].vocalization).toEqual("A");
+
+      utterance.add_button({label: "space", vocalization: ":space"});
+      expect(app_state.get('button_list').length).toEqual(1);
+      expect(app_state.get('button_list')[0].label).toEqual("A ");
+      expect(app_state.get('button_list')[0].vocalization).toEqual("A ");
+      expect(app_state.get('button_list')[0].in_progress).toEqual(false);
+    });
   });
   
   describe("speak_button", function() {

--- a/spec/lib/system_sidebar_boards_spec.rb
+++ b/spec/lib/system_sidebar_boards_spec.rb
@@ -9,6 +9,7 @@ describe SystemSidebarBoards do
       expect(Board.find_by_path('lingolinq/keyboard')).to_not eq(nil)
       expect(Board.find_by_path('lingolinq/inflections')).to_not eq(nil)
       expect(Board.find_by_path('lingolinq/keyboard').public).to eq(true)
+      expect(Board.find_by_path('lingolinq/keyboard').settings['locale']).to eq('en')
       expect(Board.find_by_path('lingolinq/inflections').public).to eq(true)
     end
 
@@ -19,6 +20,16 @@ describe SystemSidebarBoards do
       board = described_class.ensure_utility_board(user, described_class::UTILITIES.first)
       expect(board.user_id).to eq(user.id)
       expect(board.parent_board_id).to eq(source.id)
+    end
+
+    it "repairs a stale keyboard locale on the content user" do
+      user = User.create(user_name: 'lingolinq')
+      keyboard = described_class.generate_keyboard(user)
+      keyboard.settings['locale'] = 'es'
+      keyboard.save!
+
+      board = described_class.ensure_utility_board(user, described_class::UTILITIES.first)
+      expect(board.settings['locale']).to eq('en')
     end
 
     it "is idempotent" do


### PR DESCRIPTION
Preserve special keyboard vocalizations through board translation overlays so letter, space, and shift controls keep composing correctly. Default generated and stale system keyboard boards to English when no explicit user language override is present.