### PR TITLE
feat(tracking): worldwide location + source/ad-key to HubSpot on signup

### DIFF
--- a/lib/external_tracker.rb
+++ b/lib/external_tracker.rb
@@ -87,8 +87,9 @@ module ExternalTracker
     if source.present?
       json[:properties] << {property: 'lingolinq_referrer', value: source}
     end
-    if user.settings['ad_referrer'].present?
-      json[:properties] << {property: 'lingolinq_ad_referrer', value: user.settings['ad_referrer']}
+    ad_key = ad_key_clean(user.settings['ad_referrer'])
+    if ad_key.present?
+      json[:properties] << {property: 'lingolinq_ad_referrer', value: ad_key}
     end
     if user && (user.settings['activations'] || []).length > 0
       json[:properties] << {
@@ -113,17 +114,29 @@ module ExternalTracker
   end
 
   # Reduce a referring URL to just its scheme+host (origin) so any PII in the
-  # path or query string is dropped before the value is sent to HubSpot.
-  # Returns nil when the value is blank or cannot be parsed into an http(s)
-  # origin, so the caller drops it rather than leaking an unparseable string.
+  # path, query string, or userinfo is dropped before the value is sent to
+  # HubSpot. Restricted to http(s) with a present host; returns nil for blank,
+  # non-web, hostless, or unparseable values so the caller drops it rather than
+  # leaking or polluting attribution with a non-origin string.
   def self.referrer_origin(referrer)
     return nil if referrer.blank?
     begin
-      uri = URI.parse(referrer)
-      return nil unless uri.scheme && uri.host
+      uri = URI.parse(referrer.to_s)
+      return nil unless ['http', 'https'].include?(uri.scheme) && uri.host.present?
       "#{uri.scheme}://#{uri.host}"
-    rescue URI::InvalidURIError
+    rescue URI::Error
       nil
     end
+  end
+
+  # The ad key comes straight from the ?ref= URL param (app.js), so it is fully
+  # attacker-controllable and unbounded. Only let through a short campaign-token
+  # shape (letters/digits/._-); anything else (URLs, PII, CSV/formula-injection
+  # payloads, oversized blobs) is dropped rather than egressed to HubSpot.
+  def self.ad_key_clean(ad_referrer)
+    return nil if ad_referrer.blank?
+    value = ad_referrer.to_s
+    return nil unless value.match?(/\A[A-Za-z0-9._\-]{1,64}\z/)
+    value
   end
 end

--- a/lib/external_tracker.rb
+++ b/lib/external_tracker.rb
@@ -29,12 +29,13 @@ module ExternalTracker
       end
     end
     email = user.settings['email']
-    city = nil
-    state = nil
-    if location && (location['country_code'] == 'USA' || location['country_code'] == 'US')
-      city = location['city']
-      state = location['subdivision']
-    end
+    # Capture geolocation for every country, not just the US. iplocate returns
+    # city / subdivision (region/state/province) / country globally, so non-US
+    # trials (largely GDPR-region prospects) now get city + region populated too.
+    # country lets HubSpot still tell US leads apart from international ones.
+    city = location && location['city']
+    state = location && location['subdivision']
+    country = location && location['country']
 
 
     acct = "Communicator Account"
@@ -71,10 +72,24 @@ module ExternalTracker
         {property: 'username', value: user.user_name},
         # {property: 'hs_language', value: 'en'},
         {property: 'state', value: state},
+        {property: 'country', value: country},
         {property: 'account_type', value: acct},
         {property: 'hs_legal_basis', value: 'Legitimate interest – prospect/lead'}
       ]
     }
