### PR TITLE
Melissa/fix ssrf dns rebinding fix

### DIFF
--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -226,12 +226,19 @@ class Api::SearchController < ApplicationController
     
     error = nil
     s3_cache_miss = false
+    fetched_content_type = nil
+    fetched_body = nil
     begin
       request = safe_proxy_request(uri.to_s)
-      content_type, body = get_url_in_chunks(request)
-      if content_type == 'redirect'
-        request = safe_proxy_request(body)
-        content_type, body = get_url_in_chunks(request)
+      redirects = 0
+      loop do
+        fetched_content_type, fetched_body = get_url_in_chunks(request)
+        break unless fetched_content_type == 'redirect'
+
+        redirects += 1
+        raise BadFileError, 'too many redirects' if redirects > SafeHttp::MAX_REDIRECTS
+
+        request = safe_proxy_request(fetched_body)
       end
     rescue BadFileError => e
       error = e.message
@@ -252,16 +259,16 @@ class Api::SearchController < ApplicationController
     if s3_cache_miss && @api_user
       retried = attempt_button_set_regenerate(url)
       if retried
-        content_type, body = retried
+        fetched_content_type, fetched_body = retried
         error = nil
       end
     end
 
     if !error
-      str = "data:" + content_type
-      str += ";base64," + Base64.strict_encode64(body)
+      str = "data:" + fetched_content_type
+      str += ";base64," + Base64.strict_encode64(fetched_body)
       # Rails 7: render json: expects a hash, not a pre-encoded string
-      render json: {content_type: content_type, data: str}
+      render json: {content_type: fetched_content_type, data: str}
     else
       api_error 400, {error: error}
     end

--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -224,15 +224,13 @@ class Api::SearchController < ApplicationController
       end
     end
     
-    # TODO: add timeout for slow requests
-    request = Typhoeus::Request.new(uri.to_s, followlocation: true)
     error = nil
     s3_cache_miss = false
     begin
+      request = safe_proxy_request(uri.to_s)
       content_type, body = get_url_in_chunks(request)
       if content_type == 'redirect'
-        uri = URI.parse(body)
-        request = Typhoeus::Request.new(uri.to_s, followlocation: true)
+        request = safe_proxy_request(body)
         content_type, body = get_url_in_chunks(request)
       end
     rescue BadFileError => e
@@ -271,6 +269,12 @@ class Api::SearchController < ApplicationController
 
   private
 
+  def safe_proxy_request(url)
+    request = SafeHttp.build_typhoeus_request(url)
+    raise BadFileError, 'blocked or invalid URL' unless request
+    request
+  end
+
   def attempt_button_set_regenerate(url)
     match = url.to_s.match(%r{/button_set_cache/([^/]+)/})
     return nil unless match
@@ -304,7 +308,7 @@ class Api::SearchController < ApplicationController
     return nil unless result && result[:success] && result[:url]
     return nil if result[:url] == url
 
-    retry_request = Typhoeus::Request.new(result[:url], followlocation: true)
+    retry_request = safe_proxy_request(result[:url])
     content_type, body = get_url_in_chunks(retry_request)
     [content_type, body]
   rescue => e

--- a/app/models/concerns/uploadable.rb
+++ b/app/models/concerns/uploadable.rb
@@ -158,7 +158,7 @@ module Uploadable
     if self.url && self.settings && self.settings['content_type'] && self.settings['content_type'].match(/image\/svg/) && !self.settings['rasterized']
       self.settings['rasterized'] = 'pending'
       self.settings['rasterized_at'] = Time.now.iso8601
-      res = Typhoeus.head(Uploader.sanitize_url(URI.escape("#{self.url}.raster.png")), followlocation: true)
+      res = SafeHttp.head(URI.escape("#{self.url}.raster.png"))
       # check if there's already a .raster.png for the image (i.e. on opensymbols)
       if res.success?
         self.settings['rasterized'] = 'from_url'
@@ -220,12 +220,7 @@ module Uploadable
       file.write(Base64.strict_decode64(data))
     else
       self.settings['source_url'] = url if !rasterize
-      res = Typhoeus.get(Uploader.sanitize_url(URI.escape(url)), followlocation: true)
-      if res.headers['Location']
-        redirect_url = res.headers['Location']
-        redirect_url = redirect_url.sub(/\?/, "%3F") if redirect_url.match(/lessonpix\.com/) && redirect_url.match(/\?.*\.png/)
-        res = Typhoeus.get(Uploader.sanitize_url(URI.escape(redirect_url)))
-      end
+      res = SafeHttp.get(URI.escape(url))
       re = /^audio/
       re = /^image/ if file_type == 'images'
       re = /^video/ if file_type == 'videos'

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -1,5 +1,7 @@
 require 'timeout'
 
+require 'safe_http'
+
 class Webhook < ApplicationRecord
   include Async
   include SecureSerialize
@@ -152,18 +154,23 @@ class Webhook < ApplicationRecord
           end
         end
         res = nil
+        log_url = url
         s = 10
         begin
           Timeout::timeout(s + 1) do
             sanitized = Uploader.sanitize_url(url)
-            res = SafeHttp.post(url, body: body, timeout: s)
-            url = res.effective_url || sanitized
+            if sanitized
+              res = SafeHttp.post(sanitized, body: body, timeout: s)
+              log_url = res.effective_url || sanitized
+            else
+              res = OpenStruct.new(code: 0, body: 'blocked or invalid URL')
+            end
           end
         rescue Timeout::Error => e
           res = OpenStruct.new(:code => 0, :body => "Timeout, request took more than #{s} seconds")
         end
         results << {
-          url: url,
+          url: log_url,
           response_code: res.code,
           response_body: res.body
         }
@@ -171,7 +178,7 @@ class Webhook < ApplicationRecord
         self.settings['callback_attempts'] << {
           'timestamp' => Time.now.to_i,
           'code' => res.code,
-          'url' => url
+          'url' => log_url
         }
         self.settings['callback_attempts'] = self.settings['callback_attempts'].last(20)
         self.save

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -155,8 +155,9 @@ class Webhook < ApplicationRecord
         s = 10
         begin
           Timeout::timeout(s + 1) do
-            url = Uploader.sanitize_url(url)
-            res = Typhoeus.post(url, body: body, timeout: s)
+            sanitized = Uploader.sanitize_url(url)
+            res = SafeHttp.post(url, body: body, timeout: s)
+            url = res.effective_url || sanitized
           end
         rescue Timeout::Error => e
           res = OpenStruct.new(:code => 0, :body => "Timeout, request took more than #{s} seconds")

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -4300,11 +4300,9 @@ the example txn, restored on rollback) for a deterministic baseline. Mirror
 
 **Fix shape:** two layers — (1) `sanitize_url` for fast string-level checks (scheme, IP literals, encodings); (2) `lib/safe_http.rb` for every user-supplied fetch: resolve hostname via `Addrinfo.getaddrinfo`, reject if **any** A/AAAA answer is in a blocked range, then pin validated IPs into libcurl via `CURLOPT_RESOLVE` (`resolve:` in Typhoeus) so connect-time DNS cannot rebind. Redirects are followed manually (max 5 hops) with full re-validation per hop; `followlocation` is always false. Shared IP classification lives in `SafeHttp.blocked_address?` (also used by `sanitize_url` for literals).
 
-**Call sites:** `SafeHttp.get/head/post` replaces `Typhoeus.*(Uploader.sanitize_url(...))` in uploadable, uploader `remote_zip`, converters, exporter, openaac.rake, and webhook callbacks.
+**Call sites:** `SafeHttp.get/head/post` replaces `Typhoeus.*(Uploader.sanitize_url(...))` in uploadable, uploader `remote_zip`, converters, exporter, openaac.rake, and webhook callbacks. Streaming proxy fetches use `SafeHttp.build_typhoeus_request` in `api/search_controller.rb#proxy`.
 
-**Residual:** `api/search_controller.rb` image/audio proxy still fetches user URLs without this stack — separate follow-up PR.
-
-**Test:** `spec/lib/uploader_spec.rb` "sanitize_url" stays network-free (adversarial string cases). DNS/pin behavior in `spec/lib/safe_http_spec.rb` with stubbed `Addrinfo.getaddrinfo`.
+**Test:** `spec/lib/uploader_spec.rb` "sanitize_url" stays network-free (adversarial string cases). DNS/pin behavior in `spec/lib/safe_http_spec.rb` with stubbed `Addrinfo.getaddrinfo`. Proxy SSRF rejection in `spec/controllers/api/search_controller_spec.rb`.
 
 **Lesson:** before "fixing" a client-side upload finding, trace to the server fetch — the create-board drag-drop "SSRF" finding was really a gap in the shared `sanitize_url`, fixed once at the chokepoint, not in the UI component. Also: client supplied image URLs are baked as `<img src>` (no HTML execution sink), and `data:` URLs are stored, never fetched — so "stored XSS via data: URL" doesn't apply here.
 

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -4298,15 +4298,17 @@ the example txn, restored on rollback) for a deterministic baseline. Mirror
 
 **Gotcha:** `sanitize_url` is the single SSRF chokepoint, but its original host checks (`^127`, `localhost`, `^0`, decimal-IP) MISSED link-local `169.254.169.254` (cloud metadata) and RFC1918 private ranges (`10/172.16-31/192.168`) — so an authenticated user could point any image-URL flow at internal services. It also didn't restrict the scheme (so `file://`/`gopher://`/`data:` reached the builder, and a nil-host URI could crash the `uri.host.match` line).
 
