### PR TITLE
security: rate-limit + audit-trail quick wins (audit High findings)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1643,6 +1643,10 @@ class User < ApplicationRecord
     if params['password'] && params['password'] != ""
       if !self.settings['password'] || valid_password?(params['old_password']) || non_user_params[:allow_password_change]
         @password_changed = !!self.settings['password']
+        # Remember whether this was a self-service change (old password verified)
+        # vs. a forced change without the old password (admin reset / forgot-password
+        # token). Recorded in the audit trail by notify_of_changes (LL-747bb0e02d).
+        @password_change_self_service = @password_changed && !non_user_params[:allow_password_change]
         self.generate_password(params['password'])
       else
         add_processing_error("incorrect current password")
@@ -2260,7 +2264,18 @@ class User < ApplicationRecord
   def notify_of_changes
     if @password_changed
       UserMailer.schedule_delivery(:password_changed, self.global_id)
+      # Record an immutable audit trail entry for every password change, including
+      # admin-initiated / token resets (LL-747bb0e02d). log_command is best-effort
+      # (it rescues and never raises), so a failed audit insert can never break the
+      # password change or alter the existing mailer behavior. No password material
+      # or PII is stored - only the change type and self-service flag; user_key is
+      # the opaque global_id.
+      AuditEvent.log_command(self.global_id, {
+        'type' => 'password_changed',
+        'self_service' => !!@password_change_self_service
+      })
       @password_changed = false
+      @password_change_self_service = false
     end
     if @email_changed
       # TODO: should have confirmation flow for new email address

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -82,7 +82,24 @@ module RedisInit
     @redis_inst = Redis.new(redis_options(uri, :timeout => 5))
     @default = Redis::Namespace.new("lingolinq-stash#{ns_suffix}", :redis => @redis_inst)
     @permissions = Redis::Namespace.new("lingolinq-permissions#{ns_suffix}", :redis => @redis_inst)
-    self.cache_token = 'abc'
+    self.cache_token = resolved_cache_token
+  end
+
+  # The cache_token namespaces the shared permission cache (see Permissable
+  # below), so EVERY web/worker process in a deploy MUST resolve to the SAME
+  # value or they would read/write disjoint permission caches. A static 'abc'
+  # (LL-c6dd65a2aa) was predictable and never rotated. Resolve from env in
+  # preference order, all of which are process-invariant within a deploy:
+  #   CACHE_TOKEN       - explicit operator-set secret (preferred)
+  #   RENDER_GIT_COMMIT - deploy SHA on Render (current platform)
+  #   K_REVISION        - Cloud Run revision name (GCP migration target)
+  # Falling back to 'abc' only in local/dev/test where none are set, preserving
+  # existing behavior there. Deterministic: no per-process randomness.
+  def self.resolved_cache_token
+    ENV['CACHE_TOKEN'].presence ||
+      ENV['RENDER_GIT_COMMIT'].presence ||
+      ENV['K_REVISION'].presence ||
+      'abc'
   end
 
   def self.memory

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -23,7 +23,9 @@ module Throttling
     'api/v1/supervisor_relationships/consent_response',
     'api/v1/supervisor_relationships/.+/consent_response',
     'api/v1/supervisor_relationships/.+/approve',
-    'api/v1/supervisor_relationships/.+/deny'
+    'api/v1/supervisor_relationships/.+/deny',
+    # Org bulk user-claim: abusable account-claim/enumeration surface (LL-e65d34f109).
+    'api/v1/organizations/.+/claim_user'
   ].freeze
   PROTECTED_RE = /#{PROTECTED_PATHS.join('|')}/
 

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -25,7 +25,15 @@ module Throttling
     'api/v1/supervisor_relationships/.+/approve',
     'api/v1/supervisor_relationships/.+/deny',
     # Org bulk user-claim: abusable account-claim/enumeration surface (LL-e65d34f109).
