### PR TITLE
fix(redis): enable TLS for rediss:// (Memorystore) while leaving redis:// unchanged

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -7,6 +7,49 @@ module RedisInit
     URI.parse(redis_url)
   end
 
+  # Builds the option hash for Redis.new from a parsed redis URI. Backward
+  # compatible: a redis:// URI yields exactly the historical {host, port,
+  # password} hash with no :ssl key, so the Render environment is unchanged.
+  # A rediss:// URI (GCP Memorystore with AUTH + TLS, SERVER_AUTHENTICATION
+  # mode) additionally enables :ssl and validates the server cert against the
+  # supplied CA. SERVER_AUTHENTICATION presents no client cert.
+  def self.redis_options(uri, extra = {})
+    opts = { :host => uri.host, :port => uri.port, :password => uri.password }
+    if uri.scheme == 'rediss'
+      opts[:ssl] = true
+      ssl_params = redis_ssl_params
+      opts[:ssl_params] = ssl_params unless ssl_params.empty?
+    end
+    opts.merge(extra)
+  end
+
+  # SSL params for a rediss:// (TLS) connection, passed straight to
+  # OpenSSL::SSL::SSLContext#set_params by redis-rb. Prefers a CA file path
+  # (REDIS_CA_FILE), falling back to inline PEM contents (REDIS_CA_CERT) which
+  # suits Cloud Run + Secret Manager where mounting a file is extra work.
+  # Either source may hold multiple concatenated certificates so a Memorystore
+  # CA rotation does not drop the connection. When neither is set the OpenSSL
+  # default trust store is used (verification still on); the Memorystore
+  # per-instance CA is NOT in that store, so one of these env vars must be set
+  # against a live instance.
+  def self.redis_ssl_params
+    require 'openssl'
+
+    ca_file = ENV['REDIS_CA_FILE']
+    return { :ca_file => ca_file } if ca_file && !ca_file.empty?
+
+    ca_cert = ENV['REDIS_CA_CERT']
+    if ca_cert && !ca_cert.empty?
+      store = OpenSSL::X509::Store.new
+      ca_cert.scan(/-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m).each do |pem|
+        store.add_cert(OpenSSL::X509::Certificate.new(pem))
+      end
+      return { :cert_store => store }
+    end
+
+    {}
+  end
+
   def self.init
     uri = redis_uri
     return if !uri && ENV['SKIP_VALIDATIONS']
@@ -20,10 +63,10 @@ module RedisInit
     end
     @ns_suffix = ns_suffix
     if defined?(Resque)
-      Resque.redis = Redis.new(:host => uri.host, :port => uri.port, :password => uri.password)
+      Resque.redis = Redis.new(redis_options(uri))
       Resque.redis.namespace = "lingolinq#{ns_suffix}"
     end
-    @redis_inst = Redis.new(:host => uri.host, :port => uri.port, :password => uri.password, :timeout => 5)
+    @redis_inst = Redis.new(redis_options(uri, :timeout => 5))
     @default = Redis::Namespace.new("lingolinq-stash#{ns_suffix}", :redis => @redis_inst)
     @permissions = Redis::Namespace.new("lingolinq-permissions#{ns_suffix}", :redis => @redis_inst)
     self.cache_token = 'abc'
@@ -57,7 +100,7 @@ module RedisInit
 
   def self.errors
     uri = RedisInit.redis_uri
-    redis = Redis.new(:host => uri.host, :port => uri.port, :password => uri.password)
+    redis = Redis.new(redis_options(uri))
     key = "lingolinq#{@ns_suffix}:failed"
     redis.type(key)
     len = redis.llen(key)
@@ -107,7 +150,7 @@ module RedisInit
 
   def self.size_check(verbose=false)
     uri = redis_uri
-    redis = Redis.new(:host => uri.host, :port => uri.port, :password => uri.password)
+    redis = Redis.new(redis_options(uri))
     total =  0
     prefixes = {}
     redis.keys.each do |key|

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -41,15 +41,22 @@ module RedisInit
     ca_cert = ENV['REDIS_CA_CERT']
     if ca_cert && !ca_cert.empty?
       store = OpenSSL::X509::Store.new
+      added = 0
       ca_cert.scan(/-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m).each do |pem|
         begin
           store.add_cert(OpenSSL::X509::Certificate.new(pem))
