### PR TITLE
security(deps): bump puma to 7.2.1 (CVE-2026-47736 / CVE-2026-47737)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'aws-sdk-cloudfront', '~> 1'
 gem 'aws-sdk-s3', '~> 1'
 gem 'http-2'
 gem 'resque', '~> 3.0'
-gem 'puma'
+gem 'puma', '~> 7.2' # >= 7.2.1 clears CVE-2026-47736 / CVE-2026-47737 (PROXY protocol v1 parser)
 gem 'paper_trail', '~> 15.0'
 gem 'geokit'
 gem 'obf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.1.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -613,7 +613,7 @@ DEPENDENCIES
   permissable-coughdrop
   pg (~> 1.5)
   pg_search
-  puma
+  puma (~> 7.2)
   rack (>= 3.0)
   rack-attack
   rack-cors


### PR DESCRIPTION
## What

Bumps **puma 7.1.0 -> 7.2.1** and pins the Gemfile to `~> 7.2`.

## Why

The CI `security-scan` (bundle-audit) job started failing once the ruby-advisory-db picked up two new High-severity puma advisories:

- **CVE-2026-47736** - PROXY Protocol v1 parser allows remote memory exhaustion
- **CVE-2026-47737** - PROXY Protocol v1 accepts repeated protocol headers on persistent connections

Both are cleared by `~> 7.2.1` or `>= 8.0.2`. This PR takes the minimal path (stay on the 7.x line).

## Exposure

Low in practice: both CVEs live in puma's PROXY Protocol v1 parser, and `config/puma.rb` does **not** enable `proxy_protocol`, so the vulnerable code path is not reachable today. This is hygiene + clearing the scanner, not an active-incident fix.

## Verification

- `bundle update puma --conservative` resolved to 7.2.1 (Gemfile.lock diff is puma-only)
- `bundle exec bundle-audit check` -> **No vulnerabilities found**
- Rails boots clean on 7.2.1 (`rails runner` smoke test)
- Full rspec runs in CI on this PR

## Notes

Unrelated to the open Cloud Run Phase 2 PR (#349); this is a standalone dependency patch off `staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)