### PR TITLE
fix(converters): accept ext_coughdrop_* namespace on OBF/OBZ import

### DIFF
--- a/lib/converters/lingo_linq.rb
+++ b/lib/converters/lingo_linq.rb
@@ -3,6 +3,19 @@ require 'obf'
 module Converters::LingoLinq
   EXT_PARAMS = ['link_disabled', 'add_to_vocalization', 'add_vocalization', 'hide_label', 'home_lock', 'blocking_speech', 'part_of_speech', 'external_id', 'video', 'book']
 
+  # OpenBoards / CoughDrop-origin OBF/OBZ files namespace their extension
+  # attributes as ext_coughdrop_*, while LingoLinq exports use ext_lingolinq_*.
+  # LingoLinq is a CoughDrop fork, so accept either namespace on import. Without
+  # this, button settings like hide_label and add_vocalization (and board-level
+  # settings/background) are silently dropped from upstream boards. Prefers the
+  # ext_lingolinq_* value when both are present.
+  def self.ext_attr(obj, param)
+    return nil unless obj
+    val = obj["ext_lingolinq_#{param}"]
+    val = obj["ext_coughdrop_#{param}"] if val.nil?
+    val
+  end
+
   def self.to_obf(board, dest_path, path_hash=nil)
     json = nil
     Progress.as_percent(0, 0.1) do
@@ -299,10 +312,11 @@ module Converters::LingoLinq
     raise "user required" unless opts['user']
     raise "missing id" unless obj['id']
     protected_sources = opts['user'] ? opts['user'].enabled_protected_sources(true) : []
-    if obj['ext_lingolinq_settings'] && obj['ext_lingolinq_settings']['protected'] && obj['ext_lingolinq_settings']['key']
+    guard_settings = Converters::LingoLinq.ext_attr(obj, 'settings') || {}
+    if guard_settings['protected'] && guard_settings['key']
       importer = opts['user']
