### PR TITLE
fix(a11y): board-tile symbol alt text on all render paths (LL-2967f77e6d)

### DIFF
--- a/app/frontend/app/models/board.js
+++ b/app/frontend/app/models/board.js
@@ -1712,7 +1712,8 @@ LingoLinq.Board = DS.Model.extend({
       var appState = _this.appState || (typeof window !== 'undefined' && window.appState);
       var userForDisplay = (appState && appState.get('speak_mode')) ? appState.get('referenced_user') : appState.get('currentUser');
       if(appState && userForDisplay && !userForDisplay.get('hide_symbols') && local_image_url && local_image_url != 'none' && !_this.get('text_only') && !button.text_only) {
-        res = res + "<img src=\"" + Button.clean_url(local_image_url) + "\" rel=\"" + Button.clean_url(pref_original_image_url || original_image_url) + "\" onerror='button_broken_image(this);' draggable='false' style='" + opts.image_style + "' class='symbol " + (hc ? ' hc' : '') + "' />";
+        var symbol_alt = Button.clean_text(opts.label || '').replace(/"/g, '&quot;');
+        res = res + "<img src=\"" + Button.clean_url(local_image_url) + "\" rel=\"" + Button.clean_url(pref_original_image_url || original_image_url) + "\" alt=\"" + symbol_alt + "\" onerror='button_broken_image(this);' draggable='false' style='" + opts.image_style + "' class='symbol " + (hc ? ' hc' : '') + "' />";
       }
       res = res + "</span>";
       if(button.sound_id && local_sound_url && local_sound_url != 'none') {

--- a/app/frontend/app/templates/board/index.hbs
+++ b/app/frontend/app/templates/board/index.hbs
@@ -120,7 +120,7 @@
                       {{#unless this.app_state.currentUser.hide_symbols}}
                         {{#unless button.board.text_only}}
                           {{#unless button.text_only}}
-                            <img src={{button.local_image_url}} rel={{button.original_image_url}} draggable='false' onerror="button_broken_image(this);" style={{button.image_style}} class={{if button.hc_image "symbol hc" "symbol"}}>
+                            <img src={{button.local_image_url}} rel={{button.original_image_url}} alt={{button.label}} draggable='false' onerror="button_broken_image(this);" style={{button.image_style}} class={{if button.hc_image "symbol hc" "symbol"}}>
                           {{/unless}}
                         {{/unless}}
                       {{/unless}}

--- a/app/frontend/app/utils/button.js
+++ b/app/frontend/app/utils/button.js
@@ -446,7 +446,8 @@ var Button = EmberObject.extend({
       var appState = this.appState || app_state;
       res = res + "<span style='" + this.get('image_holder_style') + "'>";
       if(!appState.get('currentUser.hide_symbols') && this.get('local_image_url') && !this.get('board.text_only') && !this.get('text_only')) {
-        res = res + "<img src=\"" + clean_url(this.get('local_image_url')) + "\" rel=\"" + clean_url(this.get('original_image_url') || this.get('image.url')) + "\" onerror='button_broken_image(this);' draggable='false' style='" + this.get('image_style') + "' class='symbol" + (this.get('hc_image') ? ' hc' : '') + "' />";
+        var symbol_alt = clean_text(this.get('label') || '').replace(/"/g, '&quot;');
+        res = res + "<img src=\"" + clean_url(this.get('local_image_url')) + "\" rel=\"" + clean_url(this.get('original_image_url') || this.get('image.url')) + "\" alt=\"" + symbol_alt + "\" onerror='button_broken_image(this);' draggable='false' style='" + this.get('image_style') + "' class='symbol" + (this.get('hc_image') ? ' hc' : '') + "' />";
       }
       res = res + "</span>";
       if(this.get('sound')) {


### PR DESCRIPTION
## Finding
Addresses audit finding **LL-2967f77e6d** (High, WCAG): board-tile symbol image has no alt text.

This does **NOT** close the finding. Status stays `open` at High until Scot verifies and attests. Disposition stays `fixed` (intent recorded in #419).

## Root cause
The board-tile symbol `<img>` was rendered with no `alt` attribute, so assistive tech announced nothing for the symbol (WCAG 1.1.1 Non-text Content, 4.1.2 Name/Role/Value; EN 301 549 9.1.1). The tile symbol is built in **three** independent places, and fixing one does not fix the others:
- `app/frontend/app/utils/button.js` (the `fast_html` string -- the cited path)
- `app/frontend/app/models/board.js` (board-level fast render string)
- `app/frontend/app/templates/board/index.hbs` (live grid template)

## Change
Add `alt` = the button label on all three paths:
- raw-string paths: `clean_text(label)` (HTML-escaped) plus a `"` -> `&quot;` replace, since the attribute is double-quoted and `clean_text` does not escape quotes.
- template path: `alt={{button.label}}` (Handlebars auto-escapes), mirroring the adjacent `alt={{button.action_alt}}` on the action image.

Additive only; no existing markup, classes, or behavior changed.

## Testing
- Edited JS files pass an ES-module parse check.
- The template change mirrors the known-good `alt={{button.action_alt}}` binding two lines above it.
- Frontend QUnit unit specs do not execute behaviorally in this repo (AMD loader defect, issue #314), so a unit test would never run and was intentionally not added. Recommend a manual screen-reader spot check on a board in speak mode during verification.

## Notes
Compliance/a11y code, Claude-authored. May trigger the n8n DeepSeek adversary pass; diff is non-PHI markup, accepted for now.