### PR TITLE
chore(tooling): track Copilot + SecureCoder configs, ignore Antigravity CLI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+# GitHub Copilot Instructions
+
+> **Project Rules and Standards for LingoLinq-AAC**
+> This file provides project-specific context for GitHub Copilot Chat and Agents. It is synchronized with `CLAUDE.md` and `GEMINI.md`.
+
+## Project Overview
+
+LingoLinq is an open-source web-based AAC (Augmentative and Alternative Communication) application. It consists of a Rails backend and an Ember.js frontend.
+
+Key characteristics:
+- Cloud-based with offline support via IndexedDB/SQLite
+- Multi-device sync with automatic conflict resolution
+- Supervisor/user permission model for therapy teams
+- Uses Open Board Format (OBF) for board import/export
+- Deployed on Render with background job processing via Resque
+
+## Development considerations
+- **i18n**: All user-facing strings MUST use i18n helpers. No raw text strings in templates or JS.
+- **Quoting**: 
+    - User-facing strings: Use DOUBLE QUOTES `"string"`.
+    - Code/Internal strings: Use SINGLE QUOTES `'string'`.
+- **Node Version**: Use Node 20.
+- **jQuery**: Prefer native DOM APIs or Ember patterns over jQuery (`$`) where practical.
+
+## Architecture
+
+### Backend (Rails 7.23)
+- **ID System**: Custom `global_id` format (`#shardnum#_#dbid#`). Use `find_by_global_id`.
+- **JSON API**: Responses generated in `lib/json_api/`.
+- **Background Jobs**: Resque (`lib/worker.rb`).
+
+### Frontend (Ember 3.28)
+- **State Management**: `app_state.js`.
+- **Persistence**: `dbman.js` / `persistence.js`.
+- **Edit Manager**: `edit_manager.js`.
+
+## Development Conventions
+
+### Code Style
+- **Callbacks**: Capture `this` as `_this` at the top of functions/computed properties to avoid context issues in plain objects or Promises.
+- **ESLint**: Respect `lingolinq/no-this-in-promise-executor`.
+- **Deprecations**: Fix root causes; never suppress or hide deprecations.
+- **CSS/SCSS**: Wrap mixed-unit math in `calc()` for SassC compatibility.
+
+## Feature Flags
+New user-facing features MUST be behind a feature flag in `lib/feature_flags.rb`.
+
+## Security
+- Avoid OWASP Top 10 vulnerabilities.
+- Use `secure_serialize` for sensitive fields.
+- Console access must be audited via `bin/audit_console`.
+
+## Testing
+- **Backend**: RSpec (`bundle exec rspec`).
+- **Frontend**: QUnit (`ember test`).
+
+---
+*Last Updated: 2026-05-17*

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@ Key characteristics:
 
 ## Architecture
 
-### Backend (Rails 7.23)
+### Backend (Rails 7.2)
 - **ID System**: Custom `global_id` format (`#shardnum#_#dbid#`). Use `find_by_global_id`.
 - **JSON API**: Responses generated in `lib/json_api/`.
 - **Background Jobs**: Resque (`lib/worker.rb`).
@@ -49,6 +49,7 @@ New user-facing features MUST be behind a feature flag in `lib/feature_flags.rb`
 - Avoid OWASP Top 10 vulnerabilities.
 - Use `secure_serialize` for sensitive fields.
 - Console access must be audited via `bin/audit_console`.
+- **PII & compliance**: Never generate code that logs, displays, or sends student/patient PII (names, birthdates, contact info) to third parties. Honor FERPA, HIPAA, GDPR, and COPPA, and preserve data isolation between district accounts. Route any AI or external-service calls through the PII scrubber (`lib/pii_scrubber.rb`) so identifiable data is never sent off-platform.
 
 ## Testing
 - **Backend**: RSpec (`bundle exec rspec`).

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ __pycache__/
 # antigravity-mcp is a separate git repository
 /antigravity-mcp
 
+# Antigravity CLI per-project config (machine-specific symlink into ~/.gemini)
+/.antigravitycli
+
 # Ignore node modules
 /node_modules
 

--- a/.securecoderignore
+++ b/.securecoderignore
@@ -1,0 +1,50 @@
+# SecureCoder ignore file
+# Exclude files from security scanning using glob patterns, one per line.
+# Patterns are matched against the full absolute file path.
+# Lines starting with # are comments. Blank lines are ignored.
+
+# --- Version Control & IDE Metadata ---
+**/.git/**
+**/.svn/**
+**/.idea/**
+**/.vscode/**
+**/.claude/**
+**/.cursor/**
+**/.playwright-mcp/**
+
+# --- Dependency & Package Directories ---
+# Scanning third-party dependencies is slow and produces duplicate security alerts.
+# These should be managed via package managers/audit tools instead.
+**/node_modules/**
+**/bower_components/**
+**/vendor/**
+**/bin/**
+
+# --- Temporary, Cache & Log Files ---
+**/tmp/**
+**/temp/**
+**/log/**
+**/*.log
+**/*.sqlite3
+**/*.db
+**/coverage/**
+**/test-results/**
+**/playwright-report/**
+
+# --- Build & Output Artifacts ---
+**/dist/**
+**/public/assets/**
+**/public/packs/**
+**/build/**
+**/*.generated.*
+**/*.pb.go
+
+# --- Test files ---
+# Test files often use mock/dummy secrets or testing helpers that trigger false positives.
+*test.*
+*_test.*
+**/*_test.*
+**/test/**
+**/tests/**
+**/spec/**
+**/*_spec.rb

--- a/.securecoderignore
+++ b/.securecoderignore
@@ -41,8 +41,6 @@
 
 # --- Test files ---
 # Test files often use mock/dummy secrets or testing helpers that trigger false positives.
-*test.*
-*_test.*
 **/*_test.*
 **/test/**
 **/tests/**


### PR DESCRIPTION
## What

Tidies up AI-agent tooling config files that were sitting untracked in the working tree.

- **Commit `.github/copilot-instructions.md`** — project rules for GitHub Copilot Chat/Agents (mirrors `CLAUDE.md` / `GEMINI.md`). Committing it means the whole team shares the same Copilot context instead of each person carrying a local copy.
- **Commit `.securecoderignore`** — SecureCoder scan exclusions (VCS/IDE metadata, dependencies, build artifacts, test/spec files). Cuts scan noise and false positives for anyone running the scanner.
- **Gitignore `/.antigravitycli`** — that path was a machine-specific symlink into `~/.gemini`; Antigravity is no longer a secondary agent, so the symlink was deleted and the path ignored to stop it reappearing as untracked noise.

## Why

Antigravity was retired as the secondary agent (token quota dropped). Of the three stray files, only `.antigravitycli/` was Antigravity-related — the Copilot and SecureCoder configs are unrelated, useful, and belong in version control.

## Notes

- No application code touched. Config/metadata only.
- deepseek-codex (the new secondary agent) reads `AGENTS.md`, which is already generated by `sync-configs.js` and gitignored — no change needed here for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)