### PR TITLE
security: uniform forgot_password response to stop account enumeration (LL-9a3ee852d5)

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -698,30 +698,16 @@ class Api::UsersController < ApplicationController
     end
     not_disabled_users = users.select{|u| !u.settings['email_disabled'] }
     reset_users = not_disabled_users.select{|u| u.generate_password_reset }
-    if users.length > 0
-      if reset_users.length > 0
-        UserMailer.schedule_delivery(:forgot_password, reset_users.map(&:global_id))
-        if reset_users.length == users.length
-          render json: {email_sent: true, users: users.length}
-        else
-          message = "One or more of the users matching that name or email have had too many password resets, so those links weren't emailed to you. Please wait at least three hours and try again."
-          render json: {email_sent: true, users: users.length, message: message}
-        end
-      else
-        message = "All users matching that name or email have had too many password resets. Please wait at least three hours and try again."
-        message = "The user matching that name or email has had too many password resets. Please wait at least three hours and try again." if users.length == 1
-        message = "The email address for that account has been manually disabled." if not_disabled_users.length == 0
-        api_error 400, {email_sent: false, users: 0, error: message, message: message}
-      end
-    else
-      if params['key'] && params['key'].match(/@/)
-        UserMailer.schedule_delivery(:login_no_user, params['key'])
-        render json: {email_sent: true, users: 0}
-      else
-        message = "No users found with that name or email."
-        api_error 400, {email_sent: false, users: 0, error: message, message: message}
-      end
+    # Send the appropriate email when one is warranted, but always return the
+    # same response shape regardless of whether an account exists, is disabled,
+    # or is throttled. Leaking existence (via a users count, a 400 status, or a
+    # distinguishing message) enabled account enumeration (finding LL-9a3ee852d5).
+    if reset_users.length > 0
+      UserMailer.schedule_delivery(:forgot_password, reset_users.map(&:global_id))
+    elsif users.length == 0 && params['key'] && params['key'].match(/@/)
+      UserMailer.schedule_delivery(:login_no_user, params['key'])
     end
+    render json: {email_sent: true}
   end
 
   # Re-send parental consent email when the child cannot log in until a parent approves (same flow as signup).

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -1401,87 +1401,92 @@ describe Api::UsersController, :type => :controller do
       expect(response).to be_successful
     end
     
-    it "should throttle token creation and emailing" do
+    it "should not email a throttled user but should still return a uniform response" do
       u = User.create
       10.times{|i| u.generate_password_reset }
       u.save
       expect(UserMailer).not_to receive(:schedule_delivery)
       post :forgot_password, params: {:key => u.user_name}
-      expect(response).not_to be_successful
+      expect(response).to be_successful
       json = JSON.parse(response.body)
-      expect(json['email_sent']).to eq(false)
-      expect(json['users']).to eq(0)
-      expect(json['message']).to eq('The user matching that name or email has had too many password resets. Please wait at least three hours and try again.')
+      expect(json).to eq({'email_sent' => true})
     end
-    
-    it "should return message when no users found" do
+
+    it "should not email for an unknown username but should still return a uniform response" do
+      expect(UserMailer).not_to receive(:schedule_delivery)
       post :forgot_password, params: {:key => 'shoelace'}
-      expect(response).not_to be_successful
+      expect(response).to be_successful
       json = JSON.parse(response.body)
-      expect(json['email_sent']).to eq(false)
-      expect(json['users']).to eq(0)
-      expect(json['message']).to eq('No users found with that name or email.')
+      expect(json).to eq({'email_sent' => true})
     end
-    
-    
+
+    it "should not leak account existence (identical response for real and bogus keys)" do
+      u = User.create(:settings => {'email' => 'bob@example.com'})
+      post :forgot_password, params: {:key => u.user_name}
+      real = JSON.parse(response.body)
+      real_status = response.status
+      post :forgot_password, params: {:key => 'definitely-not-a-user'}
+      bogus = JSON.parse(response.body)
+      expect(response.status).to eq(real_status)
+      expect(bogus).to eq(real)
+      expect(real).to eq({'email_sent' => true})
+    end
+
     it "should schedule a message delivery when non-throttled user is found" do
       u = User.create(:settings => {'email' => 'bob@example.com'})
       expect(UserMailer).to receive(:schedule_delivery)
       post :forgot_password, params: {:key => u.user_name}
       expect(response).to be_successful
     end
-    
+
     it "should return a success message when no users found but an email address provided" do
       post :forgot_password, params: {:key => 'shoelace@example.com'}
       expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json['email_sent']).to eq(true)
     end
