### PR TITLE
chore(gcp): Phase 4 cutover prep — setval sequences (S1) + generateValue secret preservation (S2)

### DIFF
--- a/lib/tasks/phase4_sequences.rake
+++ b/lib/tasks/phase4_sequences.rake
@@ -1,0 +1,36 @@
+# Phase 4 (Render -> GCP Cloud Run migration) sequence tasks.
+#
+# After a pg_dump -> restore into Cloud SQL, every column-owned sequence is left behind the
+# restored MAX(id). Because global_id (app/models/concerns/global_id.rb) encodes the RAW primary
+# key, the next INSERT would collide. These tasks wrap the single-source-of-truth SQL in
+# scripts/gcp/ so the SAME logic can be rehearsed and unit-tested locally (here) and run against
+# Cloud SQL at cutover (scripts/gcp/phase4-setval-sequences.sh). Do not duplicate the SQL logic.
+namespace :db do
+  # Execute one Phase 4 .sql file via the live connection, printing a clean failure banner on a
+  # raised SQL error (e.g. the verify DO block's RAISE EXCEPTION) so a mid-NOTICE failure is not
+  # buried in noise. The original error is re-raised so the task exits non-zero.
+  def run_phase4_sql(label, filename)
+    path = Rails.root.join('scripts', 'gcp', filename)
+    raise "Phase 4 SQL file not found: #{path}" unless File.exist?(path)
+    ActiveRecord::Base.connection.execute(File.read(path))
+  rescue => e
+    warn ''
+    warn '=' * 60
+    warn "FAILED: #{label}"
+    warn e.message.to_s.lines.first(8).join
+    warn '=' * 60
+    raise
+  end
+
+  desc 'Advance every column-owned sequence to MAX(owning column) after a restore (idempotent)'
+  task setval_all_sequences: :environment do
+    run_phase4_sql('db:setval_all_sequences', 'phase4-setval-sequences.sql')
+    puts 'db:setval_all_sequences: done.'
+  end
+
+  desc 'Verify every column-owned sequence is past its MAX and no identity-PK drift exists'
+  task verify_sequences: :environment do
+    run_phase4_sql('db:verify_sequences', 'phase4-verify-sequences.sql')
+    puts 'db:verify_sequences: OK.'
+  end
+end

