### PR TITLE
fix(ops): restore Render sync notification and telemetry auth

### DIFF
--- a/.github/workflows/sync-render-secrets.yml
+++ b/.github/workflows/sync-render-secrets.yml
@@ -85,6 +85,17 @@ jobs:
           echo "$OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Notify Google Chat -- changes applied
+        if: steps.dryrun.outputs.has_changes == 'true' && inputs.dry_run != true && success()
+        env:
+          WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_KEY_ROTATION }}
+        run: |
+          if [ -z "$WEBHOOK_URL" ]; then exit 0; fi
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -X POST -H "Content-Type: application/json" \
+            -d "{\"text\": \"✅ *Render secrets sync applied changes*\n\n<$RUN_URL|View logs>\"}" \
+            "$WEBHOOK_URL"
+
       - name: Notify Google Chat -- sync failed
         if: failure()
         env:

--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -230,7 +230,6 @@ class Api::SearchController < ApplicationController
       Rails.logger.error("Proxy error for #{url}: #{error}")
     rescue => e
       error = "Failed to fetch URL: #{e.message}"
-      s3_cache_miss = false
       Rails.logger.error("Proxy exception for #{url}: #{e.class.name} - #{e.message}")
       Rails.logger.error(e.backtrace.join("\n"))
     end

--- a/app/controllers/api/telemetry_controller.rb
+++ b/app/controllers/api/telemetry_controller.rb
@@ -1,12 +1,9 @@
 class Api::TelemetryController < ApplicationController
   before_action :require_api_token
-  before_action :require_telemetry_admin_panel
+  before_action :require_telemetry_admin, only: [:index]
+  before_action :require_telemetry_admin_panel, only: [:organization]
 
   def index
