### PR TITLE
security(eval-ai): gate eval narrator with COPPA + PiiScrubber + AiApiLog

### DIFF
--- a/app/controllers/api/eval_sessions_controller.rb
+++ b/app/controllers/api/eval_sessions_controller.rb
@@ -47,8 +47,20 @@ class Api::EvalSessionsController < ApplicationController
       api_error(400, { error: 'eval_session payload required' })
       return
     end
+    # Resolve the evaluated student so the narrator can apply the same
+    # COPPA parental-consent hard-gate and org-level AI opt-out as every
+    # other external-model call site. The requester must supervise the
+    # student before any eval data becomes eligible to leave for an AI
+    # provider. When no student can be resolved, the narrator refuses the
+    # AI draft and returns the deterministic local template (no external
+    # call) instead of sending data ungated.
+    user = params['user_id'].present? ? User.find_by_path(params['user_id']) : nil
+    if params['user_id'].present?
+      return unless exists?(user, params['user_id'])
+      return unless allowed?(user, 'supervise')
+    end
     payload = eval_data.respond_to?(:to_unsafe_h) ? eval_data.to_unsafe_h : eval_data.to_h
-    narrative = EvalNarrator.draft_narrative(payload.with_indifferent_access)
+    narrative = EvalNarrator.draft_narrative(payload.with_indifferent_access, user: user)
     render json: { 'narrative' => narrative }
   rescue EvalNarrator::NarrationError => e
     api_error 502, { error: e.message }
@@ -63,7 +75,11 @@ class Api::EvalSessionsController < ApplicationController
   end
 
   def ai_feature_enabled?
-    return true if FeatureFlags.feature_enabled_for?('comprehensive_eval_ai', @api_user)
+    # ai_feature_enabled_for? combines the feature flag with the org-level
+    # AI opt-out (disable_ai_features), so an org that has opted out of AI
+    # processing cannot reach the narrator at all. Requires
+    # 'comprehensive_eval_ai' to be registered in FeatureFlags::AI_FEATURES.
+    return true if FeatureFlags.ai_feature_enabled_for?('comprehensive_eval_ai', @api_user)
     api_error 400, { error: 'comprehensive_eval_ai feature not enabled' }
     false
   end