--- a/scripts/gcp/PHASE4-CUTOVER-DATA-RUNBOOK.md
+++ b/scripts/gcp/PHASE4-CUTOVER-DATA-RUNBOOK.md
@@ -1,0 +1,155 @@
+# Phase 4 Cutover - Data Runbook (S1 setval + S2 secret preservation)
+
+LingoLinq Render -> GCP Cloud Run migration. This runbook covers the two "after restore"
+data-layer cutover steps that this branch ships:
+
+- **S1** - reset Postgres sequences after the dump/restore so the next insert cannot collide.
+- **S2** - copy the four `generateValue` secrets into GCP Secret Manager, preserving their bytes.
+
+It is the operator companion to:
+
+- `scripts/gcp/phase4-setval-sequences.sql` + `phase4-verify-sequences.sql` (S1 logic, single source of truth)
+- `scripts/gcp/phase4-setval-sequences.sh` (S1 cutover runner) and `rake db:setval_all_sequences` / `rake db:verify_sequences` (S1 rehearsal/test)
+- `scripts/gcp/phase4-seed-boot-secrets.sh` (S2 runner)
+
+> Nothing in this runbook is run before Scot's explicit go. S1 and S2 are safe to **rehearse**
+> (rake against a local DB, `--verify`/`--fingerprint`/plan modes), but the real restore + seed
+> against `lingolinq-prod` are cutover actions. Render stays fully live and authoritative until
+> the DNS flip; these steps never touch Render.
+
+---
+
+## 0. Operator identity (HIPAA)
+
+Run as **Scot or a designated engineer** holding all three: prod GCP access (project
+`lingolinq-prod`), the **1Password "LingoLinq Prod"** vault, and a **Render** API key for the
+prod service. This is an auditable production change. Run on a single-operator host, never a
+shared box, and never under `bash -x` (tracing would leak secret material; the scripts disable
+xtrace defensively in their secret regions, but the surrounding shell would not).
+
+## 1. Preflight (confirm ALL before any command - avoids half-runs)
+
+- [ ] Cloud SQL `lingolinq-prod-pg` reachable (cloud-sql-proxy running on a local port, OR you
+      will use `gcloud sql connect`).
+- [ ] `gcloud auth list` shows the right active account; `gcloud config get project` = `lingolinq-prod`.
+- [ ] 1Password session valid: `op whoami` (or `op vault list`) succeeds.
+- [ ] `RENDER_API_KEY` exported, e.g. `export RENDER_API_KEY="$(op read 'op://LingoLinq Admin/Render API/credential')"`.
+- [ ] `psql`, `jq`, `curl`, `gcloud`, `op` all on PATH.
+- [ ] The Render prod DB has been dumped and restored into `lingolinq_production` on Cloud SQL
+      (the step that precedes S1). Row counts reconciled against the dump baseline.
+
+## 2. Order of operations
+
+The full cutover order is: write-freeze Render -> dump -> restore -> **S1 (setval+verify)** ->
+**S2 (verify+seed)** -> migrate Job -> un-inert (`GCP_PROJECT_ID`) -> LB -> DNS. This runbook is
+S1 then S2. Do S1 first: the sequences must be correct before anything writes to the new DB.
+
+### S1 - reset and verify sequences
+
+Why: a restore leaves each column-owned sequence behind its table's `MAX(id)`. Because
+`global_id` (app/models/concerns/global_id.rb) encodes the **raw** primary key, the next insert
+would reuse an existing id and corrupt global_id references. Idempotent and safe to re-run.
+
+```bash
+# Connect through the proxy (the /cloudsql socket only exists inside Cloud Run):
+cloud-sql-proxy --port 5432 lingolinq-prod:us-central1:lingolinq-prod-pg &
+
+DATABASE_URL='postgres://lingolinq_app:PASSWORD@127.0.0.1:5432/lingolinq_production' \
+  ./scripts/gcp/phase4-setval-sequences.sh
+```
+
+The script prints the resolved project + Cloud SQL instance + db/host/user **before** touching
+the DB (confirm the target), runs the setval, then runs verify. Verify exits non-zero and halts
+if any sequence is still behind its `MAX`, or if an identity-column PK has drifted past the
+SERIAL-only reset. Expected tail: `Phase 4 setval + verify complete.`
+
+Rehearsal (no Cloud SQL needed), run on this branch before cutover:
+
+```bash
+DB_USER=scotw RAILS_ENV=test bundle exec rake db:setval_all_sequences
+DB_USER=scotw RAILS_ENV=test bundle exec rake db:verify_sequences
+DB_USER=scotw RAILS_ENV=test bundle exec rspec spec/lib/tasks/phase4_sequences_spec.rb
+```
+
+### S2 - preserve and seed the four generateValue secrets
+
+The four: `SECRET_KEY_BASE`, `COOKIE_KEY`, `SECURE_ENCRYPTION_KEY`, `SECURE_NONCE_KEY`. These
+are `generateValue` on Render and **must be preserved, never regenerated**: regenerating
+`SECURE_ENCRYPTION_KEY` / `SECURE_NONCE_KEY` makes every `secure_serialize`'d column and
+`ExternalNonce` permanently undecryptable; regenerating `SECRET_KEY_BASE` / `COOKIE_KEY`
+invalidates all live sessions. A wrong value is **silent** until logins or decryption fail.
+
+**Source of truth:** the **1Password "LingoLinq Prod" / "Rails Secrets"** item. This is what
+`scripts/sync-render-env.js` already treats as canonical and pushes to Render hourly, so
+1Password is authoritative and Render is downstream of it. The script seeds GCP from 1Password
+and independently verifies each value byte-for-byte (sha256, never echoed) against the **live
+Render** env before writing.
+
+```bash
+# 1) Plan (zero creds, writes nothing) - confirms scope:
+./scripts/gcp/phase4-seed-boot-secrets.sh
+
+# 2) Compliance fingerprints (1Password only, sha256, no plaintext):
+./scripts/gcp/phase4-seed-boot-secrets.sh --fingerprint
+
+# 3) Dry verification - compare 1Password vs live Render, NO write. Must be green first:
+./scripts/gcp/phase4-seed-boot-secrets.sh --verify
+
+# 4) Real seed (verify THEN write into GCP Secret Manager):
+CONFIRM_SEED_SECRETS=1 ./scripts/gcp/phase4-seed-boot-secrets.sh
+```
+
+Out of scope here: `DATABASE_URL` / `REDIS_URL` / `REDIS_CA_CERT` are already seeded by
+`phase3-data-layer.sh`; `DEFAULT_HOST` and the mail secrets are non-encryption config seeded
+separately. The deploy workflow's full `BOOT_SECRETS` list is in
+`.github/workflows/deploy-cloudrun.yml`.
+
+> **Pre-cutover task - `SMS_ENCRYPTION_KEY` (separate from the four above).**
+> `app/models/remote_target.rb:56` uses `SMS_ENCRYPTION_KEY` as the salt for a **persisted**
+> one-way hash (`source_hash`, set at remote_target.rb:44 via `GoSecure.sha512`). It is NOT
+> reversible encryption, so a wrong value does not make data undecryptable, but regenerating it
+> would break matching of existing stored SMS `source_hash` values (SMS source routing for
+> existing records). It is a perEnv secret in 1Password ("LingoLinq Prod"/"Rails Secrets",
+> field `SMS_ENCRYPTION_KEY`), and it is currently **not in the deploy workflow `BOOT_SECRETS`**.
+> Before cutover, if SMS routing is used in prod: (a) preserve `SMS_ENCRYPTION_KEY` from
+> 1Password the same way as the four (do not regenerate), and (b) add it to `BOOT_SECRETS` in
+> `deploy-cloudrun.yml` so the runtime can read it. This script intentionally does not seed it
+> (it is not a generateValue secret); track it as its own task.
+
+## 3. The hard rules these scripts enforce
+
+- **Never echo plaintext.** Values are read into shell vars, hashed, piped straight into
+  `gcloud secrets versions add --data-file=-`, and unset. Only sha256 prefixes and "value not
+  shown" lines are printed.
+- **Empty value = STOP.** If either 1Password or Render returns an empty/absent value, the
+  script stops without seeding.
+- **Mismatch = STOP.** If a 1Password value does not match live Render byte-for-byte, it is a
+  hard stop. The usual cause is a stray trailing newline or an edit-drift between the two; the
+  fix is to reconcile, not to override.
+- **A Render 429 / 5xx is a STOP, not a retry.** The Render env list is fetched once; a failed
+  fetch aborts. Retrying mid-cutover risks a partial seed. Wait, investigate, then re-run from
+  `--verify`.
+
+## 4. Rollback
+
+- **S1 verification fails** (a sequence still behind): re-run `phase4-setval-sequences.sh` - the
+  setval is idempotent, so re-running advances any laggard and re-verifies. If verify reports an
+  identity-PK drift instead, STOP: the SQL must be extended before cutover (out of scope here).
+- **S2 mismatch / empty**: **stop and investigate, never retry the seed.** Reconcile 1Password
+  vs Render, re-run `--verify` until green, then seed. A GCP secret version is additive and can
+  be re-pointed, but the correct move on a mismatch is always to fix the source, not to write a
+  guessed value.
+- **Both S1 and S2 are pre-DNS-flip.** Render remains live and authoritative the entire time, so
+  the master rollback for the whole cutover (flip DNS back to Render) still applies; nothing here
+  is destructive to Render.
+
+## 5. Verification checklist
+
+- [ ] S1: `phase4-setval-sequences.sh` ends with `setval + verify complete`; verify exit code 0.
+- [ ] S1: spot-check - in a rolled-back transaction, insert one row into a high-traffic table
+      and confirm no PK collision.
+- [ ] S2: `--verify` is green (all four match) before any seed.
+- [ ] S2: after seed, `gcloud secrets versions list <NAME> --project=lingolinq-prod` shows a new
+      (or unchanged, if idempotent-skipped) version for each of the four.
+- [ ] S2: the migration Job / web boot succeeds (proves the seeded secrets decrypt existing data
+      and sessions remain valid). This is the real confirmation that no value was regenerated.

