### PR TITLE
fix(demo): exit Try a Demo to offline-boards, not home

### DIFF
--- a/app/frontend/app/controllers/demo/speak.js
+++ b/app/frontend/app/controllers/demo/speak.js
@@ -111,10 +111,6 @@ export default Controller.extend({
     this.set('edit_mode', false);
   },
 
-  from_offline_boards: computed('source', function() {
-    return this.get('source') === 'offline_boards';
-  }),
-
   _set_board: function(board) {
     this.set('board', board);
     this.set('ordered_buttons', board ? board.ordered_buttons : []);

--- a/app/frontend/app/templates/demo/speak.hbs
+++ b/app/frontend/app/templates/demo/speak.hbs
@@ -1,27 +1,15 @@
 <div class="demo-board-page {{if this.edit_mode "demo-board-page--editing" "demo-board-page--speak-only"}} md-shell md-shell--board-detail md-board-detail--dark">
   <main class="md-board-detail-main demo-board-page__main">
     <div id="speak" class="md-board-detail-sentence-row demo-board-page__sentence-row">
-      {{#if this.from_offline_boards}}
-        <LinkTo @route="offline_boards" class="md-board-detail-home-btn demo-board-page__exit-link" aria-label={{t "Exit demo" key="demo_exit_demo"}} title={{t "Exit demo" key="demo_exit_demo"}}>
-          <svg width="33" height="33" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <g transform="translate(24 0) scale(-1 1)">
-              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
-              <polyline points="16 17 21 12 16 7"/>
-              <line x1="21" y1="12" x2="9" y2="12"/>
-            </g>
-          </svg>
-        </LinkTo>
-      {{else}}
-        <LinkTo @route="index" class="md-board-detail-home-btn demo-board-page__exit-link" aria-label={{t "Exit demo" key="demo_exit_demo"}} title={{t "Exit demo" key="demo_exit_demo"}}>
-          <svg width="33" height="33" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <g transform="translate(24 0) scale(-1 1)">
-              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
-              <polyline points="16 17 21 12 16 7"/>
-              <line x1="21" y1="12" x2="9" y2="12"/>
-            </g>
-          </svg>
-        </LinkTo>
-      {{/if}}
+      <LinkTo @route="offline_boards" class="md-board-detail-home-btn demo-board-page__exit-link" aria-label={{t "Exit demo" key="demo_exit_demo"}} title={{t "Exit demo" key="demo_exit_demo"}}>
+        <svg width="33" height="33" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <g transform="translate(24 0) scale(-1 1)">
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+            <polyline points="16 17 21 12 16 7"/>
+            <line x1="21" y1="12" x2="9" y2="12"/>
+          </g>
+        </svg>
+      </LinkTo>
       <div class="md-board-detail-sentence-bar" role="region" aria-label={{t "Message composition" key="board_detail_message_composition"}}>
         {{#if this.has_board_history}}
           <button type="button" class="md-board-detail-sentence-bar__back-btn" {{action "go_back"}} aria-label={{t "Go back to previous board" key="board_detail_go_back"}}>

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -125,6 +125,8 @@ Board-detail has `_auto_rename_board`, which POSTs `/rename` when `board.name` c
 
 **Sticky QP gotcha:** `board` is sticky by default. Topbar "Try a Demo" links must pass `@query={{hash board=null source=null}}`, and the route should only honor `?board=...` when `source=offline_boards` (offline picker). Otherwise always load manifest root (`public/demo-boards/manifest.json` → Project Core 36). First seen in [2026-06-07-demo-try-default-board.md](./2026-06-07-demo-try-default-board.md).
 
+**Exit target:** Demo speak exit should always `LinkTo offline_boards` — do not branch on `source`; "Try a Demo" used to fall through to `index`.
+
 ## Pattern: phased board prefetch — shared planner, dual persistence files
 
 **Surface:** session navigation cache (`board_detail_cache.js`) and offline IndexedDB sync (`sync_boards`).


### PR DESCRIPTION
Demo speak exit always returned to /offline-boards when source=offline_boards, but Try a Demo cleared that param and sent users to index instead.