### PR TITLE
fix: close four AI-consent validation gaps from PR #266 (COPPA 1b)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -476,6 +476,9 @@ class User < ApplicationRecord
   # bare ids are normalized to global_id form before the self-grant check.
   def grant_ai_consent!(disclosures_version:, granted_by:, source:, ip: nil, user_agent: nil, granted_by_user_id: nil)
     raise ArgumentError, 'invalid_source' unless AI_CONSENT_SOURCES.include?(source)
+    # A parent-consent record without a grantor identity is not auditable. Reject
+    # blank granted_by before granted_at is written. Machine token; Phase 3 owns copy.
+    raise ArgumentError, 'invalid_granted_by' if granted_by.blank?
     if granted_by_user_id.present?
       granted_by_user_id = normalize_ai_consent_granted_by_user_id!(granted_by_user_id)
       raise ArgumentError, 'self_grant_forbidden' if granted_by_user_id == self.global_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -468,8 +468,9 @@ class User < ApplicationRecord
   # against the same user. D-04 / D-05.
   #
   # Raises ArgumentError on `invalid_source` (source not in AI_CONSENT_SOURCES),
-  # `invalid_granted_by_user_id` (malformed granted_by_user_id), and
-  # `self_grant_forbidden` (granted_by_user_id resolves to self.global_id). These
+  # `invalid_granted_by` (blank granted_by), `invalid_disclosures_version` (nil,
+  # non-numeric, or < 1), `invalid_granted_by_user_id` (malformed granted_by_user_id),
+  # and `self_grant_forbidden` (granted_by_user_id resolves to self.global_id). These
   # are stable machine tokens, not English prose - Phase 3 owns user-facing copy.
   #
   # `granted_by_user_id:` must be a global_id ("1_42") or bare numeric db id;
@@ -479,6 +480,11 @@ class User < ApplicationRecord
     # A parent-consent record without a grantor identity is not auditable. Reject
     # blank granted_by before granted_at is written. Machine token; Phase 3 owns copy.
     raise ArgumentError, 'invalid_granted_by' if granted_by.blank?
+    # Coerce to a positive Integer up front: a nil/garbage disclosures_version would
+    # otherwise write a granted_at row that ai_consent_granted? can never honor (and
+    # that a later valid grant can't repair), and a string version would make the
+    # stale-version check lexicographic. Raises 'invalid_disclosures_version'.
+    disclosures_version = ai_consent_normalize_version!(disclosures_version)
     if granted_by_user_id.present?
       granted_by_user_id = normalize_ai_consent_granted_by_user_id!(granted_by_user_id)
       raise ArgumentError, 'self_grant_forbidden' if granted_by_user_id == self.global_id
@@ -501,10 +507,15 @@ class User < ApplicationRecord
       #                                       queries can distinguish first-grant
       #                                       from version-upgrade events.
       if c['granted_at'].present? && c['revoked_at'].blank?
-        next if c['disclosures_version'] == disclosures_version
-        next if disclosures_version.nil? || c['disclosures_version'].nil?
-        next if disclosures_version < c['disclosures_version']
-        prior_disclosures_version = c['disclosures_version']
+        # Coerce a stored string version so the comparison stays numeric, not
+        # lexicographic. disclosures_version is already a positive Integer (coerced
+        # above), so the only nil/garbage that can appear here is a legacy stored value.
+        prior_version = c['disclosures_version']
+        prior_version = Integer(prior_version) if prior_version.is_a?(String) && prior_version.strip.match?(/\A\d+\z/)
+        next if prior_version.nil?
+        next if prior_version == disclosures_version
+        next if disclosures_version < prior_version
+        prior_disclosures_version = prior_version
       end
       # RFC-4122 UUID (122 bits); not GoSecure.nonce, which had low entropy under bulk backfill.
       c['record_id'] = SecureRandom.uuid if c['record_id'].blank?
