### PR TITLE
security(redis): finalize Memorystore TLS (CA wiring + hostname hatch)

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -39,6 +39,9 @@ name: Deploy to Cloud Run
 # GCP SECRET MANAGER secrets Phase 2 step 4 must seed (referenced by name via --set-secrets,
 # NOT GitHub secrets): SECRET_KEY_BASE, SECURE_ENCRYPTION_KEY, SECURE_NONCE_KEY, DATABASE_URL,
 #   REDIS_URL, DEFAULT_EMAIL_FROM, SYSTEM_ERROR_EMAIL, COOKIE_KEY, DEFAULT_HOST.
+#   REDIS_CA_CERT is seeded later by scripts/gcp/phase3-data-layer.sh (the Memorystore
+#   per-instance CA, fetched from the live instance) -- the app's Redis client loads it to
+#   verify the rediss:// TLS chain.
 #
 # MANUAL TRIGGER (only meaningful after Phase 1):
 #   gh workflow run deploy-cloudrun.yml
@@ -83,9 +86,13 @@ jobs:
       # The worker (rake environment resque:work) and the migration Job (rake db:migrate)
       # both fully boot Rails, so they need the same boot set as the web service -- not a
       # narrower subset, which would crash them on boot.
-      BOOT_SECRETS: SECRET_KEY_BASE=SECRET_KEY_BASE:latest,COOKIE_KEY=COOKIE_KEY:latest,SECURE_ENCRYPTION_KEY=SECURE_ENCRYPTION_KEY:latest,SECURE_NONCE_KEY=SECURE_NONCE_KEY:latest,DATABASE_URL=DATABASE_URL:latest,REDIS_URL=REDIS_URL:latest,DEFAULT_HOST=DEFAULT_HOST:latest
+      BOOT_SECRETS: SECRET_KEY_BASE=SECRET_KEY_BASE:latest,COOKIE_KEY=COOKIE_KEY:latest,SECURE_ENCRYPTION_KEY=SECURE_ENCRYPTION_KEY:latest,SECURE_NONCE_KEY=SECURE_NONCE_KEY:latest,DATABASE_URL=DATABASE_URL:latest,REDIS_URL=REDIS_URL:latest,REDIS_CA_CERT=REDIS_CA_CERT:latest,DEFAULT_HOST=DEFAULT_HOST:latest
       # Web adds the mail-sending envs used by request-path mailers.
       WEB_EXTRA_SECRETS: DEFAULT_EMAIL_FROM=DEFAULT_EMAIL_FROM:latest,SYSTEM_ERROR_EMAIL=SYSTEM_ERROR_EMAIL:latest
+      # REDIS_TLS_VERIFY_HOSTNAME=false is set on every deploy below: Memorystore is reached by
+      # private IP and its server cert is issued for the instance, not the IP, so hostname
+      # matching cannot pass. CA-chain verification (VERIFY_PEER against REDIS_CA_CERT) stays on.
+      # See config/initializers/resque.rb.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -134,7 +141,7 @@ jobs:
             --vpc-egress private-ranges-only \
             --command bundle \
             --args "exec,rake,db:migrate" \
-            --set-env-vars "RACK_ENV=production,RAILS_ENV=production" \
+            --set-env-vars "RACK_ENV=production,RAILS_ENV=production,REDIS_TLS_VERIFY_HOSTNAME=false" \
             --set-secrets "$BOOT_SECRETS"
           gcloud run jobs execute lingolinq-migrate \
             --region "${{ vars.GCP_REGION }}" \
@@ -154,7 +161,7 @@ jobs:
             --network "${{ vars.GCP_VPC_NETWORK }}" \
             --subnet "${{ vars.GCP_VPC_SUBNET }}" \
             --vpc-egress private-ranges-only \
-            --set-env-vars "RACK_ENV=production,RAILS_ENV=production" \
+            --set-env-vars "RACK_ENV=production,RAILS_ENV=production,REDIS_TLS_VERIFY_HOSTNAME=false" \
             --set-secrets "$BOOT_SECRETS,$WEB_EXTRA_SECRETS" \
             --allow-unauthenticated
 
@@ -170,5 +177,5 @@ jobs:
             --network "${{ vars.GCP_VPC_NETWORK }}" \
             --subnet "${{ vars.GCP_VPC_SUBNET }}" \
             --vpc-egress private-ranges-only \
-            --set-env-vars "RACK_ENV=production,RAILS_ENV=production" \
+            --set-env-vars "RACK_ENV=production,RAILS_ENV=production,REDIS_TLS_VERIFY_HOSTNAME=false" \
             --set-secrets "$BOOT_SECRETS"

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -71,7 +71,17 @@ module RedisInit
       params[:cert_store] = store
     end
 