-**Fix shape:** restrict scheme to http/https; for IP-LITERAL hosts use Ruby `IPAddr` predicates `loopback?`/`private?`/`link_local?` (+ explicit `100.64.0.0/10` CGN) to reject the reserved ranges. `IPAddr.new(host)` raising on a non-literal hostname is the signal to fall through (don't block public hostnames). `require 'ipaddr'` at the top. Keep the existing string/decimal checks — they catch encodings IPAddr won't (`http://0/`, bare-decimal IPv4).
+**Fix shape:** two layers — (1) `sanitize_url` for fast string-level checks (scheme, IP literals, encodings); (2) `lib/safe_http.rb` for every user-supplied fetch: resolve hostname via `Addrinfo.getaddrinfo`, reject if **any** A/AAAA answer is in a blocked range, then pin validated IPs into libcurl via `CURLOPT_RESOLVE` (`resolve:` in Typhoeus) so connect-time DNS cannot rebind. Redirects are followed manually (max 5 hops) with full re-validation per hop; `followlocation` is always false. Shared IP classification lives in `SafeHttp.blocked_address?` (also used by `sanitize_url` for literals).
 
-**Residual (documented, not yet fixed):** a hostname that RESOLVES to an internal IP (DNS rebinding) still passes — IP-literal checks can't see it. The robust fix is resolve-and-pin at the HTTP-client (Typhoeus) layer; adding DNS resolution inside `sanitize_url` was rejected because it makes the (network-free) spec do live lookups and adds latency to the hot fetch path.
+**Call sites:** `SafeHttp.get/head/post` replaces `Typhoeus.*(Uploader.sanitize_url(...))` in uploadable, uploader `remote_zip`, converters, exporter, openaac.rake, and webhook callbacks.
 
-**Test:** `spec/lib/uploader_spec.rb` "sanitize_url" has a thorough adversarial block (header injection, `@`-tricks, tabs, unicode) — extend it, don't replace it. New cases must keep public hosts (`8.8.8.8`, `172.15/172.32` which are OUTSIDE 172.16-31) passing.
+**Residual:** `api/search_controller.rb` image/audio proxy still fetches user URLs without this stack — separate follow-up PR.
+
+**Test:** `spec/lib/uploader_spec.rb` "sanitize_url" stays network-free (adversarial string cases). DNS/pin behavior in `spec/lib/safe_http_spec.rb` with stubbed `Addrinfo.getaddrinfo`.
 
 **Lesson:** before "fixing" a client-side upload finding, trace to the server fetch — the create-board drag-drop "SSRF" finding was really a gap in the shared `sanitize_url`, fixed once at the chokepoint, not in the UI component. Also: client supplied image URLs are baked as `<img src>` (no HTML execution sink), and `data:` URLs are stored, never fetched — so "stored XSS via data: URL" doesn't apply here.
 
-**Evidence:** task log `2026-06-12-pr-security-review-response.md`.
+**Evidence:** task logs `2026-06-12-pr-security-review-response.md`, `2026-06-12-ssrf-dns-rebinding-fix.md`.
 
 ## Pattern: ButtonImage content_type is the image-type allowlist chokepoint (stored-XSS defense)
 

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -4300,13 +4300,19 @@ the example txn, restored on rollback) for a deterministic baseline. Mirror
 
 **Fix shape:** two layers — (1) `sanitize_url` for fast string-level checks (scheme, IP literals, encodings); (2) `lib/safe_http.rb` for every user-supplied fetch: resolve hostname via `Addrinfo.getaddrinfo`, reject if **any** A/AAAA answer is in a blocked range, then pin validated IPs into libcurl via `CURLOPT_RESOLVE` (`resolve:` in Typhoeus) so connect-time DNS cannot rebind. Redirects are followed manually (max 5 hops) with full re-validation per hop; `followlocation` is always false. Shared IP classification lives in `SafeHttp.blocked_address?` (also used by `sanitize_url` for literals).
 
-**Call sites:** `SafeHttp.get/head/post` replaces `Typhoeus.*(Uploader.sanitize_url(...))` in uploadable, uploader `remote_zip`, converters, exporter, openaac.rake, and webhook callbacks. Streaming proxy fetches use `SafeHttp.build_typhoeus_request` in `api/search_controller.rb#proxy`.
+## Ethon 0.15 resolve runtime (2026-06-12 follow-up)
+
+Ethon 0.15 rejects `resolve:` as a Ruby Array at **run** time (`Ethon::Errors::InvalidValue`); Typhoeus::Request.new accepts it but `request.run` fails. Convert pin strings to `Ethon::Curl.slist_append` + `FFI::AutoPointer` before passing to Typhoeus. Specs that mock Typhoeus should expect `kind_of(FFI::AutoPointer)` for `:resolve`, not a string array.
+
+**Proxy controller gotcha:** `ActionController::Metal` delegates `content_type` to `response`. A local assignment like `content_type, body = get_url_in_chunks(...)` inside `proxy` does **not** bind a local — it calls the reader. Use distinct names (e.g. `fetched_content_type`) in controller actions that shadow response helpers.
 
 **Test:** `spec/lib/uploader_spec.rb` "sanitize_url" stays network-free (adversarial string cases). DNS/pin behavior in `spec/lib/safe_http_spec.rb` with stubbed `Addrinfo.getaddrinfo`. Proxy SSRF rejection in `spec/controllers/api/search_controller_spec.rb`.
 
 **Lesson:** before "fixing" a client-side upload finding, trace to the server fetch — the create-board drag-drop "SSRF" finding was really a gap in the shared `sanitize_url`, fixed once at the chokepoint, not in the UI component. Also: client supplied image URLs are baked as `<img src>` (no HTML execution sink), and `data:` URLs are stored, never fetched — so "stored XSS via data: URL" doesn't apply here.
 
-**Evidence:** task logs `2026-06-12-pr-security-review-response.md`, `2026-06-12-ssrf-dns-rebinding-fix.md`.
+**IPv6 gotcha:** `IPAddr#private?` / `#link_local?` miss IPv4-compatible (`::169.254.169.254`) and non-canonical mapped forms (`::ffff:0:7f00:1`). `SafeHttp#embedded_ipv4` must peel these via raw `hton` bytes — and comparisons must use `.b` literals because `hton` returns ASCII-8BIT while `"\xff\xff"` is UTF-8 in Ruby 3 (`==` fails on encoding even when bytes match). Strip zone index (`fe80::1%eth0`) before parse.
+
+**Evidence:** task logs `2026-06-12-pr-security-review-response.md`, `2026-06-12-ssrf-dns-rebinding-fix.md`, `2026-06-12-safe-http-adversarial-fixes.md`.
 
 ## Pattern: ButtonImage content_type is the image-type allowlist chokepoint (stored-XSS defense)
 

--- a/lib/converters/utils.rb
+++ b/lib/converters/utils.rb
@@ -1,3 +1,5 @@
+require 'safe_http'
+
 module Converters::Utils
   require_relative 'lingo_linq'
 

--- a/lib/converters/utils.rb
+++ b/lib/converters/utils.rb
@@ -109,7 +109,7 @@ module Converters::Utils
   def self.remote_to_boards(user, url)
     result = []
     Progress.update_current_progress(0.1, :downloading_file)
-    response = Typhoeus.get(Uploader.sanitize_url(url))
+    response = SafeHttp.get(url)
     file = Tempfile.new('stash')
     file.binmode
     file.write response.body

--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -1,3 +1,5 @@
+require 'safe_http'
+
 module Exporter
   LOG_DIVIDER = 'quarter' # quarter, week, doy
   LOG_CUTOFF = 500

--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -526,7 +526,7 @@ More information about the file formats being used is available at https://www.o
   def self.process_log(data, type, user_id, author_id, device_id)
     sessions = nil
     if data.match(/^http/)
-      data = Typhoeus.get(Uploader.sanitize_url(data), timeout: 10).body
+      data = SafeHttp.get(data, timeout: 10).body
     end
     user = User.find_by_path(user_id)
     raise "invalid user" unless user