-      board_owner_id = obj['ext_lingolinq_settings']['protected_user_id']
-      user_name = obj['ext_lingolinq_settings']['key'].split(/\//)[0]
+      board_owner_id = guard_settings['protected_user_id']
+      user_name = guard_settings['key'].split(/\//)[0]
       # Allow import if: (1) key says same user, (2) importer is board owner, or
       # (3) importer has edit permission on the board owner (supervisor/manager)
       board_owner = board_owner_id && User.find_by_global_id(board_owner_id)
@@ -376,7 +390,7 @@ module Converters::LingoLinq
     non_user_params = {'user' => opts['user']}
     params['name'] = obj['name']
     params['description'] = obj['description_html']
-    params['image_url'] = obj['ext_lingolinq_image_url'] || obj['image_url']
+    params['image_url'] = Converters::LingoLinq.ext_attr(obj, 'image_url') || obj['image_url']
     params['license'] = OBF::Utils.parse_license(obj['license'])
     params['locale'] = obj['locale'] || 'en'
 
@@ -417,9 +431,8 @@ module Converters::LingoLinq
         new_button['sound_id'] = hashes[button['sound_id']]
       end
       EXT_PARAMS.each do |param|
-        if button["ext_lingolinq_#{param}"]
-          new_button[param] = button["ext_lingolinq_#{param}"]
-        end
+        val = Converters::LingoLinq.ext_attr(button, param)
+        new_button[param] = val if val
       end
 
       if button['translations']
@@ -434,7 +447,8 @@ module Converters::LingoLinq
           end
           ref['label'] ||= hash['label'] if hash['label']
           ref['vocalization'] ||= hash['vocalization'] if hash['vocalization']
-          ref['rules'] ||= hash['ext_lingolinq_rules'] if hash['ext_lingolinq_rules']
+          trans_rules = Converters::LingoLinq.ext_attr(hash, 'rules')
+          ref['rules'] ||= trans_rules if trans_rules
           (hash['inflections'] || {}).each do |key, str|
             if str == 'ext_lingolinq_defaults'
             elsif loc_hash[key] && !(hash['inflections']['ext_lingolinq_defaults'] || []).include?(key)
@@ -458,8 +472,9 @@ module Converters::LingoLinq
           end
         end
       elsif button['url']
-        if button['ext_lingolinq_apps']
-          new_button['apps'] = button['ext_lingolinq_apps']
+        ext_apps = Converters::LingoLinq.ext_attr(button, 'apps')
+        if ext_apps
+          new_button['apps'] = ext_apps
         else
           new_button['url'] = button['url']
         end
@@ -467,18 +482,20 @@ module Converters::LingoLinq
       new_button
     end
     params['grid'] = obj['grid']
-    params['public'] = !(obj['ext_lingolinq_settings'] && obj['ext_lingolinq_settings']['private'])
-    params['home_board'] = (obj['ext_lingolinq_settings'] || {})['home_board'] || false
-    params['categories'] = (obj['ext_lingolinq_settings'] || {})['categories'] || []
-    params['word_suggestions'] = obj['ext_lingolinq_settings'] && obj['ext_lingolinq_settings']['word_suggestions']
-    params['text_only'] = (obj['ext_lingolinq_settings'] || {})['text_only'] || false
-    params['hide_empty'] = (obj['ext_lingolinq_settings'] || {})['hide_empty'] || false
+    ext_settings = Converters::LingoLinq.ext_attr(obj, 'settings') || {}
+    params['public'] = !ext_settings['private']
+    params['home_board'] = ext_settings['home_board'] || false
+    params['categories'] = ext_settings['categories'] || []
+    params['word_suggestions'] = ext_settings['word_suggestions']
+    params['text_only'] = ext_settings['text_only'] || false
+    params['hide_empty'] = ext_settings['hide_empty'] || false
 
-    if obj['ext_lingolinq_background'] || obj['background']
-      params['background'] = obj['ext_lingolinq_background'] || obj['background']
+    ext_background = Converters::LingoLinq.ext_attr(obj, 'background')
+    if ext_background || obj['background']
+      params['background'] = ext_background || obj['background']
     end
 
-    non_user_params[:key] = (obj['ext_lingolinq_settings'] && obj['ext_lingolinq_settings']['key'] && obj['ext_lingolinq_settings']['key'].split(/\//)[-1])
+    non_user_params[:key] = (ext_settings['key'] && ext_settings['key'].split(/\//)[-1])
     board = nil
     if opts['boards'] && opts['boards'][obj['id']]
       board = Board.find_by_path(opts['boards'][obj['id']]['id']) || Board.find_by_path(opts['boards'][obj['id']]['key'])
@@ -572,7 +589,8 @@ module Converters::LingoLinq
         board = Board.find_by_path(opts['boards'][obj['id']]['id']) || Board.find_by_path(opts['boards'][obj['id']]['key'])
       else
         non_user_params = {'user' => opts['user']}
-        non_user_params[:key] = (obj['ext_lingolinq_settings'] && obj['ext_lingolinq_settings']['key'] && obj['ext_lingolinq_settings']['key'].split(/\//)[-1])
+        preload_settings = Converters::LingoLinq.ext_attr(obj, 'settings') || {}
+        non_user_params[:key] = (preload_settings['key'] && preload_settings['key'].split(/\//)[-1])
         params = {}
         params['name'] = obj['name']
         board = Board.process_new(params, non_user_params)

--- a/lib/converters/lingo_linq.rb
+++ b/lib/converters/lingo_linq.rb
@@ -432,7 +432,10 @@ module Converters::LingoLinq
       end
       EXT_PARAMS.each do |param|
         val = Converters::LingoLinq.ext_attr(button, param)
-        new_button[param] = val if val
+        # Set on presence, not truthiness, so an explicit boolean false
+        # (e.g. hide_label: false) is preserved rather than dropped to the
+        # LingoLinq default. Several EXT_PARAMS are booleans.
+        new_button[param] = val unless val.nil?
       end
 
       if button['translations']

--- a/spec/lib/converters/lingo_linq_spec.rb
+++ b/spec/lib/converters/lingo_linq_spec.rb
@@ -752,7 +752,57 @@ describe Converters::LingoLinq do
       expect(button['url']).to eq(nil)
       expect(button['apps']).to eq({'a' => 1})
     end
-    
+
+    it "should accept the ext_coughdrop_* namespace on import (CoughDrop/OpenBoards origin)" do
+      u = User.create
+      shell = OBF::Utils.obf_shell
+      shell['id'] = '3001'
+      shell['name'] = "Cool Board"
+      shell['buttons'] = [{
+        'id' => '1',
+        'label' => 'hardly',
+        'url' => 'http://www.example.com',
+        'ext_coughdrop_apps' => {'a' => 1}
+      }]
+      b = Converters::LingoLinq.from_obf(shell, {'user' => u})
+      button = b.settings['buttons'][0]
+      expect(button['url']).to eq(nil)
+      expect(button['apps']).to eq({'a' => 1})
+    end
+
+    it "should prefer ext_lingolinq_* over ext_coughdrop_* when both are present" do
+      u = User.create
+      shell = OBF::Utils.obf_shell
+      shell['id'] = '3002'
+      shell['name'] = "Cool Board"
+      shell['buttons'] = [{
+        'id' => '1',
+        'label' => 'hardly',
+        'url' => 'http://www.example.com',
+        'ext_lingolinq_apps' => {'a' => 'lingo'},
+        'ext_coughdrop_apps' => {'a' => 'cough'}
+      }]
+      b = Converters::LingoLinq.from_obf(shell, {'user' => u})
+      expect(b.settings['buttons'][0]['apps']).to eq({'a' => 'lingo'})
+    end
+
+    it "should preserve an explicit boolean false button setting on import" do
+      u = User.create
+      shell = OBF::Utils.obf_shell
+      shell['id'] = '3003'
+      shell['name'] = "Cool Board"
+      shell['buttons'] = [{
+        'id' => '1',
+        'label' => 'go',
+        'ext_coughdrop_hide_label' => false
+      }]
+      b = Converters::LingoLinq.from_obf(shell, {'user' => u})
+      button = b.settings['buttons'][0]
+      # Before the fix this dropped to nil (the old `if val` guard skipped
+      # false); now an explicit false survives import.
+      expect(button['hide_label']).to eq(false)
+    end
+
     it "should not allow importing a protected board for a different user than the original user" do
       u = User.create
       u.settings['email'] = 'fred@example.com'


### PR DESCRIPTION
## Problem

Word/letter buttons (the "WordArt" buttons: keyboard keys, inflection words, plain-text buttons) imported from OpenBoards / OpenAAC vocabulary sets render as missing-image placeholders. Symbol buttons import fine; text buttons lose their label and button-level settings.

## Root cause

`Converters::LingoLinq` only read extension attributes from the `ext_lingolinq_*` namespace. OpenBoards / CoughDrop-origin OBF/OBZ files namespace those same attributes as `ext_coughdrop_*` (LingoLinq is a CoughDrop fork). Every `ext_lingolinq_*` read silently dropped the upstream value, so `hide_label`, `add_vocalization`, the board-level settings block, background, protected-board key, and image_url were all lost on import.

## Fix

A single helper, `Converters::LingoLinq.ext_attr(obj, param)`, that reads `ext_lingolinq_<param>` and falls back to `ext_coughdrop_<param>`. Applied uniformly across all 9 read sites (button EXT_PARAMS loop, image_url, translation rules, button apps, board settings block, background, board key, protected-board guard, and the from_external_nested preload).

- Prefers `ext_lingolinq_*` when both namespaces are present, so existing LingoLinq exports are unaffected (backward compatible).
- Returns `nil` only when both are absent, so falsey-but-present values are preserved.

## Testing

`DB_USER=scotw bundle exec rspec spec/lib/converters/lingo_linq_spec.rb` → 54 examples, 0 failures, 3 pending (pre-existing).

## Merge order

This is the root-cause fix the vocabulary-library data relies on to render correctly. Merge this **before** #scot/feat/system-vocab-library (the imported keyboard / Senner-Baud / Project Core boards will only render their word buttons correctly once this lands).

## Not covered here

Defect B (blue image placeholders from S3 re-host at import) is a separate issue, tracked for a follow-up after a real seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)