### PR TITLE
security(mcp): deny mcp__context7__* in regulated repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,5 +4,9 @@
   "worktree": {
     "baseRef": "head"
   },
+  "_note_permissions": "Context7 (mcp__context7__*) is denied in this regulated repo. The brain MCP master config enables Context7 user-scope (global), but it is a cloud documentation service: even the npx variant egresses the library name and query topic to context7/Upstash, a non-BAA third party. Denying the tool pattern here keeps that library/topic metadata off third parties during PHI-adjacent work. A user-scope server cannot be scoped by directory and disabledMcpjsonServers does not apply to it, so a project-level permission deny is the mechanism that actually works (same pattern as mcp__stripe__*). See ai-company-brain/outputs/docs/2026-06-17-tooling-adoption-phase-11a.md.",
+  "permissions": {
+    "deny": ["mcp__context7__*"]
+  },
   "hooks": {}
 }


### PR DESCRIPTION
## What

Adds a project-level permission deny for `mcp__context7__*` to `.claude/settings.json`.

## Why

Context7 is being adopted **user-scope (global)** through the ai-company-brain MCP master config (brain PR #81). Context7 is a cloud documentation service: even the `npx @upstash/context7-mcp` variant proxies the queried **library name and topic** to context7/Upstash to fetch docs. Upstash holds **no BAA**. Source code and PHI are not sent, but the query metadata leaves the machine.

This repo is FERPA/HIPAA/GDPR-regulated, so Context7 must not be invokable here. A user-scope MCP server **cannot** be scoped by working directory, and `disabledMcpjsonServers` only applies to project `.mcp.json` servers, not user-scope ones. A project-level **permission deny** takes precedence regardless of where the server is defined (the brain already denies `mcp__stripe__*` the same way).

## Sequencing

This guard must merge **before** Context7 is enabled globally from the brain (brain PR #81 is being held until this lands).

Ref: `ai-company-brain/outputs/docs/2026-06-17-tooling-adoption-phase-11a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)