### PR TITLE
fix(demo): always open Project Core 36 from Try a Demo link

### DIFF
--- a/app/frontend/app/routes/demo/speak.js
+++ b/app/frontend/app/routes/demo/speak.js
@@ -16,7 +16,9 @@ export default Route.extend({
 
   model: function(params) {
     var boardKey = params.board_key || params.board;
-    if(boardKey) {
+    // "Try a Demo" always loads the manifest root (Project Core 36). Only the
+    // offline-board picker passes ?board=...&source=offline_boards.
+    if(boardKey && params.source === 'offline_boards') {
       return demoBoardLoader.load_obf_board(boardKey).then(function(board) {
         return {
           board: board,

--- a/app/frontend/app/routes/demo/style.js
+++ b/app/frontend/app/routes/demo/style.js
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   beforeModel: function() {
-    this.replaceWith('demo.speak');
+    this.replaceWith('demo.speak', { queryParams: { board: null, source: null } });
   }
 });

--- a/app/frontend/app/templates/components/app-navbar.hbs
+++ b/app/frontend/app/templates/components/app-navbar.hbs
@@ -19,7 +19,7 @@
             </h1>
           </span>
           <div class="la-topbar-nav header-unauth-nav" role="menubar" aria-label={{t "Page sections" key="fsa_page_sections"}}>
-            <LinkTo @route="demo.speak" class="la-topbar-link" role="menuitem">{{t "Try a Demo" key="demo_try_speak_mode"}}</LinkTo>
+            <LinkTo @route="demo.speak" @query={{hash board=null source=null}} class="la-topbar-link" role="menuitem">{{t "Try a Demo" key="demo_try_speak_mode"}}</LinkTo>
             <LinkTo @route="features" class="la-topbar-link" role="menuitem">{{t "Features" key="fsa_nav_features"}}</LinkTo>
             {{!-- <LinkTo @route="pricing" class="la-topbar-link" role="menuitem">{{t "Pricing" key="fsa_nav_pricing"}}</LinkTo> --}}
             <LinkTo @route="about" class="la-topbar-link" role="menuitem">{{t "About" key="fsa_nav_about"}}</LinkTo>
@@ -59,7 +59,7 @@
             </button>
           </div>
           <LaMobileDrawer @isOpen={{this.isLandingDrawerOpen}} @onClose={{action "closeLandingDrawer"}}>
-            <LinkTo @route="demo.speak" class="la-mobile-drawer__link" {{action "closeLandingDrawer"}}>{{t "Try a Demo" key="demo_try_speak_mode"}}</LinkTo>
+            <LinkTo @route="demo.speak" @query={{hash board=null source=null}} class="la-mobile-drawer__link" {{action "closeLandingDrawer"}}>{{t "Try a Demo" key="demo_try_speak_mode"}}</LinkTo>
             <LinkTo @route="features" class="la-mobile-drawer__link" {{action "closeLandingDrawer"}}>{{t "Features" key="fsa_nav_features"}}</LinkTo>
             {{!-- <LinkTo @route="pricing" class="la-mobile-drawer__link" {{action "closeLandingDrawer"}}>{{t "Pricing" key="fsa_nav_pricing"}}</LinkTo> --}}
             <LinkTo @route="about" class="la-mobile-drawer__link" {{action "closeLandingDrawer"}}>{{t "About" key="fsa_nav_about"}}</LinkTo>

--- a/app/frontend/app/templates/components/board-page-header-content.hbs
+++ b/app/frontend/app/templates/components/board-page-header-content.hbs
@@ -420,7 +420,7 @@
         {{#unless @controller.app_state.embedded}}
           {{#unless @controller.app_state.no_linky}}
             <div class="la-topbar-nav header-unauth-nav" role="menubar" aria-label={{t "Page sections" key='fsa_page_sections'}}>
-              <LinkTo @route="demo.speak" class="la-topbar-link" role="menuitem">{{t "Try a Demo" key='demo_try_speak_mode'}}</LinkTo>
+              <LinkTo @route="demo.speak" @query={{hash board=null source=null}} class="la-topbar-link" role="menuitem">{{t "Try a Demo" key='demo_try_speak_mode'}}</LinkTo>
               <LinkTo @route="features" class="la-topbar-link" role="menuitem">{{t "Features" key='fsa_nav_features'}}</LinkTo>
               {{!-- <LinkTo @route="pricing" class="la-topbar-link" role="menuitem">{{t "Pricing" key='fsa_nav_pricing'}}</LinkTo> --}}
               <LinkTo @route="about" class="la-topbar-link" role="menuitem">{{t "About" key='fsa_nav_about'}}</LinkTo>
@@ -434,7 +434,7 @@
               </button>
             </div>
             <LaMobileDrawer @isOpen={{@controller.landingNavOpen}} @onClose={{action "closeLandingNav" target=@controller}}>
-              <LinkTo @route="demo.speak" class="la-mobile-drawer__link" {{action "closeLandingNav" target=@controller}}>{{t "Try a Demo" key='demo_try_speak_mode'}}</LinkTo>
+              <LinkTo @route="demo.speak" @query={{hash board=null source=null}} class="la-mobile-drawer__link" {{action "closeLandingNav" target=@controller}}>{{t "Try a Demo" key='demo_try_speak_mode'}}</LinkTo>
               <LinkTo @route="features" class="la-mobile-drawer__link">{{t "Features" key='fsa_nav_features'}}</LinkTo>
               {{!-- <LinkTo @route="pricing" class="la-mobile-drawer__link" {{action "closeLandingNav" target=@controller}}>{{t "Pricing" key='fsa_nav_pricing'}}</LinkTo> --}}
               <LinkTo @route="about" class="la-mobile-drawer__link" {{action "closeLandingNav" target=@controller}}>{{t "About" key='fsa_nav_about'}}</LinkTo>

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -123,6 +123,8 @@ Board-detail has `_auto_rename_board`, which POSTs `/rename` when `board.name` c
 
 `demo.speak` uses controller property `board` for the rendered board object. If a shareable URL needs `?board=...`, declare an aliased query param such as `{ board_key: 'board' }` and use `board_key` internally. Reusing `board` for both the query param and model state will clobber the loaded board object.
 
+**Sticky QP gotcha:** `board` is sticky by default. Topbar "Try a Demo" links must pass `@query={{hash board=null source=null}}`, and the route should only honor `?board=...` when `source=offline_boards` (offline picker). Otherwise always load manifest root (`public/demo-boards/manifest.json` → Project Core 36). First seen in [2026-06-07-demo-try-default-board.md](./2026-06-07-demo-try-default-board.md).
+
 ## Pattern: phased board prefetch — shared planner, dual persistence files
 
 **Surface:** session navigation cache (`board_detail_cache.js`) and offline IndexedDB sync (`sync_boards`).


### PR DESCRIPTION
Sticky board query params kept the last demo board after offline picker use. Reset params on nav links and only honor ?board= when source=offline_boards.