-        rescue OpenSSL::X509::StoreError
-          # A duplicate cert (e.g. an old + new blob that overlap during a CA
-          # rotation) raises "cert already in hash table"; skip it rather than
-          # crashing boot, which would defeat the rotation resilience above.
+          added += 1
+        rescue OpenSSL::OpenSSLError
+          # Skip a bad cert rather than crashing boot, which would defeat the
+          # rotation resilience above. Both failure modes descend from
+          # OpenSSLError: a duplicate (old + new blob overlapping during a CA
+          # rotation) raises X509::StoreError ("cert already in hash table"),
+          # and a malformed body inside valid fences raises X509::CertificateError.
         end
       end
+      # Name the misconfiguration at boot rather than failing later as an opaque
+      # handshake error: REDIS_CA_CERT was set but produced no usable anchors.
+      raise 'REDIS_CA_CERT set but no valid certificates parsed' if added == 0
       return { :cert_store => store }
     end
 

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -42,7 +42,13 @@ module RedisInit
     if ca_cert && !ca_cert.empty?
       store = OpenSSL::X509::Store.new
       ca_cert.scan(/-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m).each do |pem|
-        store.add_cert(OpenSSL::X509::Certificate.new(pem))
+        begin
+          store.add_cert(OpenSSL::X509::Certificate.new(pem))
+        rescue OpenSSL::X509::StoreError
+          # A duplicate cert (e.g. an old + new blob that overlap during a CA
+          # rotation) raises "cert already in hash table"; skip it rather than
+          # crashing boot, which would defeat the rotation resilience above.
+        end
       end
       return { :cert_store => store }
     end

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -9,7 +9,7 @@ module Throttling
     uri = RedisInit.redis_uri
     unless ENV['SKIP_VALIDATIONS']
       raise "redis URI needed for throttling" unless uri
-      redis = Redis.new(:host => uri.host, :port => uri.port, :password => uri.password)
+      redis = Redis.new(RedisInit.redis_options(uri))
       redis = Redis::Namespace.new("throttling", :redis => redis)
       Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisProxy.new(redis)
     end

--- a/spec/initializers/resque_redis_options_spec.rb
+++ b/spec/initializers/resque_redis_options_spec.rb
@@ -82,5 +82,40 @@ describe RedisInit do
       expect { RedisInit.redis_options(rediss_uri) }.not_to raise_error
       expect(RedisInit.redis_options(rediss_uri)[:ssl_params][:cert_store]).to be_a(OpenSSL::X509::Store)
     end
+
+    it 'skips a malformed (fenced-but-garbage) cert without crashing if a good one remains' do
+      key = OpenSSL::PKey::RSA.new(2048)
+      garbage = "-----BEGIN CERTIFICATE-----\nnot-valid-base64!!!\n-----END CERTIFICATE-----\n"
+      ENV['REDIS_CA_CERT'] = build_cert(key, 'ca-good').to_pem + garbage
+      expect { RedisInit.redis_options(rediss_uri) }.not_to raise_error
+      expect(RedisInit.redis_options(rediss_uri)[:ssl_params][:cert_store]).to be_a(OpenSSL::X509::Store)
+    end
+
+    it 'raises a named error when REDIS_CA_CERT is set but yields zero valid certs' do
+      ENV['REDIS_CA_CERT'] = "-----BEGIN CERTIFICATE-----\nnope\n-----END CERTIFICATE-----\n"
+      expect { RedisInit.redis_options(rediss_uri) }.to raise_error(/no valid certificates/)
+    end
+  end
+
+  # The load-bearing security property: the ssl_params we hand to redis-rb must
+  # produce a context that actually verifies the server cert (VERIFY_PEER), in
+  # both the inline-CA and no-CA rediss:// cases. redis-rb forwards ssl_params
+  # to OpenSSL::SSL::SSLContext#set_params, so mirror that here. Guards against a
+  # future refactor silently downgrading to VERIFY_NONE.
+  describe 'TLS verification is enforced for rediss://' do
+    def verify_mode_for(opts)
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.set_params(opts[:ssl_params] || {})
+      ctx.verify_mode
+    end
+
+    it 'verifies the peer when no CA env is set (system store)' do
+      expect(verify_mode_for(RedisInit.redis_options(rediss_uri))).to eq(OpenSSL::SSL::VERIFY_PEER)
+    end
+
+    it 'verifies the peer when an inline CA is supplied' do
+      ENV['REDIS_CA_CERT'] = build_cert(OpenSSL::PKey::RSA.new(2048), 'ca').to_pem
+      expect(verify_mode_for(RedisInit.redis_options(rediss_uri))).to eq(OpenSSL::SSL::VERIFY_PEER)
+    end
   end
 end