--- a/scripts/gcp/phase4-seed-boot-secrets.sh
+++ b/scripts/gcp/phase4-seed-boot-secrets.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+#
+# phase4-seed-boot-secrets.sh - LingoLinq Render -> GCP Cloud Run migration, Phase 4 (cutover).
+#
+# Copies the FOUR generateValue secrets into GCP Secret Manager, preserving their exact bytes:
+#
+#     SECRET_KEY_BASE  COOKIE_KEY  SECURE_ENCRYPTION_KEY  SECURE_NONCE_KEY
+#
+# These MUST be preserved, never regenerated. SECURE_ENCRYPTION_KEY and SECURE_NONCE_KEY feed
+# GoSecure's symmetric encryption (config/environment.rb, app/models/external_nonce.rb,
+# app/models/concerns/secure_serialize.rb). Regenerating either makes every secure_serialize'd
+# column and ExternalNonce permanently undecryptable; regenerating SECRET_KEY_BASE (COOKIE_KEY is
+# its non-prod fallback, config/initializers/secret_token.rb) invalidates all live sessions. A
+# wrong value here is SILENT until users cannot log in or encrypted data fails to decrypt -- so
+# this script proves correctness before it writes.
+#
+# SOURCE OF TRUTH (decided 2026-06-18): the 1Password "LingoLinq Prod" vault, item "Rails
+# Secrets". This is what scripts/sync-render-env.js already treats as canonical and pushes to
+# Render hourly, so 1Password is authoritative and Render is downstream of it. We seed GCP from
+# 1Password and INDEPENDENTLY verify each value byte-for-byte (sha256) against the LIVE Render
+# env before writing. Any mismatch or empty value is a HARD STOP, never a silent paper-over.
+#
+# WHITESPACE: `op read` appends a trailing newline (a CLI artifact, not part of the secret).
+# bash `$(...)` strips trailing newlines, recovering the true value -- exactly what
+# sync-render-env.js does with `.trim()`, so the bytes match what is already live in Render and
+# what the app uses. We then seed with `printf '%s'` (no added newline). We do NOT trim anything
+# else: the sha256 compare is over the full value, so genuine internal contamination still STOPs.
+#
+# NEVER ECHOED: secret values are read into shell vars, hashed, piped straight into
+# `gcloud secrets versions add --data-file=-`, and unset. Only sha256 prefixes and "value not
+# shown" lines are printed. The secret-handling region defensively disables xtrace so `bash -x`
+# cannot leak a value.
+#
+# MODES:
+#   ./phase4-seed-boot-secrets.sh                 # PLAN: print the 4 names + what seed would do.
+#                                                 #   No reads, no creds needed, writes nothing.
+#   ./phase4-seed-boot-secrets.sh --fingerprint   # read 1Password only; print each sha256.
+#                                                 #   For compliance review; no Render/GCP, no write.
+#   ./phase4-seed-boot-secrets.sh --verify        # read 1Password + Render; compare; report.
+#                                                 #   No write. The dry verification.
+#   CONFIRM_SEED_SECRETS=1 ./phase4-seed-boot-secrets.sh   # verify THEN seed GCP Secret Manager.
+#
+# Run as Scot or a designated engineer with prod GCP + 1Password Prod + Render access (HIPAA:
+# this is an auditable change). On a single-operator host; do not run on a shared box or under -x.
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-lingolinq-prod}"
+OP_VAULT="${OP_VAULT:-LingoLinq Prod}"
+OP_ITEM="${OP_ITEM:-Rails Secrets}"
+RENDER_PROD_SERVICE_ID="${RENDER_PROD_SERVICE_ID:-srv-d510bsemcj7s73966i60}"   # lingolinq-prod
+RUNTIME_SA_ID="${RUNTIME_SA_ID:-lingolinq-run}"
+RUNTIME_SA="${RUNTIME_SA_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Name is identical across all three systems: GCP secret == 1Password field == Render env key.
+SECRETS=(SECRET_KEY_BASE COOKIE_KEY SECURE_ENCRYPTION_KEY SECURE_NONCE_KEY)
+
+CONFIRM_SEED_SECRETS="${CONFIRM_SEED_SECRETS:-0}"
+
+log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+skip() { printf '    \033[1;33m(skip)\033[0m %s\n' "$*"; }
+gate() { printf '\n\033[1;31m[GATE]\033[0m %s\n' "$*"; }
+
+# ---- mode resolution -------------------------------------------------------------------------
+MODE="plan"
+case "${1:-}" in
+  "")             [ "$CONFIRM_SEED_SECRETS" = "1" ] && MODE="seed" || MODE="plan" ;;
+  --verify)       MODE="verify" ;;
+  --fingerprint)  MODE="fingerprint" ;;
+  *) echo "usage: $0 [--verify | --fingerprint]   (set CONFIRM_SEED_SECRETS=1 to seed)" >&2; exit 2 ;;
+esac
+
+# ---- helpers (no plaintext ever printed) -----------------------------------------------------
+read_1p()       { op read "op://${OP_VAULT}/${OP_ITEM}/$1" 2>/dev/null; }   # $()=strips CLI newline
+sha()           { printf '%s' "$1" | sha256sum | cut -d' ' -f1; }
+# first(...) so a duplicate key on Render can't newline-join two values; // empty => "" when absent.
+render_value()  { printf '%s' "$RENDER_ENV_JSON" | jq -r --arg k "$1" 'first(.[] | (.envVar // .) | select(.key==$k) | .value) // empty'; }
+RENDER_ENV_JSON=""
+
+# Fetch the FULL prod env-var list into RENDER_ENV_JSON, paging until exhausted. Render paginates
+# (default 20; we ask 100/page) and returns [{envVar:{key,value}, cursor}]. We must page to the end
+# so a target key cannot fall off page 1 and read as a false "empty on Render" (which would STOP the
+# cutover with a misleading message). -f makes curl fail non-zero on any 4xx/5xx incl 429; a failure
+# here is a HARD STOP, never a retry (retrying a 429 mid-cutover risks a partial seed).
+# CALLER MUST have xtrace disabled before calling this: the Bearer token is on the curl arg line.
+fetch_render_all() {
+  command -v curl >/dev/null 2>&1 || { echo "ERROR: curl not found (needed to read Render)." >&2; exit 1; }
+  command -v jq   >/dev/null 2>&1 || { echo "ERROR: jq not found (needed to parse Render)." >&2; exit 1; }
+  [ -n "${RENDER_API_KEY:-}" ] || { echo "ERROR: RENDER_API_KEY not set. e.g. export RENDER_API_KEY=\$(op read 'op://LingoLinq Admin/Render API/credential')" >&2; exit 1; }
+  local base="https://api.render.com/v1/services/${RENDER_PROD_SERVICE_ID}/env-vars?limit=100"
+  local url cursor="" page n combined='[]'
+  while :; do
+    if [ -n "$cursor" ]; then url="${base}&cursor=${cursor}"; else url="$base"; fi
+    page="$(curl -fsS --max-time 20 \
+      -H "Authorization: Bearer ${RENDER_API_KEY}" -H 'Accept: application/json' "$url")" \
+      || { echo "ERROR: Render API request failed (HTTP error / 429 / network). STOP -- do not retry blindly." >&2; exit 1; }
+    printf '%s' "$page" | jq -e 'type=="array"' >/dev/null 2>&1 \
+      || { echo "ERROR: unexpected Render API response shape (expected a JSON array)." >&2; exit 1; }
+    n="$(printf '%s' "$page" | jq 'length')"
+    combined="$(jq -s 'add' <(printf '%s' "$combined") <(printf '%s' "$page"))"
+    cursor="$(printf '%s' "$page" | jq -r '.[-1].cursor // empty')"
+    [ "$n" -lt 100 ] && break          # short page => last page
+    [ -z "$cursor" ] && break          # no cursor => nothing more to fetch
+  done
+  RENDER_ENV_JSON="$combined"
+}
+
+# ---- PLAN mode: zero creds, zero reads, zero writes ------------------------------------------
+if [ "$MODE" = "plan" ]; then
+  cat <<PLAN
+
+  PHASE 4 generateValue secret preservation -- PLAN (nothing read, nothing written)
+  -------------------------------------------------------------------------------
+  Source of truth : 1Password  "${OP_VAULT}" / "${OP_ITEM}"
+  Verified against: live Render service ${RENDER_PROD_SERVICE_ID} (sha256, never echoed)
+  Target          : GCP Secret Manager in project ${PROJECT_ID}
+
+  Secrets that WOULD be seeded (only on byte-for-byte 1Password==Render match):
+$(printf '    - %s\n' "${SECRETS[@]}")
+
+  These four are generateValue on Render and MUST be preserved, never regenerated.
+  DATABASE_URL / REDIS_URL / REDIS_CA_CERT are already seeded by phase3-data-layer.sh;
+  DEFAULT_HOST + the mail secrets are non-encryption config seeded separately -- NOT here.
+
+  Next:
+    $0 --fingerprint                         # print 1Password sha256 fingerprints (compliance)
+    $0 --verify                              # compare 1Password vs Render, no write
+    CONFIRM_SEED_SECRETS=1 $0                # verify THEN seed GCP Secret Manager
+PLAN
+  gate "PLAN only. Re-run with CONFIRM_SEED_SECRETS=1 to seed (after --verify is green)."
+  exit 0
+fi
+
+# ---- preflight for read/seed modes -----------------------------------------------------------
+command -v op >/dev/null 2>&1 || { echo "ERROR: 1Password CLI 'op' not found." >&2; exit 1; }
+op vault list >/dev/null 2>&1 || { echo "ERROR: 'op' is not signed in (run: op signin, or set OP_SERVICE_ACCOUNT_TOKEN)." >&2; exit 1; }
+
+# ---- FINGERPRINT mode: 1Password only --------------------------------------------------------
+if [ "$MODE" = "fingerprint" ]; then
+  log "1Password fingerprints ($OP_VAULT / $OP_ITEM) -- sha256 only, no plaintext"
+  case "$-" in *x*) XWAS=1 ;; *) XWAS=0 ;; esac
+  set +x
+  for NAME in "${SECRETS[@]}"; do
+    V="$(read_1p "$NAME")" || true
+    [ -n "$V" ] || { echo "ERROR: $NAME is empty/absent in 1Password ($OP_VAULT/$OP_ITEM)." >&2; exit 1; }
+    echo "    $NAME sha256=$(sha "$V")"
+    unset V
+  done
+  [ "${XWAS:-0}" -eq 1 ] && set -x || true
+  exit 0
+fi
+
+# ---- VERIFY / SEED modes ---------------------------------------------------------------------
+if [ "$MODE" = "seed" ]; then
+  command -v gcloud >/dev/null 2>&1 || { echo "ERROR: gcloud not found (needed to seed)." >&2; exit 1; }
+  gcloud projects describe "$PROJECT_ID" >/dev/null 2>&1 || { echo "ERROR: project $PROJECT_ID not accessible." >&2; exit 1; }
+fi
+
+# Disable xtrace for the ENTIRE token+secret region: the Render Bearer token (on fetch_render_all's
+# curl arg line) and every secret value below must never be traced under an inherited `set -x` /
+# SHELLOPTS=xtrace. Restored at the end of the loop.
+case "$-" in *x*) XWAS=1 ;; *) XWAS=0 ;; esac
+set +x
+
+log "Reading live Render env (service $RENDER_PROD_SERVICE_ID) for the cross-check"
+fetch_render_all
+echo "    Render env list fetched (${#SECRETS[@]} keys to verify)"
+
+log "Verify 1Password == live Render for each secret (sha256, never echoed)"
+for NAME in "${SECRETS[@]}"; do
+  V1P="$(read_1p "$NAME")" || true
+  VR="$(render_value "$NAME")" || true
+
+  # Empty/null guard: never seed against an empty value; an empty side means a missing 1Password
+  # field or a transient Render gap. Treat as a mismatch and STOP.
+  if [ -z "$V1P" ] || [ -z "$VR" ]; then
+    MISS=""
+    [ -z "$V1P" ] && MISS="1Password"
+    [ -z "$VR" ] && MISS="${MISS:+$MISS and }Render"
+    echo "STOP: $NAME is empty on $MISS -- not seeding. Investigate before retrying." >&2
+    unset V1P VR
+    [ "${XWAS:-0}" -eq 1 ] && set -x || true
+    exit 1
+  fi
+
+  H1P="$(sha "$V1P")"
+  HR="$(sha "$VR")"
+  if [ "$H1P" != "$HR" ]; then
+    echo "MISMATCH $NAME: 1Password sha256 ${H1P:0:12}... != Render sha256 ${HR:0:12}..." >&2
+    echo "  HARD STOP -- do NOT seed. Likely a stray trailing newline or edit drift in the" >&2
+    echo "  1Password field vs what is live on Render. Reconcile, then re-run --verify." >&2
+    unset V1P VR H1P HR
+    [ "${XWAS:-0}" -eq 1 ] && set -x || true
+    exit 1
+  fi
+  echo "    $NAME: 1Password == Render OK (sha256 ${H1P:0:12}...)"
+
+  if [ "$MODE" = "seed" ]; then
+    gcloud secrets describe "$NAME" --project="$PROJECT_ID" >/dev/null 2>&1 \
+      || { echo "ERROR: secret $NAME not found in $PROJECT_ID; it should exist (empty) from Phase 1." >&2; unset V1P VR H1P HR; [ "${XWAS:-0}" -eq 1 ] && set -x || true; exit 1; }
+    # Idempotent: only add a version if the value actually changed, so re-runs do not churn.
+    CUR="$(gcloud secrets versions access latest --secret="$NAME" --project="$PROJECT_ID" 2>/dev/null || true)"
+    if [ -n "$CUR" ] && [ "$(sha "$CUR")" = "$H1P" ]; then
+      skip "$NAME already holds the verified value in GCP (no new version)"
+    else
+      printf '%s' "$V1P" | gcloud secrets versions add "$NAME" --project="$PROJECT_ID" --data-file=- >/dev/null
+      echo "    $NAME: new version added to GCP Secret Manager (value not shown)"
+    fi
+    # Re-assert the runtime SA accessor (idempotent; Phase 1 already granted it).
+    gcloud secrets add-iam-policy-binding "$NAME" --project="$PROJECT_ID" \
+      --member="serviceAccount:${RUNTIME_SA}" --role=roles/secretmanager.secretAccessor --quiet >/dev/null
+    unset CUR
+  fi
+  unset V1P VR H1P HR
+done
+[ "${XWAS:-0}" -eq 1 ] && set -x || true
+
+if [ "$MODE" = "verify" ]; then
+  log "VERIFY complete: all ${#SECRETS[@]} secrets match between 1Password and Render. Nothing written."
+  gate "Re-run with CONFIRM_SEED_SECRETS=1 to seed GCP Secret Manager."
+else
+  log "SEED complete: all ${#SECRETS[@]} generateValue secrets verified and present in GCP Secret Manager ($PROJECT_ID)."
+fi