@@ -577,6 +588,18 @@ class User < ApplicationRecord
       res = true
     end
     res
+  end
+
+  # Coerces disclosures_version to a positive Integer so version comparisons are
+  # numeric (not lexicographic) and a nil/garbage value can never write a consent
+  # row that ai_consent_granted? can't honor. Accepts an Integer or an all-digit
+  # String; rejects nil, blank, non-numeric, and < 1 with 'invalid_disclosures_version'.
+  def ai_consent_normalize_version!(raw)
+    ok = raw.is_a?(Integer) || (raw.is_a?(String) && raw.strip.match?(/\A\d+\z/))
+    raise ArgumentError, 'invalid_disclosures_version' unless ok
+    v = Integer(raw.is_a?(String) ? raw.strip : raw)
+    raise ArgumentError, 'invalid_disclosures_version' if v < 1
+    v
   end
 
   # Coerces granted_by_user_id to shard-prefixed global_id ("1_42") so the

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -584,6 +584,11 @@ class User < ApplicationRecord
           'type' => 'ai_consent_revoke',
           'disclosures_version' => c['disclosures_version'],
           'source' => source,
+          # Who revoked and why must live in the immutable audit trail, not only in
+          # settings: the settings copy is DELETED on the next re-grant, so without
+          # these the trail permanently loses the revocation actor and reason.
+          'revoked_by' => revoked_by,
+          'revoked_reason' => reason,
           'record_id' => c['record_id']
         },
         event_type: 'ai_consent_revoke',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -452,7 +452,9 @@ class User < ApplicationRecord
 
   # Records a parent-granted AI data-sharing consent at the given disclosures_version.
   # Idempotent on same-version re-call (returns false). Does NOT silently grant on
-  # stale-version re-call (returns false; Phase 3 controller surfaces re-prompt UX).
+  # stale-version re-call (returns false; Phase 3 controller surfaces re-prompt UX) -
+  # this holds even after a revoke, so an outdated grant link cannot reactivate
+  # consent at a superseded version.
   #
   # Precondition: the user must be persisted. `with_lock` calls `reload(lock: true)`
   # internally and will raise ActiveRecord::RecordNotFound on a User.new.
@@ -496,26 +498,28 @@ class User < ApplicationRecord
       self.settings ||= {}
       c = self.settings['ai_consent']
       c = {} unless c.is_a?(Hash)
-      # D-04 three-branch idempotency for an existing active (unrevoked) consent:
-      #   - same version requested:           no-op, return false (already granted)
-      #   - older version requested:          no-op, return false (downgrade refused;
-      #                                       Phase 3 controller re-prompts at current
-      #                                       version)
-      #   - newer version requested:          fall through; record the upgrade,
-      #                                       preserve record_id, capture the prior
-      #                                       version in the audit payload so audit
-      #                                       queries can distinguish first-grant
-      #                                       from version-upgrade events.
-      if c['granted_at'].present? && c['revoked_at'].blank?
-        # Coerce a stored string version so the comparison stays numeric, not
-        # lexicographic. disclosures_version is already a positive Integer (coerced
-        # above), so the only nil/garbage that can appear here is a legacy stored value.
-        prior_version = c['disclosures_version']
-        prior_version = Integer(prior_version) if prior_version.is_a?(String) && prior_version.strip.match?(/\A\d+\z/)
-        next if prior_version.nil?
-        next if prior_version == disclosures_version
+      # Idempotency / version contract against any prior consent record (D-04):
+      #   - stale (older) version:  no-op, return false. Applies whether or not the
+      #                             prior consent is currently revoked: following an
+      #                             outdated grant link must never reactivate consent
+      #                             against superseded disclosures. (Issue #1)
+      #   - same version, active:   no-op, return false (already granted). A same-version
+      #                             grant AFTER a revoke legitimately reactivates, so this
+      #                             no-op is gated on the consent still being active.
+      #   - newer version, active:  fall through; record the upgrade, preserve record_id,
+      #                             capture the prior version in the audit payload so audit
+      #                             queries can distinguish first-grant from upgrade events.
+      #   - any version after a revoke (>= prior): fall through and reactivate.
+      # Coerce a stored string version so the comparison stays numeric, not lexicographic.
+      # disclosures_version is already a positive Integer (coerced above).
+      prior_version = c['disclosures_version']
+      prior_version = Integer(prior_version) if prior_version.is_a?(String) && prior_version.strip.match?(/\A\d+\z/)
+      has_prior = c['granted_at'].present? && prior_version.is_a?(Integer)
+      active    = has_prior && c['revoked_at'].blank?
+      if has_prior
         next if disclosures_version < prior_version
