### PR TITLE
fix: transfer License seats on user merge (LL-e775d86e6a)

### DIFF
--- a/lib/flusher.rb
+++ b/lib/flusher.rb
@@ -183,6 +183,8 @@ module Flusher
     ButtonSound.where(user_id: source.id).update_all(user_id: target.id)
     ButtonImage.where(user_id: source.id).update_all(user_id: target.id)
     UserVideo.where(user_id: source.id).update_all(user_id: target.id)
+    # Move org seats with the user so the seat is not orphaned on merge.
+    License.where(user_id: source.id).update_all(user_id: target.id)
 
     #invalidate any caches
     source.touch

--- a/spec/lib/flusher_spec.rb
+++ b/spec/lib/flusher_spec.rb
@@ -321,7 +321,7 @@ describe Flusher do
       u1 = User.create
       u2 = User.create
       ref = {}
-      expect(ref).to receive(:update_all).with(user_id: u2.id).and_return(1).exactly(10).times
+      expect(ref).to receive(:update_all).with(user_id: u2.id).and_return(1).exactly(11).times
       expect(NfcTag).to receive(:where).with(:user_id => u1.id).and_return(ref)
       expect(UserIntegration).to receive(:where).with(:user_id => u1.id).and_return(ref)
       expect(UserGoal).to receive(:where).with(:user_id => u1.id).and_return(ref)
@@ -332,7 +332,17 @@ describe Flusher do
       expect(ButtonSound).to receive(:where).with(:user_id => u1.id).and_return(ref)
       expect(ButtonImage).to receive(:where).with(:user_id => u1.id).and_return(ref)
       expect(UserVideo).to receive(:where).with(:user_id => u1.id).and_return(ref)
+      expect(License).to receive(:where).with(:user_id => u1.id).and_return(ref)
       Flusher.transfer_user_content(u1.global_id, u1.user_name, u2.global_id, u2.user_name)
+    end
+
+    it "should transfer license seats so they are not orphaned on merge" do
+      u1 = User.create
+      u2 = User.create
+      o = Organization.create
+      l = License.create!(organization: o, user: u1, seat_type: 'student', status: 'active')
+      Flusher.transfer_user_content(u1.global_id, u1.user_name, u2.global_id, u2.user_name)
+      expect(l.reload.user_id).to eq(u2.id)
     end
   end
   


### PR DESCRIPTION
## Finding
Addresses audit finding **LL-e775d86e6a** (High): License not handled in transfer_user_content (orphaned seats on merge).

This does **NOT** close the finding. Status stays `open` at High until Scot verifies and attests. Disposition stays `fixed` (intent recorded in #419).

## Root cause
`Flusher.transfer_user_content` reassigns NfcTag, UserIntegration, UserGoal, UserBadge, Webhook, UserBoardConnection, UserLink, ButtonSound, ButtonImage and UserVideo from the source user to the target, but never reassigned `License`. On a user merge, the source user's org seat kept pointing at the merged-away user, orphaning the seat.

## Change
Add `License.where(user_id: source.id).update_all(user_id: target.id)`, mirroring the existing transfers. `License belongs_to :user, optional: true` with no uniqueness constraint on `user_id`, so a plain `update_all` is safe and consistent with the other lines.

## Tests
- Updated the existing mock-count spec: `update_all` expectation 10 -> 11 and added `License` to the mocked `where` chain.
- Added a behavioral spec: a `License` created on the source user is reassigned to the target after the merge. Verified it fails without the change (license stays with the source user).
- `transfer_user_content` describe block: 3/3 pass.

## Notes
Compliance code, Claude-authored. May trigger the n8n DeepSeek adversary pass; diff is non-PHI technical code, accepted for now.