--- a/lib/safe_http.rb
+++ b/lib/safe_http.rb
@@ -1,0 +1,186 @@
+require 'ipaddr'
+require 'socket'
+
+# SSRF-safe outbound HTTP: resolve hostnames once, validate all IPs, pin via
+# libcurl CURLOPT_RESOLVE so connect-time DNS cannot rebind to internal targets.
+module SafeHttp
+  MAX_REDIRECTS = 5
+  CGN_RANGE = IPAddr.new('100.64.0.0/10')
+
+  class << self
+    def get(url, **opts)
+      request(:get, url, **opts)
+    end
+
+    def head(url, **opts)
+      request(:head, url, **opts)
+    end
+
+    def post(url, **opts)
+      request(:post, url, **opts)
+    end
+
+    def request(method, url, **opts)
+      current_url = url
+      redirects = 0
+      loop do
+        prepared = prepare_request(current_url)
+        return attach_effective_url(failed_response, nil) unless prepared
+
+        response = execute_request(method, prepared, opts)
+        attach_effective_url(response, prepared[:effective_url])
+
+        redirect_url = redirect_target(response, prepared[:uri])
+        unless redirect_url
+          return response
+        end
+
+        redirects += 1
+        return attach_effective_url(failed_response('too many redirects'), prepared[:effective_url]) if redirects > MAX_REDIRECTS
+
+        current_url = redirect_url
+      end
+    end
+
+    def blocked_address?(ip)
+      return false if skip_blocked_checks?
+
+      addr = ip.is_a?(IPAddr) ? ip : IPAddr.new(ip.to_s)
+      addr.loopback? || addr.private? || addr.link_local? || CGN_RANGE.include?(addr)
+    rescue IPAddr::InvalidAddressError
+      true
+    end
+
+    def resolve_addresses(host)
+      addrs = Addrinfo.getaddrinfo(host, nil, Socket::AF_UNSPEC, Socket::SOCK_STREAM)
+      ips = addrs.map(&:ip_address).uniq
+      return nil if ips.empty?
+
+      ips.each do |ip|
+        return nil if blocked_address?(ip)
+      end
+      ips
+    rescue SocketError, SystemCallError
+      nil
+    end
+
+    def resolve_pins(uri, ips)
+      return nil if ips.nil? || ips.empty?
+
+      host = uri.host
+      port = uri.port
+      formatted = ips.map { |ip| format_pin_address(ip) }.join(',')
+      ["#{host}:#{port}:#{formatted}"]
+    end
+
+    def ip_literal_host?(host)
+      IPAddr.new(host.sub(/^\[/, '').sub(/\]$/, ''))
+      true
+    rescue IPAddr::InvalidAddressError
+      false
+    end
+
+    private
+
+    def skip_blocked_checks?
+      defined?(Rails) && Rails.env.development?
+    end
+
+    def prepare_request(url)
+      sanitized = Uploader.sanitize_url(url)
+      return nil unless sanitized
+
+      uri = URI.parse(sanitized)
+      return nil unless uri.host
+
+      if ip_literal_host?(uri.host)
+        literal = IPAddr.new(uri.host.sub(/^\[/, '').sub(/\]$/, ''))
+        return nil if blocked_address?(literal)
+        { effective_url: sanitized, uri: uri, pins: nil }
+      else
+        ips = resolve_addresses(uri.host)
+        return nil unless ips
+
+        pins = resolve_pins(uri, ips)
+        return nil unless pins
+        { effective_url: sanitized, uri: uri, pins: pins }
+      end
+    end
+
+    def execute_request(method, prepared, opts)
+      request_opts = opts.merge(followlocation: false)
+      request_opts[:resolve] = prepared[:pins] if prepared[:pins]
+
+      case method
+      when :get
+        Typhoeus.get(prepared[:effective_url], **request_opts)
+      when :head
+        Typhoeus.head(prepared[:effective_url], **request_opts)
+      when :post
+        Typhoeus.post(prepared[:effective_url], **request_opts)
+      else
+        raise ArgumentError, "unsupported HTTP method: #{method}"
+      end
+    end
+
+    def redirect_target(response, base_uri)
+      return nil unless response && response.code.to_i >= 300 && response.code.to_i < 400
+
+      location = response.headers && (response.headers['Location'] || response.headers['location'])
+      if location.present?
+        return absolute_redirect_url(location, base_uri)
+      end
+
+      link = response.headers && (response.headers['Link'] || response.headers['link'])
+      if link && response.code.to_i == 302
+        extracted = link.split(/<|>/)[1]
+        return absolute_redirect_url(extracted, base_uri) if extracted.present?
+      end
+
+      nil
+    end
+
+    def absolute_redirect_url(location, base_uri)
+      location = normalize_redirect_url(location.to_s.strip)
+      return nil if location.empty?
+
+      redirect_uri = URI.parse(location) rescue nil
+      return nil unless redirect_uri
+
+      if redirect_uri.host.nil?
+        URI.join(base_uri.to_s, location).to_s
+      else
+        location
+      end
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def normalize_redirect_url(location)
+      location = location.to_s.strip
+      return nil if location.empty?
+
+      location = location.sub(/\?/, '%3F') if location.match(/lessonpix\.com/) && location.match(/\?.*\.png/)
+      location
+    end
+
+    def format_pin_address(ip)
+      ip.include?(':') ? "[#{ip}]" : ip
+    end
+
+    def failed_response(message = 'blocked or invalid URL')
+      OpenStruct.new(
+        success?: false,
+        code: 0,
+        body: message,
+        headers: {},
+        return_message: message
+      )
+    end
+
+    def attach_effective_url(response, effective_url)
+      response.define_singleton_method(:effective_url) { effective_url }
+      response
+    end
+  end
+end

--- a/lib/safe_http.rb
+++ b/lib/safe_http.rb
@@ -80,6 +80,18 @@ module SafeHttp
       false
     end
 
+    # Build a Typhoeus::Request with DNS pins for streaming/callback use (e.g. proxy).
+    def build_typhoeus_request(url, **opts)
+      prepared = prepare_request(url)
+      return nil unless prepared
+
+      request_opts = opts.merge(followlocation: false)
+      request_opts[:resolve] = prepared[:pins] if prepared[:pins]
+      request = Typhoeus::Request.new(prepared[:effective_url], **request_opts)
+      attach_effective_url(request, prepared[:effective_url])
+      request
+    end
+
     private
 
     def skip_blocked_checks?

--- a/lib/safe_http.rb
+++ b/lib/safe_http.rb
@@ -1,11 +1,21 @@
+require 'ffi'
 require 'ipaddr'
 require 'socket'
+require 'timeout'
+require 'ethon'
 
 # SSRF-safe outbound HTTP: resolve hostnames once, validate all IPs, pin via
 # libcurl CURLOPT_RESOLVE so connect-time DNS cannot rebind to internal targets.
 module SafeHttp
   MAX_REDIRECTS = 5
+  DNS_RESOLVE_TIMEOUT = 5
+  # Carrier-grade NAT (RFC 6598). Intentionally blocked for SSRF defense even
+  # though some cloud/CDN ranges overlap; hostname fetches should use public names.
   CGN_RANGE = IPAddr.new('100.64.0.0/10')
+  NULL_8 = "\x00".b * 8
+  NULL_10 = "\x00".b * 10
+  NULL_12 = "\x00".b * 12
+  FF_FF = "\xff\xff".b
 
   class << self
     def get(url, **opts)
@@ -28,7 +38,7 @@ module SafeHttp
         return attach_effective_url(failed_response, nil) unless prepared
 
         response = execute_request(method, prepared, opts)
-        attach_effective_url(response, prepared[:effective_url])
+        response = attach_effective_url(response, prepared[:effective_url])
 
         redirect_url = redirect_target(response, prepared[:uri])
         unless redirect_url
@@ -45,22 +55,24 @@ module SafeHttp
     def blocked_address?(ip)
       return false if skip_blocked_checks?
 
-      addr = ip.is_a?(IPAddr) ? ip : IPAddr.new(ip.to_s)
-      addr.loopback? || addr.private? || addr.link_local? || CGN_RANGE.include?(addr)
-    rescue IPAddr::InvalidAddressError
-      true
+      addr = coerce_ipaddr(ip)
+      return true unless addr
+
+      blocked_ipaddr?(addr)
     end
 
     def resolve_addresses(host)
-      addrs = Addrinfo.getaddrinfo(host, nil, Socket::AF_UNSPEC, Socket::SOCK_STREAM)
-      ips = addrs.map(&:ip_address).uniq
+      addrs = Timeout.timeout(DNS_RESOLVE_TIMEOUT) do
+        Addrinfo.getaddrinfo(host, nil, Socket::AF_UNSPEC, Socket::SOCK_STREAM)
+      end
+      ips = addrs.map { |addr| normalize_resolved_ip(addr.ip_address) }.uniq
       return nil if ips.empty?
 
       ips.each do |ip|
         return nil if blocked_address?(ip)
       end
       ips
-    rescue SocketError, SystemCallError
+    rescue Timeout::Error, SocketError, SystemCallError
       nil
     end
 
@@ -74,10 +86,7 @@ module SafeHttp
     end
 
     def ip_literal_host?(host)
-      IPAddr.new(host.sub(/^\[/, '').sub(/\]$/, ''))
-      true
-    rescue IPAddr::InvalidAddressError
-      false
+      !coerce_ipaddr(host).nil?
     end
 
     # Build a Typhoeus::Request with DNS pins for streaming/callback use (e.g. proxy).
@@ -85,8 +94,7 @@ module SafeHttp
       prepared = prepare_request(url)
       return nil unless prepared
 
-      request_opts = opts.merge(followlocation: false)
-      request_opts[:resolve] = prepared[:pins] if prepared[:pins]
+      request_opts = apply_typhoeus_request_opts(opts, prepared[:pins])
       request = Typhoeus::Request.new(prepared[:effective_url], **request_opts)
       attach_effective_url(request, prepared[:effective_url])
       request
@@ -94,19 +102,78 @@ module SafeHttp
 
     private
 