+    # Marketing attribution captured at signup (see User#process: settings['referrer']
+    # is document.referrer, the "source"; settings['ad_referrer'] is the ?ref= URL
+    # param, the "ad key"). Sent to LingoLinq custom HubSpot contact properties.
+    # referrer is truncated to scheme+host before egress so a referring URL that
+    # happens to carry PII in its path/query (e.g. a webmail or tokenized link)
+    # does not leave the platform; the attribution signal (origin) is preserved.
+    source = referrer_origin(user.settings['referrer'])
+    if source.present?
+      json[:properties] << {property: 'lingolinq_referrer', value: source}
+    end
+    if user.settings['ad_referrer'].present?
+      json[:properties] << {property: 'lingolinq_ad_referrer', value: user.settings['ad_referrer']}
+    end
     if user && (user.settings['activations'] || []).length > 0
       json[:properties] << {
         property: 'lingolinq_start_code', value: user.settings['activations'].map{|a| a['code'] }.compact[-1]
@@ -95,5 +110,20 @@ module ExternalTracker
       Rails.logger.error("ExternalTracker: HubSpot contact sync failed for user #{user.global_id}: status=#{res.code}")
     end
     res.code
+  end
+
+  # Reduce a referring URL to just its scheme+host (origin) so any PII in the
+  # path or query string is dropped before the value is sent to HubSpot.
+  # Returns nil when the value is blank or cannot be parsed into an http(s)
+  # origin, so the caller drops it rather than leaking an unparseable string.
+  def self.referrer_origin(referrer)
+    return nil if referrer.blank?
+    begin
+      uri = URI.parse(referrer)
+      return nil unless uri.scheme && uri.host
+      "#{uri.scheme}://#{uri.host}"
+    rescue URI::InvalidURIError
+      nil
+    end
   end
 end

--- a/spec/lib/external_tracker_spec.rb
+++ b/spec/lib/external_tracker_spec.rb
@@ -269,6 +269,34 @@ describe ExternalTracker do
       res = ExternalTracker.persist_new_user(u.global_id)
       expect(res).to eq('201')
     end
+
+    it "should drop a hostile ad_referrer but still send a valid source" do
+      u = User.create
+      u.settings['email'] = 'testing@example.com'
+      u.settings['preferences'] ||= {}
+      u.settings['preferences']['registration_type'] = 'therapist'
+      u.settings['referrer'] = 'https://www.bing.com/search?q=aac'
+      u.settings['ad_referrer'] = "=cmd|'/c calc'!A1"
+      u.save
+      ENV['HUBSPOT_ACCESS_TOKEN'] = 'hubby'
+      expect(Typhoeus).to receive(:post).with("https://api.hubapi.com/contacts/v1/contact/", {
+        body: {properties: [
+          {property: 'email', value: 'testing@example.com' },
+          {property: 'firstname', value: 'No'},
+          {property: 'lastname', value: 'name'},
+          {property: 'city', value: nil},
+          {property: 'username', value: u.user_name},
+          {property: 'state', value: nil},
+          {property: 'country', value: nil},
+          {property: 'account_type', value: 'Therapist'},
+          {property: 'hs_legal_basis', value: 'Legitimate interest – prospect/lead'},
+          {property: 'lingolinq_referrer', value: 'https://www.bing.com'}
+        ]}.to_json,
+        headers: {'Content-Type' => 'application/json', "Authorization"=>"Bearer hubby"}
+      }).and_return(OpenStruct.new(code: '201'))
+      res = ExternalTracker.persist_new_user(u.global_id)
+      expect(res).to eq('201')
+    end
   end
 
   describe "referrer_origin" do
@@ -286,6 +314,38 @@ describe ExternalTracker do
       expect(ExternalTracker.referrer_origin('')).to eq(nil)
       expect(ExternalTracker.referrer_origin('not a url')).to eq(nil)
       expect(ExternalTracker.referrer_origin('javascript:alert(1)')).to eq(nil)
+    end
+
+    it "should reject non-http(s) schemes and empty hosts" do
+      expect(ExternalTracker.referrer_origin('ftp://host.example.com/x')).to eq(nil)
+      expect(ExternalTracker.referrer_origin('https:///path')).to eq(nil)
+      expect(ExternalTracker.referrer_origin('app://capacitor/index')).to eq(nil)
+    end
+
+    it "should not raise on non-string values" do
+      expect(ExternalTracker.referrer_origin({'a' => 1})).to eq(nil)
+      expect(ExternalTracker.referrer_origin(12345)).to eq(nil)
+    end
+  end
+
+  describe "ad_key_clean" do
+    it "should allow a short campaign-token shape" do
+      expect(ExternalTracker.ad_key_clean('fb-spring-2026')).to eq('fb-spring-2026')
+      expect(ExternalTracker.ad_key_clean('google_cpc.v2')).to eq('google_cpc.v2')
+    end
+
+    it "should drop URLs, PII, and injection payloads" do
+      expect(ExternalTracker.ad_key_clean("=cmd|'/c calc'!A1")).to eq(nil)
+      expect(ExternalTracker.ad_key_clean('https://x.com/?email=foo@bar.com')).to eq(nil)
+      expect(ExternalTracker.ad_key_clean('a,b,c')).to eq(nil)
+      expect(ExternalTracker.ad_key_clean('with space')).to eq(nil)
+    end
+
+    it "should drop oversized, blank, and non-string values" do
+      expect(ExternalTracker.ad_key_clean('a' * 65)).to eq(nil)
+      expect(ExternalTracker.ad_key_clean(nil)).to eq(nil)
+      expect(ExternalTracker.ad_key_clean('')).to eq(nil)
+      expect(ExternalTracker.ad_key_clean({'a' => 1})).to eq(nil)
     end
   end
 end

--- a/spec/lib/external_tracker_spec.rb
+++ b/spec/lib/external_tracker_spec.rb
@@ -122,6 +122,7 @@ describe ExternalTracker do
           {property: 'city', value: nil},
           {property: 'username', value: u.user_name},
           {property: 'state', value: nil},
+          {property: 'country', value: nil},
           {property: 'account_type', value: 'Therapist'},
           {property: 'hs_legal_basis', value: 'Legitimate interest – prospect/lead'}
         ]}.to_json,