-    'api/v1/organizations/.+/claim_user'
+    'api/v1/organizations/.+/claim_user',
+    # Registration, 2FA enrollment, and SAML assertion consumption: account
+    # creation/auth surfaces that were unthrottled (LL-56f0f19fca). The
+    # 'api/v1/users' entry is anchored to the collection (create/index) ONLY so
+    # the many per-user member endpoints keep their normal NORMAL_CUTOFF limit.
+    'api/v1/users(\.json)?$',
+    'api/v1/users/.+/confirm_registration',
+    'api/v1/users/.+/2fa',
+    'saml/consume'
   ].freeze
   PROTECTED_RE = /#{PROTECTED_PATHS.join('|')}/
 

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -5,6 +5,28 @@ module Throttling
   # Relax limits in development to avoid 429 during login testing; test env keeps strict limits for specs
   TOKEN_CUTOFF = Rails.env.development? ? 200 : 20
   PROTECTED_CUTOFF = Rails.env.development? ? 100 : 10
+
+  # Paths that get the stricter PROTECTED_CUTOFF rate limit. Each entry is an
+  # unanchored regex fragment matched against req.path, so 'api/v1/messages'
+  # also covers '/api/v1/messages/...'. Exposed as a module constant (instead of
+  # a local in the Application body) so the path classification is unit-testable
+  # without booting Rack::Attack; the Application body builds the same regex from
+  # this list, so runtime behavior is unchanged.
+  PROTECTED_PATHS = [
+    'oauth2/token', '^/token', 'api/v1/forgot_password', 'api/v1/gifts/code_check',
+    'api/v1/boards/.+/imports', 'api/v1/boards/.+/download', 'api/v1/boards/.+/rename',
+    'api/v1/users/\w+/replace_board', 'api/v1/users/\w+/rename', 'auth/lookup', 'saml/tmp_token',
+    'api/v1/purchase_gift', 'api/v1/messages', 'api/v1/beta_feedback_recordings', 'api/v1/logs/code_check',
+    # Supervisor/parent consent decisions: brute-forceable consent-token and
+    # approval endpoints (LL-ca38d4d99e). Covers the collection consent_response,
+    # the per-relationship consent_response, and the approve/deny actions.
+    'api/v1/supervisor_relationships/consent_response',
+    'api/v1/supervisor_relationships/.+/consent_response',
+    'api/v1/supervisor_relationships/.+/approve',
+    'api/v1/supervisor_relationships/.+/deny'
+  ].freeze
+  PROTECTED_RE = /#{PROTECTED_PATHS.join('|')}/
+
   class LingoLinq::Application < Rails::Application
     uri = RedisInit.redis_uri
     unless ENV['SKIP_VALIDATIONS']
@@ -15,11 +37,7 @@ module Throttling
     end
 
     # Always register throttle rules (specs override cache store to test throttling)