+    # Skipped in development so local/private endpoints remain reachable during dev.
     def skip_blocked_checks?
       defined?(Rails) && Rails.env.development?
+    end
+
+    def normalize_ip_literal(ip)
+      ip.to_s.strip.sub(/\A\[/, '').sub(/\]\z/, '').sub(/%.*\z/, '')
+    end
+
+    def coerce_ipaddr(ip)
+      normalized = normalize_ip_literal(ip)
+      return nil if normalized.empty?
+
+      IPAddr.new(normalized)
+    rescue IPAddr::InvalidAddressError
+      nil
+    end
+
+    def blocked_ipaddr?(addr)
+      return true if addr.loopback? || addr.private? || addr.link_local? || CGN_RANGE.include?(addr)
+
+      embedded = embedded_ipv4(addr)
+      return blocked_ipaddr?(embedded) if embedded
+
+      false
+    end
+
+    # Detect IPv4-compatible (::w.x.y.z), standard mapped (::ffff:w.x.y.z), and
+    # non-canonical embeddings (e.g. ::ffff:0:7f00:1) that IPAddr range helpers miss.
+    def embedded_ipv4(addr)
+      return nil unless addr.ipv6?
+
+      if addr.ipv4_mapped?
+        return addr.native
+      end
+
+      bytes = addr.hton
+      return ipv4_from_bytes(bytes[-4, 4]) if bytes_match?(bytes, 0, 12, NULL_12)
+
+      if bytes_match?(bytes, 0, 10, NULL_10) && bytes_match?(bytes, 10, 2, FF_FF)
+        return ipv4_from_bytes(bytes[-4, 4])
+      end
+
+      if bytes_match?(bytes, 0, 8, NULL_8) && bytes_match?(bytes, 8, 2, FF_FF)
+        return ipv4_from_bytes(bytes[-4, 4])
+      end
+
+      nil
+    end
+
+    def bytes_match?(bytes, offset, length, expected)
+      bytes.byteslice(offset, length) == expected
+    end
+
+    def ipv4_from_bytes(bytes)
+      IPAddr.new(bytes.unpack('C4').join('.'))
+    rescue IPAddr::InvalidAddressError
+      nil
     end
 
     def prepare_request(url)
       sanitized = Uploader.sanitize_url(url)
       return nil unless sanitized
 
+      sanitized = escape_lessonpix_query(sanitized)
+
       uri = URI.parse(sanitized)
       return nil unless uri.host
 
       if ip_literal_host?(uri.host)
-        literal = IPAddr.new(uri.host.sub(/^\[/, '').sub(/\]$/, ''))
+        literal = coerce_ipaddr(uri.host)
+        return nil unless literal
         return nil if blocked_address?(literal)
         { effective_url: sanitized, uri: uri, pins: nil }
       else
@@ -120,8 +187,7 @@ module SafeHttp
     end
 
     def execute_request(method, prepared, opts)
-      request_opts = opts.merge(followlocation: false)
-      request_opts[:resolve] = prepared[:pins] if prepared[:pins]
+      request_opts = apply_typhoeus_request_opts(opts, prepared[:pins])
 
       case method
       when :get
@@ -170,14 +236,45 @@ module SafeHttp
 
     def normalize_redirect_url(location)
       location = location.to_s.strip
-      return nil if location.empty?
+      return '' if location.empty?
 
-      location = location.sub(/\?/, '%3F') if location.match(/lessonpix\.com/) && location.match(/\?.*\.png/)
-      location
+      escape_lessonpix_query(location)
+    end
+
+    def escape_lessonpix_query(location)
+      if location.match(/lessonpix\.com/) && location.include?('?') && location.match(/\.png/)
+        location.sub(/\?/, '%3F')
+      else
+        location
+      end
+    end
+
+    def normalize_resolved_ip(ip)
+      addr = coerce_ipaddr(ip)
+      return ip unless addr
+
+      addr.ipv4_mapped? ? addr.native.to_s : addr.to_s
     end
 
     def format_pin_address(ip)
       ip.include?(':') ? "[#{ip}]" : ip
+    end
+
+    def apply_typhoeus_request_opts(opts, pins)
+      request_opts = opts.merge(followlocation: false)
+      request_opts[:resolve] = build_resolve_slist(pins) if pins
+      request_opts
+    end
+
+    # Ethon 0.15+ requires CURLOPT_RESOLVE as a curl slist (FFI::Pointer), not a Ruby Array.
+    def build_resolve_slist(pins)
+      return nil if pins.nil? || pins.empty?
+
+      list = nil
+      pins.each do |pin|
+        list = Ethon::Curl.slist_append(list, pin.to_s)
+      end
+      FFI::AutoPointer.new(list, Ethon::Curl.method(:slist_free_all))
     end
 
     def failed_response(message = 'blocked or invalid URL')

--- a/lib/tasks/openaac.rake
+++ b/lib/tasks/openaac.rake
@@ -43,7 +43,7 @@ namespace :openaac do
       url = "#{OPENBOARDS_BASE}/#{filename}"
       puts "\n[#{filename}] Downloading from #{url}..."
 
-      response = Typhoeus.get(Uploader.sanitize_url(url), timeout: 300, connecttimeout: 30)
+      response = SafeHttp.get(url, timeout: 300, connecttimeout: 30)
       unless response.success?
         puts "  SKIP: HTTP #{response.code} - #{response.return_message}"
         next

--- a/lib/tasks/openaac.rake
+++ b/lib/tasks/openaac.rake
@@ -29,6 +29,7 @@ namespace :openaac do
 
   desc 'Download OBZ files from openboards.s3.amazonaws.com and import via Converters::LingoLinq.from_obz()'
   task import_vocabularies: :environment do
+    require 'safe_http'
     require Rails.root.join('lib', 'converters', 'lingo_linq')
     user_name = ENV['VOCABULARY_USER_NAME'] || 'lingolinq'
     user = User.find_by(user_name: user_name)

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk-s3'
 require 'accessible-books'
 require 'ipaddr'
+require_relative 'safe_http'
 
 module Uploader
   S3_EXPIRATION_TIME=60*60
@@ -90,14 +91,10 @@ module Uploader
       # the SSRF targets the string checks above miss: cloud metadata
       # 169.254.169.254 (link-local), RFC1918 10.x / 172.16-31.x / 192.168.x
       # (private), ::1, fe80::, fc00::, and carrier-grade NAT 100.64/10. Only
-      # applies to literal IPs; a hostname that isn't an IP literal fails the
-      # IPAddr parse and falls through (DNS-rebinding to an internal address is a
-      # deeper, HTTP-client-layer concern — see SECURITY note in this method).
+      # applies to literal IPs; hostname DNS-to-internal and rebinding are blocked
+      # at fetch time by SafeHttp (resolve + CURLOPT_RESOLVE pin).
       literal = (IPAddr.new(uri.host.sub(/^\[/, '').sub(/\]$/, '')) rescue nil)
-      if literal && (literal.loopback? || literal.private? || literal.link_local? ||
-                     IPAddr.new('100.64.0.0/10').include?(literal))
-        return nil
-      end
+      return nil if literal && SafeHttp.blocked_address?(literal)
     end
     port_suffix = ""
     port_suffix = ":#{uri.port}" if (uri.scheme == 'http' && uri.port != 80)
@@ -365,7 +362,7 @@ module Uploader
   def self.remote_zip(url, &block)
     result = []
     Progress.update_current_progress(0.1, :downloading_file)
-    response = Typhoeus.get(Uploader.sanitize_url(url))
+    response = SafeHttp.get(url)
     Progress.update_current_progress(0.2, :processing_file)
     file = Tempfile.new('stash')
     file.binmode

--- a/spec/controllers/api/search_controller_spec.rb
+++ b/spec/controllers/api/search_controller_spec.rb
@@ -339,6 +339,15 @@ describe Api::SearchController, :type => :controller do
       json = JSON.parse(response.body)
       expect(json['error']).to eq('something bad')
     end
+
+    it "should reject SSRF targets before fetching" do
+      token_user
+      expect(controller).not_to receive(:get_url_in_chunks)
+      get :proxy, params: {:url => 'http://169.254.169.254/latest/meta-data/'}
+      expect(response).not_to be_successful
+      json = JSON.parse(response.body)
+      expect(json['error']).to eq('blocked or invalid URL')
+    end
     
     it "should escape the URI if needed" do
       token_user

--- a/spec/controllers/api/search_controller_spec.rb
+++ b/spec/controllers/api/search_controller_spec.rb
@@ -316,6 +316,45 @@ describe Api::SearchController, :type => :controller do
   end
   
   describe "proxy" do