--- a/scripts/gcp/phase4-setval-sequences.sh
+++ b/scripts/gcp/phase4-setval-sequences.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# phase4-setval-sequences.sh - LingoLinq Render -> GCP Cloud Run migration, Phase 4 (cutover).
+#
+# Runs the sequence reset + verification against Cloud SQL immediately AFTER the Render dump has
+# been restored, and BEFORE any traffic reaches the new database. Because global_id encodes the
+# raw primary key, a sequence left behind its table's MAX(id) means the next INSERT collides.
+#
+#   Step 1: phase4-setval-sequences.sql  - advance every column-owned sequence (idempotent).
+#   Step 2: phase4-verify-sequences.sql  - fail non-zero if any sequence is still behind, or an
+#                                          identity-PK has drifted past the SERIAL-only reset.
+#
+# The .sql files are the single source of truth (the same files `rake db:setval_all_sequences`
+# runs). This wrapper only resolves the connection, prints WHERE it is about to run (operators
+# run this months later), and executes the two files with ON_ERROR_STOP so a failure halts.
+#
+# CONNECTION: point DATABASE_URL at a TCP DSN that reaches Cloud SQL through the cloud-sql-proxy
+# (the /cloudsql unix socket only exists inside Cloud Run, not on an operator laptop), e.g.:
+#
+#   cloud-sql-proxy --port 5432 lingolinq-prod:us-central1:lingolinq-prod-pg &
+#   DATABASE_URL='postgres://lingolinq_app:PASSWORD@127.0.0.1:5432/lingolinq_production' \
+#     ./scripts/gcp/phase4-setval-sequences.sh
+#
+# If DATABASE_URL is unset, psql falls back to the standard libpq PG* env vars (PGHOST/PGDATABASE/
+# PGUSER/...). Either way the script prints the resolved db/host/user before touching anything.
+# No secret is ever echoed (the password lives only inside DATABASE_URL, which is not printed).
+#
+# Safe to re-run: setval is idempotent and verify is read-only.
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-lingolinq-prod}"
+SQL_INSTANCE="${SQL_INSTANCE:-lingolinq-prod-pg}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETVAL_SQL="$SCRIPT_DIR/phase4-setval-sequences.sql"
+VERIFY_SQL="$SCRIPT_DIR/phase4-verify-sequences.sql"
+
+log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+
+command -v psql >/dev/null 2>&1 || { echo "ERROR: psql not found." >&2; exit 1; }
+[ -f "$SETVAL_SQL" ] || { echo "ERROR: $SETVAL_SQL not found." >&2; exit 1; }
+[ -f "$VERIFY_SQL" ] || { echo "ERROR: $VERIFY_SQL not found." >&2; exit 1; }
+
+# Build the psql connection argument. An empty array => psql uses the libpq PG* env defaults.
+PSQL_TARGET=()
+[ -n "${DATABASE_URL:-}" ] && PSQL_TARGET=("$DATABASE_URL")
+
+# Print exactly where this will run BEFORE mutating anything, so the operator can confirm the
+# target. Resolve the Cloud SQL connection name for cross-checking against the proxy invocation.
+log "Phase 4 setval target"
+echo "    GCP project : $PROJECT_ID"
+if command -v gcloud >/dev/null 2>&1; then
+  CONN="$(gcloud sql instances describe "$SQL_INSTANCE" --project="$PROJECT_ID" --format='value(connectionName)' 2>/dev/null || true)"
+  if [ -n "$CONN" ]; then
+    echo "    Cloud SQL   : $SQL_INSTANCE ($CONN)"
+  else
+    echo "    Cloud SQL   : $SQL_INSTANCE (connection name unresolved; relying on DATABASE_URL)"
+  fi
+fi
+# Show psql's resolved db/host/user (never the password) as a final sanity check.
+SAFE_CONN="$(PGCONNECT_TIMEOUT=5 psql "${PSQL_TARGET[@]}" -tAc \
+  "select 'db='||current_database()||' host='||coalesce(host(inet_server_addr()),'local')||' user='||current_user;" 2>&1 || true)"
+echo "    psql target : ${SAFE_CONN:-<could not connect>}"
+
+log "Step 1: advance all column-owned sequences (idempotent)"
+psql "${PSQL_TARGET[@]}" -v ON_ERROR_STOP=1 -f "$SETVAL_SQL"
+
+log "Step 2: verify (exits non-zero if any sequence is behind or an identity PK drifted)"
+psql "${PSQL_TARGET[@]}" -v ON_ERROR_STOP=1 -f "$VERIFY_SQL"
+
+log "Phase 4 setval + verify complete."