--- a/app/frontend/app/components/eval-comprehensive-runner.js
+++ b/app/frontend/app/components/eval-comprehensive-runner.js
@@ -302,10 +302,15 @@ export default Component.extend({
       }
       this.set('aiBusy', true);
       this.set('aiError', null);
+      // Send the evaluated student's id so the server can apply the same
+      // COPPA consent + org AI opt-out gate as every other AI call site
+      // before any eval data leaves for the AI provider.
+      const user = this.get('user');
+      const userId = user && user.get ? user.get('id') : null;
       persistence.ajax('/api/v1/eval_sessions/narrate', {
         type: 'POST',
         contentType: 'application/json',
-        data: JSON.stringify({ eval_session: payload.data })
+        data: JSON.stringify({ eval_session: payload.data, user_id: userId })
       }).then(function(res) {
         _this.set('aiBusy', false);
         const narrative = res && res.narrative;

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -5219,3 +5219,36 @@ hits this because it uses `db:create db:schema:load` (fresh DB, no `encryption_h
 decrypt). Local fix (test DB only, regenerates on boot):
 `psql -U scotw -d lingolinq-test -c "delete from settings where key='encryption_hash'"`. Do not
 "fix" it by editing the dotenv load order in spec_helper.
+
+## Pattern: every external-model call site must gate the same way (COPPA + org opt-out + PiiScrubber + AiApiLog)
+
+The canonical AI egress shape is fixed across call sites (`lib/ai_word_predictor.rb`,
+`lib/ai_board_generator.rb`): (1) `FeatureFlags.ai_feature_enabled_for?(feature, user)` for the
+feature flag + org `disable_ai_features` opt-out, (2) `FeatureFlags.coppa_blocks_ai_for?(user)`
+short-circuit (default-ON via `COPPA_AI_HARD_GATE`) BEFORE any provider call, (3)
+`PiiScrubber.redact_for_ai` on the payload with the user's names + any free-text person name added
+via `PiiScrubber.configure_blocklist`, and (4) an `AiApiLog.log_ai_call(provider: 'claude', ...)`
+row in an `ensure` so success AND failure are audited. `lib/eval_narrator.rb` was the lone exception
+(finding LL-2e4c14d370 et al.); when adding a NEW AI call site, copy this shape exactly rather than
+inventing a new flag. Gate on whoever's data leaves (the evaluated student), not necessarily the
+requesting user. When no data subject can be resolved, refuse the external call and fall back to a
+local/deterministic path rather than sending ungated.
+
+## Gotcha: `ai_feature_enabled_for?` silently returns false unless the flag is in `FeatureFlags::AI_FEATURES`
+
+`FeatureFlags.ai_feature_enabled_for?(feature, user)` first does `return false unless
+AI_FEATURES.include?(feature)` (`feature_flags.rb:139`). A flag can be live in
+`AVAILABLE_FRONTEND_FEATURES`/`ENABLED_FRONTEND_FEATURES` yet still be denied by the AI gate because
+it was never added to the `AI_FEATURES` allowlist (`:77`). Adding a feature to the AI gate means
+registering it in `AI_FEATURES`. `system_feature_registry.rb:80` also derives its `ai_feature:`
+flag from this list, so registering there correctly tags it in the admin registry.
+
+## Gotcha: `EvalNarrator` shipped against the OLD `ruby-anthropic` API; the gem is official `anthropic ~> 1.23`
+
+`lib/eval_narrator.rb#draft_via_anthropic` originally used `Anthropic::Client.new(access_token:)` +
+`client.messages(parameters: {...})` + a Hash response (the alexrudall `ruby-anthropic` gem). The
+Gemfile pins official `anthropic ~> 1.23`, whose API is `Anthropic::Client.new(api_key:)` +
+`client.messages.create(...)`, with `response.content` an array of blocks (`#type`/`#text`) and
+`response.usage.input_tokens/output_tokens`. The old call raised and soft-fell-back to the template,
+so the AI path was dead. Match the sibling AI libs' usage; isolate the SDK call behind a
+`call_anthropic` method so specs can stub the network boundary.

--- a/lib/eval_narrator.rb
+++ b/lib/eval_narrator.rb
@@ -47,6 +47,20 @@ module EvalNarrator
   # eval data externally -- the deterministic template draft is returned
   # instead. This is the invariant the comment at
   # feature_flags.rb:150-152 ("used by every AI call site") describes.
+  #
+  # SLP/student split (intentional, diverges from the sibling sites): the
+  # comprehensive_eval_ai *feature flag* is SLP-facing tooling enabled per
+  # supervisor/org, so it is checked against the requesting clinician
+  # (@api_user) in the controller. The data subject whose eval data would
+  # leave is the STUDENT, so the COPPA consent gate and the org-level AI
+  # opt-out (disable_ai_features, via ai_enabled_for?) are checked against
+  # the student here. We deliberately do NOT require the comprehensive_eval_ai
+  # flag to be enabled on the student's own account: it is beta-opt-in and a
+  # student account is almost never the SLP-tooling audience, so requiring it
+  # would block legitimate narration. The student org's disable_ai_features
+  # is the FERPA backstop for a school that wants no AI processing at all.
+  # (In AiBoardGenerator/AiWordPredictor the `user` IS the feature audience,
+  # so they gate the flag on that same user.)
   def self.ai_allowed_for?(user)
     return false unless user
     return false if FeatureFlags.coppa_blocks_ai_for?(user)
@@ -80,13 +94,13 @@ module EvalNarrator
     user_content = JSON.pretty_generate(scrubbed_payload)
 
     model = ENV['EVAL_NARRATOR_MODEL'] || 'claude-opus-4-7'
-    system_prompt = [
-      {
-        type: 'text',
-        text: ANTHROPIC_SYSTEM_PROMPT,
-        cache_control: { type: 'ephemeral' }
-      }
-    ]
+    # Plain-string system prompt, matching AiBoardGenerator / AiWordPredictor
+    # against the official anthropic (~> 1.23) gem. The prior array +
+    # cache_control "ephemeral" shape was never verified against this gem; a
+    # malformed request would silently soft-fall-back to the template and
+    # mask the failure. Eval narration is low-volume, so the prompt-cache
+    # saving is marginal -- correctness on this compliance path wins.
+    system_prompt = ANTHROPIC_SYSTEM_PROMPT
 
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     narrative = nil
@@ -121,6 +135,9 @@ module EvalNarrator
         success: success,
         error_message: error_message
       )
+      # Clear the thread-local blocklist so a later PiiScrubber caller on
+      # this Puma worker thread does not inherit this student's name list.
+      PiiScrubber.reset_blocklist!
     end
 
     raise NarrationError, 'Anthropic returned an empty narrative' if narrative.blank?
@@ -153,7 +170,22 @@ module EvalNarrator
     end
     sett = payload['sett']
     names << sett['student'].to_s.strip if sett.is_a?(Hash) && sett['student'].to_s.strip.present?
-    PiiScrubber.configure_blocklist(names)
+
+    # Expand multi-token names into individual tokens so a known name is
+    # redacted even when only one part appears (e.g. SETT student "Janie"
+    # while the surname "Doe" is typed in slp_notes). This intentionally
+    # over-redacts on the external-egress path and is stricter than the
+    # sibling AI sites: an over-zealous redaction in an editable SLP draft
+    # is recoverable, a leaked student/family name is not. Tokens under 2
+    # chars are dropped so initials do not match everywhere. NOTE: this
+    # cannot catch a third-party name (family, school, peer) typed free-hand
+    # in slp_notes that matches none of these sources -- that needs NER and
+    # remains a surface-wide limitation, not specific to this path.
+    expanded = names.flat_map { |n| [n] + n.to_s.split(/\s+/) }
+                    .map { |n| n.to_s.strip }
+                    .reject { |n| n.length < 2 }
+                    .uniq
+    PiiScrubber.configure_blocklist(expanded)
   end
 
   # Records the AI call in AiApiLog for compliance auditing. Never raises

--- a/lib/eval_narrator.rb
+++ b/lib/eval_narrator.rb
@@ -1,3 +1,6 @@
+require 'json'
+require_relative 'pii_scrubber'
+
 module EvalNarrator
   # Drafts an SLP-readable narrative for a Comprehensive Eval. Takes
   # the session payload (intake, recommendation, events, sett,
@@ -19,13 +22,13 @@ module EvalNarrator
 
   class NarrationError < StandardError; end
 
-  def self.draft_narrative(eval_session)
+  def self.draft_narrative(eval_session, user: nil)
     payload = eval_session.is_a?(Hash) ? eval_session : eval_session.to_h
     raise NarrationError, 'eval_session must be a Hash' unless payload.is_a?(Hash)
 
-    if anthropic_configured? && payload['use_anthropic'] != false
+    if anthropic_configured? && payload['use_anthropic'] != false && ai_allowed_for?(user)
       begin
-        return draft_via_anthropic(payload)
+        return draft_via_anthropic(payload, user)
       rescue => e
         # Soft-fall back to the template draft if the Anthropic SDK
         # call fails so the SLP always gets something to start from.
@@ -36,13 +39,47 @@ module EvalNarrator
     draft_via_template(payload)
   end
 
+  # Compliance hard-gate shared with every other AI call site
+  # (AiWordPredictor, AiBoardGenerator). The external-model draft path may
+  # run only when there is a resolved student User who (a) is not awaiting
+  # COPPA parental consent and (b) belongs to an organization that has not
+  # opted out of AI processing. Without a resolvable student we never send
+  # eval data externally -- the deterministic template draft is returned
+  # instead. This is the invariant the comment at
+  # feature_flags.rb:150-152 ("used by every AI call site") describes.
+  def self.ai_allowed_for?(user)
+    return false unless user
+    return false if FeatureFlags.coppa_blocks_ai_for?(user)
+    return false unless FeatureFlags.ai_enabled_for?(user)
+    true
+  end
+
   # Anthropic SDK integration (optional, gated by env var). Uses the
-  # claude-api skill's prompt-caching pattern: cache the system
-  # prompt + few-shot examples, send only the per-session payload as
-  # the user message. Cuts per-call cost ~90% after the first call.
-  def self.draft_via_anthropic(payload)
+  # claude-api skill's prompt-caching pattern: cache the system prompt +
+  # few-shot examples, send only the per-session payload as the user
+  # message. Cuts per-call cost ~90% after the first call.
+  #
+  # Compliance: the payload is PII-scrubbed (PiiScrubber.redact_for_ai)
+  # before egress and the call is recorded in AiApiLog with an audit
+  # trail, exactly like AiWordPredictor / AiBoardGenerator. The COPPA +
+  # org opt-out gate is enforced upstream in draft_narrative via
+  # ai_allowed_for?, so this method only runs for an eligible student.
+  def self.draft_via_anthropic(payload, user = nil)
+    require 'anthropic'
     raise NarrationError, 'Anthropic client not available' unless defined?(::Anthropic::Client)
-    client = ::Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY'])
+
+    # Configure the PII blocklist with the student's account names AND the
+    # free-text SETT student name, so the name is redacted everywhere it
+    # appears (sett.student, slp_notes, intake free-text) before egress.
+    configure_blocklist_for(user, payload)
+
+    scrub_result = PiiScrubber.redact_for_ai(payload_for_prompt(payload))
+    scrubbed_payload = scrub_result[:payload]
+    pii_detected = scrub_result[:pii_found]
+    pii_findings = scrub_result[:findings]
+    user_content = JSON.pretty_generate(scrubbed_payload)
+
+    model = ENV['EVAL_NARRATOR_MODEL'] || 'claude-opus-4-7'
     system_prompt = [
       {
         type: 'text',
@@ -50,15 +87,99 @@ module EvalNarrator
         cache_control: { type: 'ephemeral' }
       }
     ]
-    response = client.messages(parameters: {
-      model: ENV['EVAL_NARRATOR_MODEL'] || 'claude-opus-4-7',
+
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    narrative = nil
+    success = false
+    error_message = nil
+    tokens_sent = nil
+    tokens_received = nil
+
+    begin
+      response = call_anthropic(model: model, system_prompt: system_prompt, user_content: user_content)
+      narrative = extract_text(response)
+      if response.respond_to?(:usage) && response.usage
+        tokens_sent = response.usage.respond_to?(:input_tokens) ? response.usage.input_tokens : nil
+        tokens_received = response.usage.respond_to?(:output_tokens) ? response.usage.output_tokens : nil
+      end
+      success = narrative.present?
+    rescue => e
+      error_message = "#{e.class}: #{e.message}"
+      raise
+    ensure
+      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round
+      log_ai_call(
+        model: model,
+        user: user,
+        request_summary: "Eval narration (#{payload['eval_mode'] || 'comprehensive'})",
+        response_summary: narrative.to_s,
+        tokens_sent: tokens_sent,
+        tokens_received: tokens_received,
+        duration_ms: duration_ms,
+        pii_detected: pii_detected,
+        pii_findings: pii_findings,
+        success: success,
+        error_message: error_message
+      )
+    end
+
+    raise NarrationError, 'Anthropic returned an empty narrative' if narrative.blank?
+    narrative
+  end
+
+  # Official anthropic gem (~> 1.23) call. Isolated so specs can stub the
+  # network boundary, matching AiWordPredictor / AiBoardGenerator.
+  def self.call_anthropic(model:, system_prompt:, user_content:)
+    client = ::Anthropic::Client.new(api_key: ENV['ANTHROPIC_API_KEY'])
+    client.messages.create(
+      model: model,
       max_tokens: 1200,
       system: system_prompt,
-      messages: [
-        { role: 'user', content: payload_for_prompt(payload) }
-      ]
-    })
-    extract_text(response)
+      messages: [{ role: 'user', content: user_content }]
+    )
+  end
+
+  # Build the PiiScrubber blocklist for this narration call. Mirrors the
+  # AiWordPredictor / AiBoardGenerator pattern (user account names) and
+  # adds the free-text SETT student name so a clinician-typed name is
+  # redacted even when it differs from the account name.
+  def self.configure_blocklist_for(user, payload)
+    names = []
+    if user
+      names << user.user_name if user.respond_to?(:user_name) && user.user_name.present?
+      if user.respond_to?(:settings) && user.settings.is_a?(Hash) && user.settings['full_name'].present?
+        names << user.settings['full_name']
+      end
+    end
+    sett = payload['sett']
+    names << sett['student'].to_s.strip if sett.is_a?(Hash) && sett['student'].to_s.strip.present?
+    PiiScrubber.configure_blocklist(names)
+  end
+
+  # Records the AI call in AiApiLog for compliance auditing. Never raises
+  # into the caller -- a logging failure must not break narration.
+  def self.log_ai_call(model:, user:, request_summary:, response_summary:,
+                       tokens_sent: nil, tokens_received: nil, duration_ms: nil,
+                       pii_detected: false, pii_findings: [], success: true, error_message: nil)
+    return unless defined?(AiApiLog)
+    AiApiLog.log_ai_call(
+      provider: 'claude',
+      model: model,
+      type: 'eval_narration',
+      user: user,
+      request_summary: request_summary,
+      response_summary: response_summary,
+      tokens_sent: tokens_sent,
+      tokens_received: tokens_received,
+      duration_ms: duration_ms,
+      pii_detected: pii_detected,
+      pii_findings: pii_findings,
+      success: success,
+      error_message: error_message,
+      feature_flag: 'comprehensive_eval_ai'
+    )
+  rescue StandardError => e
+    Rails.logger.warn "EvalNarrator: failed to log AI API call: #{e.message}" if defined?(Rails)
   end
 
   def self.anthropic_configured?
@@ -178,22 +299,30 @@ module EvalNarrator
     "SETT framework — #{parts.join(' · ')}"
   end
 
+  # Selects only the fields the model needs, as a Hash. The caller scrubs
+  # this through PiiScrubber and JSON-encodes it before egress, so the raw
+  # student name in sett.student never leaves un-redacted.
   def self.payload_for_prompt(payload)
-    # Compact JSON the model can ingest deterministically.
-    require 'json'
-    JSON.pretty_generate(
+    {
       'mode' => payload['eval_mode'],
       'intake' => payload['intake'],
       'recommendation' => payload['recommendation'],
       'sett' => payload['sett'],
       'slp_notes' => payload['slp_notes'],
       'duration_s' => payload['duration_s']
-    )
+    }
   end
 
   def self.extract_text(response)
     return response.to_s if response.is_a?(String)
-    body = response['content'] || response[:content]
+    # Official anthropic gem (~> 1.23): response.content is an array of
+    # content blocks with #type / #text.
+    if response.respond_to?(:content) && response.content.is_a?(Array)
+      text_blocks = response.content.select { |b| b.respond_to?(:type) && b.type.to_s == 'text' }
+      return text_blocks.map { |b| b.respond_to?(:text) ? b.text : b.to_s }.join("\n").strip
+    end
+    # Hash-shaped fallback (older SDK / stubbed responses in specs).
+    body = response.respond_to?(:[]) ? (response['content'] || response[:content]) : nil
     return '' if body.blank?
     body.first.is_a?(Hash) ? (body.first['text'] || body.first[:text]).to_s : body.to_s
   end

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -75,7 +75,7 @@ module FeatureFlags
     'multi_user_board_import' => 'May 15, 2026'
   }
   AI_FEATURES = %w[ai_board_generation ai_word_prediction ai_board_suggestions
-                   ai_symbol_search ai_compliance_logging].freeze
+                   ai_symbol_search ai_compliance_logging comprehensive_eval_ai].freeze
   def self.frontend_flags_for(user)
     flags = {}
     enabled_list = SystemFeatureSettings.effective_enabled_for(user)

--- a/spec/controllers/api/eval_sessions_controller_spec.rb
+++ b/spec/controllers/api/eval_sessions_controller_spec.rb
@@ -53,4 +53,80 @@ describe Api::EvalSessionsController, type: :controller do
       expect(JSON.parse(response.body)['error']).to eq('feature not enabled')
     end
   end
+
+  describe 'narrate' do
+    let(:eval_payload) { {eval_mode: 'comprehensive', intake: {}, recommendation: {}, sett: {}, slp_notes: ''} }
+
+    before do
+      # Endpoint gate now uses ai_feature_enabled_for? so the org-level AI
+      # opt-out is honored. Stub it on for the happy-path tests.
+      allow(FeatureFlags).to receive(:ai_feature_enabled_for?).and_call_original
+      allow(FeatureFlags).to receive(:ai_feature_enabled_for?).with('comprehensive_eval_ai', anything).and_return(true)
+    end
+
+    it 'requires an access token' do
+      post :narrate, params: {eval_session: eval_payload}
+      assert_missing_token
+    end
+
+    it 'aborts with 400 when the AI feature is disabled (flag off or org opted out)' do
+      allow(FeatureFlags).to receive(:ai_feature_enabled_for?).with('comprehensive_eval_ai', anything).and_return(false)
+      token_user
+      post :narrate, params: {eval_session: eval_payload, user_id: @user.global_id}
+      expect(response.code.to_i).to eq(400)
+      expect(JSON.parse(response.body)['error']).to eq('comprehensive_eval_ai feature not enabled')
+    end
+
+    it 'requires the target user to exist when a user_id is given' do
+      token_user
+      post :narrate, params: {eval_session: eval_payload, user_id: 'no-such-user'}
+      assert_not_found('no-such-user')
+    end
+
+    it 'requires supervise permission on the target user' do
+      token_user
+      other = User.create
+      post :narrate, params: {eval_session: eval_payload, user_id: other.global_id}
+      assert_unauthorized
+    end
+
+    it 'aborts with 400 when the eval_session payload is missing' do
+      token_user
+      post :narrate, params: {user_id: @user.global_id}
+      expect(response.code.to_i).to eq(400)
+      expect(JSON.parse(response.body)['error']).to eq('eval_session payload required')
+    end
+
+    it 'resolves the evaluated student and hands it to the narrator for gating' do
+      token_user
+      captured_user = :unset
+      allow(EvalNarrator).to receive(:draft_narrative) do |_payload, user:|
+        captured_user = user
+        'drafted'
+      end
+      post :narrate, params: {eval_session: eval_payload, user_id: @user.global_id}
+      expect(captured_user).to be_a(User)
+      expect(captured_user.global_id).to eq(@user.global_id)
+    end
+
+    it 'returns the drafted narrative for the supervising user' do
+      token_user
+      allow(EvalNarrator).to receive(:draft_narrative).and_return('A drafted narrative.')
+      post :narrate, params: {eval_session: eval_payload, user_id: @user.global_id}
+      json = assert_success_json
+      expect(json['narrative']).to eq('A drafted narrative.')
+    end
+
+    it 'still drafts (template fallback) when no user_id is supplied' do
+      token_user
+      captured_user = :unset
+      allow(EvalNarrator).to receive(:draft_narrative) do |_payload, user:|
+        captured_user = user
+        'template draft'
+      end
+      post :narrate, params: {eval_session: eval_payload}
+      expect(assert_success_json['narrative']).to eq('template draft')
+      expect(captured_user).to be_nil
+    end
+  end
 end

--- a/spec/lib/eval_narrator_spec.rb
+++ b/spec/lib/eval_narrator_spec.rb
@@ -119,6 +119,24 @@ describe EvalNarrator do
       expect(captured[:user_content]).to include('[REDACTED_EMAIL]')
     end
 
+    it 'redacts a known name token even when only one part appears (tokenized blocklist)' do
+      # SETT student is a first name only; the surname appears alone in
+      # slp_notes. The user full_name "Janie Doe" tokenizes to include "Doe".
+      payload['sett']['student'] = 'Janie'
+      payload['slp_notes'] = 'Met with the Doe family about IEP goals.'
+      captured = {}
+      allow(described_class).to receive(:call_anthropic) do |model:, system_prompt:, user_content:|
+        captured[:user_content] = user_content
+        anthropic_response('ok')
+      end
+      allow(AiApiLog).to receive(:log_ai_call)
+
+      described_class.draft_narrative(payload, user: user)
+
+      expect(captured[:user_content]).not_to match(/\bDoe\b/)
+      expect(captured[:user_content]).not_to match(/\bJanie\b/)
+    end
+
     it 'records the AI call in AiApiLog with an audit trail' do
       allow(described_class).to receive(:call_anthropic).and_return(anthropic_response('Drafted narrative.'))
 

--- a/spec/lib/eval_narrator_spec.rb
+++ b/spec/lib/eval_narrator_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe EvalNarrator do
+  def anthropic_response(text)
+    usage = double('usage', input_tokens: 10, output_tokens: 20)
+    block = double('text_block', type: 'text', text: text)
+    double('anthropic_response', content: [block], usage: usage)
+  end
+
+  let(:payload) do
+    {
+      'eval_mode' => 'comprehensive',
+      'intake' => { 'age_band' => '6-12' },
+      'recommendation' => { 'access_method' => 'touch' },
+      'sett' => { 'student' => 'Janie Doe', 'environment' => 'classroom' },
+      'slp_notes' => 'Met with Janie Doe; email mom at jane@example.com.',
+      'duration_s' => 600
+    }
+  end
+
+  describe '.ai_allowed_for?' do
+    it 'is false without a resolved user (never send eval data ungated)' do
+      expect(described_class.ai_allowed_for?(nil)).to eq(false)
+    end
+
+    it 'is false when COPPA parental consent is pending' do
+      u = User.new(settings: { 'coppa' => { 'pending_parent_consent' => true } })
+      allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(u).and_return(true)
+      expect(described_class.ai_allowed_for?(u)).to eq(false)
+    end
+
+    it 'is false when the org has opted out of AI processing' do
+      u = User.new(settings: {})
+      allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(u).and_return(false)
+      allow(FeatureFlags).to receive(:ai_enabled_for?).with(u).and_return(false)
+      expect(described_class.ai_allowed_for?(u)).to eq(false)
+    end
+
+    it 'is true for a consented user in an AI-enabled org' do
+      u = User.new(settings: {})
+      allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(u).and_return(false)
+      allow(FeatureFlags).to receive(:ai_enabled_for?).with(u).and_return(true)
+      expect(described_class.ai_allowed_for?(u)).to eq(true)
+    end
+  end
+
+  describe '.draft_narrative gating' do
+    before do
+      allow(described_class).to receive(:anthropic_configured?).and_return(true)
+      allow(described_class).to receive(:call_anthropic)
+      allow(AiApiLog).to receive(:log_ai_call)
+    end
+
+    it 'never calls the AI when no user is resolved (returns template)' do
+      out = described_class.draft_narrative(payload, user: nil)
+      expect(described_class).not_to have_received(:call_anthropic)
+      expect(out).to be_a(String)
+      expect(out).to include('Evaluation Summary')
+    end
+
+    it 'never calls the AI for a COPPA-consent-pending student' do
+      u = User.new(settings: { 'coppa' => { 'pending_parent_consent' => true } })
+      allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(u).and_return(true)
+      out = described_class.draft_narrative(payload, user: u)
+      expect(described_class).not_to have_received(:call_anthropic)
+      expect(AiApiLog).not_to have_received(:log_ai_call)
+      expect(out).to include('Evaluation Summary')
+    end
+
+    it 'never calls the AI when the student org has opted out of AI' do
+      u = User.new(settings: {})
+      allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(u).and_return(false)
+      allow(FeatureFlags).to receive(:ai_enabled_for?).with(u).and_return(false)
+      described_class.draft_narrative(payload, user: u)
+      expect(described_class).not_to have_received(:call_anthropic)
+      expect(AiApiLog).not_to have_received(:log_ai_call)
+    end
+  end
+
+  describe '.draft_narrative for a consented student' do
+    let(:user) do
+      u = User.create
+      u.settings ||= {}
+      u.settings['full_name'] = 'Janie Doe'
+      u.save
+      u
+    end
+
+    around(:each) do |example|
+      old = ENV['ANTHROPIC_API_KEY']
+      ENV['ANTHROPIC_API_KEY'] = 'test-anthropic-key'
+      example.run
+    ensure
+      ENV['ANTHROPIC_API_KEY'] = old
+    end
+
+    before do
+      allow(described_class).to receive(:anthropic_configured?).and_return(true)
+      allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(user).and_return(false)
+      allow(FeatureFlags).to receive(:ai_enabled_for?).with(user).and_return(true)
+    end
+
+    it 'scrubs the student name and email out of the payload before egress' do
+      captured = {}
+      allow(described_class).to receive(:call_anthropic) do |model:, system_prompt:, user_content:|
+        captured[:user_content] = user_content
+        anthropic_response('Drafted narrative.')
+      end
+      allow(AiApiLog).to receive(:log_ai_call)
+
+      described_class.draft_narrative(payload, user: user)
+
+      expect(captured[:user_content]).to be_present
+      expect(captured[:user_content]).not_to include('Janie Doe')
+      expect(captured[:user_content]).not_to include('jane@example.com')
+      expect(captured[:user_content]).to include('[REDACTED_NAME]')
+      expect(captured[:user_content]).to include('[REDACTED_EMAIL]')
+    end
+
+    it 'records the AI call in AiApiLog with an audit trail' do
+      allow(described_class).to receive(:call_anthropic).and_return(anthropic_response('Drafted narrative.'))
+
+      expect {
+        described_class.draft_narrative(payload, user: user)
+      }.to change(AiApiLog, :count).by(1)
+
+      log = AiApiLog.order(:created_at).last
+      expect(log.ai_provider).to eq('claude')
+      expect(log.request_type).to eq('eval_narration')
+      expect(log.feature_flag).to eq('comprehensive_eval_ai')
+      expect(log.success).to eq(true)
+    end
+
+    it 'returns the AI-drafted narrative' do
+      allow(described_class).to receive(:call_anthropic).and_return(anthropic_response('Drafted narrative.'))
+      allow(AiApiLog).to receive(:log_ai_call)
+      expect(described_class.draft_narrative(payload, user: user)).to eq('Drafted narrative.')
+    end
+
+    it 'falls back to the template (and logs failure) when the AI call raises' do
+      allow(described_class).to receive(:call_anthropic).and_raise(StandardError, 'boom')
+
+      expect {
+        out = described_class.draft_narrative(payload, user: user)
+        expect(out).to include('Evaluation Summary')
+      }.to change(AiApiLog, :count).by(1)
+
+      expect(AiApiLog.order(:created_at).last.success).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## What and why

The Comprehensive Eval AI narration path sent student eval data to an external model (Anthropic) with **no COPPA parental-consent hard-gate, no PiiScrubber, and no AiApiLog audit row** -- the only AI call site bypassing the gate that `feature_flags.rb` claims is "used by every AI call site." Latent only because `ANTHROPIC_API_KEY` may be unset (deterministic template fallback); it goes live the moment the key lands.

Closes audit findings **LL-2e4c14d370** (COPPA gate), **LL-e573a39d2b** (PiiScrubber), **LL-ef5ac1b2a5** (AiApiLog), all on the same call site (`api/eval_sessions#narrate` -> `EvalNarrator`).

## Changes

- **`lib/feature_flags.rb`** -- register `comprehensive_eval_ai` in `AI_FEATURES` (required, or `ai_feature_enabled_for?` returns false for it and 400s the feature).
- **`app/controllers/api/eval_sessions_controller.rb`** -- endpoint now gates on `ai_feature_enabled_for?` (honors the SLP org's `disable_ai_features` opt-out); resolves the evaluated student `User` from `user_id` and requires `allowed?(user, 'supervise')`, mirroring `#recommend`; passes the student to the narrator.
- **`lib/eval_narrator.rb`** -- new `ai_allowed_for?(user)` short-circuits to the local template (no external call) when there is no resolvable student, COPPA consent is pending, or the student's org has opted out of AI. `draft_via_anthropic` now PII-scrubs the payload (account names + free-text `sett.student`, tokenized), writes an `AiApiLog` row on success and failure, resets the thread-local blocklist, and is realigned from the dead `ruby-anthropic` API to the official `anthropic ~> 1.23` API behind a stubbable `call_anthropic`.
- **`app/frontend/app/components/eval-comprehensive-runner.js`** -- sends `user_id` so the server can gate the data subject.

## Design notes

- **SLP/student gate split (intentional):** `comprehensive_eval_ai` is beta-opt-in SLP tooling, so the feature flag is checked against the requesting clinician; the COPPA consent + org AI opt-out gates apply to the **student** (the data subject). Requiring the flag on the student account would block almost all narration. Documented in `ai_allowed_for?`.
- **No new feature flag:** reuses the existing `COPPA_AI_HARD_GATE` kill switch, exactly like the sibling AI sites.
- **PII residual (honest):** PiiScrubber now covers pattern PII (email/phone/SSN/IDs) + configured-name tokens. A third-party name (family/peer/school) typed free-hand in `slp_notes` and matching no source still needs NER -- a surface-wide limitation, not specific to this path.

## Testing

- `spec/lib/eval_narrator_spec.rb` (new) + narrate specs in `spec/controllers/api/eval_sessions_controller_spec.rb`: **25 examples, 0 failures** -- covers under-13/consent-pending blocked (template, no external call), org opt-out honored, payload scrubbed (name + email + tokenized surname), AiApiLog row written, consented user gets the AI draft, failure falls back to template.
- Regression: `feature_flags` + `ai_board_generator` + `ai_word_predictor` -- **32 examples, 0 failures**.

## Review

Claude adversary review run pre-PR (no Critical/High; Medium/Low addressed). Per the Claude-only-compliance rule, the DeepSeek reviewer path should be skipped for this compliance diff. Governance: `audit-reports/FINDINGS.json` left untouched -- the findings close via the audit pipeline + sign-off after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)