### PR TITLE
fix(gcp): Memorystore AUTH flag is --enable-auth, not --auth-enabled

### DIFF
--- a/scripts/gcp/phase3-data-layer.sh
+++ b/scripts/gcp/phase3-data-layer.sh
@@ -339,9 +339,10 @@ if [ "$CONFIRM_REDIS" = "1" ]; then
     skip "Redis instance $REDIS_INSTANCE already exists"
   else
     # connect-mode PRIVATE_SERVICE_ACCESS reuses the Step 1c peering (no separate range).
-    # --auth-enabled + SERVER_AUTHENTICATION in-transit encryption = HIPAA posture (Scot's
+    # --enable-auth + SERVER_AUTHENTICATION in-transit encryption = HIPAA posture (Scot's
     # call). PREREQUISITE before this secret is consumed: the app's Redis client must speak
     # TLS for the rediss:// URL (see the handoff block + config/initializers/resque.rb).
+    # NOTE: the AUTH flag is --enable-auth (gcloud >= 400-ish), NOT --auth-enabled.
     gcloud redis instances create "$REDIS_INSTANCE" \
       --project="$PROJECT_ID" \
       --region="$REGION" \
@@ -350,7 +351,7 @@ if [ "$CONFIRM_REDIS" = "1" ]; then
       --redis-version="$REDIS_VERSION" \
       --network="projects/${PROJECT_ID}/global/networks/${VPC_NAME}" \
       --connect-mode=PRIVATE_SERVICE_ACCESS \
-      --auth-enabled \
+      --enable-auth \
       --transit-encryption-mode=SERVER_AUTHENTICATION
   fi
 


### PR DESCRIPTION
## What

The Phase 3 data-layer provisioning script (`scripts/gcp/phase3-data-layer.sh`, merged in #399) used `--auth-enabled` on `gcloud redis instances create`. That flag does not exist; gcloud 564.0.0 rejects it with `unrecognized arguments: --auth-enabled`. The correct flag is **`--enable-auth`**.

## Impact (already provisioned)

This surfaced during the real Phase 3 provisioning run against `lingolinq-prod`:

- ✅ Network (VPC + subnet + PSA peering) and Cloud SQL (`lingolinq-prod-pg`, POSTGRES_18, private IP) provisioned successfully on the first run.
- ❌ The Memorystore step failed on the bad flag, leaving Redis uncreated.

After this one-word fix, an idempotent re-run skipped all existing resources and created **`lingolinq-prod-redis`** (basic, 1 GiB, AUTH + TLS `SERVER_AUTHENTICATION`) at `10.160.1.3:6378`, seeded the `REDIS_URL` secret, and set the GH repo vars. `GCP_PROJECT_ID` remains unset, so the deploy workflow stays inert.

## Change

- `--auth-enabled` → `--enable-auth` on the Redis create command.
- Updated the adjacent comment and added a guard note so the wrong flag is not reintroduced.

No behavior change beyond the corrected flag; the AUTH + TLS posture (Scot's HIPAA call) is unchanged.

## Verification

- Verified the correct flag against the live `gcloud redis instances create --help` (SDK 564.0.0).
- Verified end-to-end by the successful re-run described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)