--- a/scripts/gcp/phase4-setval-sequences.sql
+++ b/scripts/gcp/phase4-setval-sequences.sql
@@ -1,0 +1,78 @@
+-- phase4-setval-sequences.sql
+-- LingoLinq Render -> GCP Cloud Run migration, Phase 4 (cutover).
+--
+-- WHAT: After a pg_dump -> restore into Cloud SQL, every column-owned sequence is left at
+--       its dump-time value, which lags the restored MAX(id). The next INSERT would reuse an
+--       existing primary key. LingoLinq's global_id (app/models/concerns/global_id.rb) encodes
+--       the RAW primary key ("1_<id>"), so a PK collision is not just a DB error -- it corrupts
+--       global_id references. This script advances every column-owned sequence to its table's
+--       MAX(owning column) so the next INSERT is collision-free.
+--
+-- HOW:  Discovery is fully dynamic via pg_depend (deptype 'a' = a sequence AUTO-owned by a
+--       column, i.e. SERIAL / bigserial). It covers every such sequence in the live schema with
+--       NO hardcoded table list, so new tables are handled automatically. Ordered by
+--       schema/table/column for deterministic NOTICE output (stable audit logs).
+--
+-- WHY ONLY deptype 'a': we intentionally reset ONLY column-owned sequences. Standalone/custom
+--       sequences not tied to a column (deptype != 'a') are excluded -- their "next value" is
+--       application-defined, not derivable from a MAX(column), so blindly setval-ing them could
+--       break intended numbering. GENERATED ... AS IDENTITY columns use deptype 'i' and are NOT
+--       matched here by design; phase4-verify-sequences.sql asserts none have crept in (drift
+--       check), so if Rails ever switches to identity PKs this surfaces loudly instead of being
+--       silently skipped.
+--
+-- IDEMPOTENT: re-running lands on the same values (setval to MAX, or to 1/not-called for an
+--       empty table). Safe to run more than once.
+--
+-- RUNNERS: scripts/gcp/phase4-setval-sequences.sh (psql, cutover) and
+--       `rake db:setval_all_sequences` (lib/tasks/phase4_sequences.rake, rehearsal/test).
+--       This file is the single source of truth for the logic; do not duplicate it.
+
+DO $$
+DECLARE
+  r         RECORD;
+  maxid     BIGINT;
+  newval    BIGINT;
+  is_called BOOLEAN;
+  n_done    INTEGER := 0;
+BEGIN
+  FOR r IN
+    SELECT n.nspname AS schema_name,
+           s.relname AS seq_name,
+           t.relname AS table_name,
+           a.attname AS column_name
+    FROM pg_class s
+    JOIN pg_depend d    ON d.objid = s.oid
+                       AND d.classid = 'pg_class'::regclass
+                       AND d.deptype = 'a'
+    JOIN pg_class t     ON t.oid = d.refobjid
+    JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid
+    JOIN pg_namespace n ON n.oid = s.relnamespace
+    WHERE s.relkind = 'S'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+    ORDER BY n.nspname, t.relname, a.attname
+  LOOP
+    EXECUTE format('SELECT COALESCE(MAX(%I), 0) FROM %I.%I',
+                   r.column_name, r.schema_name, r.table_name)
+      INTO maxid;
+
+    IF maxid > 0 THEN
+      -- Non-empty table: set the sequence to MAX and mark it called, so nextval = MAX + 1.
+      newval := maxid;
+      is_called := true;
+    ELSE
+      -- Empty table: set to 1, NOT called, so the first nextval returns 1.
+      newval := 1;
+      is_called := false;
+    END IF;
+
+    PERFORM setval(format('%I.%I', r.schema_name, r.seq_name)::regclass, newval, is_called);
+    n_done := n_done + 1;
+
+    RAISE NOTICE 'setval %.% -> % (is_called=%; from %.%.% MAX=%)',
+      r.schema_name, r.seq_name, newval, is_called,
+      r.schema_name, r.table_name, r.column_name, maxid;
+  END LOOP;
+
+  RAISE NOTICE 'phase4-setval-sequences: advanced % column-owned sequence(s).', n_done;
+END $$;

