### PR TITLE
security: verify SNS signature on transcoding callbacks (LL-6d8314e37b)

### DIFF
--- a/app/controllers/api/callbacks_controller.rb
+++ b/app/controllers/api/callbacks_controller.rb
@@ -24,6 +24,10 @@ class Api::CallbacksController < ApplicationController
       if !topic_arn
         api_error 400, {error: 'missing topic arn'}
       elsif topic_arn.match(/audio_conversion_events/) || topic_arn.match(/video_conversion_events/)
+        verifier = Aws::SNS::MessageVerifier.new
+        if !verifier.authentic?(body)
+          return api_error 401, {error: 'inauthentic message'}
+        end
         Rails.logger.warn(json_body.to_json)
         res = Transcoder.handle_event(json_body)
         if res

--- a/spec/controllers/api/callbacks_controller_spec.rb
+++ b/spec/controllers/api/callbacks_controller_spec.rb
@@ -74,7 +74,23 @@ describe Api::CallbacksController, :type => :controller do
       expect(json).to eq({'error' => 'unrecognized callback', 'status' => 400})
     end
     
+    it "should reject an inauthentic transcoding event" do
+      v = OpenStruct.new
+      expect(Aws::SNS::MessageVerifier).to receive(:new).and_return(v)
+      expect(v).to receive(:authentic?).and_return(false)
+      expect(Transcoder).to_not receive(:handle_event)
+      request.headers['x-amz-sns-message-type'] = 'Notification'
+      request.headers['x-amz-sns-topic-arn'] = 'fried:audio_conversion_events:chicken'
+      post 'callback', body: {a: '1'}.to_json
+      expect(response).to_not be_successful
+      json = JSON.parse(response.body)
+      expect(json).to eq({'error' => 'inauthentic message', 'status' => 401})
+    end
+
     it "should error on unhandled transcoding event" do
+      v = OpenStruct.new
+      expect(Aws::SNS::MessageVerifier).to receive(:new).and_return(v)
+      expect(v).to receive(:authentic?).and_return(true)
       request.headers['x-amz-sns-message-type'] = 'Notification'
       request.headers['x-amz-sns-topic-arn'] = 'fried:audio_conversion_events:chicken'
       expect(Transcoder).to receive(:handle_event){|params|
@@ -85,8 +101,11 @@ describe Api::CallbacksController, :type => :controller do
       json = JSON.parse(response.body)
       expect(json).to eq({'error' => 'event not handled', 'status' => 400})
     end
-    
+
     it "should succeed on handled transcoding event" do
+      v = OpenStruct.new
+      expect(Aws::SNS::MessageVerifier).to receive(:new).and_return(v)
+      expect(v).to receive(:authentic?).and_return(true)
       request.headers['x-amz-sns-message-type'] = 'Notification'
       request.headers['x-amz-sns-topic-arn'] = 'fried:audio_conversion_events:chicken'
       expect(Transcoder).to receive(:handle_event){|params|
@@ -140,6 +159,9 @@ describe Api::CallbacksController, :type => :controller do
 
       Worker.process_queues
 
+      v = OpenStruct.new
+      expect(Aws::SNS::MessageVerifier).to receive(:new).and_return(v)
+      expect(v).to receive(:authentic?).and_return(true)
       request.headers['x-amz-sns-message-type'] = 'Notification'
       request.headers['x-amz-sns-topic-arn'] = 'fried:audio_conversion_events:chicken'
       post 'callback', body: {'Message' => {


### PR DESCRIPTION
## Finding
Addresses audit finding **LL-6d8314e37b** (High): SNS transcoding callbacks accepted without signature verification.

This does **NOT** close the finding. Per the compliance workflow, status stays `open` at High until Scot verifies the fix and attests. Disposition stays `fixed` (intent already recorded in #419).

## Root cause
`Api::CallbacksController#callback` verified the SNS signature on the SMS-inbound branch (`Aws::SNS::MessageVerifier.new.authentic?(body)`), but the transcoding-event branch (`audio_conversion_events` / `video_conversion_events`) called `Transcoder.handle_event` with no signature check. Forged notifications to those topic ARNs were accepted unauthenticated.

## Change
Mirror the existing SMS-inbound verifier into the transcoding branch. Inauthentic messages now return `401 {error: 'inauthentic message'}`. The working SMS path is untouched.

## Tests
- Stubbed `Aws::SNS::MessageVerifier` in the three existing transcoding specs (they posted without a verifier stub and would otherwise break).
- Added a negative spec: an inauthentic transcoding notification is rejected with 401, and `Transcoder.handle_event` is never called. Verified it fails without the controller change.
- `callbacks_controller_spec.rb`: 9/10 pass. The one failure (`should error on confirming invalid arn`, line 5) is **pre-existing and unrelated** -- a brittle `expect(ENV).to receive('[]')` mock colliding with a Rack 3.2.6 internal env lookup; it fails identically on staging without this change.

## Notes
Compliance code, Claude-authored. This PR may trigger the n8n DeepSeek adversary pass; the diff is non-PHI technical code, accepted for now.