@@ -145,7 +146,8 @@ describe ExternalTracker do
       geo = {
         'country_code' => 'US',
         'city' => 'Sandy',
-        'subdivision' => 'Utah'
+        'subdivision' => 'Utah',
+        'country' => 'United States'
       }
       expect(Typhoeus).to receive(:get).with("https://iplocate.io/api/lookup/1.2.3.4?apikey=#{ENV['IPLOCATE_API_KEY']}", {timeout: 5}).and_return(OpenStruct.new(body: geo.to_json))
       expect(Typhoeus).to receive(:post).with("https://api.hubapi.com/contacts/v1/contact/", {
@@ -156,6 +158,7 @@ describe ExternalTracker do
           {property: 'city', value: 'Sandy'},
           {property: 'username', value: u.user_name},
           {property: 'state', value: 'Utah'},
+          {property: 'country', value: 'United States'},
           {property: 'account_type', value: 'AT Specialist/Lending Library'},
           {property: 'hs_legal_basis', value: 'Legitimate interest – prospect/lead'}
         ]}.to_json,
@@ -179,7 +182,8 @@ describe ExternalTracker do
       geo = {
         'country_code' => 'US',
         'city' => 'Sandy',
-        'subdivision' => 'Utah'
+        'subdivision' => 'Utah',
+        'country' => 'United States'
       }
       expect(Typhoeus).to receive(:get).with("https://iplocate.io/api/lookup/1.2.3.4?apikey=#{ENV['IPLOCATE_API_KEY']}", {timeout: 5}).and_return(OpenStruct.new(body: geo.to_json))
       expect(Typhoeus).to receive(:post).with("https://api.hubapi.com/contacts/v1/contact/", {
@@ -190,6 +194,7 @@ describe ExternalTracker do
           {property: 'city', value: 'Sandy'},
           {property: 'username', value: u.user_name},
           {property: 'state', value: 'Utah'},
+          {property: 'country', value: 'United States'},
           {property: 'account_type', value: 'Therapist'},
           {property: 'hs_legal_basis', value: 'Legitimate interest – prospect/lead'}
         ]}.to_json,
@@ -197,6 +202,90 @@ describe ExternalTracker do
       }).and_return(OpenStruct.new(code: '201'))
       res = ExternalTracker.persist_new_user(u.global_id)
       expect(res).to eq('201')