-        prior_disclosures_version = prior_version
+        next if active && disclosures_version == prior_version
+        prior_disclosures_version = prior_version if active && disclosures_version > prior_version
       end
       # RFC-4122 UUID (122 bits); not GoSecure.nonce, which had low entropy under bulk backfill.
       c['record_id'] = SecureRandom.uuid if c['record_id'].blank?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4252,6 +4252,38 @@ describe User, :type => :model do
       expect(u.settings['ai_consent']['disclosures_version']).to eq(3)
       expect(u.ai_consent_granted?(disclosures_version: 3)).to eq(true)
     end
+
+    it 'does NOT reactivate consent at a stale version after a revoke (revoked-then-stale grant is a no-op)' do
+      u = User.create
+      u.grant_ai_consent!(disclosures_version: 2, granted_by: 'Parent <p@example.com>', source: 'email_link')
+      u.revoke_ai_consent!
+      u.reload
+      pre_count = AuditEvent.count
+      # Following an OLD v1 grant link after revoking v2 must not reactivate at v1.
+      res = u.grant_ai_consent!(disclosures_version: 1, granted_by: 'Parent <p@example.com>', source: 'email_link')
+      expect(res).to eq(false)
+      expect(AuditEvent.count - pre_count).to eq(0)
+      u.reload
+      c = u.settings['ai_consent']
+      expect(c['revoked_at']).to be_present       # still revoked, not reactivated
+      expect(c['disclosures_version']).to eq(2)   # not downgraded to v1
+      expect(u.ai_consent_granted?(disclosures_version: 1)).to eq(false)
+      expect(u.ai_consent_granted?(disclosures_version: 2)).to eq(false)
+    end
+
+    it 'reactivates consent on a same-or-newer version grant after a revoke' do
+      u = User.create
+      u.grant_ai_consent!(disclosures_version: 1, granted_by: 'Parent <p@example.com>', source: 'email_link')
+      u.revoke_ai_consent!
+      u.reload
+      res = u.grant_ai_consent!(disclosures_version: 2, granted_by: 'Parent <p@example.com>', source: 'in_app')
+      expect(res).to eq(true)
+      u.reload
+      c = u.settings['ai_consent']
+      expect(c['revoked_at']).to be_blank
+      expect(c['disclosures_version']).to eq(2)
+      expect(u.ai_consent_granted?(disclosures_version: 2)).to eq(true)
+    end
   end
 
   describe '#revoke_ai_consent!' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4377,6 +4377,33 @@ describe User, :type => :model do
       u2.grant_ai_consent!(disclosures_version: 1, granted_by: 'Parent', source: 'email_link')
       expect { u2.revoke_ai_consent!(source: 'system') }.not_to raise_error
     end
