### PR TITLE
feat: add opt-in accessibility QA seed users and starter boards

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,9 @@
 #   SEED_ADMIN_PASSWORD     - lingolinq_admin (default in dev: 'admin2025!')
 #   SEED_DEMO_PASSWORD      - demo user(s) (default in dev: 'password')
 #   SEED_LINGOLINQ_PASSWORD - lingolinq system boards user (default in dev: 'password')
+#   SEED_ACCESSIBILITY_USERS  - set to 1 to seed lingolinq-eyegaze and lingolinq-switchuser
+#   SEED_EYE_GAZE_PASSWORD    - lingolinq-eyegaze (default in dev: 'password')
+#   SEED_SWITCH_USER_PASSWORD - lingolinq-switchuser (default in dev: 'password')
 
 def seed_password(env_key, dev_default)
   if (Rails.env.production? || ENV['RAILS_ENV'] == 'staging') && ENV[env_key].blank?
@@ -19,6 +22,12 @@ end
 load Rails.root.join('lib', 'beta_seed.rb')
 
 BetaSeed.ensure_baseline!
+load Rails.root.join('lib', 'accessibility_seed.rb')
+if ENV['SEED_ACCESSIBILITY_USERS'].to_s =~ BetaSeed::TRUTHY_PATTERN
+  AccessibilitySeed.ensure_all!
+else
+  puts 'Skipping accessibility users (set SEED_ACCESSIBILITY_USERS=1)'
+end
 SEED_DEMO_DATA = BetaSeed.demo_data_enabled?
 #
 # Examples:

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -2664,6 +2664,16 @@ Default seeds should create beta-critical public/system data (`lingolinq`, `ling
 
 ---
 
+## Pattern: accessibility QA accounts are opt-in, separate from demo district
+
+**Surface:** eye-gaze and switch-scanning test accounts for manual QA.
+
+Use `SEED_ACCESSIBILITY_USERS=1` on `db:seed` or `rake lingolinq:seed_accessibility_users` to create `lingolinq-eyegaze` and `lingolinq-switchuser` with pre-set device prefs and public action-heavy boards. These are **not** part of `BetaSeed.verify_beta_seed` or `SEED_DEMO_DATA`. Passwords: `SEED_EYE_GAZE_PASSWORD`, `SEED_SWITCH_USER_PASSWORD` (required in production/staging).
+
+**Evidence:** `lib/accessibility_seed.rb`, `db/seeds.rb`, `lib/tasks/lingolinq.rake`; task log `2026-06-08-accessibility-user-seeds.md`.
+
+---
+
 ## Pattern: Beta program access on registration — server defaults + org opt-out
 
 **Surface:** self-service signup, org start codes, beta welcome routes.

--- a/lib/accessibility_seed.rb
+++ b/lib/accessibility_seed.rb
@@ -1,0 +1,275 @@
+# Opt-in seed data for access-method QA accounts (eye gaze, switch scanning).
+module AccessibilitySeed
+  EYE_GAZE_USER_NAME = 'lingolinq-eyegaze'.freeze
+  SWITCH_USER_NAME = 'lingolinq-switchuser'.freeze
+  EYE_GAZE_BOARD_SLUGS = %w[home yesno more].freeze
+
+  ACTION_BUTTONS = [
+    {id: 16, label: 'Backspace', vocalization: ':backspace', background_color: '#607D8B'},
+    {id: 17, label: 'Clear', vocalization: ':clear', background_color: '#F44336'},
+    {id: 18, label: 'Back', vocalization: ':back', background_color: '#795548'},
+    {id: 19, label: 'Home', vocalization: ':home', background_color: '#2196F3'},
+    {id: 20, label: 'Speak', vocalization: ':speak', background_color: '#4CAF50'}
+  ].freeze
+
+  YES_IMAGE_URL = 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/yes_2.png'.freeze
+  NO_IMAGE_URL = 'https://opensymbols.s3.amazonaws.com/libraries/arasaac/no_2.png'.freeze
+
+  def self.enabled?
+    ENV['SEED_ACCESSIBILITY_USERS'].to_s =~ BetaSeed::TRUTHY_PATTERN
+  end
+
+  def self.board_key(slug)
+    "#{EYE_GAZE_USER_NAME}/#{slug}"
+  end
+
+  def self.ensure_all!
+    puts "\n===== Ensure accessibility seed users ====="
+    eye_gaze_user = ensure_eye_gaze_user!
+    boards = ensure_eye_gaze_boards!(eye_gaze_user)
+    wire_eye_gaze_user!(eye_gaze_user, boards)
+    ensure_switch_user!
+    puts "  Accessibility seed complete"
+  end
+
+  def self.ensure_eye_gaze_user!
+    password = BetaSeed.seed_password('SEED_EYE_GAZE_PASSWORD', 'password')
+    user = BetaSeed.ensure_user!(
+      user_name: EYE_GAZE_USER_NAME,
+      name: 'LingoLinq Eye Gaze',
+      email: 'eyegaze@lingolinq.com',
+      public: true,
+      password: password,
+      description: 'Public eye-gaze test boards and pre-configured dwell settings for QA',
+      location: 'Everywhere'
+    )
+    BetaSeed.ensure_lifetime_subscription!(user)
+    apply_eye_gaze_preferences!(user)
+    puts "  Ensured #{EYE_GAZE_USER_NAME} user with eye-gaze preferences"
+    user
+  end
+
+  def self.apply_eye_gaze_preferences!(user)
+    user.settings ||= {}
+    user.settings['preferences'] ||= {}
+    prefs = user.settings['preferences']
+    prefs['role'] = 'communicator'
+    prefs['auto_open_speak_mode'] = true
+    prefs['blank_status'] = true
+    prefs['devices'] ||= {}
+    prefs['devices']['default'] ||= {}
+    device = prefs['devices']['default']
+    device.merge!(
+      'dwell' => true,
+      'dwell_type' => 'eyegaze',
+      'dwell_duration' => 1200,
+      'dwell_delay' => 100,
+      'dwell_cursor' => true,
+      'dwell_icon' => 'circle',
+      'dwell_gravity' => true,
+      'dwell_targeting' => 'shrink',
+      'button_spacing' => 'medium',
+      'button_text' => 'large',
+      'vocalization_height' => 'large'
+    )
+    User.preference_defaults['device'].each do |attr, val|
+      device[attr] = val if device[attr].nil?
+    end
+    user.settings = {}.merge(user.settings)
+    user.save!
+    user
+  end
+
+  def self.ensure_eye_gaze_boards!(user)
+    yesno = ensure_yesno_board!(user)
+    more = ensure_more_board!(user)
+    home = ensure_home_board!(user, more)
+    [home, yesno, more].each { |board| BetaSeed.ensure_public_board!(board) }
+    puts "  Ensured #{EYE_GAZE_USER_NAME} public boards: #{EYE_GAZE_BOARD_SLUGS.join(', ')}"
+    {home: home, yesno: yesno, more: more}
+  end
+
+  def self.ensure_yesno_board!(user)
+    board = Board.find_by_path(board_key('yesno'))
+    unless board
+      board = Board.process_new({
+        name: 'Yes/No',
+        public: true,
+        buttons: [
+          {id: 1, label: 'Yes', image_url: YES_IMAGE_URL},
+          {id: 2, label: 'No', image_url: NO_IMAGE_URL}
+        ],
+        grid: {
+          rows: 1,
+          columns: 2,
+          order: [[1, 2]]
+        }
+      }, {user: user, key: 'yesno'})
+    end
+    board
+  end
+
+  def self.ensure_more_board!(user)
+    board = Board.find_by_path(board_key('more'))
+    vocabulary = [
+      {id: 1, label: 'food', background_color: '#FF9800'},
+      {id: 2, label: 'water', background_color: '#03A9F4'},
+      {id: 3, label: 'play', background_color: '#4CAF50'},
+      {id: 4, label: 'tired', background_color: '#9E9E9E'},
+      {id: 5, label: 'hurt', background_color: '#E91E63'},
+      {id: 6, label: 'school', background_color: '#673AB7'},
+      {id: 7, label: 'friend', background_color: '#FFEB3B'},
+      {id: 8, label: 'all done', background_color: '#F44336'}
+    ]
+    buttons = vocabulary + action_buttons_with_ids(9)
+    more_grid = {
+      rows: 4,
+      columns: 5,
+      order: [
+        [1, 2, 3, 4, 5],
+        [6, 7, 8, 0, 0],
+        [0, 0, 0, 0, 0],
+        [9, 10, 11, 12, 13]
+      ]
+    }
+    if !board
+      board = Board.process_new({
+        name: 'More',
+        public: true,
+        buttons: buttons,
+        grid: more_grid
+      }, {user: user, key: 'more'})
+    elsif board.settings['buttons'].blank? || board.settings['buttons'].empty?
+      board.process({
+        name: 'More',
+        public: true,
+        buttons: buttons,
+        grid: more_grid
+      })
+    end
+    board
+  end
+
+  def self.ensure_home_board!(user, more_board)
+    board = Board.find_by_path(board_key('home'))
+    vocabulary = [
+      {id: 1, label: 'I', background_color: '#FFEB3B'},
+      {id: 2, label: 'want', background_color: '#FF9800'},
+      {id: 3, label: 'need', background_color: '#FF9800'},
+      {id: 4, label: 'help', background_color: '#2196F3'},
+      {id: 5, label: 'more', background_color: '#9C27B0', load_board: {id: more_board.global_id, key: more_board.key}},
+      {id: 6, label: 'yes', background_color: '#4CAF50'},
+      {id: 7, label: 'no', background_color: '#F44336'},
+      {id: 8, label: 'please', background_color: '#9C27B0'},
+      {id: 9, label: 'stop', background_color: '#F44336'},
+      {id: 10, label: 'go', background_color: '#4CAF50'},
+      {id: 11, label: 'happy', background_color: '#FFEB3B'},
+      {id: 12, label: 'sad', background_color: '#607D8B'},
+      {id: 13, label: 'bathroom', background_color: '#795548'},
+      {id: 14, label: 'eat', background_color: '#FF9800'},
+      {id: 15, label: 'drink', background_color: '#03A9F4'}
+    ]
+    buttons = vocabulary + ACTION_BUTTONS
+    if !board
+      board = Board.process_new({
+        name: 'Home',
+        public: true,
+        buttons: buttons,
+        grid: {
+          rows: 4,
+          columns: 5,
+          order: [
+            [1, 2, 3, 4, 5],
+            [6, 7, 8, 9, 10],
+            [11, 12, 13, 14, 15],
+            [16, 17, 18, 19, 20]
+          ]
+        }
+      }, {user: user, key: 'home'})
+    elsif board.settings['buttons'].blank? || board.settings['buttons'].empty?
+      board.process({
+        name: 'Home',
+        public: true,
+        buttons: buttons,
+        grid: {
+          rows: 4,
+          columns: 5,
+          order: [
+            [1, 2, 3, 4, 5],
+            [6, 7, 8, 9, 10],
+            [11, 12, 13, 14, 15],
+            [16, 17, 18, 19, 20]
+          ]
+        }
+      })
+    end
+    board
+  end
+
+  def self.action_buttons_with_ids(start_id)
+    ACTION_BUTTONS.map.with_index do |button, idx|
+      button.merge(id: start_id + idx)
+    end
+  end
+
+  def self.wire_eye_gaze_user!(user, boards)
+    home = boards[:home]
+    yesno = boards[:yesno]
+    user.reload
+    user.settings['preferences'] ||= {}
+    user.settings['preferences']['home_board'] = {
+      'id' => home.global_id,
+      'key' => home.key
+    }
+    user.settings['preferences']['progress'] ||= {}
+    user.settings['preferences']['progress']['home_board_set'] = true
+    existing_stars = user.settings['starred_board_ids'] || []
+    ids = [home, yesno].compact.map(&:global_id)
+    user.settings['starred_board_ids'] = (existing_stars + ids).uniq
+    user.settings = {}.merge(user.settings)
+    user.save!
+  end
+
+  def self.ensure_switch_user!
+    password = BetaSeed.seed_password('SEED_SWITCH_USER_PASSWORD', 'password')
+    user = BetaSeed.ensure_user!(
+      user_name: SWITCH_USER_NAME,
+      name: 'LingoLinq Switch User',
+      email: 'switch@lingolinq.com',
+      public: true,
+      password: password,
+      description: 'Public switch-scanning test boards and pre-configured scanning settings for QA',
+      location: 'Everywhere'
+    )
+    BetaSeed.ensure_lifetime_subscription!(user)
+    apply_switch_preferences!(user)
+    puts "  Ensured #{SWITCH_USER_NAME} user (switch boards not yet defined — user shell only)"
+    user
+  end
+
+  def self.apply_switch_preferences!(user)
+    user.settings ||= {}
+    user.settings['preferences'] ||= {}
+    prefs = user.settings['preferences']
+    prefs['role'] = 'communicator'
+    prefs['auto_open_speak_mode'] = true
+    prefs['devices'] ||= {}
+    prefs['devices']['default'] ||= {}
+    device = prefs['devices']['default']
+    device.merge!(
+      'scanning' => true,
+      'scanning_mode' => 'row',
+      'scanning_interval' => 1500,
+      'scanning_prompt' => true,
+      'scanning_select_keycode' => 32,
+      'button_spacing' => 'medium',
+      'button_text' => 'large'
+    )
+    User.preference_defaults['device'].each do |attr, val|
+      device[attr] = val if device[attr].nil?
+    end
+    user.settings = {}.merge(user.settings)
+    user.save!
+    user
+  end
+end

--- a/lib/tasks/lingolinq.rake
+++ b/lib/tasks/lingolinq.rake
@@ -7,6 +7,12 @@ namespace :lingolinq do
     puts 'Done.'
   end
 
+  desc 'Seed lingolinq-eyegaze and lingolinq-switchuser accounts and boards'
+  task seed_accessibility_users: :environment do
+    load Rails.root.join('lib', 'accessibility_seed.rb')
+    AccessibilitySeed.ensure_all!
+  end
+
   desc 'Verify that beta-critical seed records and public source boards exist'
   task verify_beta_seed: :environment do
     require_library_boards = ENV['REQUIRE_LIBRARY_BOARDS'].to_s !~ /^(0|false|no)$/i

--- a/spec/lib/accessibility_seed_spec.rb
+++ b/spec/lib/accessibility_seed_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe AccessibilitySeed do
+  describe '.ensure_all!' do
+    it 'creates accessibility users, boards, and preferences idempotently' do
+      2.times { described_class.ensure_all! }
+
+      eye_gaze_user = User.find_by(user_name: AccessibilitySeed::EYE_GAZE_USER_NAME)
+      switch_user = User.find_by(user_name: AccessibilitySeed::SWITCH_USER_NAME)
+
+      expect(eye_gaze_user).to_not eq(nil)
+      expect(switch_user).to_not eq(nil)
+      expect(eye_gaze_user.settings['public']).to eq(true)
+      expect(switch_user.settings['public']).to eq(true)
+
+      device = eye_gaze_user.settings.dig('preferences', 'devices', 'default')
+      expect(device['dwell']).to eq(true)
+      expect(device['dwell_type']).to eq('eyegaze')
+
+      switch_device = switch_user.settings.dig('preferences', 'devices', 'default')
+      expect(switch_device['scanning']).to eq(true)
+      expect(switch_device['scanning_mode']).to eq('row')
+
+      AccessibilitySeed::EYE_GAZE_BOARD_SLUGS.each do |slug|
+        board = Board.find_by_path(AccessibilitySeed.board_key(slug))
+        expect(board).to_not eq(nil)
+        expect(board.public).to eq(true)
+      end
+
+      home = Board.find_by_path(AccessibilitySeed.board_key('home'))
+      vocalizations = home.settings['buttons'].map { |b| b['vocalization'] }.compact
+      expect(vocalizations).to include(':clear', ':speak', ':home', ':back', ':backspace')
+
+      expect(eye_gaze_user.settings.dig('preferences', 'home_board', 'id')).to eq(home.global_id)
+      expect(User.where(user_name: [AccessibilitySeed::EYE_GAZE_USER_NAME, AccessibilitySeed::SWITCH_USER_NAME]).count).to eq(2)
+      expect(Board.where(user_id: eye_gaze_user.id).count).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
Introduce AccessibilitySeed for lingolinq-eyegaze (dwell prefs + home/yesno/more boards with action row) and lingolinq-switchuser (scanning prefs shell only), gated by SEED_ACCESSIBILITY_USERS=1 with a standalone rake task and RSpec coverage.

Note: eyegaze board content and layout still need more work before this is considered QA-ready.