### PR TITLE
security: rate-limit password_reset code verification (follow-up to #420)

### DIFF
--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -33,7 +33,12 @@ module Throttling
     'api/v1/users(\.json)?$',
     'api/v1/users/.+/confirm_registration',
     'api/v1/users/.+/2fa',
-    'saml/consume'
+    'saml/consume',
+    # Password-reset code verification: exchanges a reset code for a reset token
+    # (users#password_reset), so an unthrottled endpoint invites reset-code
+    # brute-forcing. Follow-up to the audit rate-limit pass; sibling of the
+    # already-protected forgot_password.
+    'api/v1/users/.+/password_reset'
   ].freeze
   PROTECTED_RE = /#{PROTECTED_PATHS.join('|')}/
 

--- a/spec/initializers/throttling_paths_spec.rb
+++ b/spec/initializers/throttling_paths_spec.rb
@@ -46,6 +46,11 @@ describe Throttling do
       expect(protected?('/saml/consume')).to eq(true)
     end
 
+    # Password-reset code verification endpoint (users#password_reset).
+    it 'protects the password_reset code-verification endpoint' do
+      expect(protected?('/api/v1/users/1_2/password_reset')).to eq(true)
+    end
+
     # Regression guard for the anchored 'api/v1/users' entry: protecting the
     # collection must NOT broaden the throttle to every per-user member route.
     it 'does not over-throttle ordinary per-user member endpoints' do


### PR DESCRIPTION
Defense-in-depth follow-up surfaced during the senior-dev (codex/DeepSeek) review of #420.

**Stacked on #420** (`scot/security/high-findings-quick-wins`). The diff shown against `staging` includes #420's five commits; **merge #420 first**, then this becomes a clean one-commit delta. GitHub will auto-retarget once #420 lands.

## What & why

`POST /api/v1/users/:id/password_reset` (`users#password_reset`, `app/controllers/api/users_controller.rb:763`) exchanges a reset **code** for a reset **token** and was not under the stricter `PROTECTED_CUTOFF` (10 req/3s) throttle — leaving reset-code verification brute-forceable. It is the natural sibling of the already-protected `forgot_password`. Risk is moderate (the code is a high-entropy `GoSecure.nonce`, capped at 5, 3-hour expiry), so this is hardening rather than a critical gap.

## Change
- `config/initializers/throttling.rb`: add `api/v1/users/.+/password_reset` to `Throttling::PROTECTED_PATHS`.
- `spec/initializers/throttling_paths_spec.rb`: classification assertion. 7 examples, 0 failures.

## Not in scope
This was **not** one of the five originally-assigned audit findings. If it warrants a register entry, that is Scot's separate step — no `audit-reports/**` files are touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