--- a/scripts/gcp/phase4-verify-sequences.sql
+++ b/scripts/gcp/phase4-verify-sequences.sql
@@ -1,0 +1,88 @@
+-- phase4-verify-sequences.sql
+-- LingoLinq Render -> GCP Cloud Run migration, Phase 4 (cutover) -- post-setval verification.
+--
+-- Confirms phase4-setval-sequences.sql did its job and that the schema has not drifted in a way
+-- the setval discovery would silently miss. Two checks, both fail LOUD:
+--
+--   CHECK A (lag): every column-owned sequence (deptype 'a') must be advanced past its table's
+--     MAX(owning column) -- i.e. the next nextval must exceed MAX -- so the next INSERT cannot
+--     collide on a primary key. A sequence still at/behind MAX is a setval failure.
+--
+--   CHECK B (identity drift): no user table may have a PRIMARY-KEY column that is a
+--     GENERATED ... AS IDENTITY column (attidentity in 'a','d'). phase4-setval-sequences.sql
+--     resets only deptype 'a' (SERIAL) sequences; an identity PK would be skipped silently and
+--     could collide after restore. LingoLinq is all-SERIAL today (verified against db/schema.rb),
+--     so this must stay empty. If it ever fires, the setval script must be extended before cutover.
+--
+-- On any problem this RAISES EXCEPTION (so psql with ON_ERROR_STOP and the rake runner both exit
+-- non-zero and HALT the cutover). On success it emits a NOTICE and returns cleanly. Read-only:
+-- it never advances a sequence (uses last_value/is_called, never nextval/setval).
+
+DO $$
+DECLARE
+  r          RECORD;
+  maxid      BIGINT;
+  seq_last   BIGINT;
+  seq_called BOOLEAN;
+  eff_next   BIGINT;
+  problems   TEXT := '';
+  n_checked  INTEGER := 0;
+BEGIN
+  -- CHECK A: owned sequences behind their column MAX.
+  FOR r IN
+    SELECT n.nspname AS schema_name,
+           s.relname AS seq_name,
+           t.relname AS table_name,
+           a.attname AS column_name
+    FROM pg_class s
+    JOIN pg_depend d    ON d.objid = s.oid
+                       AND d.classid = 'pg_class'::regclass
+                       AND d.deptype = 'a'
+    JOIN pg_class t     ON t.oid = d.refobjid
+    JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid
+    JOIN pg_namespace n ON n.oid = s.relnamespace
+    WHERE s.relkind = 'S'
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+    ORDER BY n.nspname, t.relname, a.attname
+  LOOP
+    EXECUTE format('SELECT COALESCE(MAX(%I), 0) FROM %I.%I',
+                   r.column_name, r.schema_name, r.table_name)
+      INTO maxid;
+    EXECUTE format('SELECT last_value, is_called FROM %I.%I',
+                   r.schema_name, r.seq_name)
+      INTO seq_last, seq_called;
+
+    -- Effective next value the sequence would hand out.
+    eff_next := CASE WHEN seq_called THEN seq_last + 1 ELSE seq_last END;
+    n_checked := n_checked + 1;
+
+    IF maxid > 0 AND eff_next <= maxid THEN
+      problems := problems || format(
+        E'\n  - %I.%I behind: next=%s but %I.%I MAX=%s',
+        r.schema_name, r.seq_name, eff_next, r.table_name, r.column_name, maxid);
+    END IF;
+  END LOOP;
+
+  -- CHECK B: identity-column PKs (drift the SERIAL-only setval would skip).
+  FOR r IN
+    SELECT n.nspname AS schema_name, t.relname AS table_name, a.attname AS column_name
+    FROM pg_attribute a
+    JOIN pg_class t       ON t.oid = a.attrelid AND t.relkind = 'r'
+    JOIN pg_namespace n   ON n.oid = t.relnamespace
+    JOIN pg_constraint pk ON pk.conrelid = t.oid AND pk.contype = 'p'
+                         AND a.attnum = ANY (pk.conkey)
+    WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND a.attidentity IN ('a', 'd')   -- GENERATED ALWAYS / BY DEFAULT AS IDENTITY
+    ORDER BY n.nspname, t.relname, a.attname
+  LOOP
+    problems := problems || format(
+      E'\n  - identity PK not covered by SERIAL setval: %I.%I.%I',
+      r.schema_name, r.table_name, r.column_name);
+  END LOOP;
+
+  IF problems <> '' THEN
+    RAISE EXCEPTION E'phase4-verify-sequences FAILED:%', problems;
+  END IF;
+
+  RAISE NOTICE 'phase4-verify-sequences: OK -- % owned sequence(s) past MAX, no identity-PK drift.', n_checked;
+END $$;