+
+    it 'records revoked_by and revoked_reason in the immutable AuditEvent payload, not just settings' do
+      u = User.create
+      u.grant_ai_consent!(disclosures_version: 1, granted_by: 'Parent <p@example.com>', source: 'email_link')
+      u.revoke_ai_consent!(revoked_by: 'Parent <p@example.com>', reason: 'Withdrawing consent', source: 'parent')
+      ae = AuditEvent.last
+      expect(ae.data['type']).to eq('ai_consent_revoke')
+      expect(ae.data['revoked_by']).to eq('Parent <p@example.com>')
+      expect(ae.data['revoked_reason']).to eq('Withdrawing consent')
+    end
+
+    it 'preserves revoked_by/revoked_reason in the audit trail even after a re-grant clears the settings copy' do
+      u = User.create
+      u.grant_ai_consent!(disclosures_version: 1, granted_by: 'Parent <p@example.com>', source: 'email_link')
+      u.revoke_ai_consent!(revoked_by: 'Parent <p@example.com>', reason: 'changed mind')
+      revoke_ae = AuditEvent.last
+      u.reload
+      u.grant_ai_consent!(disclosures_version: 1, granted_by: 'Parent <p@example.com>', source: 'email_link')
+      u.reload
+      # The settings copy is cleared on re-grant...
+      expect(u.settings['ai_consent']['revoked_by']).to be_blank
+      expect(u.settings['ai_consent']['revoked_reason']).to be_blank
+      # ...but the audit row still carries who revoked and why.
+      revoke_ae.reload
+      expect(revoke_ae.data['revoked_by']).to eq('Parent <p@example.com>')
+      expect(revoke_ae.data['revoked_reason']).to eq('changed mind')
+    end
   end
 
   describe 'AI consent atomicity and audit-event coupling' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4191,6 +4191,24 @@ describe User, :type => :model do
         )
       }.not_to raise_error
     end
+
+    it 'raises ArgumentError when granted_by is nil and writes no consent row' do
+      u = User.create
+      expect {
+        u.grant_ai_consent!(disclosures_version: 1, granted_by: nil, source: 'email_link')
+      }.to raise_error(ArgumentError, 'invalid_granted_by')
+      u.reload
+      expect(u.settings && u.settings['ai_consent']).to be_blank
+    end
+
+    it 'raises ArgumentError when granted_by is blank and writes no consent row' do
+      u = User.create
+      expect {
+        u.grant_ai_consent!(disclosures_version: 1, granted_by: '   ', source: 'email_link')
+      }.to raise_error(ArgumentError, 'invalid_granted_by')
+      u.reload
+      expect(u.settings && u.settings['ai_consent']).to be_blank
+    end
   end
 
   describe '#revoke_ai_consent!' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3902,6 +3902,12 @@ describe User, :type => :model do
   end
 
   describe '#ai_consent_granted?' do
+    # AuditEvent.create! fires inside grant/revoke under with_lock(requires_new: true)
+    # and commits outside the per-example fixture transaction, so rows leak across
+    # examples and break the `expect(AuditEvent.count).to eq(0)` baselines. Clean per
+    # example, scoped to the consent specs so there is no global suite blast radius.
+    before(:each) { AuditEvent.delete_all }
+
     it 'returns false for a newly created user with no ai_consent grant' do
       u = User.create
       expect(u.settings).to be_a(Hash)
@@ -3953,6 +3959,8 @@ describe User, :type => :model do
   end
 
   describe '#grant_ai_consent!' do
+    before(:each) { AuditEvent.delete_all }  # see #ai_consent_granted? note above
+
     it 'writes the settings hash and returns truthy on first call' do
       u = User.create
       res = u.grant_ai_consent!(disclosures_version: 1, granted_by: 'Parent Name <parent@example.com>', source: 'email_link')
@@ -4287,6 +4295,8 @@ describe User, :type => :model do
   end
 
   describe '#revoke_ai_consent!' do
+    before(:each) { AuditEvent.delete_all }  # see #ai_consent_granted? note above
+
     it 'returns false when called on a user with no consent record' do
       expect(AuditEvent.count).to eq(0)
       u = User.create
@@ -4407,6 +4417,8 @@ describe User, :type => :model do
   end
 
   describe 'AI consent atomicity and audit-event coupling' do