-    
+
     it "should schedule a message delivery when no user found by an email address provided" do
       expect(UserMailer).to receive(:schedule_delivery).with(:login_no_user, 'shoelace@example.com')
       post :forgot_password, params: {:key => 'shoelace@example.com'}
       expect(response).to be_successful
     end
 
-    it "should not include disabled emails" do
+    it "should not email disabled accounts but should still return a uniform response" do
       u = User.create(:settings => {'email' => 'bob@example.com', 'email_disabled' => true})
       expect(UserMailer).not_to receive(:schedule_delivery)
       post :forgot_password, params: {:key => u.user_name}
-      expect(response).not_to be_successful
-      json = JSON.parse(response.body)
-      expect(json['email_sent']).to eq(false)
-      expect(json['users']).to eq(0)
-      expect(json['message']).to eq('The email address for that account has been manually disabled.')
-    end
-    
-    it "should include possibly-multiple users for the given email address" do
-      u = User.create(:settings => {'email' => 'bob@example.com'})
-      post :forgot_password, params: {:key => u.user_name}
       expect(response).to be_successful
       json = JSON.parse(response.body)
-      expect(json['email_sent']).to eq(true)
-      expect(json['users']).to eq(1)
-      
+      expect(json).to eq({'email_sent' => true})
+    end
+
+    it "should email all matching users for the given email address" do
+      u = User.create(:settings => {'email' => 'bob@example.com'})
       u2 = User.create(:settings => {'email' => 'bob@example.com'})
+      expect(UserMailer).to receive(:schedule_delivery) do |template, ids|
+        expect(template).to eq(:forgot_password)
+        expect(ids.sort).to eq([u.global_id, u2.global_id].sort)
+      end
       post :forgot_password, params: {:key => 'bob@example.com'}
       expect(response).to be_successful
       json = JSON.parse(response.body)
-      expect(json['email_sent']).to eq(true)
-      expect(json['users']).to eq(2)
+      expect(json).to eq({'email_sent' => true})
     end
-    it "should provide helpful message if some user accounts but not others were throttled" do
+
+    it "should still email non-throttled users when some accounts are throttled" do
       u = User.create(:settings => {'email' => 'bob@example.com'})
       u2 = User.create(:settings => {'email' => 'bob@example.com'})
       10.times{|i| u.generate_password_reset }
       u.save
-      expect(UserMailer).to receive(:schedule_delivery)
+      expect(UserMailer).to receive(:schedule_delivery) do |template, ids|
+        expect(template).to eq(:forgot_password)
+        expect(ids).to eq([u2.global_id])
+      end
       post :forgot_password, params: {:key => 'bob@example.com'}
       expect(response).to be_successful
       json = JSON.parse(response.body)
-      expect(json['email_sent']).to eq(true)
-      expect(json['users']).to eq(2)
-      expect(json['message']).to eq("One or more of the users matching that name or email have had too many password resets, so those links weren't emailed to you. Please wait at least three hours and try again.")
+      expect(json).to eq({'email_sent' => true})
     end
   end
 


### PR DESCRIPTION
## Finding
Addresses audit finding **LL-9a3ee852d5** (High): forgot_password leaks account existence via response shape and users count.

This does **NOT** close the finding. Status stays `open` at High until Scot verifies and attests. Disposition stays `fixed` (intent recorded in #419).

## Root cause
`forgot_password` returned distinguishable responses depending on whether an account existed:
- success: `200 {email_sent: true, users: N}` (leaks the match count)
- throttled / disabled / not-found: `400 {email_sent: false, users: 0, message: "..."}` (leaks existence via status + message)

An attacker could enumerate valid usernames/emails by diffing the status code, the `users` count, or the message text.

## Change
Always respond `200 {email_sent: true}` regardless of existence, disabled, or throttled state. All server-side email side-effects are preserved exactly:
- reset emails still go to eligible (non-disabled, non-throttled) users
- the `login_no_user` courtesy email still fires for unknown email addresses
- throttling and disabled-account suppression still apply server-side

## Frontend safety (verified per disposition)
The only consumers (`controllers/forgot_password.js`, `controllers/forgot-login.js`, and their `.hbs` templates) read `response.email_sent` (and `response.message` only on a network-error fallback). Nothing reads `response.users`, so dropping the count is safe.

## Tests
- Rewrote the `forgot_password` specs to assert the uniform `{email_sent: true}` response while keeping the `UserMailer.schedule_delivery` side-effect contracts (eligible users emailed; throttled/disabled/unknown not emailed).
- Added an enumeration spec: a real key and a bogus key return an identical status + body. Verified it fails (400 vs 200) without the controller change.
- Full `forgot_password` describe block: 10/10 pass.

## Notes
Compliance code, Claude-authored. May trigger the n8n DeepSeek adversary pass; diff is non-PHI technical code, accepted for now.