+    class ProxyFakeRequest
+      attr_reader :url
+
+      def initialize(content_type: 'image/png', body: '12345', url: 'http://www.example.com/pic.png')
+        @content_type = content_type
+        @body = body
+        @url = url
+      end
+
+      def headers
+        { 'Content-Type' => @content_type }
+      end
+
+      def on_headers(&block)
+        @header_block = block
+      end
+
+      def on_body(&block)
+        @body_block = block
+      end
+
+      def on_complete(&block)
+        @complete_block = block
+      end
+
+      def run
+        res = OpenStruct.new(success?: true, code: 200, headers: { 'Content-Type' => @content_type })
+        @header_block.call(res)
+        @body_block.call(@body)
+        @complete_block.call(res)
+      end
+    end
+
+    def stub_proxy_request(content_type: 'image/png', body: '12345', url: 'http://www.example.com/pic.png')
+      req = ProxyFakeRequest.new(content_type: content_type, body: body, url: url)
+      allow(SafeHttp).to receive(:build_typhoeus_request).and_return(req)
+      req
+    end
+
     it "should require api token" do
       get :proxy, params: {:url => 'http://www.example.com/pic.png'}
       assert_missing_token
@@ -323,7 +362,7 @@ describe Api::SearchController, :type => :controller do
     
     it "should return content type and data-uri" do
       token_user
-      expect(controller).to receive(:get_url_in_chunks).and_return(['image/png', '12345'])
+      stub_proxy_request
       get :proxy, params: {:url => 'http://www.example.com/pic.png'}
       expect(response).to be_successful
       json = JSON.parse(response.body)
@@ -351,10 +390,9 @@ describe Api::SearchController, :type => :controller do
     
     it "should escape the URI if needed" do
       token_user
-      expect(controller).to receive(:get_url_in_chunks) { |req|
-        expect(req.url).to eq("http://www.example.com/a%20good%20pic.png")
-        true
-      }.and_return(['image/png', '12345'])
+      expect(SafeHttp).to receive(:build_typhoeus_request).with('http://www.example.com/a%20good%20pic.png').and_return(
+        ProxyFakeRequest.new(url: 'http://www.example.com/a%20good%20pic.png')
+      )
       get :proxy, params: {:url => 'http://www.example.com/a good pic.png'}
       expect(response).to be_successful
       json = JSON.parse(response.body)
@@ -364,10 +402,9 @@ describe Api::SearchController, :type => :controller do
 
     it "should not re-escape the URI if not needed" do
       token_user
-      expect(controller).to receive(:get_url_in_chunks) { |req|
-        expect(req.url).to eq("http://www.example.com/a%20good%20pic.png")
-        true
-      }.and_return(['image/png', '12345'])
+      expect(SafeHttp).to receive(:build_typhoeus_request).with('http://www.example.com/a%20good%20pic.png').and_return(
+        ProxyFakeRequest.new(url: 'http://www.example.com/a%20good%20pic.png')
+      )
       get :proxy, params: {:url => 'http://www.example.com/a%20good%20pic.png'}
       expect(response).to be_successful
       json = JSON.parse(response.body)
@@ -385,16 +422,14 @@ describe Api::SearchController, :type => :controller do
       fresh_url = "https://example.s3.amazonaws.com/extras-cache/button_set_cache/#{bs.global_id}/chksm12345/h1.json"
 
       # First fetch (stale URL) raises BadFileError; retry (fresh URL) succeeds
-      call_count = 0
-      expect(controller).to receive(:get_url_in_chunks).twice do |req|
-        call_count += 1
-        if call_count == 1
-          raise Api::SearchController::BadFileError, "File not retrieved, status 403 for #{req.url}"
-        else
-          expect(req.url).to eq(fresh_url)
-          ['text/json', '{"buttons":[]}']
-        end
-      end
+      stale_req = ProxyFakeRequest.new(content_type: 'text/json', body: '{"buttons":[]}', url: stale_url)
+      fresh_req = ProxyFakeRequest.new(content_type: 'text/json', body: '{"buttons":[]}', url: fresh_url)
+      expect(SafeHttp).to receive(:build_typhoeus_request).with(stale_url).and_return(stale_req)
+      expect(SafeHttp).to receive(:build_typhoeus_request).with(fresh_url).and_return(fresh_req)
+      expect(controller).to receive(:get_url_in_chunks).with(stale_req).and_raise(
+        Api::SearchController::BadFileError, "File not retrieved, status 403 for #{stale_url}"
+      )
+      expect(controller).to receive(:get_url_in_chunks).with(fresh_req).and_return(['text/json', '{"buttons":[]}'])
       expect(BoardDownstreamButtonSet).to receive(:generate_for).with(b.global_id, @user.global_id).and_return({success: true, state: 'uploaded', url: fresh_url})
 
       get :proxy, params: {:url => stale_url}

--- a/spec/lib/converters/utils_spec.rb
+++ b/spec/lib/converters/utils_spec.rb
@@ -89,13 +89,13 @@ describe Converters::Utils do
   describe "remote_to_boards" do
     it "should make a request to the specified url" do
       res = OpenStruct.new(:body => "bacon", :headers => {'Content-Type' => 'image/png'})
-      expect(Typhoeus).to receive(:get).with("http://example.com/board").and_return(res)
+      expect(SafeHttp).to receive(:get).with("http://example.com/board").and_return(res)
       expect { Converters::Utils.remote_to_boards(nil, "http://example.com/board") }.to raise_error("Unrecognized file type: image/png")
     end
     
     it "should error on unrecognized file type" do
       res = OpenStruct.new(:body => "bacon", :headers => {'Content-Type' => 'image/png'})
-      expect(Typhoeus).to receive(:get).with("http://example.com/board").and_return(res)
+      expect(SafeHttp).to receive(:get).with("http://example.com/board").and_return(res)
       expect { Converters::Utils.remote_to_boards(nil, "http://example.com/board") }.to raise_error("Unrecognized file type: image/png")
     end
     
@@ -105,7 +105,7 @@ describe Converters::Utils do
       shell['name'] = "Cool Board"
 
       res = OpenStruct.new(:body => shell.to_json, :headers => {'Content-Type' => 'application/obf'})
-      expect(Typhoeus).to receive(:get).with("http://example.com/board").and_return(res)
+      expect(SafeHttp).to receive(:get).with("http://example.com/board").and_return(res)
       b = Board.new
       expect(Converters::LingoLinq).to receive(:from_obf).and_return(b)
       res = Converters::Utils.remote_to_boards(nil, "http://example.com/board")
@@ -118,7 +118,7 @@ describe Converters::Utils do
       shell['name'] = "Cool Board"
 
       res = OpenStruct.new(:body => shell.to_json, :headers => {'Content-Type' => 'application/obz'})
-      expect(Typhoeus).to receive(:get).with("http://example.com/board").and_return(res)
+      expect(SafeHttp).to receive(:get).with("http://example.com/board").and_return(res)
       b = Board.new
       expect(Converters::LingoLinq).to receive(:from_obz).and_return([b])
       res = Converters::Utils.remote_to_boards(nil, "http://example.com/board")

--- a/spec/lib/exporter_spec.rb
+++ b/spec/lib/exporter_spec.rb
@@ -856,7 +856,7 @@ describe Exporter do
       u = User.create
       d = Device.create(user: u)
       expect(Exporter).to receive(:process_obl).with('asdf', u, u, d).and_return([u, d])
-      expect(Typhoeus).to receive(:get).with('http://www.example.com/file.obl', {timeout: 10}).and_return(OpenStruct.new(body: 'asdf'))
+      expect(SafeHttp).to receive(:get).with('http://www.example.com/file.obl', timeout: 10).and_return(OpenStruct.new(body: 'asdf'))
       res = Exporter.process_log('http://www.example.com/file.obl', 'obl', u.global_id, u.global_id, d.global_id)
       expect(res).to eq([u.global_id, d.global_id])
     end