-    protected_paths = ['oauth2/token', '^/token', 'api/v1/forgot_password', 'api/v1/gifts/code_check',
-          'api/v1/boards/.+/imports', 'api/v1/boards/.+/download', 'api/v1/boards/.+/rename',
-          'api/v1/users/\w+/replace_board', 'api/v1/users/\w+/rename', 'auth/lookup', 'saml/tmp_token',
-          'api/v1/purchase_gift', 'api/v1/messages', 'api/v1/beta_feedback_recordings', 'api/v1/logs/code_check']
-    re = /#{protected_paths.join('|')}/
+    re = Throttling::PROTECTED_RE
 
     limit_proc = proc {|req|
       if req.path.match(/^\/token/)

--- a/spec/initializers/resque_redis_options_spec.rb
+++ b/spec/initializers/resque_redis_options_spec.rb
@@ -118,4 +118,50 @@ describe RedisInit do
       expect(verify_mode_for(RedisInit.redis_options(rediss_uri))).to eq(OpenSSL::SSL::VERIFY_PEER)
     end
   end
+
+  # LL-c6dd65a2aa: the permission-cache token must no longer be the static 'abc'.
+  # It is shared across all web/worker processes, so the resolver must be
+  # deterministic (no randomness) and prefer an explicit env value, falling back
+  # through deploy-identity env vars before the dev-only literal.
+  describe '.resolved_cache_token' do
+    around(:each) do |example|
+      keys = %w[CACHE_TOKEN RENDER_GIT_COMMIT K_REVISION]
+      saved = ENV.values_at(*keys)
+      keys.each { |k| ENV.delete(k) }
+      example.run
+      keys.each_with_index { |k, i| saved[i].nil? ? ENV.delete(k) : ENV[k] = saved[i] }
+    end
+
+    it 'prefers CACHE_TOKEN when set' do
+      ENV['CACHE_TOKEN'] = 'explicit-secret'
+      ENV['RENDER_GIT_COMMIT'] = 'deadbeef'
+      expect(RedisInit.resolved_cache_token).to eq('explicit-secret')
+    end
+
+    it 'falls back to the Render deploy SHA when CACHE_TOKEN is absent' do
+      ENV['RENDER_GIT_COMMIT'] = 'deadbeef'
+      ENV['K_REVISION'] = 'svc-00001-abc'
+      expect(RedisInit.resolved_cache_token).to eq('deadbeef')
+    end
+
+    it 'falls back to the Cloud Run revision when no CACHE_TOKEN/Render SHA' do
+      ENV['K_REVISION'] = 'svc-00001-abc'
+      expect(RedisInit.resolved_cache_token).to eq('svc-00001-abc')
+    end
+
+    it 'treats a blank env value as unset (skips to the next source)' do
+      ENV['CACHE_TOKEN'] = ''
+      ENV['RENDER_GIT_COMMIT'] = 'deadbeef'
+      expect(RedisInit.resolved_cache_token).to eq('deadbeef')
+    end
+
+    it 'falls back to the legacy literal only when nothing is set' do
+      expect(RedisInit.resolved_cache_token).to eq('abc')
+    end
+
+    it 'is deterministic: repeated calls return the same value' do
+      ENV['RENDER_GIT_COMMIT'] = 'deadbeef'
+      expect(RedisInit.resolved_cache_token).to eq(RedisInit.resolved_cache_token)
+    end
+  end
 end

--- a/spec/initializers/throttling_paths_spec.rb
+++ b/spec/initializers/throttling_paths_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+# Unit-level guard on the rate-limit path classification. The feature spec in
+# spec/features/throttling_spec.rb exercises the live 429 behavior end to end;
+# this spec asserts which paths fall under the stricter PROTECTED_CUTOFF by
+# matching Throttling::PROTECTED_RE directly, so each newly protected endpoint
+# is locked in without booting Rack::Attack or hammering a real route.
+describe Throttling do
+  def protected?(path)
+    !path.match(Throttling::PROTECTED_RE).nil?
+  end
+
+  describe 'PROTECTED_RE' do
+    it 'still protects the pre-existing sensitive paths' do
+      expect(protected?('/oauth2/token')).to eq(true)
+      expect(protected?('/api/v1/forgot_password')).to eq(true)
+      expect(protected?('/api/v1/users/1_2/rename')).to eq(true)
+      expect(protected?('/api/v1/purchase_gift')).to eq(true)
+    end
+
+    it 'does not protect ordinary unguarded paths' do
+      expect(protected?('/')).to eq(false)
+      expect(protected?('/api/v1/users/1_2/stats/daily')).to eq(false)
+      expect(protected?('/api/v1/boards/1_2/stats')).to eq(false)
+    end
+
+    # LL-ca38d4d99e: supervisor/parent consent decision endpoints.
+    it 'protects the supervisor consent endpoints' do
+      expect(protected?('/api/v1/supervisor_relationships/consent_response')).to eq(true)
+      expect(protected?('/api/v1/supervisor_relationships/1_2/consent_response')).to eq(true)
+      expect(protected?('/api/v1/supervisor_relationships/1_2/approve')).to eq(true)
+      expect(protected?('/api/v1/supervisor_relationships/1_2/deny')).to eq(true)
+    end
+  end
+end

--- a/spec/initializers/throttling_paths_spec.rb
+++ b/spec/initializers/throttling_paths_spec.rb
@@ -31,5 +31,10 @@ describe Throttling do
       expect(protected?('/api/v1/supervisor_relationships/1_2/approve')).to eq(true)
       expect(protected?('/api/v1/supervisor_relationships/1_2/deny')).to eq(true)
     end
+
+    # LL-e65d34f109: org bulk user-claim endpoint.
+    it 'protects the organization claim_user endpoint' do
+      expect(protected?('/api/v1/organizations/1_2/claim_user')).to eq(true)
+    end
   end
 end

--- a/spec/initializers/throttling_paths_spec.rb
+++ b/spec/initializers/throttling_paths_spec.rb
@@ -36,5 +36,22 @@ describe Throttling do
     it 'protects the organization claim_user endpoint' do
       expect(protected?('/api/v1/organizations/1_2/claim_user')).to eq(true)
     end
+
+    # LL-56f0f19fca: registration, 2FA, and SAML assertion consumption.
+    it 'protects registration, 2FA, and SAML consume endpoints' do
+      expect(protected?('/api/v1/users')).to eq(true)
+      expect(protected?('/api/v1/users.json')).to eq(true)
+      expect(protected?('/api/v1/users/1_2/confirm_registration')).to eq(true)
+      expect(protected?('/api/v1/users/1_2/2fa')).to eq(true)
+      expect(protected?('/saml/consume')).to eq(true)
+    end
+
+    # Regression guard for the anchored 'api/v1/users' entry: protecting the
+    # collection must NOT broaden the throttle to every per-user member route.
+    it 'does not over-throttle ordinary per-user member endpoints' do
+      expect(protected?('/api/v1/users/1_2')).to eq(false)
+      expect(protected?('/api/v1/users/1_2/stats/daily')).to eq(false)
+      expect(protected?('/api/v1/users/1_2/board_tags/ensure')).to eq(false)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -700,7 +700,52 @@ describe User, :type => :model do
       }, {}) }.to_not raise_error
       expect(u.valid_password?('braised-beef')).to eq(true)
     end