+    before(:each) { AuditEvent.delete_all }  # see #ai_consent_granted? note above
+
     it 'populates audit_events.event_type and record_id columns on grant (not just the data blob)' do
       u = User.create
       u.grant_ai_consent!(disclosures_version: 1, granted_by: 'Parent Name <parent@example.com>', source: 'email_link')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4209,6 +4209,49 @@ describe User, :type => :model do
       u.reload
       expect(u.settings && u.settings['ai_consent']).to be_blank
     end
+
+    it 'raises ArgumentError when disclosures_version is nil and writes no consent row' do
+      u = User.create
+      expect {
+        u.grant_ai_consent!(disclosures_version: nil, granted_by: 'Parent', source: 'email_link')
+      }.to raise_error(ArgumentError, 'invalid_disclosures_version')
+      u.reload
+      expect(u.settings && u.settings['ai_consent']).to be_blank
+    end
+
+    it 'raises ArgumentError when disclosures_version is non-numeric' do
+      u = User.create
+      expect {
+        u.grant_ai_consent!(disclosures_version: 'abc', granted_by: 'Parent', source: 'email_link')
+      }.to raise_error(ArgumentError, 'invalid_disclosures_version')
+    end
+
+    it 'raises ArgumentError when disclosures_version is below 1' do
+      u = User.create
+      expect {
+        u.grant_ai_consent!(disclosures_version: 0, granted_by: 'Parent', source: 'email_link')
+      }.to raise_error(ArgumentError, 'invalid_disclosures_version')
+    end
+
+    it 'compares versions numerically, not lexicographically (v10 is newer than v2)' do
+      u = User.create
+      u.grant_ai_consent!(disclosures_version: 2, granted_by: 'Parent', source: 'email_link')
+      pre_count = AuditEvent.count
+      res = u.grant_ai_consent!(disclosures_version: 10, granted_by: 'Parent', source: 'in_app')
+      # Lexicographic "10" < "2" would wrongly treat v10 as stale and no-op.
+      expect(res).to eq(true)
+      expect(AuditEvent.count - pre_count).to eq(1)
+      u.reload
+      expect(u.settings['ai_consent']['disclosures_version']).to eq(10)
+    end
+
+    it 'coerces a numeric-string disclosures_version to an Integer' do
+      u = User.create
+      u.grant_ai_consent!(disclosures_version: '3', granted_by: 'Parent', source: 'email_link')
+      u.reload
+      expect(u.settings['ai_consent']['disclosures_version']).to eq(3)
+      expect(u.ai_consent_granted?(disclosures_version: 3)).to eq(true)
+    end
   end
 
   describe '#revoke_ai_consent!' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,11 +67,6 @@ RSpec.configure do |config|
       )
     end
     RemoteAction.delete_all
-    # AuditEvent.create! (fired synchronously inside User#grant_ai_consent! /
-    # #revoke_ai_consent! under with_lock(requires_new: true)) commits outside the
-    # per-example fixture transaction, so rows accumulate across examples and break
-    # any `expect(AuditEvent.count).to eq(0)` baseline. Clean it like RemoteAction.
-    AuditEvent.delete_all
     RedisInit.reset_queue_pressure_cache!
     PaperTrail.request.whodunnit = nil
     RedisInit.cache_token = "#{rand(999)}.#{Time.now.to_f}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,11 @@ RSpec.configure do |config|
       )
     end
     RemoteAction.delete_all
+    # AuditEvent.create! (fired synchronously inside User#grant_ai_consent! /
+    # #revoke_ai_consent! under with_lock(requires_new: true)) commits outside the
+    # per-example fixture transaction, so rows accumulate across examples and break
+    # any `expect(AuditEvent.count).to eq(0)` baseline. Clean it like RemoteAction.
+    AuditEvent.delete_all
     RedisInit.reset_queue_pressure_cache!
     PaperTrail.request.whodunnit = nil
     RedisInit.cache_token = "#{rand(999)}.#{Time.now.to_f}"


### PR DESCRIPTION
## What