--- a/spec/lib/safe_http_spec.rb
+++ b/spec/lib/safe_http_spec.rb
@@ -1,0 +1,182 @@
+require 'spec_helper'
+
+describe SafeHttp do
+  describe '.blocked_address?' do
+    it 'blocks cloud metadata, RFC1918, link-local, and CGN ranges' do
+      expect(SafeHttp.blocked_address?('169.254.169.254')).to eq(true)
+      expect(SafeHttp.blocked_address?('10.0.0.5')).to eq(true)
+      expect(SafeHttp.blocked_address?('172.16.4.4')).to eq(true)
+      expect(SafeHttp.blocked_address?('192.168.1.1')).to eq(true)
+      expect(SafeHttp.blocked_address?('100.64.0.1')).to eq(true)
+      expect(SafeHttp.blocked_address?('::1')).to eq(true)
+      expect(SafeHttp.blocked_address?('fe80::1')).to eq(true)
+    end
+
+    it 'allows public addresses including RFC1918 boundaries' do
+      expect(SafeHttp.blocked_address?('8.8.8.8')).to eq(false)
+      expect(SafeHttp.blocked_address?('172.15.0.1')).to eq(false)
+      expect(SafeHttp.blocked_address?('172.32.0.1')).to eq(false)
+    end
+  end
+
+  describe '.resolve_addresses' do
+    it 'returns deduped public IPs when all answers are safe' do
+      addrs = [
+        instance_double(Addrinfo, ip_address: '93.184.216.34'),
+        instance_double(Addrinfo, ip_address: '93.184.216.34'),
+        instance_double(Addrinfo, ip_address: '2606:2800:220:1:248:1893:25c8:1946')
+      ]
+      expect(Addrinfo).to receive(:getaddrinfo).with('example.com', nil, Socket::AF_UNSPEC, Socket::SOCK_STREAM).and_return(addrs)
+
+      expect(SafeHttp.resolve_addresses('example.com')).to eq([
+        '93.184.216.34',
+        '2606:2800:220:1:248:1893:25c8:1946'
+      ])
+    end
+
+    it 'rejects when any answer resolves to a blocked range' do
+      addrs = [
+        instance_double(Addrinfo, ip_address: '8.8.8.8'),
+        instance_double(Addrinfo, ip_address: '10.0.0.1')
+      ]
+      expect(Addrinfo).to receive(:getaddrinfo).and_return(addrs)
+
+      expect(SafeHttp.resolve_addresses('evil.example.com')).to eq(nil)
+    end
+
+    it 'returns nil on resolution failure' do
+      expect(Addrinfo).to receive(:getaddrinfo).and_raise(SocketError)
+
+      expect(SafeHttp.resolve_addresses('missing.example.com')).to eq(nil)
+    end
+  end
+
+  describe '.resolve_pins' do
+    it 'formats IPv4 and IPv6 pins for libcurl' do
+      uri = URI.parse('https://example.com/path')
+      pins = SafeHttp.resolve_pins(uri, ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'])
+
+      expect(pins).to eq(['example.com:443:93.184.216.34,[2606:2800:220:1:248:1893:25c8:1946]'])
+    end
+  end
+
+  describe '.get' do
+    it 'pins resolved public IPs and disables followlocation' do
+      addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
+      expect(Addrinfo).to receive(:getaddrinfo).and_return(addrs)
+      response = OpenStruct.new(code: 200, headers: {}, body: 'ok')
+      expect(response).to receive(:success?).and_return(true)
+      expect(Typhoeus).to receive(:get).with(
+        'http://www.example.com/pic.png',
+        hash_including(
+          followlocation: false,
+          resolve: ['www.example.com:80:93.184.216.34']
+        )
+      ).and_return(response)
+
+      res = SafeHttp.get('http://www.example.com/pic.png')
+      expect(res).to eq(response)
+      expect(res.effective_url).to eq('http://www.example.com/pic.png')
+    end
+
+    it 'returns a failed response for blocked URLs without calling Typhoeus' do
+      expect(Typhoeus).not_to receive(:get)
+
+      res = SafeHttp.get('http://169.254.169.254/latest/meta-data/')
+      expect(res.success?).to eq(false)
+      expect(res.code).to eq(0)
+      expect(res.effective_url).to eq(nil)
+    end
+
+    it 'follows redirects through the full validation pipeline' do
+      addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
+      expect(Addrinfo).to receive(:getaddrinfo).twice.and_return(addrs)
+
+      redirect = OpenStruct.new(
+        code: 302,
+        headers: { 'Location' => 'http://www.example.com/final.png' },
+        body: ''
+      )
+      expect(redirect).to receive(:success?).and_return(false)
+
+      final = OpenStruct.new(code: 200, headers: { 'Content-Type' => 'image/png' }, body: 'data')
+      expect(final).to receive(:success?).and_return(true)
+
+      expect(Typhoeus).to receive(:get).with(
+        'http://www.example.com/start.png',
+        hash_including(followlocation: false, resolve: ['www.example.com:80:93.184.216.34'])
+      ).and_return(redirect)
+      expect(Typhoeus).to receive(:get).with(
+        'http://www.example.com/final.png',
+        hash_including(followlocation: false, resolve: ['www.example.com:80:93.184.216.34'])
+      ).and_return(final)
+
+      res = SafeHttp.get('http://www.example.com/start.png')
+      expect(res).to eq(final)
+      expect(res.effective_url).to eq('http://www.example.com/final.png')
+    end
+
+    it 'does not follow redirects to blocked targets' do
+      public_addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
+      expect(Addrinfo).to receive(:getaddrinfo).once.and_return(public_addrs)
+
+      redirect = OpenStruct.new(
+        code: 302,
+        headers: { 'Location' => 'http://169.254.169.254/meta' },
+        body: ''
+      )
+      expect(redirect).to receive(:success?).and_return(false)
+
+      expect(Typhoeus).to receive(:get).once.and_return(redirect)
+
+      res = SafeHttp.get('http://www.example.com/start.png')
+      expect(res.success?).to eq(false)
+      expect(res.body).to eq('blocked or invalid URL')
+    end
+
+    it 'applies lessonpix redirect query escaping' do
+      addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
+      expect(Addrinfo).to receive(:getaddrinfo).twice.and_return(addrs)
+
+      redirect = OpenStruct.new(
+        code: 302,
+        headers: { 'Location' => 'https://lessonpix.com/pic.png?token=abc' },
+        body: ''
+      )
+      expect(redirect).to receive(:success?).and_return(false)
+
+      final = OpenStruct.new(code: 200, headers: { 'Content-Type' => 'image/png' }, body: 'data')
+      expect(final).to receive(:success?).and_return(true)
+
+      expect(Typhoeus).to receive(:get).with('http://www.example.com/start.png', anything).and_return(redirect)
+      expect(Typhoeus).to receive(:get).with(
+        'https://lessonpix.com/pic.png%3Ftoken=abc',
+        anything
+      ).and_return(final)
+
+      SafeHttp.get('http://www.example.com/start.png')
+    end
+  end
+
+  describe '.post' do
+    it 'posts with DNS pins for hostnames' do
+      addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
+      expect(Addrinfo).to receive(:getaddrinfo).and_return(addrs)
+      response = OpenStruct.new(code: 200, headers: {}, body: 'ok')
+      expect(response).to receive(:success?).and_return(true)
+
+      expect(Typhoeus).to receive(:post).with(
+        'http://www.example.com/callback',
+        hash_including(
+          body: { notification: 'test' },
+          timeout: 10,
+          followlocation: false,
+          resolve: ['www.example.com:80:93.184.216.34']
+        )
+      ).and_return(response)
+
+      res = SafeHttp.post('http://www.example.com/callback', body: { notification: 'test' }, timeout: 10)
+      expect(res.effective_url).to eq('http://www.example.com/callback')
+    end
+  end
+end

--- a/spec/lib/safe_http_spec.rb
+++ b/spec/lib/safe_http_spec.rb
@@ -1,3 +1,4 @@
+require 'ffi'
 require 'spec_helper'
 
 describe SafeHttp do
@@ -12,14 +13,46 @@ describe SafeHttp do
       expect(SafeHttp.blocked_address?('fe80::1')).to eq(true)
     end
 
+    it 'blocks non-canonical IPv6 mapped forms with binary-safe byte comparison' do
+      # ::ffff:0:7f00:1 encodes 127.0.0.1; hton returns ASCII-8BIT so comparisons must use .b literals.
+      expect(SafeHttp.blocked_address?('::ffff:0:7f00:1')).to eq(true)
+      expect(SafeHttp.blocked_address?('::ffff:0:a9fe:a9fe')).to eq(true)
+    end
+
+    it 'blocks IPv4-compatible and non-canonical IPv6 embeddings of blocked IPv4' do
+      expect(SafeHttp.blocked_address?('::ffff:169.254.169.254')).to eq(true)
+      expect(SafeHttp.blocked_address?('::169.254.169.254')).to eq(true)
+      expect(SafeHttp.blocked_address?('::10.0.0.1')).to eq(true)
+      expect(SafeHttp.blocked_address?('::127.0.0.1')).to eq(true)
+      expect(SafeHttp.blocked_address?('::ffff:0:7f00:1')).to eq(true)
+      expect(SafeHttp.blocked_address?('0000:0000:0000:0000:0000:0000:a9fe:a9fe')).to eq(true)
+      expect(SafeHttp.blocked_address?('[::ffff:169.254.169.254]')).to eq(true)
+    end
+
+    it 'blocks link-local IPv6 with zone index after normalization' do
+      expect(SafeHttp.blocked_address?('fe80::1%eth0')).to eq(true)
+      expect(SafeHttp.blocked_address?('fe80::1%25eth0')).to eq(true)
+    end
+
     it 'allows public addresses including RFC1918 boundaries' do
       expect(SafeHttp.blocked_address?('8.8.8.8')).to eq(false)
       expect(SafeHttp.blocked_address?('172.15.0.1')).to eq(false)
       expect(SafeHttp.blocked_address?('172.32.0.1')).to eq(false)
+      expect(SafeHttp.blocked_address?('2606:2800:220:1:248:1893:25c8:1946')).to eq(false)
     end
   end
 
   describe '.resolve_addresses' do
+    it 'collapses IPv4-mapped IPv6 answers to IPv4 for block checks' do
+      addrs = [
+        instance_double(Addrinfo, ip_address: '::ffff:93.184.216.34'),
+        instance_double(Addrinfo, ip_address: '93.184.216.34')
+      ]
+      expect(Addrinfo).to receive(:getaddrinfo).and_return(addrs)
+
+      expect(SafeHttp.resolve_addresses('example.com')).to eq(['93.184.216.34'])
+    end
+
     it 'returns deduped public IPs when all answers are safe' do
       addrs = [
         instance_double(Addrinfo, ip_address: '93.184.216.34'),
@@ -49,6 +82,15 @@ describe SafeHttp do
 
       expect(SafeHttp.resolve_addresses('missing.example.com')).to eq(nil)
     end
+
+    it 'returns nil when DNS resolution times out' do
+      expect(Addrinfo).to receive(:getaddrinfo) do
+        sleep(SafeHttp::DNS_RESOLVE_TIMEOUT + 1)
+        []
+      end
+
+      expect(SafeHttp.resolve_addresses('slow.example.com')).to eq(nil)
+    end
   end
 
   describe '.resolve_pins' do
@@ -60,17 +102,28 @@ describe SafeHttp do
     end
   end
 
+  describe 'Ethon resolve slist' do
+    it 'builds an FFI slist Ethon accepts for CURLOPT_RESOLVE' do
+      pins = ['www.example.com:80:93.184.216.34']
+      slist = SafeHttp.send(:build_resolve_slist, pins)
+
+      expect(slist).to be_a(FFI::AutoPointer)
+
+      easy = Ethon::Easy.new(url: 'http://www.example.com/')
+      expect { easy.resolve = slist }.not_to raise_error
+    end
+  end
+
   describe '.get' do
     it 'pins resolved public IPs and disables followlocation' do
       addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
       expect(Addrinfo).to receive(:getaddrinfo).and_return(addrs)
       response = OpenStruct.new(code: 200, headers: {}, body: 'ok')
-      expect(response).to receive(:success?).and_return(true)
       expect(Typhoeus).to receive(:get).with(
         'http://www.example.com/pic.png',
         hash_including(
           followlocation: false,
-          resolve: ['www.example.com:80:93.184.216.34']
+          resolve: kind_of(FFI::AutoPointer)
         )
       ).and_return(response)
 
@@ -88,6 +141,32 @@ describe SafeHttp do
       expect(res.effective_url).to eq(nil)
     end
 
+    it 'returns a failed response for IPv4-compatible IPv6 literals without calling Typhoeus' do
+      expect(Typhoeus).not_to receive(:get)
+
+      res = SafeHttp.get('http://[::169.254.169.254]/meta')
+      expect(res.success?).to eq(false)
+      expect(res.code).to eq(0)
+    end
+
+    it 'forwards Typhoeus options such as connecttimeout and ssl_verifypeer' do
+      addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
+      expect(Addrinfo).to receive(:getaddrinfo).and_return(addrs)
+      response = OpenStruct.new(code: 200, headers: {}, body: 'ok')
+
+      expect(Typhoeus).to receive(:get).with(
+        'http://www.example.com/pic.png',
+        hash_including(
+          followlocation: false,
+          connecttimeout: 30,
+          ssl_verifypeer: true,
+          resolve: kind_of(FFI::AutoPointer)
+        )
+      ).and_return(response)
+
+      SafeHttp.get('http://www.example.com/pic.png', connecttimeout: 30, ssl_verifypeer: true)
+    end
+
     it 'follows redirects through the full validation pipeline' do
       addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
       expect(Addrinfo).to receive(:getaddrinfo).twice.and_return(addrs)
@@ -97,18 +176,16 @@ describe SafeHttp do
         headers: { 'Location' => 'http://www.example.com/final.png' },
         body: ''
       )
-      expect(redirect).to receive(:success?).and_return(false)
 
       final = OpenStruct.new(code: 200, headers: { 'Content-Type' => 'image/png' }, body: 'data')
-      expect(final).to receive(:success?).and_return(true)
 
       expect(Typhoeus).to receive(:get).with(
         'http://www.example.com/start.png',
-        hash_including(followlocation: false, resolve: ['www.example.com:80:93.184.216.34'])
+        hash_including(followlocation: false, resolve: kind_of(FFI::AutoPointer))
       ).and_return(redirect)
       expect(Typhoeus).to receive(:get).with(
         'http://www.example.com/final.png',
-        hash_including(followlocation: false, resolve: ['www.example.com:80:93.184.216.34'])
+        hash_including(followlocation: false, resolve: kind_of(FFI::AutoPointer))
       ).and_return(final)
 
       res = SafeHttp.get('http://www.example.com/start.png')
@@ -125,7 +202,6 @@ describe SafeHttp do
         headers: { 'Location' => 'http://169.254.169.254/meta' },
         body: ''
       )