-    
+
+    describe "password-change audit trail (LL-747bb0e02d)" do
+      # AuditEvent.log_command commits outside the per-example transaction, so
+      # rows leak across examples and inflate counts. Scope the reset to this
+      # describe block (not globally) per the AuditEvent testing convention.
+      before(:each) { AuditEvent.delete_all }
+
+      it "logs an AuditEvent when an existing password is changed by the user" do
+        u = User.create
+        u.generate_password('horseradish')
+        u.save!
+        expect(AuditEvent.count).to eq(0)
+        expect(u.process_params({'password' => 'chicken', 'old_password' => 'horseradish'}, {})).to_not eq(false)
+        u.save!
+        expect(u.valid_password?('chicken')).to eq(true)
+        expect(AuditEvent.count).to eq(1)
+        ae = AuditEvent.last
+        expect(ae.user_key).to eq(u.global_id)
+        expect(ae.data['type']).to eq('password_changed')
+        expect(ae.data['self_service']).to eq(true)
+      end
+
+      it "logs an AuditEvent for an admin-initiated / forced reset without the old password" do
+        u = User.create
+        u.generate_password('horseradish')
+        u.save!
+        expect(AuditEvent.count).to eq(0)
+        expect(u.process_params({'password' => 'chicken-little'}, {:allow_password_change => true})).to_not eq(false)
+        u.save!
+        expect(u.valid_password?('chicken-little')).to eq(true)
+        expect(AuditEvent.count).to eq(1)
+        ae = AuditEvent.last
+        expect(ae.data['type']).to eq('password_changed')
+        expect(ae.data['self_service']).to eq(false)
+      end
+
+      it "does not log an AuditEvent when an initial password is first set" do
+        u = User.create
+        expect(u.settings['password']).to be_nil
+        expect(u.process_params({'password' => 'first-pass'}, {})).to_not eq(false)
+        u.save!
+        expect(u.valid_password?('first-pass')).to eq(true)
+        expect(AuditEvent.count).to eq(0)
+      end
+    end
+
     it "should generate a username only if none yet and provided or forced" do
       u = User.new
       u.process_params({


### PR DESCRIPTION
Five quick security-hardening fixes from the audit findings register. Code only; one atomic commit per finding so any can be reverted independently. **No `audit-reports/**` or `docs/legal/**` files were touched** — closure/attestation/triage of these findings is Scot's separate step.

## Findings addressed

| Finding | Sev | What changed | file:line (this branch) |
|---|---|---|---|
| **LL-ca38d4d99e** | High | Supervisor/parent consent endpoints (`consent_response` collection + member, `approve`, `deny`) now fall under the stricter `PROTECTED_CUTOFF` (10 req/3s) throttle | `config/initializers/throttling.rb:25-31` |
| **LL-e65d34f109** | High | `api/v1/organizations/:id/claim_user` added to the protected throttle list | `config/initializers/throttling.rb:33` |
| **LL-56f0f19fca** | Medium | Registration (`POST api/v1/users`), `confirm_registration`, `2fa`, and `saml/consume` added to the protected throttle list | `config/initializers/throttling.rb:38-41` |
| **LL-c6dd65a2aa** | High | `RedisInit.cache_token` no longer hardcoded to `'abc'`; resolved from `CACHE_TOKEN` → `RENDER_GIT_COMMIT` → `K_REVISION` → `'abc'` | `config/initializers/resque.rb:85`, resolver at `:88-104` |
| **LL-747bb0e02d** | High | Password changes now write an `AuditEvent` (incl. admin/token resets), alongside the unchanged notification mailer | `app/models/user.rb:2263-2273` (+ capture at `:1647`) |

## Implementation notes / safety

- **Throttling refactor:** the protected-path list/regex was extracted into `Throttling::PROTECTED_PATHS` / `PROTECTED_RE` module constants so classification is unit-testable without booting Rack::Attack. **Runtime behavior is unchanged** — the Application body builds the same regex from the same list.
- **Registration anchor (regression guard):** `api/v1/users` is anchored as `api/v1/users(\.json)?$` so it throttles only the collection (create/index), **not** the many per-user member endpoints (`.../rename`, `.../stats/daily`, etc.) which keep `NORMAL_CUTOFF`. A spec asserts member routes are not over-throttled.
- **cache_token shared-cache invariant preserved:** all fallback sources are process-invariant within a deploy, so every web/worker process still resolves to the **same** token (shared permission cache intact). The resolver is deterministic — no per-process randomness.
- **Password audit is additive & fail-open:** uses `AuditEvent.log_command` (rescues, never raises) so a failed audit insert cannot break the password change or alter the mailer. Records only `type` + `self_service` flag — no password material or PII; `user_key` is the opaque global_id.

## Tests

All new/adjusted specs pass locally (`DB_USER=scotw RAILS_ENV=test`):
- `spec/initializers/throttling_paths_spec.rb` — 6 examples (classification + over-throttle regression guard)
- `spec/initializers/resque_redis_options_spec.rb` — +6 examples (cache_token precedence, blank-handling, determinism, dev fallback); 17 total green
- `spec/models/user_spec.rb` — +3 examples (self-service / forced-reset / no-audit-on-initial-set), `AuditEvent.delete_all` scoped to the describe block; full `process_params` describe green (50 ex, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
