### PR TITLE
test(specs): stabilize repo-wide Worker.scheduled? rspec flake

### DIFF
--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -4671,3 +4671,38 @@ instruct finders to cite the WCAG SC number in emitted fields and reference EN 3
 3-part parent clause (`9.1.4`) or in prose. Verified 2026-06-15 via a /tmp dry-run: with `9.1.4.3`
 in `notes` -> merge `skipped=1 (refused: pii:ip)`; with `9.1.4` -> merge `new=1`, citation-check
 PASS. Evidence: `scripts/audit-merge.rb` PII_PATTERNS[:ip]; `.claude/skills/accessibility-audit/SKILL.md`.
+
+## Gotcha: `Worker.scheduled?` specs flake repo-wide off BoyBand's stale 30s `sizeof/<queue>` cache
+
+`Worker.scheduled?` -> `BoyBand::WorkerMethods#scheduled_for?` short-circuits with
+`return false if idx > 500`, where `idx = queue_size(queue)` reads a Redis cache
+`sizeof/<queue>` with a **30-second TTL** that only recomputes when the cached value is `0`.
+`Worker.flush_queues` (run in `spec_helper.rb` `before(:each)`) empties the queue LISTS but
+never clears that cache. So one earlier example that pushes `sizeof/default` past 500 makes
+EVERY `Worker.scheduled?` return a FALSE NEGATIVE (`expected true, got false`) for the next 30
+WALL-CLOCK seconds - regardless of the flushed queue. Whether a given spec lands in that window
+varies run-to-run, so it presents as a random "timing" flake that passes on re-run. It is
+repo-wide: 38 spec files / 201 `scheduled?` assertion sites are exposed; `external_tracker_spec:16`
+and `flusher_spec:403` are just the most frequently bitten. Two traps: (1) "force Resque inline"
+is the WRONG fix - these specs assert the job IS queued, and inline runs it and empties the queue,
+failing them deterministically; (2) `config.order = "defined"` + single-process CI + fresh Redis
+rules out order-dependence and cross-process races, so the only nondeterminism is wall-clock vs the
+TTL. Fix (verified): in `before(:each)` after `flush_queues`, also
+`Resque.redis.keys('sizeof/*').each{|k| Resque.redis.del(k)}` and the same for `*_queue_size`
+(`RedisInit#queue_size`'s separate 5-min cache). Deterministic repro:
+`redis-cli set lingolinq-test:sizeof/default 600` then run the two specs -> exact CI failure;
+clearing the cache makes them pass. Evidence: `boy_band-0.1.16/lib/boy_band.rb:43,266`;
+`spec/spec_helper.rb` before(:each); CI run 27601259798.
+
+## Gotcha: local `lingolinq-test` `bad decrypt` at boot from a stale `encryption_hash` sentinel row
+
+Running rspec locally can fail at environment load with
+`OpenSSL::Cipher::CipherError: bad decrypt` in `Setting.get` (config/environment.rb -> spec_helper).
+Cause: the test DB holds a single `settings` row `key='encryption_hash'` (GoSecure's
+key-validation sentinel) encrypted with a SECURE key pair that no longer matches the effective env.
+`spec_helper` loads `.env.op.template` BEFORE `.env`, and dotenv does not override already-set vars,
+so `.env.op.template`'s `SECURE_NONCE_KEY` shadows `.env`'s and breaks the encryption pair. CI never
+hits this because it uses `db:create db:schema:load` (fresh DB, no `encryption_hash` row -> no
+decrypt). Local fix (test DB only, regenerates on boot):
+`psql -U scotw -d lingolinq-test -c "delete from settings where key='encryption_hash'"`. Do not
+"fix" it by editing the dotenv load order in spec_helper.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,16 +57,21 @@ RSpec.configure do |config|
     ENV['DEFAULT_HOST'] ||= 'http://test.host'  # ensure URL generation is consistent in specs
     Time.zone = nil
     Worker.flush_queues
-    # flush_queues empties the queue lists but leaves the cached queue sizes in
-    # place: BoyBand's `sizeof/<queue>` cache (30s TTL, read by scheduled_for?)
-    # and RedisInit's `<queue>_queue_size` cache (5min TTL). queue_size only
-    # recomputes once the cached value reaches 0, so a single earlier example
-    # that inflates the cached size past 500 makes scheduled_for? hit its
-    # `return false if idx > 500` short-circuit and report false negatives for
-    # the rest of that cache window -- a wall-clock-timed flake that fails
-    # Worker.scheduled? assertions at random (see external_tracker_spec:16,
-    # flusher_spec:403). Clearing both caches forces a recompute against the
-    # real (just-flushed) queue so scheduling assertions are deterministic.
+    # flush_queues empties the queue lists but leaves two separate Redis size
+    # caches in place, and neither recomputes until its cached value reaches 0:
+    #   * BoyBand's `sizeof/<queue>` (30s TTL) is read by `scheduled_for?`, which
+    #     short-circuits `return false if idx > 500`. A single earlier example
+    #     that inflates the cached size past 500 then makes EVERY Worker.scheduled?
+    #     report false negatives for the rest of that 30s window -- a wall-clock
+    #     -timed flake that fails scheduling assertions at random (see
+    #     external_tracker_spec:16, flusher_spec:403). This is the cache that
+    #     drives the flake.
+    #   * RedisInit's `<queue>_queue_size` (5min TTL) is read by
+    #     `any_queue_pressure?` (not by scheduled?), which gates whether some jobs
+    #     get scheduled at all. `reset_queue_pressure_cache!` below only clears the
+    #     in-process memo, not this Redis key, so clearing it here closes a
+    #     separate staleness gap.
+    # Clearing both forces a recompute against the real (just-flushed) queue.
     Resque.redis.keys('sizeof/*').each { |k| Resque.redis.del(k) }
     Resque.redis.keys('*_queue_size').each { |k| Resque.redis.del(k) }
     # When S3 credentials aren't configured (e.g. CI/GitHub Actions), stub remote_upload_params

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,18 @@ RSpec.configure do |config|
     ENV['DEFAULT_HOST'] ||= 'http://test.host'  # ensure URL generation is consistent in specs
     Time.zone = nil
     Worker.flush_queues
+    # flush_queues empties the queue lists but leaves the cached queue sizes in
+    # place: BoyBand's `sizeof/<queue>` cache (30s TTL, read by scheduled_for?)
+    # and RedisInit's `<queue>_queue_size` cache (5min TTL). queue_size only
+    # recomputes once the cached value reaches 0, so a single earlier example
+    # that inflates the cached size past 500 makes scheduled_for? hit its
+    # `return false if idx > 500` short-circuit and report false negatives for
+    # the rest of that cache window -- a wall-clock-timed flake that fails
+    # Worker.scheduled? assertions at random (see external_tracker_spec:16,
+    # flusher_spec:403). Clearing both caches forces a recompute against the
+    # real (just-flushed) queue so scheduling assertions are deterministic.
+    Resque.redis.keys('sizeof/*').each { |k| Resque.redis.del(k) }
+    Resque.redis.keys('*_queue_size').each { |k| Resque.redis.del(k) }
     # When S3 credentials aren't configured (e.g. CI/GitHub Actions), stub remote_upload_params
     # so tests that exercise upload JSON paths don't fail. In development with .env loaded,
     # real credentials are used when available.


### PR DESCRIPTION
## Problem
The required `rspec` check flakes **repo-wide** on the `Worker.scheduled?` Resque specs and fails on `staging` itself, not just PRs - it just forced an admin-merge. Latest staging CI (run 27601259798) failed with:

```
expect(Worker.scheduled?(ExternalTracker, :persist_new_user, u.global_id)).to eq(true)
  expected: true
       got: false      # external_tracker_spec.rb:22 (the :16 example)
expect(Worker.scheduled?(Flusher, :flush_user_completely, u2.global_id, u2.user_name)).to eq(true)
  expected: true
       got: false      # flusher_spec.rb:409 (the :403 example)
```

Both are **false negatives** - the job IS scheduled, `scheduled?` just can't find it.

## Root cause (verified, not guessed)
`BoyBand::WorkerMethods#scheduled_for?` (`boy_band-0.1.16`) short-circuits:
```ruby
idx = queue_size(queue)        # cached size
return false if idx > 500      # "big queues mustn't be searched this way"
```
`queue_size` caches `sizeof/<queue>` in Redis with a **30s TTL** and only recomputes when the cached value is `0`. `Worker.flush_queues` (in `spec_helper.rb` `before(:each)`) empties the queue *lists* but **never clears that cache**. So once any earlier example inflates `sizeof/default` past 500, every `Worker.scheduled?` returns `false` for the next **30 wall-clock seconds**, regardless of the now-flushed queue. Whether a spec lands in that window varies run-to-run (machine speed, GC) -> a timing flake that passes on re-run.

`config.order = "defined"` + single-process CI + a fresh Redis service rule out order-dependence and cross-process races, leaving wall-clock-vs-TTL as the only nondeterminism. (`RedisInit.reset_queue_pressure_cache!` only nils an in-memory var; it does not touch any Redis size key.)

### Deterministic reproduction
```
redis-cli set "lingolinq-test:sizeof/default" 600
bundle exec rspec spec/lib/external_tracker_spec.rb:16 spec/lib/flusher_spec.rb:403
# => both fail with the exact "expected true, got false" CI signature
```
Without the seed, both pass.

## Fix
In `before(:each)`, right after `Worker.flush_queues`, clear both size caches so `queue_size` recomputes against the real (flushed) queue:
```ruby
Resque.redis.keys('sizeof/*').each { |k| Resque.redis.del(k) }
Resque.redis.keys('*_queue_size').each { |k| Resque.redis.del(k) }
```
- **Systemic, not per-spec:** 38 spec files / 201 `scheduled?`/`scheduled_actions` assertion sites were exposed - this protects all of them, which is why the flake was repo-wide.
- **No regression risk:** no spec tests the size-cache behavior; recomputing the true post-flush size is strictly more correct.
- **Why not "Resque inline":** these specs assert the job IS queued; inline would run it and empty the queue, failing them deterministically. Wrong tool.

## Verification
- Seeding `sizeof/default=600` (and `999`) before the run: both specs now **pass** because `before(:each)` clears the cache.
- The only other failures in those files locally (`flusher_spec:144,204,234`, `ButtonImage.count` 1509 vs 3) are the pre-existing orphaned-committed-rows issue in a local test DB; absent on CI's fresh DB and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)