--- a/spec/initializers/resque_redis_options_spec.rb
+++ b/spec/initializers/resque_redis_options_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'openssl'
+
+# Locks the backward-compatibility guarantee of RedisInit.redis_options: a
+# redis:// URI must keep producing the exact legacy connection hash (so the
+# Render environment is untouched), while a rediss:// URI (GCP Memorystore,
+# AUTH + TLS, SERVER_AUTHENTICATION) enables :ssl and validates against the
+# supplied CA. See config/initializers/resque.rb.
+describe RedisInit do
+  let(:redis_uri)  { URI.parse('redis://:secret@redis.example:6379') }
+  let(:rediss_uri) { URI.parse('rediss://:secret@redis.example:6378') }
+
+  # Self-signed certs built in-memory; no files, no network.
+  def build_cert(key, cn)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = cert.issuer = OpenSSL::X509::Name.parse("/CN=#{cn}")
+    cert.public_key = key.public_key
+    cert.not_before = Time.now - 3600
+    cert.not_after = Time.now + 3600
+    cert.sign(key, OpenSSL::Digest::SHA256.new)
+    cert
+  end
+
+  around(:each) do |example|
+    saved = ENV.values_at('REDIS_CA_FILE', 'REDIS_CA_CERT')
+    ENV.delete('REDIS_CA_FILE')
+    ENV.delete('REDIS_CA_CERT')
+    example.run
+    ENV['REDIS_CA_FILE'], ENV['REDIS_CA_CERT'] = saved
+    ENV.delete('REDIS_CA_FILE') if saved[0].nil?
+    ENV.delete('REDIS_CA_CERT') if saved[1].nil?
+  end
+
+  describe '.redis_options' do
+    it 'returns the exact legacy hash for redis:// (no :ssl, Render unchanged)' do
+      expect(RedisInit.redis_options(redis_uri)).to eq(
+        :host => 'redis.example', :port => 6379, :password => 'secret'
+      )
+    end
+
+    it 'merges extra options for redis:// without enabling ssl' do
+      opts = RedisInit.redis_options(redis_uri, :timeout => 5)
+      expect(opts).to eq(
+        :host => 'redis.example', :port => 6379, :password => 'secret', :timeout => 5
+      )
+      expect(opts).not_to have_key(:ssl)
+    end
+
+    it 'enables :ssl for rediss:// with no ssl_params when no CA env is set' do
+      opts = RedisInit.redis_options(rediss_uri)
+      expect(opts[:ssl]).to eq(true)
+      expect(opts).not_to have_key(:ssl_params)
+      expect(opts.values_at(:host, :port, :password)).to eq(['redis.example', 6378, 'secret'])
+    end
+
+    it 'uses ssl_params[:ca_file] for rediss:// when REDIS_CA_FILE is set' do
+      ENV['REDIS_CA_FILE'] = '/secrets/server_ca.pem'
+      opts = RedisInit.redis_options(rediss_uri)
+      expect(opts[:ssl]).to eq(true)
+      expect(opts[:ssl_params]).to eq(:ca_file => '/secrets/server_ca.pem')
+    end
+
+    it 'prefers REDIS_CA_FILE over inline REDIS_CA_CERT' do
+      ENV['REDIS_CA_FILE'] = '/secrets/server_ca.pem'
+      ENV['REDIS_CA_CERT'] = build_cert(OpenSSL::PKey::RSA.new(2048), 'ca').to_pem
+      expect(RedisInit.redis_options(rediss_uri)[:ssl_params]).to eq(:ca_file => '/secrets/server_ca.pem')
+    end
+
+    it 'builds a cert_store from inline REDIS_CA_CERT with multiple concatenated certs' do
+      key = OpenSSL::PKey::RSA.new(2048)
+      ENV['REDIS_CA_CERT'] = build_cert(key, 'ca-old').to_pem + build_cert(key, 'ca-new').to_pem
+      store = RedisInit.redis_options(rediss_uri)[:ssl_params][:cert_store]
+      expect(store).to be_a(OpenSSL::X509::Store)
+    end
+
+    it 'does not crash when REDIS_CA_CERT contains a duplicate cert (rotation overlap)' do
+      key = OpenSSL::PKey::RSA.new(2048)
+      pem = build_cert(key, 'ca-dup').to_pem
+      ENV['REDIS_CA_CERT'] = pem + pem
+      expect { RedisInit.redis_options(rediss_uri) }.not_to raise_error
+      expect(RedisInit.redis_options(rediss_uri)[:ssl_params][:cert_store]).to be_a(OpenSSL::X509::Store)
+    end
+  end
+end


