### PR TITLE
compliance(triage): disposition decisions on the 16 open High findings

### DIFF
--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -271,7 +271,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: protected_paths (throttling.rb:18-21) contains no consent path; consent endpoints are unauthenticated and fall under the 150-req/3s general limit."
+      "notes": "Verified still open 2026-06-12: protected_paths (throttling.rb:18-21) contains no consent path; consent endpoints are unauthenticated and fall under the 150-req/3s general limit.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Add the supervisor consent paths to Rack::Attack protected_paths (throttling.rb). In the high-findings-quick-wins batch."
+      }
     },
     {
       "id": "LL-740bcb10fa",
@@ -304,7 +310,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: License includes only GlobalId; no secure_serialize declared. metadata text + external_reference string remain plaintext."
+      "notes": "Verified still open 2026-06-12: License includes only GlobalId; no secure_serialize declared. metadata text + external_reference string remain plaintext.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "secure_serialize License.metadata/external_reference; needs a data migration for existing plaintext rows so reads do not break."
+      }
     },
     {
       "id": "LL-e775d86e6a",
@@ -336,7 +348,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: transfer_user_content transfers NfcTag/UserIntegration/UserGoal/UserBadge/Webhook/UserBoardConnection/UserLink/ButtonSound/ButtonImage/UserVideo but not License (flusher.rb:156-190). License IS handled in flush_user_content (see P0-2), only the transfer path is missing it."
+      "notes": "Verified still open 2026-06-12: transfer_user_content transfers NfcTag/UserIntegration/UserGoal/UserBadge/Webhook/UserBoardConnection/UserLink/ButtonSound/ButtonImage/UserVideo but not License (flusher.rb:156-190). License IS handled in flush_user_content (see P0-2), only the transfer path is missing it.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Transfer License rows in transfer_user_content so seats are not orphaned on user merge."
+      }
     },
     {
       "id": "LL-e65d34f109",
@@ -368,7 +386,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: claim_user not present in protected_paths. Shares the throttling.rb anchor with P1-1/P2-6; remediate together."
+      "notes": "Verified still open 2026-06-12: claim_user not present in protected_paths. Shares the throttling.rb anchor with P1-1/P2-6; remediate together.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Add api/v1/organizations/.+/claim_user to protected_paths. In the high-findings-quick-wins batch."
+      }
     },
     {
       "id": "LL-92dc570f30",
@@ -398,7 +422,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: multi-key acceptance persists (line 86), though surrounding flow is more defensive (token_valid?, expiry). Candidate for accepted-risk pending Scot."
+      "notes": "Verified still open 2026-06-12: multi-key acceptance persists (line 86), though surrounding flow is more defensive (token_valid?, expiry). Candidate for accepted-risk pending Scot.",
+      "disposition": {
+        "state": "accepted",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Token already validated via token_valid? + expiry guards; multi-key param acceptance is residual code-smell, not a live vuln. Accepted at current severity; not slated for change."
+      }
     },
     {
       "id": "LL-9a3ee852d5",
@@ -428,7 +458,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: forgot_password (users_controller.rb:692) returns users: users.length on success (:705/:708) and a 400 with users: 0 (:714), enabling enumeration."
+      "notes": "Verified still open 2026-06-12: forgot_password (users_controller.rb:692) returns users: users.length on success (:705/:708) and a 400 with users: 0 (:714), enabling enumeration.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Return a uniform forgot_password response; first verify the Ember frontend does not depend on users.length."
+      }
     },
     {
       "id": "LL-747bb0e02d",
@@ -461,7 +497,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: notify_of_changes (user.rb:2255) only schedules a password_changed mailer (:2257); no AuditEvent. AuditEvent is used elsewhere in user.rb (e.g. :540, :581) but not for password changes."
+      "notes": "Verified still open 2026-06-12: notify_of_changes (user.rb:2255) only schedules a password_changed mailer (:2257); no AuditEvent. AuditEvent is used elsewhere in user.rb (e.g. :540, :581) but not for password changes.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Add an AuditEvent on the password-change path (incl. admin resets). In the high-findings-quick-wins batch."
+      }
     },
     {
       "id": "LL-6d8314e37b",
@@ -491,7 +533,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Reduced-scope 2026-06-12: SMS-inbound path now verifies via Aws::SNS::MessageVerifier.authentic? (callbacks_controller.rb:37-38), but the general transcoding TODO at :8 remains. Originally scoped to all SNS callbacks."
+      "notes": "Reduced-scope 2026-06-12: SMS-inbound path now verifies via Aws::SNS::MessageVerifier.authentic? (callbacks_controller.rb:37-38), but the general transcoding TODO at :8 remains. Originally scoped to all SNS callbacks.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Apply Aws::SNS::MessageVerifier to the transcoding callback path, mirroring the SMS-inbound path."
+      }
     },
     {
       "id": "LL-4e243f3e16",
@@ -521,7 +569,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: hash truncated to [0, 5] of SHA512 (organizations_controller.rb:128)."
+      "notes": "Verified still open 2026-06-12: hash truncated to [0, 5] of SHA512 (organizations_controller.rb:128).",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Lengthen the start_code verification hash; confirm existing issued codes are not invalidated by the change."
+      }
     },
     {
       "id": "LL-6619cc1811",
@@ -553,7 +607,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: Redis.new without ssl options (resque.rb:23,26,60,110). NOTE: prod Redis is moving to GCP Memorystore over private VPC (project_render_cloud_migration Phase 3); resolution should land with that cutover. | 2026-06-17 reconcile (staging tip d72463c75, RULE #0 re-verified): #410 shipped the app-side TLS CAPABILITY but NOT live closure. redis_options now enables :ssl + :ssl_params for rediss:// URIs (config/initializers/resque.rb:16-21; redis_ssl_params at :35) and every Redis.new routes through redis_options (resque.rb:79,82,116,166). A plain redis:// URI returns the option hash with no :ssl key, so live Render Redis remains plaintext (resque.rb:12 comment: 'the Render environment is unchanged'). Enabler only; NOT verified-closed. Full closure gated on the GCP Memorystore cutover (Cloud Run migration Phase 3). Disposition (Scot 2026-06-17): keep open / severity high; do not close until the rediss:// cutover lands."
+      "notes": "Verified still open 2026-06-12: Redis.new without ssl options (resque.rb:23,26,60,110). NOTE: prod Redis is moving to GCP Memorystore over private VPC (project_render_cloud_migration Phase 3); resolution should land with that cutover. | 2026-06-17 reconcile (staging tip d72463c75, RULE #0 re-verified): #410 shipped the app-side TLS CAPABILITY but NOT live closure. redis_options now enables :ssl + :ssl_params for rediss:// URIs (config/initializers/resque.rb:16-21; redis_ssl_params at :35) and every Redis.new routes through redis_options (resque.rb:79,82,116,166). A plain redis:// URI returns the option hash with no :ssl key, so live Render Redis remains plaintext (resque.rb:12 comment: 'the Render environment is unchanged'). Enabler only; NOT verified-closed. Full closure gated on the GCP Memorystore cutover (Cloud Run migration Phase 3). Disposition (Scot 2026-06-17): keep open / severity high; do not close until the rediss:// cutover lands.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "App-side rediss:// TLS capability shipped (#410). Full closure lands at the GCP Memorystore cutover (Cloud Run migration Phase 3); do not fix twice. Status stays open until the cutover."
+      }
     },
     {
       "id": "LL-1085e59d29",
@@ -586,7 +646,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: regex /^http/ matches both http and https (webhook.rb:42)."
+      "notes": "Verified still open 2026-06-12: regex /^http/ matches both http and https (webhook.rb:42).",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Require https:// in the webhook callback URL validation; check live webhooks for existing http:// URLs before tightening."
+      }
     },
     {
       "id": "LL-c6dd65a2aa",
@@ -616,7 +682,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: literal 'abc' (resque.rb:29). Low real-world impact but unchanged."
+      "notes": "Verified still open 2026-06-12: literal 'abc' (resque.rb:29). Low real-world impact but unchanged.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Derive cache_token from an env var with a deploy-SHA fallback (shared across all processes). In the high-findings-quick-wins batch."
+      }
     },
     {
       "id": "LL-9f83617435",
@@ -646,7 +718,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Partially mitigated 2026-06-12: force_ssl=true already emits a default HSTS header (max-age 1yr) but without subdomains/preload (production.rb:62). Severity effectively lower than the April P1; left high pending Scot's call."
+      "notes": "Partially mitigated 2026-06-12: force_ssl=true already emits a default HSTS header (max-age 1yr) but without subdomains/preload (production.rb:62). Severity effectively lower than the April P1; left high pending Scot's call.",
+      "disposition": {
+        "state": "accepted",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "force_ssl already emits a default HSTS header (max-age 1yr). includeSubDomains/preload deferred to avoid the one-way preload commitment until the subdomain inventory is confirmed safe."
+      }
     },
     {
       "id": "LL-3076d244a6",
@@ -1428,7 +1506,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Surfaced by dependency finder on 2026-06-14. | adversary verifier: CONFIRMED (high); SEVERITY OPINION for Scot = should-be-medium. bootstrap 3.4.1 JS is bundled (ember-cli-build.js:88) and .tooltip()/.popover() are used, but no live untrusted-HTML-into-tooltip sink exists today (all .tooltip() omit html:true; the one html:true popover builds body via escaped innerText), so this is latent supply-chain/XSS hygiene risk, not a currently triggerable XSS. Fix is independent of the pinned Ember 3.28->5 migration. Severity downgrade is Scot's call only."
+      "notes": "Surfaced by dependency finder on 2026-06-14. | adversary verifier: CONFIRMED (high); SEVERITY OPINION for Scot = should-be-medium. bootstrap 3.4.1 JS is bundled (ember-cli-build.js:88) and .tooltip()/.popover() are used, but no live untrusted-HTML-into-tooltip sink exists today (all .tooltip() omit html:true; the one html:true popover builds body via escaped innerText), so this is latent supply-chain/XSS hygiene risk, not a currently triggerable XSS. Fix is independent of the pinned Ember 3.28->5 migration. Severity downgrade is Scot's call only.",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Replace or upgrade bootstrap 3.4.1 (EOL); a larger migration to schedule on its own, not a quick win."
+      }
     },
     {
       "id": "LL-20c48e298c",
@@ -1490,7 +1574,13 @@
         "verifierNote": "",
         "attestation": ""
       },