-    params[:verify_hostname] = false if tls_hostname_verification_disabled?
+    if tls_hostname_verification_disabled?
+      # Disabling hostname verification is only safe while the chain is still
+      # pinned to a known CA. With no REDIS_CA_FILE/REDIS_CA_CERT we would fall
+      # back to the system trust store with hostname matching off, which accepts
+      # ANY publicly-trusted cert -- a silent MITM hole. Fail closed instead.
+      if params[:ca_file].nil? && params[:cert_store].nil?
+        raise 'REDIS_TLS_VERIFY_HOSTNAME is off but no REDIS_CA_FILE/REDIS_CA_CERT is set; ' \
+              'refusing to skip hostname verification without a pinned CA'
+      end
+      params[:verify_hostname] = false
+    end
 
     params
   end

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -32,14 +32,25 @@ module RedisInit
   # default trust store is used (verification still on); the Memorystore
   # per-instance CA is NOT in that store, so one of these env vars must be set
   # against a live instance.
+  #
+  # REDIS_TLS_VERIFY_HOSTNAME=false additionally turns OFF hostname matching
+  # while leaving CA-chain verification (VERIFY_PEER) ON. This is required for
+  # Memorystore: redis-client sets the TLS SNI hostname to the connection host
+  # (the instance's private IP), and set_params defaults verify_hostname=true,
+  # so the handshake rejects the server cert -- which is issued for the instance,
+  # not the IP -- even with a correct CA. Default (unset) leaves hostname
+  # verification ON, so redis:// (Render) and any DNS-named TLS endpoint are
+  # unchanged.
   def self.redis_ssl_params
     require 'openssl'
 
-    ca_file = ENV['REDIS_CA_FILE']
-    return { :ca_file => ca_file } if ca_file && !ca_file.empty?
+    params = {}
 
+    ca_file = ENV['REDIS_CA_FILE']
     ca_cert = ENV['REDIS_CA_CERT']
-    if ca_cert && !ca_cert.empty?
+    if ca_file && !ca_file.empty?
+      params[:ca_file] = ca_file
+    elsif ca_cert && !ca_cert.empty?
       store = OpenSSL::X509::Store.new
       added = 0
       ca_cert.scan(/-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m).each do |pem|
@@ -57,10 +68,21 @@ module RedisInit
       # Name the misconfiguration at boot rather than failing later as an opaque
       # handshake error: REDIS_CA_CERT was set but produced no usable anchors.
       raise 'REDIS_CA_CERT set but no valid certificates parsed' if added == 0
-      return { :cert_store => store }
+      params[:cert_store] = store
     end
 
-    {}
+    params[:verify_hostname] = false if tls_hostname_verification_disabled?
+
+    params
+  end
+
+  # True only when REDIS_TLS_VERIFY_HOSTNAME is explicitly set to a false-y
+  # value (false / 0 / no / off, case-insensitive). Unset, blank, or anything
+  # else leaves hostname verification ON -- secure by default.
+  def self.tls_hostname_verification_disabled?
+    val = ENV['REDIS_TLS_VERIFY_HOSTNAME']
+    return false if val.nil? || val.strip.empty?
+    %w[false 0 no off].include?(val.strip.downcase)
   end
 
   def self.init

--- a/scripts/gcp/phase3-data-layer.sh
+++ b/scripts/gcp/phase3-data-layer.sh
@@ -97,6 +97,7 @@ REDIS_TIER="${REDIS_TIER:-basic}"                     # single node pre-MVP; HA 
 # Secret Manager names (created EMPTY in Phase 1; we add VALUE versions here)
 SECRET_DATABASE_URL="${SECRET_DATABASE_URL:-DATABASE_URL}"
 SECRET_REDIS_URL="${SECRET_REDIS_URL:-REDIS_URL}"
+SECRET_REDIS_CA_CERT="${SECRET_REDIS_CA_CERT:-REDIS_CA_CERT}"
 
 # GitHub repo for repo-variable writes (needs `gh` CLI authed)
 GH_REPO="${GH_REPO:-lingolinq/LingoLinq-AAC}"
@@ -381,6 +382,34 @@ if [ "$CONFIRM_REDIS" = "1" ]; then
   echo "    new version added to secret $SECRET_REDIS_URL (value not shown)"
   unset REDIS_AUTH REDIS_URL_VAL
   [ "${RXTRACE_WAS_ON:-0}" -eq 1 ] && set -x || true