+    end
+
+    it "should populate city/state/country for non-US locations" do
+      ENV['IPLOCATE_API_KEY'] = 'testkey'
+      u = User.create
+      u.settings['email'] = 'testing@example.com'
+      u.settings['preferences']['registration_type'] = 'therapist'
+      u.save
+      d = Device.create(:user => u)
+      d.settings['ip_address'] = '1.2.3.4'
+      d.save
+      ENV['HUBSPOT_ACCESS_TOKEN'] = 'hubby'
+      geo = {
+        'country_code' => 'FR',
+        'city' => 'Paris',
+        'subdivision' => 'Île-de-France',
+        'country' => 'France'
+      }
+      expect(Typhoeus).to receive(:get).with("https://iplocate.io/api/lookup/1.2.3.4?apikey=#{ENV['IPLOCATE_API_KEY']}", {timeout: 5}).and_return(OpenStruct.new(body: geo.to_json))
+      expect(Typhoeus).to receive(:post).with("https://api.hubapi.com/contacts/v1/contact/", {
+        body: {properties: [
+          {property: 'email', value: 'testing@example.com' },
+          {property: 'firstname', value: 'No'},
+          {property: 'lastname', value: 'name'},
+          {property: 'city', value: 'Paris'},
+          {property: 'username', value: u.user_name},
+          {property: 'state', value: 'Île-de-France'},
+          {property: 'country', value: 'France'},
+          {property: 'account_type', value: 'Therapist'},
+          {property: 'hs_legal_basis', value: 'Legitimate interest – prospect/lead'}
+        ]}.to_json,
+        headers: {'Content-Type' => 'application/json', "Authorization"=>"Bearer hubby"}
+      }).and_return(OpenStruct.new(code: '201'))
+      res = ExternalTracker.persist_new_user(u.global_id)
+      expect(res).to eq('201')
+    end
+
+    it "should send referrer (source, truncated to origin) and ad_referrer (ad key) when present" do
+      u = User.create
+      u.settings['email'] = 'testing@example.com'
+      u.settings['preferences'] ||= {}
+      u.settings['preferences']['registration_type'] = 'therapist'
+      # Full referring URL carries a path + query that could include PII; only the
+      # origin should leave the platform.
+      u.settings['referrer'] = 'https://mail.google.com/mail/u/0?email=foo@bar.com'
+      u.settings['ad_referrer'] = 'fb-spring-2026'
+      u.save
+      ENV['HUBSPOT_ACCESS_TOKEN'] = 'hubby'
+      expect(Typhoeus).to receive(:post).with("https://api.hubapi.com/contacts/v1/contact/", {
+        body: {properties: [
+          {property: 'email', value: 'testing@example.com' },
+          {property: 'firstname', value: 'No'},
+          {property: 'lastname', value: 'name'},
+          {property: 'city', value: nil},
+          {property: 'username', value: u.user_name},
+          {property: 'state', value: nil},
+          {property: 'country', value: nil},
+          {property: 'account_type', value: 'Therapist'},
+          {property: 'hs_legal_basis', value: 'Legitimate interest – prospect/lead'},
+          {property: 'lingolinq_referrer', value: 'https://mail.google.com'},
+          {property: 'lingolinq_ad_referrer', value: 'fb-spring-2026'}
+        ]}.to_json,
+        headers: {'Content-Type' => 'application/json', "Authorization"=>"Bearer hubby"}
+      }).and_return(OpenStruct.new(code: '201'))
+      res = ExternalTracker.persist_new_user(u.global_id)
+      expect(res).to eq('201')
+    end
+  end
+
+  describe "referrer_origin" do
+    it "should reduce a full URL to scheme+host" do
+      expect(ExternalTracker.referrer_origin('https://mail.google.com/mail/u/0?email=foo@bar.com')).to eq('https://mail.google.com')
+      expect(ExternalTracker.referrer_origin('http://example.com:8080/path#frag')).to eq('http://example.com')
+    end
+
+    it "should strip userinfo credentials from the origin" do
+      expect(ExternalTracker.referrer_origin('https://user:secret@host.example.com/x')).to eq('https://host.example.com')
+    end
+
+    it "should return nil for blank, hostless, or unparseable values" do
+      expect(ExternalTracker.referrer_origin(nil)).to eq(nil)
+      expect(ExternalTracker.referrer_origin('')).to eq(nil)
+      expect(ExternalTracker.referrer_origin('not a url')).to eq(nil)
+      expect(ExternalTracker.referrer_origin('javascript:alert(1)')).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
## What

Wires already-captured trial-registration data through to HubSpot. `ExternalTracker` previously only sent city/state for **US** IPs and never sent the **source** (`document.referrer`) or **ad key** (`?ref=` param), even though both are captured and stored at signup.

- **Location worldwide:** drop the US-only gate so city + region (`subdivision`) populate for every country, plus a new `country` field so US vs international leads stay distinguishable. iplocate returns these fields globally.
- **Source:** `settings['referrer']` to the new `lingolinq_referrer` property, **truncated to scheme+host** so a referring URL carrying PII in its path/query never leaves the platform (origin attribution preserved).
- **Ad key:** `settings['ad_referrer']` to the new `lingolinq_ad_referrer` property.

## HubSpot setup (already done)

Created three custom contact properties under Contact Information: `lingolinq_referrer`, `lingolinq_ad_referrer`, `lingolinq_start_code`. The start-code line existed in code but had always been a silent no-op because its property did not exist; it now lands.

## Compliance

GDPR: this widens the **already consent-gated, supporter-only** HubSpot sync (`cookies_opted_out?`, `supporter_registration?`, `external_email_allowed?`, legitimate-interest basis) to include EU city/region. No new consent surface. Referrer is truncated to origin to keep PII in URLs from egressing. Confirm HubSpot DPA covers EU contacts (standard).

## Tests

`spec/lib/external_tracker_spec.rb`: updated existing HubSpot expectations, added non-US (Paris) location case, source/ad-key (with origin truncation) case, and unit tests for the `referrer_origin` helper. **16 examples, 0 failures.**

## Reviewers

- `/review-pr` senior-dev pass: Approve with comments; the one High (referrer PII egress) was addressed via origin truncation in this PR.
- `/adversary-review`: pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)