### PR TITLE
security(start-code): lengthen verifier to 16 chars + throttle lookup (LL-4e243f3e16)

### DIFF
--- a/app/controllers/api/organizations_controller.rb
+++ b/app/controllers/api/organizations_controller.rb
@@ -122,10 +122,11 @@ class Api::OrganizationsController < ApplicationController
   def start_code_lookup
     code = Organization.parse_activation_code(params['code'])
     if code && !code[:disabled] && code[:target]
-      hash = params['v']
       valid = false
       include_users = false
-      if params['v'] == GoSecure.sha512(Webhook.get_record_code(code[:target]), 'start_code_verifier')[0, 5]
+      # Anonymous lookups must present the share-link verifier; accepts the
+      # current 16-char and legacy 5-char values (LL-4e243f3e16).
+      if Organization.valid_start_code_verifier?(code[:target], params['v'])
         valid = true
       elsif code[:target].is_a?(User) && code[:target].allows?(@api_user, 'edit')
         valid = true

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1315,6 +1315,30 @@ class Organization < ApplicationRecord
     true
   end
 
+  # Length of the share-link verifier ('v') embedded in start-code links. New
+  # links carry a 16-char verifier (~64 bits) instead of the original 5-char
+  # (~20 bits) value, which was brute-forceable on the unauthenticated
+  # start_code lookup (LL-4e243f3e16). The 5-char legacy length is still
+  # accepted on lookup so links already distributed keep working; the lookup
+  # endpoint is also rate-limited (Throttling::PROTECTED_PATHS) so the short
+  # legacy prefix cannot be brute-forced during the transition.
+  START_CODE_VERIFIER_LENGTH = 16
+  START_CODE_VERIFIER_LEGACY_LENGTH = 5
+
+  def self.start_code_verifier(org_or_user, length = START_CODE_VERIFIER_LENGTH)
+    GoSecure.sha512(Webhook.get_record_code(org_or_user), 'start_code_verifier')[0, length]
+  end
+
+  # True when +provided+ matches the current 16-char verifier OR the legacy
+  # 5-char verifier for +org_or_user+ (backward compatibility for already-issued
+  # links). Both lengths are explicit so only those two prefixes validate.
+  def self.valid_start_code_verifier?(org_or_user, provided)
+    return false unless provided.is_a?(String)
+    full = GoSecure.sha512(Webhook.get_record_code(org_or_user), 'start_code_verifier')
+    provided == full[0, START_CODE_VERIFIER_LENGTH] ||
+      provided == full[0, START_CODE_VERIFIER_LEGACY_LENGTH]
+  end
+
   def self.start_codes(org_or_user)
     res = []
     org_or_user.settings['activation_settings'].each do |rnd, opts|
@@ -1327,7 +1351,7 @@ class Organization < ApplicationRecord
       hash[:locale] = opts['locale'] if opts['locale']
       hash[:symbol_library] = opts['symbol_library'] if opts['symbol_library']
       hash[:premium] = opts['premium'] if opts['premium'] != nil
-      hash[:v] = GoSecure.sha512(Webhook.get_record_code(org_or_user), 'start_code_verifier')[0, 5]
+      hash[:v] = Organization.start_code_verifier(org_or_user)
       hash[:premium_symbols] = opts['premium_symbols'] if opts['premium_symbols'] != nil
       hash[:supervisors] = opts['supervisors'] if opts['supervisors']
       hash[:shallow_clone] = true if opts['shallow_clone']

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -38,7 +38,12 @@ module Throttling
     # (users#password_reset), so an unthrottled endpoint invites reset-code
     # brute-forcing. Follow-up to the audit rate-limit pass; sibling of the
     # already-protected forgot_password.
-    'api/v1/users/.+/password_reset'
+    'api/v1/users/.+/password_reset',
+    # Unauthenticated start-code lookup (organizations#start_code_lookup, routed
+    # at api/v1/start_code). Verifier lengthened to 16 chars, but legacy 5-char
+    # links are still accepted; throttling keeps that short prefix from being
+    # brute-forced during the transition (LL-4e243f3e16).
+    'api/v1/start_code'
   ].freeze
   PROTECTED_RE = /#{PROTECTED_PATHS.join('|')}/
 

--- a/spec/initializers/throttling_paths_spec.rb
+++ b/spec/initializers/throttling_paths_spec.rb
@@ -51,6 +51,12 @@ describe Throttling do
       expect(protected?('/api/v1/users/1_2/password_reset')).to eq(true)
     end
 
+    # LL-4e243f3e16: unauthenticated start-code lookup (api/v1/start_code).
+    it 'protects the start_code lookup endpoint' do
+      expect(protected?('/api/v1/start_code')).to eq(true)
+      expect(protected?('/api/v1/start_code?code=11111&v=abcde')).to eq(true)
+    end
+
     # Regression guard for the anchored 'api/v1/users' entry: protecting the
     # collection must NOT broaden the throttle to every per-user member route.
     it 'does not over-throttle ordinary per-user member endpoints' do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -3153,14 +3153,14 @@ describe Organization, :type => :model do
             code: code,
             disabled: false,
             locale: 'es',
