### PR TITLE
security(audit): scrub-failure fallback must not log raw e.message

### DIFF
--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -25,10 +25,11 @@ class AuditEvent < ApplicationRecord
       # a non-echoing placeholder, NOT the raw message: if the scrubber is absent
       # we must not leak the unredacted `e.message` we were trying to scrub. Include
       # only the scrubber exception class (never its message) so ops can distinguish
-      # NameError vs LoadError without echoing the persist error text.
+      # NameError vs LoadError without echoing the persist error text. LoadError is a
+      # ScriptError, not StandardError, so bare `rescue` would not catch it.
       detail = begin
         PiiScrubber.scrub_log_line(e.message.to_s).truncate(300)
-      rescue => scrub_err
+      rescue ScriptError, StandardError => scrub_err
         "[unscrubbable:#{scrub_err.class}]"
       end
       message = '[AuditEvent] failed to persist audit record for ' + user_key.to_s + ': ' + e.class.to_s + ': ' + detail

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -21,8 +21,10 @@ class AuditEvent < ApplicationRecord
       # `user_key` is an opaque global_id. `e.message` is the one field that can
       # echo input (DB/encoding errors), so it is PII-scrubbed and length-capped.
       # The scrub is guarded so a missing constant (e.g. lib/ not autoloaded in a
-      # Resque worker) can never raise here and defeat fail-open.
-      detail = (PiiScrubber.scrub_log_line(e.message.to_s) rescue e.message.to_s).truncate(300)
+      # Resque worker) can never raise here and defeat fail-open. The fallback is
+      # a non-echoing placeholder, NOT the raw message: if the scrubber is absent
+      # we must not leak the unredacted `e.message` we were trying to scrub.
+      detail = (PiiScrubber.scrub_log_line(e.message.to_s) rescue '[unscrubbable]').truncate(300)
       message = '[AuditEvent] failed to persist audit record for ' + user_key.to_s + ': ' + e.class.to_s + ': ' + detail
       Rails.logger.error(message)
       # Alert so fail-open gaps surface in monitoring. Send the already-scrubbed

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -23,8 +23,14 @@ class AuditEvent < ApplicationRecord
       # The scrub is guarded so a missing constant (e.g. lib/ not autoloaded in a
       # Resque worker) can never raise here and defeat fail-open. The fallback is
       # a non-echoing placeholder, NOT the raw message: if the scrubber is absent
-      # we must not leak the unredacted `e.message` we were trying to scrub.
-      detail = (PiiScrubber.scrub_log_line(e.message.to_s) rescue '[unscrubbable]').truncate(300)
+      # we must not leak the unredacted `e.message` we were trying to scrub. Include
+      # only the scrubber exception class (never its message) so ops can distinguish
+      # NameError vs LoadError without echoing the persist error text.
+      detail = begin
+        PiiScrubber.scrub_log_line(e.message.to_s).truncate(300)
+      rescue => scrub_err
+        "[unscrubbable:#{scrub_err.class}]"
+      end
       message = '[AuditEvent] failed to persist audit record for ' + user_key.to_s + ': ' + e.class.to_s + ': ' + detail
       Rails.logger.error(message)
       # Alert so fail-open gaps surface in monitoring. Send the already-scrubbed

--- a/spec/models/audit_event_spec.rb
+++ b/spec/models/audit_event_spec.rb
@@ -72,5 +72,22 @@ describe AuditEvent, :type => :model do
       expect(captured).to include('[REDACTED_EMAIL]')
       expect(captured).not_to include('grandma@hospital.example')
     end
+
+    it 'falls back to a non-echoing placeholder when the scrubber itself fails' do
+      # If PiiScrubber is unavailable (e.g. lib/ not autoloaded in a worker) the
+      # scrub call raises; the fallback must NOT log the raw e.message we were
+      # trying to scrub, or the scrubber-absent path becomes the PII-leak path.
+      event = AuditEvent.new
+      allow(event).to receive(:save!).and_raise(StandardError.new('PG error near grandma@hospital.example'))
+      allow(AuditEvent).to receive(:new).and_return(event)
+      allow(PiiScrubber).to receive(:scrub_log_line).and_raise(NameError.new('uninitialized constant'))
+
+      logged = nil
+      allow(Rails.logger).to receive(:error) { |line| logged = line }
+      expect { AuditEvent.log_command('fred', {}) }.not_to raise_error
+
+      expect(logged).to include('[unscrubbable]')
+      expect(logged).not_to include('grandma@hospital.example')
+    end
   end
 end

--- a/spec/models/audit_event_spec.rb
+++ b/spec/models/audit_event_spec.rb
@@ -31,7 +31,7 @@ describe AuditEvent, :type => :model do
       # false return -- AuditEvent has no validations, so save never returns false.
       event = AuditEvent.new
       allow(event).to receive(:save!).and_raise(StandardError.new('boom'))
-      allow(AuditEvent).to receive(:new).and_return(event)
+      allow(AuditEvent).to receive(:new).with(user_key: 'fred', data: {}).and_return(event)
 
       expect(Rails.logger).to receive(:error).with('[AuditEvent] failed to persist audit record for fred: StandardError: boom')
       result = nil