+
+  log "Step 3c: store Memorystore server CA in Secret Manager ($SECRET_REDIS_CA_CERT)"
+  # The app's Redis client verifies the rediss:// chain against this per-instance CA
+  # (config/initializers/resque.rb reads it from REDIS_CA_CERT, and connects with
+  # hostname verification off since Memorystore is reached by private IP). Unlike the
+  # Phase 1 secrets this one is NOT pre-created, so create it + grant the runtime SA
+  # read access here. A server CA is a public certificate (not a key), so no xtrace
+  # discipline is needed. serverCaCerts may carry more than one entry during a CA
+  # rotation; ship them all so the client trust store survives the overlap.
+  REDIS_CA="$(gcloud redis instances describe "$REDIS_INSTANCE" --region="$REGION" --project="$PROJECT_ID" --format='value(serverCaCerts[].cert)')"
+  case "$REDIS_CA" in
+    *"BEGIN CERTIFICATE"*) : ;;
+    *) echo "ERROR: could not read a PEM server CA for $REDIS_INSTANCE." >&2; exit 1 ;;
+  esac
+  if gcloud secrets describe "$SECRET_REDIS_CA_CERT" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    skip "secret $SECRET_REDIS_CA_CERT already exists"
+  else
+    # Match the Phase 1 secrets' replication (user-managed, pinned to $REGION).
+    gcloud secrets create "$SECRET_REDIS_CA_CERT" --project="$PROJECT_ID" \
+      --replication-policy=user-managed --locations="$REGION" >/dev/null
+    echo "    created secret $SECRET_REDIS_CA_CERT (user-managed, $REGION)"
+  fi
+  # Per-secret accessor grant for the runtime SA (mirrors the Phase 1 secret model).
+  gcloud secrets add-iam-policy-binding "$SECRET_REDIS_CA_CERT" --project="$PROJECT_ID" \
+    --member="serviceAccount:${RUNTIME_SA}" --role=roles/secretmanager.secretAccessor --quiet >/dev/null
+  printf '%s' "$REDIS_CA" | gcloud secrets versions add "$SECRET_REDIS_CA_CERT" --project="$PROJECT_ID" --data-file=- >/dev/null
+  echo "    new version added to secret $SECRET_REDIS_CA_CERT"
+  unset REDIS_CA
 else
   gate "Step 3 (Memorystore) SKIPPED. Re-run with CONFIRM_REDIS=1 to provision Redis."
 fi
@@ -432,14 +461,14 @@ PHASE 3 -> deploy-workflow edits (DONE on this branch, still INERT):
   - deploy-cloudrun.yml already passes Direct VPC egress + Cloud SQL on all three deploy
     commands (web, worker pool, migration Job) and the runtime SA (--service-account).
 
