### PR TITLE
fix(compliance): anchor calendar-render window to generatedDate, not Date.today

### DIFF
--- a/scripts/compliance-calendar-render.rb
+++ b/scripts/compliance-calendar-render.rb
@@ -28,7 +28,6 @@ end
 
 data = JSON.parse(File.read(json_path))
 meta = data['meta'] || {}
-generated = meta['generatedDate'] || Time.now.utc.strftime('%Y-%m-%d')
 owner = meta['owner'] || 'compliance-officer'
 
 def framework_label(fw)
@@ -47,8 +46,25 @@ rescue ArgumentError
   nil
 end
 
-today = Date.today
-window_end = today + 90
+# Resolve the calendar's generation date ONCE and use it for BOTH the header and the "due within
+# 90 days / overdue" window, so the render is a PURE function of the JSON (the render on disk
+# changes only when the JSON changes). Anchoring the window to Date.today made it drift every day
+# as items crossed the 90-day boundary, reddening `--check` on every PR built on a later date even
+# when nobody touched the calendar. The .md is a dated snapshot ("Generated: <date>"); live "what
+# is due right now" is surfaced by /compliance-status, not by this static render.
+#
+# A present-but-malformed generatedDate is a hand-edit mistake: fail loudly rather than silently
+# falling back to the wall clock (which would reintroduce the very drift this guards against). Only
+# a fully ABSENT generatedDate falls back to today, for an undated scratch JSON.
+if meta.key?('generatedDate')
+  generated_date = parse_date(meta['generatedDate']) ||
+    abort("compliance-calendar-render: meta.generatedDate present but unparseable: #{meta['generatedDate'].inspect}")
+else
+  generated_date = Date.today
+end
+generated = generated_date.strftime('%Y-%m-%d')
+window_anchor = generated_date
+window_end = window_anchor + 90
 
 recurring = data['recurringReviews'] || []
 fixed = data['fixedRegulatoryDates'] || []


### PR DESCRIPTION
## Problem

The `audit-artifacts-integrity` CI job runs `ruby scripts/compliance-calendar-render.rb --check`, which re-renders `compliance-calendar.md` from its JSON and string-compares against the committed render. The render computed its **"Due within 90 days or overdue"** window from `Date.today`, so the 90-day window slid with the wall clock. Items crossed the boundary as days passed, the committed render drifted from a fresh one, and `--check` went **red on every PR built on a date later than the calendar's last regeneration** - even when nobody touched the calendar. This was blocking unrelated PRs (surfaced on #396).

## Root cause

The render was an **impure function of the clock**, while a "render matches JSON" check must be a **pure function of the JSON**.

## Fix

Resolve the generation date once from `meta.generatedDate` (a JSON field) and use it for **both** the header and the due/overdue window:
- **Present + valid** generatedDate -> window anchored to it; render is now pure w.r.t. the JSON.
- **Present + malformed** -> **hard error** (a hand-edit mistake; silently falling back to the clock would reintroduce the drift this guards against).
- **Absent** -> falls back to `Date.today` (undated scratch JSON; preserves prior behavior).

Also harmonizes the header and window onto one date source (the header previously used `Time.now.utc` while the window used `Date.today`, which could disagree by a day across the UTC/local midnight boundary in the fallback).

## Why no `.md` change

The committed `compliance-calendar.md` was generated on its own `generatedDate` (2026-06-14), so `--check` now passes against the **existing** render with no regeneration, and it will not drift again until the JSON itself changes.

## Verification

- `--check` exits 0, re-render yields no `.md` diff.
- Malformed `generatedDate` (`2026-13-99`) exits 1 with a clear message.
- Absent `generatedDate` still renders via the today fallback.
- Sibling `compliance-notion-publish.rb --check` confirmed free of the same class of bug (it already masks its timestamp).

## Review

Reviewed by the Claude `reviewer` agent (Claude-only compliance toolchain; **not** routed to Codex/DeepSeek). No Critical/High. The Medium it raised (silent fallback on a malformed-but-present date) is fixed here via the hard-error path. One Low (no `spec/` coverage for this standalone script) is deliberately not addressed: there is no existing spec pattern for these scripts and the CI `--check` is the live guard; the pure-function property is now structural (`Date.today` fires only in the absent-key branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)