-      expect(redirect).to receive(:success?).and_return(false)
 
       expect(Typhoeus).to receive(:get).once.and_return(redirect)
 
@@ -143,10 +219,8 @@ describe SafeHttp do
         headers: { 'Location' => 'https://lessonpix.com/pic.png?token=abc' },
         body: ''
       )
-      expect(redirect).to receive(:success?).and_return(false)
 
       final = OpenStruct.new(code: 200, headers: { 'Content-Type' => 'image/png' }, body: 'data')
-      expect(final).to receive(:success?).and_return(true)
 
       expect(Typhoeus).to receive(:get).with('http://www.example.com/start.png', anything).and_return(redirect)
       expect(Typhoeus).to receive(:get).with(
@@ -165,9 +239,8 @@ describe SafeHttp do
 
       req = SafeHttp.build_typhoeus_request('http://www.example.com/pic.png')
       expect(req).to be_a(Typhoeus::Request)
-      expect(req.url).to eq('http://www.example.com/pic.png')
       expect(req.options[:followlocation]).to eq(false)
-      expect(req.options[:resolve]).to eq(['www.example.com:80:93.184.216.34'])
+      expect(req.options[:resolve]).to be_a(FFI::AutoPointer)
       expect(req.effective_url).to eq('http://www.example.com/pic.png')
     end
 
@@ -181,7 +254,6 @@ describe SafeHttp do
       addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
       expect(Addrinfo).to receive(:getaddrinfo).and_return(addrs)
       response = OpenStruct.new(code: 200, headers: {}, body: 'ok')
-      expect(response).to receive(:success?).and_return(true)
 
       expect(Typhoeus).to receive(:post).with(
         'http://www.example.com/callback',
@@ -189,7 +261,7 @@ describe SafeHttp do
           body: { notification: 'test' },
           timeout: 10,
           followlocation: false,
-          resolve: ['www.example.com:80:93.184.216.34']
+          resolve: kind_of(FFI::AutoPointer)
         )
       ).and_return(response)
 

--- a/spec/lib/safe_http_spec.rb
+++ b/spec/lib/safe_http_spec.rb
@@ -158,6 +158,24 @@ describe SafeHttp do
     end
   end
 
+  describe '.build_typhoeus_request' do
+    it 'returns a pinned Typhoeus::Request for hostnames' do
+      addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]
+      expect(Addrinfo).to receive(:getaddrinfo).and_return(addrs)
+
+      req = SafeHttp.build_typhoeus_request('http://www.example.com/pic.png')
+      expect(req).to be_a(Typhoeus::Request)
+      expect(req.url).to eq('http://www.example.com/pic.png')
+      expect(req.options[:followlocation]).to eq(false)
+      expect(req.options[:resolve]).to eq(['www.example.com:80:93.184.216.34'])
+      expect(req.effective_url).to eq('http://www.example.com/pic.png')
+    end
+
+    it 'returns nil for blocked URLs' do
+      expect(SafeHttp.build_typhoeus_request('http://169.254.169.254/meta')).to eq(nil)
+    end
+  end
+
   describe '.post' do
     it 'posts with DNS pins for hostnames' do
       addrs = [instance_double(Addrinfo, ip_address: '93.184.216.34')]

--- a/spec/lib/uploader_spec.rb
+++ b/spec/lib/uploader_spec.rb
@@ -1527,7 +1527,7 @@ describe Uploader do
     it "should call the block with the loaded zip" do
       expect(OBF::Utils).to receive(:load_zip).and_yield({zipper: true})
       res = OpenStruct.new(body: 'abc')
-      expect(Typhoeus).to receive(:get).with('http://www.example.com/import.zip').and_return(res)
+      expect(SafeHttp).to receive(:get).with('http://www.example.com/import.zip').and_return(res)
       Uploader.remote_zip('http://www.example.com/import.zip') do |zipper|
         expect(zipper).to eq({zipper: true})
       end

--- a/spec/models/concerns/uploadable_spec.rb
+++ b/spec/models/concerns/uploadable_spec.rb
@@ -905,14 +905,14 @@ describe Uploadable, :type => :model do
   describe "assert_raster" do
     it "should do nothing by default" do
       bi = ButtonImage.new
-      expect(Typhoeus).to_not receive(:head)
+      expect(SafeHttp).to_not receive(:head)
       expect(bi.assert_raster).to eq(nil)
     end
 
     it "should do nothing if already rasterized" do
       bi = ButtonImage.new
       bi.settings = {'content_type' => 'image/svg', 'rasterized' => true}
-      expect(Typhoeus).to_not receive(:head)
+      expect(SafeHttp).to_not receive(:head)
       expect(bi.assert_raster).to eq(nil)
     end
 
@@ -922,7 +922,7 @@ describe Uploadable, :type => :model do
       bi.settings = {'content_type' => 'image/svg'}
       res = OpenStruct.new
       expect(res).to receive(:success?).and_return(false)
-      expect(Typhoeus).to receive(:head).with("http://www.example.com/pic.svg.raster.png", followlocation: true).and_return(res)
+      expect(SafeHttp).to receive(:head).with("http://www.example.com/pic.svg.raster.png").and_return(res)
       bi.assert_raster
     end
 