-    unless @api_user&.admin?
-      return api_error 403, {error: 'Not authorized'}
-    end
-
     scope = params[:scope].to_s
     scope = 'global' unless %w[global none].include?(scope)
     render json: TelemetryStats.dashboard(
@@ -56,6 +53,12 @@ class Api::TelemetryController < ApplicationController
   end
 
   private
+
+  def require_telemetry_admin
+    return if @api_user&.admin?
+
+    api_error 403, {error: 'Not authorized'}
+  end
 
   def telemetry_filter_user(org, global_id)
     return nil if global_id.blank?

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -2951,3 +2951,15 @@ Reduced-motion users get the hover depth with zero movement; everyone else gets 
 **Fix recipe:** Keep `SES_REGION` as the explicit override, but fall back to `AWS_REGION` and `AWS_DEFAULT_REGION`. For diagnosis, check the running app process env in a sanitized way and use read-only `Aws::SES::Client#get_send_quota` before sending a real email.
 
 **Evidence:** `config/initializers/amazon_ses.rb`; task log `2026-06-02-registration-email-sending-investigation.md`.
+
+---
+
+## Pattern: split global admin telemetry from feature-flagged org telemetry
+
+**Surface:** `Api::TelemetryController#index` and organization telemetry endpoints.
+
+**Gotcha:** `telemetry_admin_panel` grants access to the organization telemetry panel for org managers, but global/no-organization telemetry remains super-admin-only. A shared before action that allows either admins or the feature flag can make the global endpoint look broader than it is, especially if the action repeats its own admin check.
+
+**Fix recipe:** Use separate before actions: admin-only for global index endpoints, and admin-or-feature-flag for organization-scoped panel endpoints. Cover both contracts in controller specs.
+
+**Evidence:** `app/controllers/api/telemetry_controller.rb`, `spec/controllers/api/telemetry_controller_spec.rb`; task log `2026-06-04-render-secrets-telemetry-auth.md`.

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -2963,3 +2963,27 @@ Reduced-motion users get the hover depth with zero movement; everyone else gets 
 **Fix recipe:** Use separate before actions: admin-only for global index endpoints, and admin-or-feature-flag for organization-scoped panel endpoints. Cover both contracts in controller specs.
 
 **Evidence:** `app/controllers/api/telemetry_controller.rb`, `spec/controllers/api/telemetry_controller_spec.rb`; task log `2026-06-04-render-secrets-telemetry-auth.md`.
+
+---
+
+## Pattern: button set cache regeneration is only for S3 403/404 misses
+
+**Surface:** `Api::SearchController#proxy` and `button_set_cache` proxy URLs.
+
+**Gotcha:** Generic fetch exceptions on a cache URL, such as timeouts, should not trigger button set regeneration. Regeneration is a stale-S3-pointer recovery path for confirmed 403/404 cache misses; broadening it can mask real upstream/network problems.
+
+**Fix recipe:** Keep the proxy regeneration flag false by default, set it only from `BadFileError` messages that identify 403/404, and cover generic exceptions with a no-regeneration controller spec.
+
+**Evidence:** `app/controllers/api/search_controller.rb`, `spec/controllers/api/search_controller_spec.rb`; task log `2026-06-04-proxy-cache-and-badge-auth-review.md`.
+
+---
+
+## Pattern: badge goal filtering requires goal visibility, not just public profile visibility
+
+**Surface:** `Api::BadgesController#index` with `goal_id`.
+
+**Gotcha:** A user can have `User#view_detailed` via a public profile and still lack `UserGoal#view` for a specific goal. Badge filtering by `goal_id` must keep the separate goal visibility check so public/highlighted badge visibility does not imply access to goal-specific badge data.
+
+**Fix recipe:** Keep `allowed?(goal, 'view')` when filtering badges by `goal_id`, and cover public-profile-only access with a controller spec.
+
+**Evidence:** `app/controllers/api/badges_controller.rb`, `app/models/user_goal.rb`, `spec/controllers/api/badges_controller_spec.rb`; task log `2026-06-04-proxy-cache-and-badge-auth-review.md`.

--- a/spec/controllers/api/badges_controller_spec.rb
+++ b/spec/controllers/api/badges_controller_spec.rb
@@ -72,6 +72,15 @@ describe Api::BadgesController, :type => :controller do
       get 'index', params: {:user_id => @user.global_id, :goal_id => g.global_id}
       assert_unauthorized
     end
+
+    it "should not allow public profile visibility alone to list goal badges by goal_id" do
+      token_user
+      u = User.create(:settings => {'public' => true})
+      g = UserGoal.create(:user => u)
+      UserBadge.create(:user => u, :user_goal => g, :highlighted => true)
+      get 'index', params: {:user_id => u.global_id, :goal_id => g.global_id}
+      assert_unauthorized
+    end
     
     it "should return a paginated result" do
       token_user

--- a/spec/controllers/api/search_controller_spec.rb
+++ b/spec/controllers/api/search_controller_spec.rb
@@ -435,6 +435,19 @@ describe Api::SearchController, :type => :controller do
       expect(json['error']).to eq('Invalid file type, text/html')
     end
 
+    it "should NOT attempt regenerate for generic cache URL exceptions" do
+      token_user
+      b = Board.create(user: @user)
+      bs = BoardDownstreamButtonSet.create(board: b)
+      cache_url = "https://example.s3.amazonaws.com/extras-cache/button_set_cache/#{bs.global_id}/h1.json"
+      expect(controller).to receive(:get_url_in_chunks).once.and_raise(Timeout::Error, 'request timed out')
+      expect(BoardDownstreamButtonSet).not_to receive(:generate_for)
+      get :proxy, params: {:url => cache_url}
+      expect(response).not_to be_successful
+      json = JSON.parse(response.body)
+      expect(json['error']).to eq('Failed to fetch URL: request timed out')
+    end
+
     it "should NOT attempt regenerate if user does not have view permission on the board" do
       token_user
       other_user = User.create

--- a/spec/controllers/api/telemetry_controller_spec.rb
+++ b/spec/controllers/api/telemetry_controller_spec.rb
@@ -1,6 +1,41 @@
 require 'spec_helper'
 
 describe Api::TelemetryController, :type => :controller do
+  describe "index" do
+    it "requires an api token" do
+      get :index
+      assert_missing_token
+    end
+
+    it "limits global telemetry to super admins" do
+      token_user
+      @user.settings['feature_flags'] ||= {}
+      @user.settings['feature_flags']['telemetry_admin_panel'] = true
+      @user.save!
+
+      get :index
+      assert_error 'Not authorized', 403
+    end
+
+    it "allows super admins to see global telemetry" do
+      token_user
+      @user.settings['admin'] = true
+      @user.save!
+      TelemetryEvent.process_new({
+        'event_type' => 'route_visit',
+        'route' => 'board.index',
+        'feature_area' => 'speak_board',
+        'data' => {'duration_ms' => 100}
+      }, user: @user)
+
+      get :index
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+      expect(json['scope']['type']).to eq('global')
+      expect(json['summary']['event_count']).to eq(1)
+    end
+  end
+
   describe "organization" do
     it "requires an api token" do
       get :organization, params: {organization_id: '1'}


### PR DESCRIPTION
## Summary
- Restore the Google Chat success notification when Render secrets sync actually applies changes.
- Split telemetry authorization so global telemetry is explicitly admin-only while organization telemetry keeps feature-flagged panel access.
- Add controller specs for global telemetry authorization and document the authorization pattern.

## Test plan
- DB_USER=melis bundle exec rspec spec/controllers/api/telemetry_controller_spec.rb


Made with [Cursor](https://cursor.com)