Closes the four consent-logic gaps GitHub Copilot flagged on PR #266
(`feat/scot-ai-consent-foundation`, the Phase 1 model-layer foundation for AI
data-sharing consent, COPPA Final Rule 1b). They were marked "low confidence"
and merged unaddressed. Each was reproduced against current staging before any
change; **none was a false positive.** Frozen decisions D-02..D-05 are preserved
and raises stay machine tokens (Phase 3 owns user-facing copy).

## The four fixes

1. **Stale-version reactivation after a revoke** (`grant_ai_consent!`). The
   downgrade guard ran only while consent was active (`c['revoked_at'].blank?`).
   A user who granted v2, revoked it, then followed an OLD v1 grant link fell
   through and reactivated consent at v1 against superseded disclosures (the
   grant path deletes `revoked_at`). Now the older-than-prior refusal applies
   whether or not consent is currently revoked; the same-version no-op stays
   gated on active consent so the revoke/re-grant-at-same-version lifecycle still
   reactivates. **This is the compliance keystone.**

2. **Revoke audit trail lost `revoked_by` / `reason`** (`revoke_ai_consent!`).
   Those were written only to `settings`, which is deleted on the next re-grant,
   so the immutable trail permanently lost who revoked consent and why. Added
   `revoked_by` and `revoked_reason` to the revoke AuditEvent payload (keys
   mirror the settings keys, as grant's `granted_by` does).

3. **`nil` / non-numeric `disclosures_version`** (`grant_ai_consent!`). A nil
   version wrote a `granted_at` row `ai_consent_granted?` can never honor and
   that a later valid grant could not repair; the stale check was also raw `<`
   (lexicographic on strings: `"10" < "2"`). Added `ai_consent_normalize_version!`
   (Integer or all-digit String, `>= 1`, else `invalid_disclosures_version`),
   coerced up front and for the stored prior version so the comparison is numeric.

4. **Blank `granted_by`** (`grant_ai_consent!`). A parent-consent record could be
   written with no grantor identity. Now raises `invalid_granted_by` before
   `granted_at` is written.

## Test-infrastructure note (please read)

While verifying, I found the ai_consent spec suite was merged **red**: 7 examples
fail on clean staging because `AuditEvent.create!` (fired inside
`with_lock(requires_new: true)`) commits **outside** RSpec's per-example fixture
transaction, so audit rows accumulate across examples and break every
`expect(AuditEvent.count).to eq(0)` baseline (15 stale rows sat in the test DB at
rest). This is why Copilot's findings sat unverified. Fixed with a `before(:each)
{ AuditEvent.delete_all }` **scoped to the four consent describe blocks** (an
earlier global hook in `spec_helper` perturbed the chronically-red, order-
dependent `log_session_spec`, so I narrowed it). `log_session_spec` is unchanged
from staging (45 failures both before and after).

## Verification

```
DB_USER=scotw RAILS_ENV=test bundle exec rspec spec/models/user_spec.rb \
  -e 'ai_consent' -e 'AI consent'
# => 51 examples, 0 failures
```

New/extended specs cover all four fixes, including the revoked-then-stale-v1
no-op (issue #1) and the revoke audit-payload completeness + survival across a
re-grant (issue #2). Regression-checked the other AuditEvent-touching specs:
`log_session_spec` stays at 45 failures, identical to staging.

## Commits (atomic, each green on its own)

- `test:` clean AuditEvent between examples (later scoped to the consent specs)
- `fix:` reject blank granted_by (#4)
- `fix:` validate/coerce disclosures_version (#3)
- `fix:` hold stale-version no-op across a revoke (#1)
- `fix:` record revoked_by/revoked_reason in the revoke AuditEvent (#2)
- `test:` scope AuditEvent cleanup to the consent specs

Diff: `app/models/user.rb` (+~50), `spec/models/user_spec.rb` (+~130 specs),
`spec/spec_helper.rb` (unchanged net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
