### PR TITLE
docs: correct Rails version in Gemini style guide (7.23 → 7.2)

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -4,7 +4,7 @@
 
 LingoLinq is an AI-first AAC (Augmentative and Alternative Communication) SaaS
 platform used by US school districts, hospitals, and European clients. It is a
-Rails 7.23 backend with an Ember 3.28 frontend, deployed on Render.
+Rails 7.2 backend with an Ember 3.28 frontend, deployed on Render.
 
 ## Compliance (flag violations immediately)
 


### PR DESCRIPTION
## What
Fixes the malformed `Rails 7.23` version string in `.gemini/styleguide.md` (the Gemini Code Assist review style guide) to `Rails 7.2`.

## Why
`Rails 7.23` is not a real version. `Gemfile.lock` pins `rails (7.2.3.1)` and the Gemfile constrains `'>= 7.2.3.1', '< 7.3'`. This is the same malformed string the automated PR reviewer flagged in `.github/copilot-instructions.md` (fixed on #359). Correct version info keeps AI code-review tools from generating version-wrong advice.

## Note
The same typo also exists in several `~/ai-company-brain/` canonical agent-config files (CODEX.md, SHARED_CONTEXT.md, etc.) that aren't in this repo; those are being addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)