@@ -932,7 +932,7 @@ describe Uploadable, :type => :model do
       bi.settings = {'content_type' => 'image/svg'}
       res = OpenStruct.new
       expect(res).to receive(:success?).and_return(true)
-      expect(Typhoeus).to receive(:head).with("http://www.example.com/pic.svg.raster.png", followlocation: true).and_return(res)
+      expect(SafeHttp).to receive(:head).with("http://www.example.com/pic.svg.raster.png").and_return(res)
       bi.assert_raster
       expect(bi.settings['rasterized']).to eq('from_url')
     end
@@ -944,7 +944,7 @@ describe Uploadable, :type => :model do
       res = OpenStruct.new
       expect(res).to receive(:success?).and_return(false)
       expect(bi).to receive(:schedule).with(:upload_to_remote, bi.url, true)
-      expect(Typhoeus).to receive(:head).with("http://www.example.com/pic.svg.raster.png", followlocation: true).and_return(res)
+      expect(SafeHttp).to receive(:head).with("http://www.example.com/pic.svg.raster.png").and_return(res)
       bi.assert_raster
     end
   end

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -231,10 +231,10 @@ describe Webhook, :type => :model do
       
       token = 'abcdefg'
       res = OpenStruct.new(code: 200, body: 'asdf')
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/1', body: {token: token, notification: 'friend', record: h.record_code}, timeout: 10).and_return(res)
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/2', body: {token: token, notification: 'friend', record: h.record_code}, timeout: 10).and_return(res)
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/4', body: {token: token, notification: 'friend', record: h.record_code}, timeout: 10).and_return(res)
-      expect(Typhoeus).to_not receive(:post).with('http://www.example.com/3', body: {token: token, notification: 'friend', record: h.record_code}, timeout: 10)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/1', body: {token: token, notification: 'friend', record: h.record_code}, timeout: 10).and_return(res)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/2', body: {token: token, notification: 'friend', record: h.record_code}, timeout: 10).and_return(res)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/4', body: {token: token, notification: 'friend', record: h.record_code}, timeout: 10).and_return(res)
+      expect(SafeHttp).to_not receive(:post).with('http://www.example.com/3', body: {token: token, notification: 'friend', record: h.record_code}, timeout: 10)
       res = h.notify('friend', h, {})
       expect(res.length).to eq(3)
       expect(res[0]).to eq({:url => 'http://www.example.com/4', :response_code => 200, :response_body => 'asdf'})
@@ -268,7 +268,7 @@ describe Webhook, :type => :model do
       
       token = 'abcdefg'
       res = OpenStruct.new
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/3', body: {token: token, notification: 'bacon', record: h.record_code, content: h.webhook_content(nil, nil, nil)}, timeout: 10).and_return(res)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/3', body: {token: token, notification: 'bacon', record: h.record_code, content: h.webhook_content(nil, nil, nil)}, timeout: 10).and_return(res)
       h.notify('bacon', h, {})
     end
 
@@ -291,7 +291,7 @@ describe Webhook, :type => :model do
       
       token = 'abcdefg'
       res = OpenStruct.new
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/baconator/3', body: {token: token, notification: 'bacon', record: h.record_code, content: json}, timeout: 10).and_return(res)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/baconator/3', body: {token: token, notification: 'bacon', record: h.record_code, content: json}, timeout: 10).and_return(res)
       h.notify('bacon', h, {})
     end
     
@@ -310,7 +310,7 @@ describe Webhook, :type => :model do
       
       token = 'abcdefg'
       res = OpenStruct.new
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/4', body: {token: token, notification: 'friend', record: h.record_code, url: "http://www.example.com/record/1"}, timeout: 10).and_return(res)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/4', body: {token: token, notification: 'friend', record: h.record_code, url: "http://www.example.com/record/1"}, timeout: 10).and_return(res)
       h.notify('friend', h, {})
     end
     
@@ -335,10 +335,10 @@ describe Webhook, :type => :model do
       
       token = 'abcdefg'
       res = OpenStruct.new
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/1', body: {token: token, notification: 'test', record: h.record_code}, timeout: 10).and_return(res)
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/2', body: {token: token, notification: 'test', record: h.record_code}, timeout: 10).and_return(res)
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/4', body: {token: token, notification: 'test', record: h.record_code}, timeout: 10).and_return(res)
-      expect(Typhoeus).to receive(:post).with('http://www.example.com/3', body: {token: token, notification: 'test', record: h.record_code, content: h.webhook_content(nil, nil, nil)}, timeout: 10).and_return(res)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/1', body: {token: token, notification: 'test', record: h.record_code}, timeout: 10).and_return(res)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/2', body: {token: token, notification: 'test', record: h.record_code}, timeout: 10).and_return(res)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/4', body: {token: token, notification: 'test', record: h.record_code}, timeout: 10).and_return(res)
+      expect(SafeHttp).to receive(:post).with('http://www.example.com/3', body: {token: token, notification: 'test', record: h.record_code, content: h.webhook_content(nil, nil, nil)}, timeout: 10).and_return(res)
       h.notify('test', h, {})
     end
   end


### PR DESCRIPTION
## Plain-language overview

This closes a security gap where someone could trick our servers into fetching private internal addresses (like cloud metadata or services on our own network) by supplying a normal-looking web address.

We already blocked obvious cases (addresses written as numbers like `169.254.169.254`). This change also covers tricks that use a regular hostname that resolves to an internal address, including DNS rebinding where the address changes between our check and the actual connection.

**What users should notice:** Almost nothing in normal use. Image imports, board imports, webhooks, and the image/audio proxy should keep working for legitimate public URLs. Callbacks or imports aimed at internal/private addresses will be rejected in production.

---

## Summary

- Add `SafeHttp` (`lib/safe_http.rb`) to resolve hostnames once, reject blocked IPs, and pin validated addresses via libcurl `CURLOPT_RESOLVE` so connect-time DNS cannot rebind to internal targets.
- Migrate all user-supplied URL fetch paths from `Typhoeus.*(Uploader.sanitize_url(...))` to `SafeHttp.get/head/post`.
- Route the search controller’s streaming image/audio proxy through `SafeHttp.build_typhoeus_request`.
- Keep `sanitize_url` as the fast, network-free string guard; DNS validation lives at fetch time only.

## Problem

`Uploader.sanitize_url` blocks IP literals in reserved ranges but never resolves hostnames. Call sites used `Typhoeus.get(Uploader.sanitize_url(url))`, so libcurl resolved DNS independently at connect time. Two bypasses remained:

1. **DNS-to-internal** — `evil.attacker.com` → A record `169.254.169.254` passes because the host string is not an IP literal.
2. **DNS rebinding (TOCTOU)** — even resolve-then-check loses if libcurl re-resolves at connect time (`followlocation: true` made redirects worse).

## Solution

| Layer | Role |
|-------|------|
| `sanitize_url` | Fast string checks (scheme, IP literals, encodings) |
| `SafeHttp` | Resolve once → validate all A/AAAA answers → pin via `CURLOPT_RESOLVE` → fetch with `followlocation: false` and manual redirect re-validation (max 5 hops) |

## Commits

1. `fix: close SSRF DNS rebinding with SafeHttp resolve-and-pin` — core module + migrated fetch paths
2. `fix: apply SafeHttp SSRF guard to search proxy fetches` — streaming proxy via `SafeHttp.build_typhoeus_request`

## Migrated call sites

- `app/models/concerns/uploadable.rb` — remote image/audio/video upload fetches
- `lib/uploader.rb` — `remote_zip`
- `lib/converters/utils.rb` — OBF/OBZ import from URL
- `lib/exporter.rb` — log import from URL
- `lib/tasks/openaac.rake` — vocabulary OBZ download
- `app/models/webhook.rb` — outbound webhook POSTs
- `app/controllers/api/search_controller.rb` — image/audio proxy (`#proxy` + button-set cache retry)

**Not migrated:** hardcoded outbound APIs (OpenSymbols, Giphy, Google TTS, S3 uploads, etc.) — not user-supplied SSRF surfaces.

## Behavior notes

- Webhooks to private IPs are blocked in non-dev environments (intentional for cloud SSRF defense).
- Development still skips blocked-IP checks (matches existing `sanitize_url` dev bypass).
- CDN multi-IP hostnames: all validated public IPs are pinned; libcurl picks one.

## Test plan

- [ ] `bundle exec rspec spec/lib/safe_http_spec.rb`
- [ ] `bundle exec rspec spec/lib/uploader_spec.rb -e "sanitize_url" -e "remote_zip"`
- [ ] `bundle exec rspec spec/lib/converters/utils_spec.rb -e "remote_to_boards"`
- [ ] `bundle exec rspec spec/controllers/api/search_controller_spec.rb -e "proxy"`
- [ ] Import an image from a public URL (symbol search, drag-drop, or board detail)
- [ ] Import a board from a public OBF/OBZ URL
- [ ] Confirm proxy still returns image/audio for a normal external URL (authenticated)
- [ ] Confirm `http://169.254.169.254/...` is rejected on import/proxy paths (non-dev)
- [ ] Smoke-test a webhook callback to a public HTTPS endpoint