-      "notes": "Surfaced by accessibility finder on 2026-06-16. WCAG 1.1.1 / 4.1.2 (EN 301 549 9.1.1). Second of the two board-grid render paths: button.js builds the tile symbol <img> as a raw HTML string with no alt attribute (the action_image at button.js:442 does include alt). Mirror of the templates/board/index.hbs finding; a fix in one path is not automatically in the other. | adversary: confirmed (2026-06-16): the fast_html symbol <img> (button.js:449) has no alt on a LIVE render path ({{button.fast_html}} / {{board.fast_html.html}}); the action_image <img> at button.js:442 DOES include alt, so the omission is specific not global. Escalation verified: when button.hide_label is set, the label span (button.js:479) is display:none via .hide-label (app.scss:9167), so it leaves the accessibility tree and the tile has NO accessible name at all -- supports high/critical. The parallel board.js render_fast_html builder repeats the same pattern (a third render path)."
+      "notes": "Surfaced by accessibility finder on 2026-06-16. WCAG 1.1.1 / 4.1.2 (EN 301 549 9.1.1). Second of the two board-grid render paths: button.js builds the tile symbol <img> as a raw HTML string with no alt attribute (the action_image at button.js:442 does include alt). Mirror of the templates/board/index.hbs finding; a fix in one path is not automatically in the other. | adversary: confirmed (2026-06-16): the fast_html symbol <img> (button.js:449) has no alt on a LIVE render path ({{button.fast_html}} / {{board.fast_html.html}}); the action_image <img> at button.js:442 DOES include alt, so the omission is specific not global. Escalation verified: when button.hide_label is set, the label span (button.js:479) is display:none via .hide-label (app.scss:9167), so it leaves the accessibility tree and the tile has NO accessible name at all -- supports high/critical. The parallel board.js render_fast_html builder repeats the same pattern (a third render path).",
+      "disposition": {
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Add i18n alt text to the board-tile symbol image on BOTH render paths (index.hbs and the button.js fast_html string)."
+      }
     },
     {
       "id": "LL-5ff3b22093",
@@ -1975,10 +2065,10 @@
         "attestation": ""
       },
       "disposition": {
-        "state": "untriaged",
-        "decidedBy": "",
-        "decidedDate": "",
-        "rationale": ""
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-06-18",
+        "rationale": "Bind the consent gate subject to the eval payload actually egressed; Phase 1B server-side eval persistence follow-up."
       },
       "source": {
         "kind": "audit",

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -13,22 +13,22 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
-| LL-d1ea8659c3 |  | high |  | untriaged | audit-run | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
-| LL-2967f77e6d |  | high | WCAG | untriaged | audit-run | Board-tile symbol image has no alt text (fast_html render path) | `app/frontend/app/utils/button.js`:449 |
-| LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | untriaged | audit | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
-| LL-6619cc1811 | Infra-P1-1 | high | HIPAA | untriaged | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
-| LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | untriaged | audit-run | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |
-| LL-c6dd65a2aa | Infra-P1-3 | high |  | untriaged | audit-run | Static cache_token='abc' never rotates (stale permission cache) | `config/initializers/resque.rb`:29 |
-| LL-9f83617435 | Infra-P1-4 | high |  | untriaged | audit-run | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
-| LL-ca38d4d99e | P1-1 | high | FERPA, HIPAA | untriaged | audit-run | Consent endpoints absent from Rack::Attack protected_paths | `config/initializers/throttling.rb`:18 |
-| LL-740bcb10fa | P1-2 | high | GDPR, HIPAA | untriaged | audit-run | License.metadata / external_reference stored unencrypted | `app/models/license.rb`:2 |
-| LL-e775d86e6a | P1-3 | high | GDPR | untriaged | audit-run | License not handled in transfer_user_content (orphaned seats on merge) | `lib/flusher.rb`:156 |
-| LL-e65d34f109 | P1-4 | high | FERPA | untriaged | audit-run | Sensitive new routes (claim_user) under general throttle only | `config/initializers/throttling.rb`:18 |
-| LL-92dc570f30 | P1-5 | high |  | untriaged | audit-run | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
-| LL-9a3ee852d5 | P1-6 | high |  | untriaged | audit-run | forgot_password leaks account existence via response shape and users count | `app/controllers/api/users_controller.rb`:705 |
-| LL-747bb0e02d | P1-7 | high | FERPA, HIPAA | untriaged | audit-run | Password changes (incl. admin resets) generate no AuditEvent | `app/models/user.rb`:2255 |
-| LL-6d8314e37b | P1-8 | high |  | untriaged | audit-run | SNS transcoding callbacks accepted without signature verification | `app/controllers/api/callbacks_controller.rb`:8 |
-| LL-4e243f3e16 | P1-9 | high |  | untriaged | audit-run | start_code_lookup uses a brute-forceable 5-char verification hash | `app/controllers/api/organizations_controller.rb`:128 |
+| LL-d1ea8659c3 |  | high |  | **fixed** | audit-run | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
+| LL-2967f77e6d |  | high | WCAG | **fixed** | audit-run | Board-tile symbol image has no alt text (fast_html render path) | `app/frontend/app/utils/button.js`:449 |
+| LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | **fixed** | audit | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
+| LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
+| LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | **fixed** | audit-run | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |
+| LL-c6dd65a2aa | Infra-P1-3 | high |  | **fixed** | audit-run | Static cache_token='abc' never rotates (stale permission cache) | `config/initializers/resque.rb`:29 |
+| LL-9f83617435 | Infra-P1-4 | high |  | **accepted** | audit-run | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
+| LL-ca38d4d99e | P1-1 | high | FERPA, HIPAA | **fixed** | audit-run | Consent endpoints absent from Rack::Attack protected_paths | `config/initializers/throttling.rb`:18 |
+| LL-740bcb10fa | P1-2 | high | GDPR, HIPAA | **fixed** | audit-run | License.metadata / external_reference stored unencrypted | `app/models/license.rb`:2 |
+| LL-e775d86e6a | P1-3 | high | GDPR | **fixed** | audit-run | License not handled in transfer_user_content (orphaned seats on merge) | `lib/flusher.rb`:156 |
+| LL-e65d34f109 | P1-4 | high | FERPA | **fixed** | audit-run | Sensitive new routes (claim_user) under general throttle only | `config/initializers/throttling.rb`:18 |
+| LL-92dc570f30 | P1-5 | high |  | **accepted** | audit-run | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
+| LL-9a3ee852d5 | P1-6 | high |  | **fixed** | audit-run | forgot_password leaks account existence via response shape and users count | `app/controllers/api/users_controller.rb`:705 |
+| LL-747bb0e02d | P1-7 | high | FERPA, HIPAA | **fixed** | audit-run | Password changes (incl. admin resets) generate no AuditEvent | `app/models/user.rb`:2255 |
+| LL-6d8314e37b | P1-8 | high |  | **fixed** | audit-run | SNS transcoding callbacks accepted without signature verification | `app/controllers/api/callbacks_controller.rb`:8 |
+| LL-4e243f3e16 | P1-9 | high |  | **fixed** | audit-run | start_code_lookup uses a brute-forceable 5-char verification hash | `app/controllers/api/organizations_controller.rb`:128 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | untriaged | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
 | LL-52ff2a9a79 |  | medium | SOC2 | untriaged | audit-run | CI security-scan job (Brakeman SAST, bundle-audit, npm audit, gitleaks) is entirely non-blocking | `.github/workflows/ci.yml`:107 |
 | LL-27d20047db |  | medium |  | untriaged | audit-run | Integration board_render_url is writable but never serialized back (read/write field-name asymmetry) | `app/frontend/app/models/integration.js`:24 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,7 +11,7 @@
 **Audited commit:** `59e20439e005b363ec67f8444d5406848a1c434f`  
 **Audited ref:** `staging`  
 **Run date:** 2026-06-18  
-**Page generated:** 2026-06-18T05:32:32Z
+**Page generated:** 2026-06-18T08:17:04Z
 
 ## Headline - open findings
 


### PR DESCRIPTION
Records Scot's triage decisions (2026-06-18) on all **16 open High** findings in the register. This is **intent only** — `disposition` is orthogonal to `status`. Every finding stays `status: open` and severity unchanged; nothing is closed here. Closure still requires the fix to land and Scot's attestation.

## Decisions

**Accepted risk (2)**
- `LL-92dc570f30` — consent_response multi-key param. `token_valid?` + expiry already guard it; residual code-smell, not a live vuln.
- `LL-9f83617435` — HSTS. Default `max-age 1yr` header already active; `includeSubDomains`/`preload` deferred to avoid the one-way preload commitment until the subdomain inventory is confirmed safe.

**Fixed-intent (14)** — the remaining Highs. Notable:
- `LL-6619cc1811` (Redis TLS) — fixed-intent but **slated for the GCP Memorystore cutover**; do not fix twice. Stays open until cutover.
- `LL-ca38d4d99e`, `LL-e65d34f109`, `LL-c6dd65a2aa`, `LL-747bb0e02d` — in the separate `high-findings-quick-wins` code batch.
- The rest carry a one-line remediation note (some with a "check X first" guard against regressions).

## Integrity
- `citation-check` PASS **59/0/3** — no evidence anchors touched.
- FINDINGS.md + Notion page re-rendered from the register; calendar byte-identical.
- No student/patient data; register is code-evidence only.

## Note
This PR touches `audit-reports/**` (compliance content). The n8n PR-review bot's DeepSeek adversary pass will run on it until the path-exclusion fix lands (tracked in the Master Inbox). No PHI is in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)