### PR TITLE
ci: make secret-detection a blocking merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,13 @@ jobs:
           npm audit --audit-level=high || true
         continue-on-error: true
 
+  # Blocking gate. Unlike the advisory security-scan job above, a leaked secret
+  # MUST fail CI. To stay safe as a required check we scan only the secrets a PR /
+  # push actually INTRODUCES (the commit delta), never the full history: one
+  # historical false positive must not block every future merge. Pair this with
+  # the staging branch-protection required-status-checks list so it gates merge.
   secret-detection:
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout repository
@@ -181,7 +185,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run gitleaks (CLI - no license required)
+      - name: Download gitleaks (CLI - no license required)
         run: |
           GITLEAKS_DOWNLOAD_URL="$(curl -sSfL \
             --retry 3 \
@@ -192,4 +196,16 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/gitleaks/gitleaks/releases/latest | python3 -c "import json, sys; release=json.load(sys.stdin); print(next(asset['browser_download_url'] for asset in release['assets'] if asset['name'].endswith('_linux_x64.tar.gz')))")"
           curl -sSfL --retry 3 --retry-delay 2 --retry-all-errors "$GITLEAKS_DOWNLOAD_URL" | tar -xz gitleaks
-          ./gitleaks detect --source . --log-opts="--all" --exit-code 1 || true
+
+      - name: Scan for newly-introduced secrets (blocking)
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+          elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            RANGE="${{ github.event.before }}..${{ github.sha }}"
+          else
+            RANGE="${{ github.sha }}~1..${{ github.sha }}"
+          fi
+          echo "Scanning commit range for secrets: $RANGE"
+          # --redact keeps any matched secret value out of the public CI log.
+          ./gitleaks detect --source . --log-opts="$RANGE" --redact --exit-code 1


### PR DESCRIPTION
## Why

From the 2026-06-14 review-workflow evaluation: `secret-detection` was advisory (`continue-on-error: true` + gitleaks `|| true`), so a committed secret could never fail CI. Combined with staging having **no required status checks**, every quality gate was honor-system.

## What

- **Make `secret-detection` blocking** (drop `continue-on-error`, drop `|| true`).
- **Scope gitleaks to the PR/push delta**, not full history, so one historical false positive can't permanently block merges. `--redact` keeps matched values out of the public log.
- This is the code half of recommendation #1/#3. The repo-settings half (enabling required status checks on `staging` branch protection: `rspec`, `build-and-test`, `audit-artifacts-integrity`, `secret-detection`) is applied separately via the GitHub API.

## Scope note

Left `security-scan` (Brakeman / bundle-audit / npm-audit) advisory on purpose — more false-positive surface; can be tightened later. This PR is intentionally tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)