### PR DESCRIPTION
## What

Make the app's Redis client speak TLS when `REDIS_URL` is `rediss://` (GCP Memorystore, AUTH + TLS, `SERVER_AUTHENTICATION` mode) while leaving the current Render `redis://` path **byte-identical**. This is the one pre-cutover code blocker deliberately deferred out of #399 (Cloud Run migration, Phase 3).

## Why

Phase 3 provisions Memorystore with `--auth-enabled --transit-encryption-mode=SERVER_AUTHENTICATION` and seeds `REDIS_URL` as `rediss://`. All 5 `Redis.new` sites built connections from a parsed URI but **discarded the URL scheme and never passed `:ssl`**, so the client could not complete a TLS handshake. AUTH alone works today; TLS did not.

## How

- New `RedisInit.redis_options(uri, extra = {})` + `RedisInit.redis_ssl_params` in `config/initializers/resque.rb`; all 5 sites routed through it (`resque.rb:23/26/60/110`, `throttling.rb:12`).
- **Backward-compat hinge = `uri.scheme == 'rediss'`.** A `redis://` URI yields the exact historical `{host, port, password}` hash with no `:ssl` key, so the Render environment is unchanged. A `rediss://` URI adds `:ssl => true` and validates the server cert against a CA from `REDIS_CA_FILE` (path, preferred) or inline `REDIS_CA_CERT` (PEM, scanned for multiple concatenated certs so a Memorystore CA rotation does not drop the connection). `SERVER_AUTHENTICATION` presents **no** client cert.

## Reviews (dual-reviewer)

- **`/review-pr` (senior-dev):** 2 Mediums fixed in-PR (duplicate-cert boot crash; missing backward-compat spec).
- **`/adversary-review`:** confirmed `redis://` is byte-identical (all 5 env aliases) and that `set_params` defaults to `VERIFY_PEER` (no silent no-verify TLS). 1 High + 2 Mediums fixed:
  - **High:** rescue caught only `X509::StoreError`, but a fenced-but-corrupt PEM raises `X509::CertificateError` (disjoint) and would crash-loop boot during a CA rotation. Broadened to `OpenSSL::OpenSSLError`.
  - **Medium:** `REDIS_CA_CERT` set but zero usable certs now raises a named error at boot instead of an opaque later handshake failure.
  - **Medium:** specs now assert `VERIFY_PEER` (the real security invariant), plus malformed-PEM-no-raise and zero-cert-raise.

## Tests

`spec/initializers/resque_redis_options_spec.rb` -- 11 examples, 0 failures. Locks: `redis://` identity, `rediss://` ssl/ca_file/cert_store shapes, duplicate/malformed cert handling, and `VERIFY_PEER` enforcement.

## Verifiable now vs. live-only

- **Verified now (unit + reasoned):** option-hash shapes; `redis://` byte-identical to legacy; verification stays on.
- **NOT verified -- live only:** the actual TLS handshake / CA validation against a real Memorystore instance. Confirmable only the first time the `CONFIRM_REDIS` gate provisions one. **Do not treat the TLS path as proven until verified live.**

## Pre-cutover follow-ups (not in this PR)

1. **Wire the CA secret** (Phase 4): decide `REDIS_CA_FILE` (mounted secret) vs `REDIS_CA_CERT` (Secret Manager -> env) and seed it. Without it, `rediss://` falls back to the system trust store, which does **not** contain Memorystore's per-instance CA -- fails closed.
2. **Hostname-vs-IP (adversary Low):** `redis-client` enables `verify_hostname` by default. If `REDIS_URL` connects to a Memorystore **private IP** not covered by the cert SAN, the handshake fails even with a correct CA, and there is currently no `verify_hostname: false` escape hatch. Confirm DNS-name vs IP against the live instance before cutover; add the hatch only if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