-REQUIRED app-code prerequisite before the REDIS gate's secret is consumed (i.e. before
-cutover): the app's Redis client must speak TLS for the rediss:// URL. Today all five
-Redis.new sites (config/initializers/resque.rb:23,26,60,110 + throttling.rb:12) build
-connections WITHOUT :ssl and ignore the URL scheme, so they CANNOT connect to a TLS Redis.
-This needs a small, backward-compatible change (enable :ssl for rediss://, keep redis://
-unchanged for Render) plus handling the Memorystore server CA, and it MUST be verified
-against the live instance (cert/CA behavior is not testable until the instance exists).
-AUTH alone works with the current client; TLS does not. Do this as its own verified commit.
+App-code Redis-over-TLS support is DONE (config/initializers/resque.rb routes all five
+Redis.new sites through RedisInit.redis_options: redis:// stays byte-identical for Render,
+rediss:// enables :ssl + verifies the Memorystore CA). This script now also seeds that CA
+(Step 3c -> REDIS_CA_CERT secret) and the deploy workflow mounts it + sets
+REDIS_TLS_VERIFY_HOSTNAME=false (Memorystore is reached by private IP, so hostname matching
+is off while CA-chain verification stays on). STILL live-only: the actual TLS handshake is
+not exercisable until a Cloud Run service inside the VPC connects to the private endpoint;
+confirm it during the Phase 4 dress rehearsal before cutover.
 
 PHASE 4 (separate branch, the cutover - NOT this script):
   - pg_dump Render prod -> restore into ${APP_DB_NAME} on ${SQL_INSTANCE}.

--- a/scripts/gcp/phase3-data-layer.sh
+++ b/scripts/gcp/phase3-data-layer.sh
@@ -407,9 +407,16 @@ if [ "$CONFIRM_REDIS" = "1" ]; then
   # Per-secret accessor grant for the runtime SA (mirrors the Phase 1 secret model).
   gcloud secrets add-iam-policy-binding "$SECRET_REDIS_CA_CERT" --project="$PROJECT_ID" \
     --member="serviceAccount:${RUNTIME_SA}" --role=roles/secretmanager.secretAccessor --quiet >/dev/null
-  printf '%s' "$REDIS_CA" | gcloud secrets versions add "$SECRET_REDIS_CA_CERT" --project="$PROJECT_ID" --data-file=- >/dev/null
-  echo "    new version added to secret $SECRET_REDIS_CA_CERT"
-  unset REDIS_CA
+  # Only add a version when the CA actually changed, so re-runs do not churn
+  # versions (the CA is stable for the life of the instance, modulo rotation).
+  CURRENT_CA="$(gcloud secrets versions access latest --secret="$SECRET_REDIS_CA_CERT" --project="$PROJECT_ID" 2>/dev/null || true)"
+  if [ "$CURRENT_CA" = "$REDIS_CA" ]; then
+    skip "secret $SECRET_REDIS_CA_CERT already holds the current CA"
+  else
+    printf '%s' "$REDIS_CA" | gcloud secrets versions add "$SECRET_REDIS_CA_CERT" --project="$PROJECT_ID" --data-file=- >/dev/null
+    echo "    new version added to secret $SECRET_REDIS_CA_CERT"
+  fi
+  unset REDIS_CA CURRENT_CA
 else
   gate "Step 3 (Memorystore) SKIPPED. Re-run with CONFIRM_REDIS=1 to provision Redis."
 fi

--- a/spec/initializers/resque_redis_options_spec.rb
+++ b/spec/initializers/resque_redis_options_spec.rb
@@ -161,5 +161,10 @@ describe RedisInit do
       expect(ctx.verify_hostname).to eq(false)
       expect(ctx.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
     end
+
+    it 'fails closed when hostname verification is off but no CA is pinned' do
+      ENV['REDIS_TLS_VERIFY_HOSTNAME'] = 'false'
+      expect { RedisInit.redis_options(rediss_uri) }.to raise_error(%r{no REDIS_CA_FILE/REDIS_CA_CERT})
+    end
   end
 end

--- a/spec/initializers/resque_redis_options_spec.rb
+++ b/spec/initializers/resque_redis_options_spec.rb
@@ -24,13 +24,15 @@ describe RedisInit do
   end
 
   around(:each) do |example|
-    saved = ENV.values_at('REDIS_CA_FILE', 'REDIS_CA_CERT')
+    saved = ENV.values_at('REDIS_CA_FILE', 'REDIS_CA_CERT', 'REDIS_TLS_VERIFY_HOSTNAME')
     ENV.delete('REDIS_CA_FILE')
     ENV.delete('REDIS_CA_CERT')
+    ENV.delete('REDIS_TLS_VERIFY_HOSTNAME')
     example.run
-    ENV['REDIS_CA_FILE'], ENV['REDIS_CA_CERT'] = saved
+    ENV['REDIS_CA_FILE'], ENV['REDIS_CA_CERT'], ENV['REDIS_TLS_VERIFY_HOSTNAME'] = saved
     ENV.delete('REDIS_CA_FILE') if saved[0].nil?
     ENV.delete('REDIS_CA_CERT') if saved[1].nil?
+    ENV.delete('REDIS_TLS_VERIFY_HOSTNAME') if saved[2].nil?
   end
 
   describe '.redis_options' do
@@ -116,6 +118,48 @@ describe RedisInit do
     it 'verifies the peer when an inline CA is supplied' do
       ENV['REDIS_CA_CERT'] = build_cert(OpenSSL::PKey::RSA.new(2048), 'ca').to_pem
       expect(verify_mode_for(RedisInit.redis_options(rediss_uri))).to eq(OpenSSL::SSL::VERIFY_PEER)
+    end
+  end
+
+  # Hostname verification is ON by default (so DNS-named TLS endpoints stay
+  # safe) and is turned OFF only when REDIS_TLS_VERIFY_HOSTNAME is explicitly
+  # false-y. Disabling it is required for Memorystore (connect-by-private-IP,
+  # cert issued for the instance not the IP) and MUST NOT weaken CA-chain
+  # verification, which stays at VERIFY_PEER. See config/initializers/resque.rb.
+  describe 'hostname verification opt-out (REDIS_TLS_VERIFY_HOSTNAME)' do
+    it 'leaves verify_hostname unset by default for rediss:// (verification ON)' do
+      ENV['REDIS_CA_CERT'] = build_cert(OpenSSL::PKey::RSA.new(2048), 'ca').to_pem
+      expect(RedisInit.redis_options(rediss_uri)[:ssl_params]).not_to have_key(:verify_hostname)
+    end
+
+    it 'sets verify_hostname=false when REDIS_TLS_VERIFY_HOSTNAME=false, keeping the CA store' do
+      ENV['REDIS_CA_CERT'] = build_cert(OpenSSL::PKey::RSA.new(2048), 'ca').to_pem
+      ENV['REDIS_TLS_VERIFY_HOSTNAME'] = 'false'
+      ssl = RedisInit.redis_options(rediss_uri)[:ssl_params]
+      expect(ssl[:verify_hostname]).to eq(false)
+      expect(ssl[:cert_store]).to be_a(OpenSSL::X509::Store)
+    end
+
+    it 'treats truthy/unrelated values as verification ON (no opt-out)' do
+      ENV['REDIS_CA_CERT'] = build_cert(OpenSSL::PKey::RSA.new(2048), 'ca').to_pem
+      ENV['REDIS_TLS_VERIFY_HOSTNAME'] = 'true'
+      expect(RedisInit.redis_options(rediss_uri)[:ssl_params]).not_to have_key(:verify_hostname)
+    end
+
+    it 'does not touch redis:// (no ssl_params) even when the flag is false' do
+      ENV['REDIS_TLS_VERIFY_HOSTNAME'] = 'false'
+      opts = RedisInit.redis_options(redis_uri)
+      expect(opts).not_to have_key(:ssl)
+      expect(opts).not_to have_key(:ssl_params)
+    end
+
+    it 'produces a context that disables the hostname check but stays VERIFY_PEER' do
+      ENV['REDIS_CA_CERT'] = build_cert(OpenSSL::PKey::RSA.new(2048), 'ca').to_pem
+      ENV['REDIS_TLS_VERIFY_HOSTNAME'] = 'off'
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.set_params(RedisInit.redis_options(rediss_uri)[:ssl_params])
+      expect(ctx.verify_hostname).to eq(false)
+      expect(ctx.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER)
     end
   end
 end


### PR DESCRIPTION
## What

Closes the two confirmed Phase 4 tabletop blockers (**B1**, **B2**) so the app can connect to the AUTH + TLS Memorystore instance stood up in Phase 3 (`lingolinq-prod-redis`, `10.160.1.3:6378`). Without these, the app can do Redis AUTH but **not** TLS, so a cutover would fail at Redis connect.

## B1 - hostname verification (`config/initializers/resque.rb`)

Root cause (verified against the gem): `redis-client` 0.27.0 sets the TLS SNI hostname to the connection host (`ruby_connection.rb:138`, the Memorystore **private IP**), and OpenSSL's `set_params` defaults `verify_hostname=true`. So the handshake fails the hostname match against the server cert — which is issued for the instance, not the IP — even with a correct CA. GCP's own docs prescribe disabling hostname verification when connecting by IP.

Fix: an **opt-in** `REDIS_TLS_VERIFY_HOSTNAME=false` that sets `verify_hostname:false` while leaving **CA-chain verification (`VERIFY_PEER`) on**. Default (unset) keeps hostname verification ON, so `redis://` (Render) and any DNS-named TLS endpoint are unchanged.

5 new specs prove it, including a test that `set_params` actually applies `verify_hostname=false` and stays `VERIFY_PEER`.

## B2 - server CA wiring

- `scripts/gcp/phase3-data-layer.sh` **Step 3c**: fetch the Memorystore server CA (`serverCaCerts[].cert`, multi-cert to survive a rotation overlap), create the `REDIS_CA_CERT` secret (user-managed / `us-central1`, matching the Phase 1 secrets), grant the runtime SA `secretAccessor`, add the version.
- `deploy-cloudrun.yml`: add `REDIS_CA_CERT` to `BOOT_SECRETS` and set `REDIS_TLS_VERIFY_HOSTNAME=false` on the migration Job, web, and worker deploys.

## Verification

- `spec/initializers/resque_redis_options_spec.rb` green: **16 examples, 0 failures**.
- Ran Step 3c against `lingolinq-prod`: `REDIS_CA_CERT` created (version 1 enabled, `secretAccessor` granted to `lingolinq-run@`, content is the instance's CA cert).
- **Live-only, deferred to the Phase 4 dress rehearsal:** the actual TLS handshake can only be exercised from a Cloud Run service inside the VPC (the private IP is unreachable from outside). The deploy workflow remains inert (`GCP_PROJECT_ID` unset).

## Security note

Disabling hostname verification is a deliberate tradeoff. It is the documented Memorystore connect-by-IP posture and does **not** weaken CA-chain validation (`VERIFY_PEER` against the per-instance CA stays on). It is scoped to the rediss:// path and opt-in via env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)