### PR TITLE
chore: worktree isolation config (baseRef + .worktreeinclude)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "_note": "Shared, version-controlled Claude Code config for LingoLinq-AAC. The audit read-only write-blocker (.claude/hooks/audit-readonly-guard.sh) is intentionally NOT registered as a global hook here: it is wired per-agent via each finder's `hooks:` frontmatter so it scopes to the read-only audit finders ONLY and never blocks normal editing in the main session or for teammates. See .claude/agents/*-auditor.md and audit-reports/README.md.",
+  "worktree": {
+    "baseRef": "head"
+  },
   "hooks": {}
 }

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,13 @@
+# .worktreeinclude -- gitignored files Claude Code copies into every NEW worktree
+# it creates (claude -w, EnterWorktree, isolation:worktree subagents, desktop
+# parallel sessions). Uses .gitignore syntax; only files that are themselves
+# gitignored are copied (tracked files like .nvmrc carry over via git already, so
+# the Node 20 pin is preserved automatically).
+#
+# NOTE: raw `git worktree add` (and therefore the claude-wt launcher) does NOT
+# process this file -- that is a Claude-Code-native feature. claude-wt copies the
+# same set itself. This file covers the native/subagent creation paths.
+.env
+.env.local
+app/frontend/.env
+app/frontend/.env.local


### PR DESCRIPTION
Part of the cross-repo isolated-by-default Claude Code launch effort (see ai-company-brain#78).

## What
- **`.claude/settings.json`** - `worktree.baseRef: "head"` so native `-w` / `EnterWorktree` / `isolation: worktree` subagents branch from local HEAD, not `origin/HEAD`.
- **`.worktreeinclude`** (new) - copies gitignored env files into each worktree (`.env`, `.env.local`, `app/frontend/.env`, `app/frontend/.env.local`). `.nvmrc` is tracked, so the Node 20 pin carries on its own.

No application code changes; Claude Code worktree config only. Node 20 pin untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)