--- a/spec/lib/tasks/phase4_sequences_spec.rb
+++ b/spec/lib/tasks/phase4_sequences_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'rake'
+
+# Exercises the Phase 4 sequence reset/verify tasks against the REAL test schema, so the
+# scripts/gcp/*.sql single-source-of-truth is validated before it is ever pointed at Cloud SQL.
+describe 'db:setval_all_sequences / db:verify_sequences rake tasks' do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('db:setval_all_sequences')
+  end
+
+  before(:each) do
+    Rake::Task['db:setval_all_sequences'].reenable
+    Rake::Task['db:verify_sequences'].reenable
+  end
+
+  let(:conn) { ActiveRecord::Base.connection }
+
+  # snapshot of every public sequence's persisted value, for idempotency comparison
+  def seq_snapshot
+    conn.select_rows(
+      "select sequencename, last_value from pg_sequences where schemaname = 'public' order by sequencename"
+    )
+  end
+
+  it 'advances every column-owned sequence over the real schema without error' do
+    expect { Rake::Task['db:setval_all_sequences'].invoke }.not_to raise_error
+    # All 57 app tables carry a column-owned sequence; the dynamic discovery must find them.
+    seqs = conn.select_value("select count(*) from pg_sequences where schemaname = 'public'").to_i
+    expect(seqs).to be >= 57
+  end
+
+  it 'is idempotent: a second run leaves every sequence value unchanged' do
+    Rake::Task['db:setval_all_sequences'].invoke
+    before = seq_snapshot
+    Rake::Task['db:setval_all_sequences'].reenable
+    Rake::Task['db:setval_all_sequences'].invoke
+    expect(seq_snapshot).to eq(before)
+  end
+
+  it 'db:verify_sequences passes after a setval run' do
+    Rake::Task['db:setval_all_sequences'].invoke
+    expect { Rake::Task['db:verify_sequences'].invoke }.not_to raise_error
+  end
+
+  it 'db:verify_sequences raises when a sequence lags its table MAX' do
+    begin
+      expect {
+        # requires_new wraps a SAVEPOINT, so the verify DO block's server-side RAISE rolls back
+        # to the savepoint and re-raises WITHOUT aborting the outer fixture transaction.
+        conn.transaction(requires_new: true) do
+          conn.execute("insert into webhooks (id, created_at, updated_at) values (999999, now(), now())")
+          conn.execute("select setval('webhooks_id_seq', 5, true)")
+          Rake::Task['db:verify_sequences'].invoke
+        end
+      }.to raise_error(ActiveRecord::StatementInvalid, /webhooks_id_seq behind/)
+    ensure
+      # setval is non-transactional, so the forced-low value survives the savepoint rollback;
+      # restore the empty-table baseline so no sequence state leaks to other specs.
+      conn.execute("select setval('webhooks_id_seq', 1, false)")
+    end
+  end
+end


