### PR TITLE
Add beta baseline seed flow

### DIFF
--- a/app/frontend/app/utils/obf-emergency.js
+++ b/app/frontend/app/utils/obf-emergency.js
@@ -157,7 +157,7 @@ var words = {
 */
 for(var key in words) {
   if(words[key] && words[key].path) {
-    words[key].url = templateHelpers.path(("images/emergency/" + words[key].path));
+    words[key].local_url = templateHelpers.path(("images/emergency/" + words[key].path));
   }
 }
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,6 @@
 #
 # Sensitive credentials: Use environment variables. In production/staging, SEED_*_PASSWORD
 # must be set; in development/test, defaults are used if not set.
-#   SEED_EXAMPLE_PASSWORD   - example user (default in dev: 'password')
 #   SEED_ADMIN_PASSWORD     - lingolinq_admin (default in dev: 'admin2025!')
 #   SEED_DEMO_PASSWORD      - demo user(s) (default in dev: 'password')
 #   SEED_LINGOLINQ_PASSWORD - lingolinq system boards user (default in dev: 'password')
@@ -17,16 +16,25 @@ def seed_password(env_key, dev_default)
   end
   ENV[env_key].presence || dev_default
 end
+load Rails.root.join('lib', 'beta_seed.rb')
+
+BetaSeed.ensure_baseline!
+SEED_DEMO_DATA = BetaSeed.demo_data_enabled?
 #
 # Examples:
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-# Check if seeding has already been done
+# Check if legacy demo/example seeding has already been done
 SEEDING_ALREADY_DONE = User.exists?(user_name: 'example') && Organization.exists?(admin: true)
 
-if SEEDING_ALREADY_DONE
+if !SEED_DEMO_DATA
+  puts "=" * 60
+  puts "Skipping legacy example/demo seed data"
+  puts "Set SEED_DEMO_DATA=1 to seed the old example account, sample logs, and demo district."
+  puts "=" * 60
+elsif SEEDING_ALREADY_DONE
   puts "=" * 60
   puts "Seeding already completed - skipping initial seed data"
   puts "=" * 60
@@ -338,8 +346,8 @@ else
   puts "=" * 60
 end
 
-# Ensure example user has logging and geo_logging enabled for stats map (runs every seed)
-example_user = User.find_by(user_name: 'example')
+# Ensure example user has logging and geo_logging enabled for stats map (demo-only)
+example_user = SEED_DEMO_DATA && User.find_by(user_name: 'example')
 if example_user
   example_user.settings ||= {}
   example_user.settings['preferences'] ||= {}
@@ -444,7 +452,12 @@ load Rails.root.join('db', 'seeds', 'eval_protocols.rb')
 # Use the lingolinq_admin user as the sentinel instead.
 DEMO_ALREADY_SEEDED = User.exists?(user_name: 'lingolinq_admin') && Organization.where(admin: false).exists?
 
-unless DEMO_ALREADY_SEEDED
+if !SEED_DEMO_DATA
+  puts "\n" + "=" * 60
+  puts "Skipping Demo School District seed data"
+  puts "Set SEED_DEMO_DATA=1 to create demo users, rooms, logs, and report history."
+  puts "=" * 60
+elsif !DEMO_ALREADY_SEEDED
   puts "\n" + "=" * 60
   puts "Seeding Demo School District with 90 days of usage data..."
   puts "=" * 60
@@ -1152,83 +1165,5 @@ end
 #     ];
 
 
-# Ensure system sidebar boards exist (idempotent; runs even when initial seed was skipped)
-puts "\n===== Ensure system sidebar boards ====="
-lingolinq_password = seed_password('SEED_LINGOLINQ_PASSWORD', 'password')
-lingolinq_user = User.find_by(user_name: 'lingolinq')
-unless lingolinq_user
-  lingolinq_user = User.process_new({
-    name: 'LingoLinq',
-    user_name: 'lingolinq',
-    email: 'content@lingolinq.com',
-    public: true,
-    password: lingolinq_password,
-    description: 'Official LingoLinq communication boards',
-    location: 'Everywhere'
-  }, {
-    is_admin: false
-  })
-  puts "  Created lingolinq user"
-else
-  puts "  Found existing lingolinq user"
-end
-lingolinq_user.settings ||= {}
-lingolinq_user.settings['subscription'] ||= {}
-lingolinq_user.settings['subscription']['never_expires'] = true
-lingolinq_user.settings['subscription']['plan_id'] = 'slp_monthly_granted'
-lingolinq_user.settings['subscription']['started'] = 1.year.ago.iso8601
-lingolinq_user.save!
-puts "  Ensured lingolinq user has lifetime subscription"
-
-board_yesno = Board.find_by(key: 'yesno', user_id: lingolinq_user.id)
-unless board_yesno
-  board_yesno = Board.process_new({
-    name: 'Yes/No',
-    public: true,
-    buttons: [
-      {
-        id: 1,
-        label: 'Yes',
-        image_url: 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/yes_2.png'
-      },
-      {
-        id: 2,
-        label: 'No',
-        image_url: 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/no_2.png'
-      }
-    ],
-    grid: {
-      rows: 1,
-      columns: 2,
-      order: [[1, 2]]
-    }
-  }, {user: lingolinq_user, key: 'yesno'})
-  puts "  Created lingolinq/yesno board"
-else
-  puts "  Found existing lingolinq/yesno board"
-end
-
-SystemSidebarBoards.ensure_for(lingolinq_user).each do |board|
-  puts "  Ensured lingolinq/#{board.key.split('/').last} board"
-end
-
-crisis_board = SystemBoardSources.ensure_crisis_vocabulary!(lingolinq_user)
-if crisis_board
-  puts "  Ensured lingolinq/#{SystemBoardSources::CRISIS_VOCABULARY_SLUG} board"
-else
-  puts "  NOTE: lingolinq/#{SystemBoardSources::CRISIS_VOCABULARY_SLUG} not found."
-  puts "        Add public/system-boards/crisis-vocabulary.obz or run: bundle exec rake lingolinq:ensure_crisis_vocabulary"
-end
-
-if lingolinq_user && !Board.find_by_path('lingolinq/quick-core-60')
-  if ENV['SEED_IMPORT_OPENAAC_VOCABULARIES'].to_s =~ /^(1|true|yes)$/i
-    puts "  Importing OpenAAC vocabulary boards for lingolinq (this may take a while)..."
-    Rake::Task['openaac:import_vocabularies'].reenable
-    ENV['VOCABULARY_USER_NAME'] = 'lingolinq'
-    Rake::Task['openaac:import_vocabularies'].invoke
-  else
-    puts "  NOTE: lingolinq/quick-core-60 not found."
-    puts "        Run: VOCABULARY_USER_NAME=lingolinq bundle exec rake openaac:import_vocabularies"
-    puts "        Or set SEED_IMPORT_OPENAAC_VOCABULARIES=1 before db:seed to import during seed."
-  end
-end
+# Beta baseline system content is ensured near the top of this file by
+# BetaSeed.ensure_baseline!, before optional demo data runs.

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -71,6 +71,7 @@ file (see [README.md](README.md)).
 - [Pattern: Bidirectional view-switch overlay — extract to a util and parameterize, don't inline a second copy](#pattern-bidirectional-view-switch-overlay--extract-to-a-util-and-parameterize-dont-inline-a-second-copy)
 - [Pattern: Board-card click navigation has TWO surfaces — board-icon `pick_board` default branch + board-preview `visit`; everything else delegates](#pattern-board-card-click-navigation-has-two-surfaces--board-icon-pick_board-default-branch--board-preview-visit-everything-else-delegates)
 - [Pattern: Signup default library boards — copy via Progress, not copy_to_home_board](#pattern-signup-default-library-boards--copy-via-progress-not-copy_to_home_board)
+- [Pattern: beta seed baseline belongs to `lingolinq`, demo analytics are opt-in](#pattern-beta-seed-baseline-belongs-to-lingolinq-demo-analytics-are-opt-in)
 - [Pattern: Word prediction locale has three layers — display locale, board locale, cache/sync locale](#pattern-word-prediction-locale-has-three-layers--display-locale-board-locale-cachesync-locale)
 - [Pattern: Translated board names must not rename route keys](#pattern-translated-board-names-must-not-rename-route-keys)
 - [Pattern: endpoint-specific 401 auth without changing legacy `require_api_token`](#pattern-endpoint-specific-401-auth-without-changing-legacy-require_api_token)
@@ -2638,6 +2639,16 @@ passed while the real rendered text was ~10px. Only DevTools (showing `1.18rem` 
 **Fix recipe:** Export with `Converters::LingoLinq.to_obz` → `public/system-boards/<slug>.obz`. Add slug to `SIGNUP_LIBRARY_SLUGS` if signup should copy it. Implement idempotent `ensure_<slug>!` via `from_obz` (mirror `openaac:import_vocabularies` post-import: public root, `generate_stats`, `save!` button set). Wire `db:seed` and optional `rake lingolinq:ensure_<slug>`. Sidebar defaults reference `SystemBoardSources.board_key(slug)` (public key), not the user's copy.
 
 **Evidence:** `lib/system_board_sources.rb`, `public/system-boards/crisis-vocabulary.obz`, task log `2026-06-01-crisis-vocabulary-defaults.md`.
+
+---
+
+## Pattern: beta seed baseline belongs to `lingolinq`, demo analytics are opt-in
+
+**Surface:** fresh beta/local DB setup through `db/seeds.rb`.
+
+Default seeds should create beta-critical public/system data (`lingolinq`, `lingolinq_admin`, admin org membership, starter boards, templates) without generating demo district users or analytics logs. Legacy `example` content that is meant to be public starter content should be recreated under `lingolinq/*`; true demo data (sample logs, rooms, demo district users, report history) should require an explicit opt-in such as `SEED_DEMO_DATA=1`. Verify fresh DB readiness with `rake lingolinq:verify_beta_seed`, using `REQUIRE_LIBRARY_BOARDS=false` only before OpenAAC/manual system-board imports have run.
+
+**Evidence:** `lib/beta_seed.rb`, `db/seeds.rb`, `lib/tasks/lingolinq.rake`; task log `2026-06-04-beta-fresh-db-seeds.md`.
 
 ---
 

--- a/lib/beta_seed.rb
+++ b/lib/beta_seed.rb
@@ -1,0 +1,363 @@
+# Baseline records required for a fresh beta database.
+module BetaSeed
+  SYSTEM_USER_NAME = 'lingolinq'.freeze
+  ADMIN_USER_NAME = 'lingolinq_admin'.freeze
+  ADMIN_ORG_NAME = 'LingoLinq Admin Organization'.freeze
+  TRUTHY_PATTERN = /^(1|true|yes)$/i.freeze
+  FALSEY_PATTERN = /^(0|false|no)$/i.freeze
+  REQUIRED_STARTER_BOARD_SLUGS = %w[one two three yesno keyboard inflections].freeze
+  REQUIRED_SIGNUP_BOARD_SLUGS = SystemBoardSources::SIGNUP_LIBRARY_SLUGS.freeze
+
+  def self.seed_password(env_key, dev_default)
+    if (Rails.env.production? || ENV['RAILS_ENV'] == 'staging') && ENV[env_key].blank?
+      raise "Cannot seed: #{env_key} must be set in production/staging. Use strong credentials."
+    end
+    ENV[env_key].presence || dev_default
+  end
+
+  def self.demo_data_enabled?
+    ENV['SEED_DEMO_DATA'].to_s =~ TRUTHY_PATTERN
+  end
+
+  def self.ensure_baseline!
+    puts "\n===== Ensure beta baseline seed data ====="
+    content_user = ensure_content_user!
+    ensure_admin_user!
+    ensure_system_content!(content_user)
+  end
+
+  def self.ensure_content_user!
+    password = seed_password('SEED_LINGOLINQ_PASSWORD', 'password')
+    user = ensure_user!(
+      user_name: SYSTEM_USER_NAME,
+      name: 'LingoLinq',
+      email: 'content@lingolinq.com',
+      public: true,
+      password: password,
+      description: 'Official Lingolinq communication boards',
+      location: 'Everywhere'
+    )
+    ensure_lifetime_subscription!(user)
+    puts "  Ensured #{SYSTEM_USER_NAME} content user"
+    user
+  end
+
+  def self.ensure_admin_user!
+    password = seed_password('SEED_ADMIN_PASSWORD', 'admin2025!')
+    admin = ensure_user!(
+      user_name: ADMIN_USER_NAME,
+      name: 'LingoLinq Admin',
+      email: 'admin@lingolinq.com',
+      public: false,
+      password: password,
+      description: 'LingoLinq site administrator',
+      location: 'Portland, OR'
+    )
+    ensure_lifetime_subscription!(admin)
+
+    admin_org = ensure_admin_organization!
+    unless Organization.admin_manager?(admin)
+      admin_org.add_manager(admin.user_name, true)
+      puts "  Linked #{ADMIN_USER_NAME} to admin organization as full manager"
+    end
+    admin
+  end
+
+  def self.ensure_admin_organization!
+    org = Organization.find_by(admin: true)
+    unless org
+      org = Organization.create!(admin: true, settings: {'name' => ADMIN_ORG_NAME})
+      puts "  Created admin organization"
+    end
+    org.settings ||= {}
+    org.settings['name'] ||= ADMIN_ORG_NAME
+    org.save! if org.changed?
+    org
+  end
+
+  def self.ensure_system_content!(user = nil)
+    user ||= SystemBoardSources.owner || ensure_content_user!
+
+    ensure_starter_boards!(user)
+    SystemSidebarBoards.ensure_for(user).each do |board|
+      puts "  Ensured #{SystemBoardSources.board_key(board.key.split('/').last)} board"
+    end
+
+    crisis_board = SystemBoardSources.ensure_crisis_vocabulary!(user)
+    if crisis_board
+      puts "  Ensured #{SystemBoardSources.board_key(SystemBoardSources::CRISIS_VOCABULARY_SLUG)} board"
+    else
+      puts "  NOTE: #{SystemBoardSources.board_key(SystemBoardSources::CRISIS_VOCABULARY_SLUG)} not found."
+      puts "        Add public/system-boards/crisis-vocabulary.obz or run: bundle exec rake lingolinq:ensure_crisis_vocabulary"
+    end
+
+    ensure_openaac_vocabularies_if_requested!(user)
+  end
+
+  def self.ensure_starter_boards!(user)
+    image1 = ensure_button_image!(user, 'http://mcswhispers.files.wordpress.com/2012/08/yellow_happy11.jpg', download: false)
+    image2 = ensure_button_image!(user, 'https://www.clipartmax.com/png/middle/186-1869260_free-family-and-friends-clip-art-by-phillip-martin-action-words-in.png', download: false)
+    sound1 = ensure_button_sound!(user, 'https://www.epidemicsound.com/sound-effects/tracks/4f080c7d-45f9-43d2-b063-e4ee506711d3/')
+
+    board1 = Board.find_by_path(SystemBoardSources.board_key('one')) || Board.process_new({}, {key: 'one', user: user})
+    board2 = Board.find_by_path(SystemBoardSources.board_key('two')) || Board.process_new({}, {key: 'two', user: user})
+
+    board3 = Board.find_by_path(SystemBoardSources.board_key('three'))
+    unless board3
+      board3 = Board.process_new({
+        name: 'Three',
+        public: true,
+        buttons: [
+          {
+            id: 1,
+            label: "Want",
+            image_id: image1.global_id,
+            load_board: {
+              id: board1.global_id,
+              key: board1.key
+            }
+          },
+          {
+            id: 2,
+            image_id: image2.global_id,
+            label: "Need"
+          }
+        ],
+        grid: {
+          rows: 1,
+          columns: 2,
+          order: [[1, 2]]
+        }
+      }, {user: user, key: 'three'})
+    end
+
+    if board2.settings['buttons'].blank? || board2.settings['buttons'].empty?
+      board2.process({
+        name: 'Two',
+        public: true,
+        buttons: [
+          {
+            id: 1,
+            label: "Jump",
+            image_id: image1.global_id,
+            load_board: {
+              id: board3.global_id,
+              key: board3.key
+            }
+          },
+          {
+            id: 2,
+            image_id: image2.global_id,
+            label: "Duck"
+          }
+        ],
+        grid: {
+          rows: 1,
+          columns: 2,
+          order: [[1, 2]]
+        }
+      })
+    end
+
+    if board1.settings['buttons'].blank? || board1.settings['buttons'].empty?
+      board1.process({
+        name: 'One',
+        public: true,
+        buttons: [
+          {
+            id: 1,
+            label: "Happy",
+            image_id: image1.global_id,
+            load_board: {
+              id: board2.global_id,
+              key: board2.key
+            }
+          },
+          {
+            id: 2,
+            image_id: image2.global_id,
+            label: "Sad",
+            border_color: "#000"
+          },
+          {
+            id: 3,
+            image_id: image2.global_id,
+            label: "Glad",
+            border_color: "#0aa"
+          },
+          {
+            id: 4,
+            image_id: image2.global_id,
+            label: "Bad",
+            background_color: "#faa"
+          },
+          {
+            id: 5,
+            image_id: image2.global_id,
+            label: "Mad"
+          },
+          {
+            id: 6,
+            image_id: image2.global_id,
+            label: "Rad",
+            sound_id: sound1.global_id
+          }
+        ],
+        grid: {
+          rows: 2,
+          columns: 4,
+          order: [[1, 2, 3, 4], [0, 5, 9, 6]]
+        }
+      })
+    end
+
+    yes_no = ensure_yes_no_board!(user)
+    [board1, board2, board3].each { |board| ensure_public_board!(board) }
+    star_boards!(user, [board1, board2, yes_no])
+    puts "  Ensured #{SYSTEM_USER_NAME} public starter boards"
+    [board1, board2, board3, yes_no]
+  end
+
+  def self.ensure_yes_no_board!(user)
+    board = Board.find_by_path(SystemBoardSources.board_key('yesno'))
+    unless board
+      board = Board.process_new({
+        name: 'Yes/No',
+        public: true,
+        buttons: [
+          {
+            id: 1,
+            label: 'Yes',
+            image_url: 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/yes_2.png'
+          },
+          {
+            id: 2,
+            label: 'No',
+            image_url: 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/no_2.png'
+          }
+        ],
+        grid: {
+          rows: 1,
+          columns: 2,
+          order: [[1, 2]]
+        }
+      }, {user: user, key: 'yesno'})
+    end
+    ensure_public_board!(board)
+    board
+  end
+
+  def self.ensure_openaac_vocabularies_if_requested!(user)
+    return unless user
+    return if Board.find_by_path(SystemBoardSources.board_key('quick-core-60'))
+
+    if ENV['SEED_IMPORT_OPENAAC_VOCABULARIES'].to_s =~ TRUTHY_PATTERN
+      puts "  Importing OpenAAC vocabulary boards for #{SYSTEM_USER_NAME} (this may take a while)..."
+      Rake::Task['openaac:import_vocabularies'].reenable
+      ENV['VOCABULARY_USER_NAME'] = SYSTEM_USER_NAME
+      Rake::Task['openaac:import_vocabularies'].invoke
+    else
+      puts "  NOTE: #{SystemBoardSources.board_key('quick-core-60')} not found."
+      puts "        Run: VOCABULARY_USER_NAME=#{SYSTEM_USER_NAME} bundle exec rake openaac:import_vocabularies"
+      puts "        Or set SEED_IMPORT_OPENAAC_VOCABULARIES=1 before db:seed to import during seed."
+    end
+  end
+
+  def self.verify_beta_seed(require_library_boards: true)
+    missing = []
+    content_user = User.find_by(user_name: SYSTEM_USER_NAME)
+    admin_user = User.find_by(user_name: ADMIN_USER_NAME)
+
+    missing << "user:#{SYSTEM_USER_NAME}" unless content_user
+    missing << "user:#{ADMIN_USER_NAME}" unless admin_user
+    missing << 'organization:admin' unless Organization.admin
+    missing << "#{ADMIN_USER_NAME}:admin_org_full_manager" unless admin_user && Organization.admin_manager?(admin_user)
+    missing << 'user_integrations:core_word_list' unless UserIntegration.find_by(template: true, integration_key: 'core_word_list')
+
+    EvalProtocol::STATIC_PROFILES.each do |code|
+      missing << "eval_protocol:#{code}" unless EvalProtocol.find_by(public_protocol_id: code)
+    end
+
+    REQUIRED_STARTER_BOARD_SLUGS.each do |slug|
+      board = Board.find_by_path(SystemBoardSources.board_key(slug))
+      missing << "board:#{SystemBoardSources.board_key(slug)}" unless content_user && board&.public?
+    end
+
+    if require_library_boards
+      REQUIRED_SIGNUP_BOARD_SLUGS.each do |slug|
+        board = Board.find_by_path(SystemBoardSources.board_key(slug))
+        missing << "board:#{SystemBoardSources.board_key(slug)}" unless board&.public?
+      end
+    end
+
+    missing
+  end
+
+  def self.ensure_user!(user_name:, name:, email:, public:, password:, description:, location:)
+    user = User.find_by(user_name: user_name)
+    unless user
+      user = User.process_new({
+        name: name,
+        user_name: user_name,
+        email: email,
+        public: public,
+        password: password,
+        description: description,
+        location: location
+      }, {
+        is_admin: false
+      })
+      raise "Could not create seed user #{user_name}: #{user.processing_errors.inspect}" if user.errored?
+    end
+
+    if user.user_name != user_name
+      raise "Seed user #{user_name} was created as #{user.user_name}; check reserved routes before seeding."
+    end
+
+    user.generate_password(password) if password.present?
+    user.settings ||= {}
+    user.settings['preferences'] ||= {}
+    user.save!
+    user
+  end
+
+  def self.ensure_lifetime_subscription!(user)
+    user.settings ||= {}
+    user.settings['subscription'] ||= {}
+    user.settings['subscription']['never_expires'] = true
+    user.settings['subscription']['plan_id'] = 'slp_monthly_granted'
+    user.settings['subscription']['started'] ||= 1.year.ago.iso8601
+    user.save!
+  end
+
+  def self.ensure_button_image!(user, url, download:)
+    ButtonImage.find_by(url: url, user_id: user.id) || ButtonImage.process_new({
+      license: {
+        type: 'private'
+      },
+      url: url
+    }, {user: user, download: download})
+  end
+
+  def self.ensure_button_sound!(user, url)
+    ButtonSound.find_by(url: url, user_id: user.id) || ButtonSound.process_new({
+      url: url
+    }, {user: user, download: false})
+  end
+
+  def self.ensure_public_board!(board)
+    board.public = true
+    board.generate_stats
+    board.save_without_post_processing
+    board
+  end
+
+  def self.star_boards!(user, boards)
+    user.reload
+    user.settings['starred_board_ids'] ||= []
+    existing = user.settings['starred_board_ids'] || []
+    ids = boards.compact.map(&:global_id)
+    user.settings['starred_board_ids'] = (existing + ids).uniq
+    user.save! if user.changed?
+  end
+end

--- a/lib/tasks/lingolinq.rake
+++ b/lib/tasks/lingolinq.rake
@@ -6,4 +6,18 @@ namespace :lingolinq do
     SpanishLibraryBoards.provision_all!(force: force)
     puts 'Done.'
   end
+
+  desc 'Verify that beta-critical seed records and public source boards exist'
+  task verify_beta_seed: :environment do
+    require_library_boards = ENV['REQUIRE_LIBRARY_BOARDS'].to_s !~ /^(0|false|no)$/i
+    missing = BetaSeed.verify_beta_seed(require_library_boards: require_library_boards)
+
+    if missing.empty?
+      puts 'OK: beta seed baseline verified'
+    else
+      puts 'Missing beta seed records:'
+      missing.each { |item| puts "  - #{item}" }
+      abort 'Beta seed verification failed'
+    end
+  end
 end

--- a/spec/lib/beta_seed_spec.rb
+++ b/spec/lib/beta_seed_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe BetaSeed do
+  describe '.ensure_baseline!' do
+    it 'creates beta baseline users, admin access, and lingolinq starter boards' do
+      allow(SystemBoardSources).to receive(:ensure_crisis_vocabulary!).and_return(nil)
+
+      described_class.ensure_baseline!
+
+      content_user = User.find_by(user_name: 'lingolinq')
+      admin_user = User.find_by(user_name: 'lingolinq_admin')
+
+      expect(content_user).to_not eq(nil)
+      expect(admin_user).to_not eq(nil)
+      expect(Organization.admin_manager?(admin_user)).to eq(true)
+      expect(User.find_by(user_name: 'example')).to eq(nil)
+
+      %w[one two three yesno keyboard inflections].each do |slug|
+        board = Board.find_by_path(SystemBoardSources.board_key(slug))
+        expect(board).to_not eq(nil)
+        expect(board.public).to eq(true)
+      end
+    end
+  end
+
+  describe '.verify_beta_seed' do
+    it 'returns no baseline misses after required templates are present' do
+      allow(SystemBoardSources).to receive(:ensure_crisis_vocabulary!).and_return(nil)
+      described_class.ensure_baseline!
+
+      UserIntegration.create!(template: true, integration_key: 'core_word_list', settings: {})
+      EvalProtocol::STATIC_PROFILES.each do |code|
+        EvalProtocol.create!(
+          public_protocol_id: code,
+          population_profile: code,
+          protocol_version: '1.0',
+          settings: {'public' => true, 'protocol' => EvalProtocol.static_protocol_definition(code)}
+        )
+      end
+
+      expect(described_class.verify_beta_seed(require_library_boards: false)).to eq([])
+    end
+
+    it 'reports missing signup library boards when required' do
+      allow(SystemBoardSources).to receive(:ensure_crisis_vocabulary!).and_return(nil)
+      described_class.ensure_baseline!
+
+      missing = described_class.verify_beta_seed(require_library_boards: true)
+
+      expect(missing).to include('board:lingolinq/quick-core-60')
+      expect(missing).to include('board:lingolinq/vocal-flair-60')
+      expect(missing).to include('board:lingolinq/vocal-flair-84')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add an idempotent beta baseline seed flow that creates the `lingolinq` content user, `lingolinq_admin`, admin org membership, starter boards, sidebar boards, and optional system vocabulary imports.
- Move legacy example/demo district data behind `SEED_DEMO_DATA=1` so fresh beta databases start with required public/system content without demo analytics data by default.
- Add `lingolinq:verify_beta_seed`, focused specs, seed learnings docs, and preserve remote offline-board image URLs when local emergency assets are unavailable.

## Test plan
- `DB_USER=melis bundle exec rspec spec/lib/beta_seed_spec.rb`
- `DB_USER=melis bundle exec rake db:drop db:create db:migrate db:seed`
- `DB_USER=melis REQUIRE_LIBRARY_BOARDS=false bundle exec rake lingolinq:verify_beta_seed`
- Verified `/offline-boards` image behavior against the Ember-served frontend after preserving remote image URLs.

Made with [Cursor](https://cursor.com)