-            v: GoSecure.sha512(Webhook.get_record_code(o), 'start_code_verifier')[0, 5]
+            v: Organization.start_code_verifier(o)
           },
           {
             code: code2,
             disabled: false,
             locale: 'fr',
             symbol_library: 'pcs',
-            v: GoSecure.sha512(Webhook.get_record_code(o), 'start_code_verifier')[0, 5]
+            v: Organization.start_code_verifier(o)
           }
         ])
       end
@@ -3184,16 +3184,48 @@ describe Organization, :type => :model do
           {
             code: code,
             disabled: false,
-            v: GoSecure.sha512(Webhook.get_record_code(u), 'start_code_verifier')[0, 5]
+            v: Organization.start_code_verifier(u)
 
           },
           {
             code: code2,
             disabled: false,
             home_board_key: b.key,
-            v: GoSecure.sha512(Webhook.get_record_code(u), 'start_code_verifier')[0, 5]
+            v: Organization.start_code_verifier(u)
           }
         ])
+      end
+    end
+
+    describe "start_code_verifier / valid_start_code_verifier?" do
+      # LL-4e243f3e16: the share-link verifier was a brute-forceable 5-char hash.
+      it "should generate a 16-char verifier by default" do
+        o = Organization.create
+        v = Organization.start_code_verifier(o)
+        expect(v.length).to eq(16)
+        full = GoSecure.sha512(Webhook.get_record_code(o), 'start_code_verifier')
+        expect(v).to eq(full[0, 16])
+      end
+
+      it "should accept the current 16-char verifier" do
+        o = Organization.create
+        expect(Organization.valid_start_code_verifier?(o, Organization.start_code_verifier(o))).to eq(true)
+      end
+
+      it "should still accept the legacy 5-char verifier for already-issued links" do
+        o = Organization.create
+        legacy = GoSecure.sha512(Webhook.get_record_code(o), 'start_code_verifier')[0, 5]
+        expect(Organization.valid_start_code_verifier?(o, legacy)).to eq(true)
+      end
+
+      it "should reject a wrong, blank, nil, or truncated verifier" do
+        o = Organization.create
+        expect(Organization.valid_start_code_verifier?(o, 'nope')).to eq(false)
+        expect(Organization.valid_start_code_verifier?(o, '')).to eq(false)
+        expect(Organization.valid_start_code_verifier?(o, nil)).to eq(false)
+        # a 4-char prefix (shorter than the legacy length) must not validate
+        full = GoSecure.sha512(Webhook.get_record_code(o), 'start_code_verifier')
+        expect(Organization.valid_start_code_verifier?(o, full[0, 4])).to eq(false)
       end
     end
 


### PR DESCRIPTION
Closes the **only** High finding from today's batch that was not actually remediated: **LL-4e243f3e16**. (My earlier status report mistakenly mapped it to #421 — #421 throttled `users#password_reset`, a different endpoint.)

## The issue
`organizations#start_code_lookup` (routed at `api/v1/start_code`, unauthenticated) validated anonymous requests against a **5-char SHA512 prefix** verifier (`v`, ~20 bits). The activation/promo code itself (`params['code']`, e.g. "Spring25") is meant to be shared, so `v` is the only real secret gating the lookup — and 5 chars is brute-forceable to enumerate org/supervisor name + up to 50 users' limited identity.

## Fix (backward compatible, defense in depth)
- **Lengthen** new verifiers to 16 chars / ~64 bits — `Organization.start_code_verifier` (used by `start_codes`).
- **Accept both** 16-char and legacy 5-char on lookup — `Organization.valid_start_code_verifier?` — so links already distributed keep working (the disposition required not invalidating issued codes).
- **Throttle** `api/v1/start_code` (PROTECTED_CUTOFF 10/3s) so the legacy short prefix can't be brute-forced during the transition.

The **memorable code stays memorable**: only the hidden `v` verifier in the share link changes; `params['code']` is untouched.

## Tests
- `organization_spec`: verifier length (16), accepts both 16 + legacy 5, rejects wrong/blank/nil/4-char.
- `throttling_paths_spec`: `api/v1/start_code` classified protected.
- Existing `start_code_lookup` controller specs pass unchanged (they use the generated `v`).
- **57 examples, 0 failures** locally (`DB_USER=scotw RAILS_ENV=test`).

## Register
LL-4e243f3e16 stays **open** until this merges to `staging`; I'll then verify the merged code and attest-close it (same verify-then-close discipline as #432). Not bundled with the register-only PR #432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)