### PR DESCRIPTION
## What

The last two zero-spend, prep-only items gating the Render → GCP Cloud Run **Phase 4** dress rehearsal (per the 2026-06-17 tabletop findings, items S1 + S2). Nothing here moves data, changes DNS, or seeds prod secrets — the real restore/seed are cutover steps gated behind explicit go.

### S1 — setval-all-sequences
After a `pg_dump` → restore into Cloud SQL, column-owned sequences lag `MAX(id)`. Because `global_id` encodes the **raw** primary key, the next insert would collide on PK and corrupt global_id references.

- `scripts/gcp/phase4-setval-sequences.sql` — dynamic `DO` block discovering every column-owned sequence via `pg_depend` (deptype `'a'`), idempotent, deterministic NOTICE order. Single source of truth.
- `scripts/gcp/phase4-verify-sequences.sql` — raises on any lagging sequence **or** identity-PK drift the SERIAL-only reset would miss.
- `scripts/gcp/phase4-setval-sequences.sh` — psql cutover runner; prints resolved project + Cloud SQL instance + db/host/user **before** touching the DB; `ON_ERROR_STOP`.
- `lib/tasks/phase4_sequences.rake` — `db:setval_all_sequences` / `db:verify_sequences` for local rehearsal + test, with a clean failure banner.
- `spec/lib/tasks/phase4_sequences_spec.rb` — validated against the **real** test schema.

### S2 — generateValue secret preservation
`SECRET_KEY_BASE`, `COOKIE_KEY`, `SECURE_ENCRYPTION_KEY`, `SECURE_NONCE_KEY` must be copied byte-for-byte, **never regenerated** (regenerating the encryption/nonce keys makes all `secure_serialize`'d data and `ExternalNonce` permanently undecryptable; a wrong value is silent until logins/decryption fail).

- `scripts/gcp/phase4-seed-boot-secrets.sh` — source of truth = **1Password "LingoLinq Prod"/"Rails Secrets"** (what `sync-render-env.js` already treats as canonical), independently **verified byte-for-byte (sha256, never echoed) against live Render** before seeding GCP Secret Manager. **HARD STOP** on any mismatch/empty; a Render 429/5xx is a STOP, not a retry. Fail-closed: plan mode writes nothing, `--fingerprint`/`--verify` are read-only, seed requires `CONFIRM_SEED_SECRETS=1`.

### Runbook
`scripts/gcp/PHASE4-CUTOVER-DATA-RUNBOOK.md` — operator identity (HIPAA), preflight, ordered commands, source-of-truth rationale, rollback, verification, and a pre-cutover note on `SMS_ENCRYPTION_KEY`.

## Verification (all run locally)

- ✅ S1 SQL rehearsed against the real test schema: **57 column-owned sequences** advanced (incl. the 3 implicit-bigint PK tables), **idempotent**, verify passes when correct and **fails loudly with a clean message** when a sequence lags.
- ✅ Spec: **4 examples, 0 failures** (`DB_USER=scotw RAILS_ENV=test`).
- ✅ S2 paths proven via mock harness: match → OK; mismatch/empty → HARD STOP before any write; `--fingerprint` → sha256-only.
- ✅ Bearer-token + secret values confirmed **not traced** under `bash -x` (relocated xtrace guard).
- ✅ Plan mode writes nothing with zero creds; `bash -n` clean on both scripts.

## Review

Adversary-reviewed (Claude): **no Critical/High**. Three Mediums addressed: bearer-token xtrace window (fixed + verified), Render pagination cap (now pages to exhaustion), `SMS_ENCRYPTION_KEY` scope (investigated — persisted-hash salt, out of the generateValue set; documented as a pre-cutover task). Secret-handling content kept Claude-only; the diff is code only (no plaintext secrets / PII).

> Running the real restore/setval and the real secret seed against `lingolinq-prod` are cutover steps that need explicit go. This PR is prep only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)