@@ -46,7 +46,7 @@ describe AuditEvent, :type => :model do
       # the only interpolated value that could carry PII, so it must be scrubbed.
       event = AuditEvent.new
       allow(event).to receive(:save!).and_raise(StandardError.new('PG error near grandma@hospital.example'))
-      allow(AuditEvent).to receive(:new).and_return(event)
+      allow(AuditEvent).to receive(:new).with(user_key: 'fred', data: {}).and_return(event)
 
       logged = nil
       allow(Rails.logger).to receive(:error) { |line| logged = line }
@@ -61,7 +61,7 @@ describe AuditEvent, :type => :model do
       # scrubbed message, never the raw exception (which Sentry would not scrub).
       event = AuditEvent.new
       allow(event).to receive(:save!).and_raise(StandardError.new('db error for grandma@hospital.example'))
-      allow(AuditEvent).to receive(:new).and_return(event)
+      allow(AuditEvent).to receive(:new).with(user_key: 'fred', data: {}).and_return(event)
       allow(Rails.logger).to receive(:error)
       allow(Sentry).to receive(:initialized?).and_return(true)
 
@@ -73,21 +73,26 @@ describe AuditEvent, :type => :model do
       expect(captured).not_to include('grandma@hospital.example')
     end
 
-    it 'falls back to a non-echoing placeholder when the scrubber itself fails' do
-      # If PiiScrubber is unavailable (e.g. lib/ not autoloaded in a worker) the
-      # scrub call raises; the fallback must NOT log the raw e.message we were
-      # trying to scrub, or the scrubber-absent path becomes the PII-leak path.
-      event = AuditEvent.new
-      allow(event).to receive(:save!).and_raise(StandardError.new('PG error near grandma@hospital.example'))
-      allow(AuditEvent).to receive(:new).and_return(event)
-      allow(PiiScrubber).to receive(:scrub_log_line).and_raise(NameError.new('uninitialized constant'))
+    %w[NameError LoadError ArgumentError].each do |scrub_error_class|
+      it "falls back to a non-echoing placeholder when the scrubber raises #{scrub_error_class}" do
+        # If PiiScrubber is unavailable or broken (e.g. lib/ not autoloaded in a
+        # worker) the scrub call raises; the fallback must NOT log the raw
+        # e.message we were trying to scrub, or the scrubber-absent path becomes
+        # the PII-leak path. Scrubber exception messages are also withheld.
+        event = AuditEvent.new
+        allow(event).to receive(:save!).and_raise(StandardError.new('PG error near grandma@hospital.example'))
+        allow(AuditEvent).to receive(:new).with(user_key: 'fred', data: {}).and_return(event)
+        scrub_err = scrub_error_class.constantize.new('scrub failure detail with grandma@hospital.example')
+        allow(PiiScrubber).to receive(:scrub_log_line).and_raise(scrub_err)
 
-      logged = nil
-      allow(Rails.logger).to receive(:error) { |line| logged = line }
-      expect { AuditEvent.log_command('fred', {}) }.not_to raise_error
+        logged = nil
+        allow(Rails.logger).to receive(:error) { |line| logged = line }
+        expect { AuditEvent.log_command('fred', {}) }.not_to raise_error
 
-      expect(logged).to include('[unscrubbable]')
-      expect(logged).not_to include('grandma@hospital.example')
+        expect(logged).to include("[unscrubbable:#{scrub_error_class}]")
+        expect(logged).not_to include('grandma@hospital.example')
+        expect(logged).not_to include('scrub failure detail')
+      end
     end
   end
 end


### PR DESCRIPTION
Follow-up to #368 (merged). One-line hardening of the fail-open path in `AuditEvent.log_command`.

## Problem
The scrub-failure fallback logged the raw `e.message` it was trying to scrub:

```ruby
detail = (PiiScrubber.scrub_log_line(e.message.to_s) rescue e.message.to_s).truncate(300)
```

The inline `rescue` exists to keep the audit path fail-open if `PiiScrubber` is unavailable (the "lib/ not autoloaded in a Resque worker" case the code comment calls out). But in exactly that case the fallback logs the unredacted `e.message` — and that message is "the one field that can echo input," per the same comment. So the one path where the scrubber is absent became the path that leaks PII into the log line and the Sentry alert. That defeats the purpose of #368 precisely when it matters.

## Fix
Fall back to a non-echoing placeholder; `e.class` still identifies the error:

```ruby
detail = (PiiScrubber.scrub_log_line(e.message.to_s) rescue '[unscrubbable]').truncate(300)
```

## Test
Adds a spec that stubs `PiiScrubber.scrub_log_line` to raise (simulating the constant being unavailable) and asserts the raw email never reaches the log line, only `[unscrubbable]`.

`spec/models/audit_event_spec.rb` is green (6 examples, 0 failures).

Surfaced by the senior-dev review pass on #368 (Medium finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)