### PR TITLE
security(webhook): require https:// for webhook callback URLs (LL-1085e59d29)

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -39,8 +39,8 @@ class Webhook < ApplicationRecord
   end
   
   def self.register(user, record, options)
-    if !options[:callback] ||!options[:callback].match(/^http/)
-      # callback provided by user must be a valid url
+    if !options[:callback] ||!options[:callback].match(/^https:\/\//)
+      # callback provided by user must be a valid https url (no plaintext http transport)
       return nil
     end
     register_internal(user, record, options)
@@ -251,7 +251,7 @@ class Webhook < ApplicationRecord
     self.settings['name'] = process_string(params['name']) if params['name']
     self.settings['include_content'] = params['include_content'] if params['include_content'] != nil
     self.settings['content_types'] = params['content_types'] if params['content_types']
-    self.settings['url'] = params['url'] if params['url'] && params['url'].match(/^http/)
+    self.settings['url'] = params['url'] if params['url'] && params['url'].match(/^https:\/\//)
     self.settings['webhook_type'] = params['webhook_type'] if params['webhook_type']
 
     if params['webhook_type'] == 'user'
@@ -261,7 +261,7 @@ class Webhook < ApplicationRecord
         notifications_param.each do |key, opts|
           if key == '*' || USER_WEBHOOKS.include?(key)
             self.settings['notifications'][key] ||= []
-            if opts['callback'] && opts['callback'].match(/^http/)
+            if opts['callback'] && opts['callback'].match(/^https:\/\//)
               self.settings['notifications'][key] = self.settings['notifications'][key].select{|n| n['callback'] != opts['callback'] }
               self.settings['notifications'][key] << {
                 'callback' => opts['callback'],

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -5,8 +5,15 @@ describe Webhook, :type => :model do
     it "should register the webhook" do
       u = User.create
       expect(Webhook.count).to eq(0)
-      Webhook.register(u, u, {:callback => 'http://www.example.com/ping', :notification_type => 'swinging'})
+      Webhook.register(u, u, {:callback => 'https://www.example.com/ping', :notification_type => 'swinging'})
       expect(Webhook.count).to eq(1)
+    end
+
+    it "should reject a plaintext http:// callback" do
+      u = User.create
+      expect(Webhook.count).to eq(0)
+      expect(Webhook.register(u, u, {:callback => 'http://www.example.com/ping', :notification_type => 'swinging'})).to eq(nil)
+      expect(Webhook.count).to eq(0)
     end
     
     it "should register an internal webhook" do
@@ -21,7 +28,7 @@ describe Webhook, :type => :model do
     it "should return a token" do
       u = User.create
       expect(Webhook.count).to eq(0)
-      t = Webhook.register(u, u, {:callback => 'http://www.example.com/ping', :notification_type => 'swinging'})
+      t = Webhook.register(u, u, {:callback => 'https://www.example.com/ping', :notification_type => 'swinging'})
       expect(t).not_to eq(nil)
       expect(t).to be_is_a(String)
       expect(Webhook.count).to eq(1)
@@ -30,9 +37,9 @@ describe Webhook, :type => :model do
     it "should log repeat registrations only once" do
       u = User.create
       expect(Webhook.count).to eq(0)
-      t = Webhook.register(u, u, {:callback => 'http://www.example.com/ping', :notification_type => 'swinging'})
-      t2 = Webhook.register(u, u, {:callback => 'http://www.example.com/ping', :notification_type => 'swinging'})
-      t3 = Webhook.register(u, u, {:callback => 'http://www.example.com/ping', :notification_type => 'swinging'})
+      t = Webhook.register(u, u, {:callback => 'https://www.example.com/ping', :notification_type => 'swinging'})
+      t2 = Webhook.register(u, u, {:callback => 'https://www.example.com/ping', :notification_type => 'swinging'})
+      t3 = Webhook.register(u, u, {:callback => 'https://www.example.com/ping', :notification_type => 'swinging'})
       expect(t).not_to eq(nil)
       expect(t).to be_is_a(String)
       expect(t).to eq(t2)
@@ -41,7 +48,7 @@ describe Webhook, :type => :model do
       h = Webhook.last
       expect(h.settings['notifications']['swinging'].length).to eq(1)
       expect(h.settings['callback_token']).to eq(t)
-      expect(h.settings['notifications']['swinging'][0]['callback']).to eq("http://www.example.com/ping")
+      expect(h.settings['notifications']['swinging'][0]['callback']).to eq("https://www.example.com/ping")
     end
   end
   
@@ -177,27 +184,27 @@ describe Webhook, :type => :model do
   describe "notify" do
     it "should post to external services for external callbacks" do
       u = User.create
-      token = Webhook.register(u, u, {:callback => 'http://www.example.com/ping', :notification_type => 'swinging'})
+      token = Webhook.register(u, u, {:callback => 'https://www.example.com/ping', :notification_type => 'swinging'})
       w = Webhook.last
       expect(Typhoeus).to receive(:post){|url, args|
-        expect(url).to eq('http://www.example.com/ping')
+        expect(url).to eq('https://www.example.com/ping')
         expect(args[:body][:token]).to eq(token)
       }.and_return(OpenStruct.new(code: 200))
       res = w.notify('swinging', w, {})
-      expect(res).to eq([{:url=>"http://www.example.com/ping", :response_code=>200, :response_body=>nil}])
+      expect(res).to eq([{:url=>"https://www.example.com/ping", :response_code=>200, :response_body=>nil}])
     end
     
     it "should error on slow external responses" do
       u = User.create
-      token = Webhook.register(u, u, {:callback => 'http://www.example.com/ping', :notification_type => 'swinging'})
+      token = Webhook.register(u, u, {:callback => 'https://www.example.com/ping', :notification_type => 'swinging'})
       w = Webhook.last
       expect(Typhoeus).to receive(:post){|url, args|
-        expect(url).to eq('http://www.example.com/ping')
+        expect(url).to eq('https://www.example.com/ping')
         expect(args[:body][:token]).to eq(token)
         raise Timeout::Error.new('asdf')
       }.and_return(OpenStruct.new(code: 200))
       res = w.notify('swinging', w, {})
-      expect(res).to eq([{:url=>"http://www.example.com/ping", :response_code=>0, :response_body=>"Timeout, request took more than 10 seconds"}])
+      expect(res).to eq([{:url=>"https://www.example.com/ping", :response_code=>0, :response_body=>"Timeout, request took more than 10 seconds"}])
     end
 
     it "should handle internal service callbacks as well" do
@@ -361,18 +368,18 @@ describe Webhook, :type => :model do
       u = User.create
       h = Webhook.process_new({
         'webhooks' => ['new_session', 'new_board'],
-        'url' => 'http://www.example.com/callback',
+        'url' => 'https://www.example.com/callback',
         'include_content' => true,
         'webhook_type' => 'user'
       }, {'user' => u})
       expect(h).to_not eq(nil)
       expect(h.settings).to_not eq(nil)
       expect(h.settings['include_content']).to eq(true)
-      expect(h.settings['url']).to eq('http://www.example.com/callback')
+      expect(h.settings['url']).to eq('https://www.example.com/callback')
       expect(h.settings['webhook_type']).to eq('user')
       expect(h.settings['notifications']).to eq({
         'new_session' => [
-          {'callback' => 'http://www.example.com/callback', 'include_content' => true, 'content_type' => nil}
+          {'callback' => 'https://www.example.com/callback', 'include_content' => true, 'content_type' => nil}
         ]
       })
     end
@@ -385,16 +392,16 @@ describe Webhook, :type => :model do
         'user' => u,
         'notifications' => {
           '*' => {
-            'callback' => 'http://www.example.com/1',
+            'callback' => 'https://www.example.com/1',
             'include_content' => true,
             'content_type' => 'asdf'
           },
           'bacon' => {
-            'callback' => 'http://www.example.com/2',
+            'callback' => 'https://www.example.com/2',
             'include_content' => false
           },
           'new_session' => {
-            'callback' => 'http://www.example.com/3'
+            'callback' => 'https://www.example.com/3'
           }
         }
         
@@ -402,12 +409,12 @@ describe Webhook, :type => :model do
       expect(h.settings).to_not eq(nil)
       expect(h.settings['notifications']).to eq({
         '*' => [
-          'callback' => 'http://www.example.com/1',
+          'callback' => 'https://www.example.com/1',
           'include_content' => true,
           'content_type' => 'asdf'
         ],
         'new_session' => [
-          'callback' => 'http://www.example.com/3',
+          'callback' => 'https://www.example.com/3',
           'include_content' => nil,
           'content_type' => nil
         ]


### PR DESCRIPTION
## What

Tightens webhook callback-URL validation to require `https://`. The intake regex `/^http/` matched both `http://` and `https://`, so a webhook could be registered that delivers its payload (callback_token, record `api_url`, optional content) over cleartext.

Changes the three **intake/validation** gates to `/^https:\/\//`:
- `Webhook.register` (`webhook.rb:42`)
- `Webhook#process_params` url gate (`webhook.rb:254`)
- `Webhook#process_params` advanced-config callback gate (`webhook.rb:264`)

## Why this is non-breaking

The **send path** dispatch guard (`webhook.rb:132` / `:185`) is intentionally left as `/^http/`. Intake validation only runs on create/update, so tightening it cannot break rows that already exist. Any already-stored legacy `http://` callback keeps firing on the unchanged send path.

## Residual (flagged, out of scope)

Existing `http://` callbacks (if any) still deliver over http. A production webhook scan should enumerate stored `http://` callbacks and migrate/notify their owners; only then should the send path be hardened. Tracked separately, not in this PR.

## Tests

- `register` / `notify` / `process_params` happy-path fixtures moved `http://` to `https://`.
- Added "should reject a plaintext http:// callback" (register returns nil, count stays 0). Verified this test FAILS against the unfixed model and the full file is green with the fix (28 examples, 0 failures).

## Finding status

Addresses audit finding **LL-1085e59d29**. This PR does **NOT** close it. Status stays `open` in `audit-reports/FINDINGS.json` until Scot verifies and attests; the register write to `verified-closed` is a separate, Scot-signed step.

Note: a compliance-touching PR may trigger the n8n DeepSeek adversary pass; this is non-PHI Ruby code, accepted for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)