### PR TITLE
security(license): encrypt License.metadata at rest (LL-740bcb10fa)

### DIFF
--- a/app/controllers/concerns/api/schema_explorer.rb
+++ b/app/controllers/concerns/api/schema_explorer.rb
@@ -39,8 +39,10 @@ module Api::SchemaExplorer
   # - organizations.external_auth_key/shortcut: SAML SSO auth hashes.
   # - boards.search_string: denormalized board content (button labels), which is
   #   AAC user vocabulary (FERPA/HIPAA), even though boards.settings is encrypted.
-  # - licenses.metadata/external_reference: License has no secure_serialize;
-  #   metadata is an untyped catch-all and external_reference is a PO/Stripe id.
+  # - licenses.metadata/external_reference: metadata is now secure_serialize'd
+  #   (encrypted, LL-740bcb10fa) but is still stripped here for defense in depth;
+  #   external_reference is a PO/Stripe id that stays plaintext (go_secure allows
+  #   only one secure column per model) and must be stripped explicitly.
   SENSITIVE_COLUMNS = {
     'organizations' => ['external_auth_key', 'external_auth_shortcut'],
     'boards'        => ['search_string'],

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,7 +1,14 @@
 class License < ApplicationRecord
   include GlobalId
+  include SecureSerialize
   belongs_to :organization
   belongs_to :user, optional: true
+
+  # LL-740bcb10fa: metadata is an untyped catch-all that may hold sensitive
+  # district/billing data, so it is encrypted at rest. go_secure permits only
+  # one secure column per model; external_reference (a PO/Stripe id) stays
+  # plaintext and is excluded from the DB-browser API in schema_explorer.rb.
+  secure_serialize :metadata
 
   validates :organization_id, presence: true
   validates :seat_type, inclusion: { in: %w[student supervisor] }

--- a/db/migrate/20260618120000_encrypt_license_metadata.rb
+++ b/db/migrate/20260618120000_encrypt_license_metadata.rb
@@ -6,8 +6,10 @@ class EncryptLicenseMetadata < ActiveRecord::Migration[7.2]
   # expected to touch 0 rows; it is written to be safe and idempotent if data
   # does exist.
   #
-  # We operate on the raw column via SQL (not the model) so we are not affected
-  # by the model's decrypting accessor while migrating.
+  # We read the raw column via SQL (not the model) so the decrypting accessor
+  # does not interfere, and write back through update_all (bound/quoted by
+  # ActiveRecord, no string interpolation; update_all bypasses the encrypting
+  # setter so the pre-encrypted blob lands in the column verbatim).
   disable_ddl_transaction!
 
   def up
@@ -28,9 +30,7 @@ class EncryptLicenseMetadata < ActiveRecord::Migration[7.2]
 
       object = raw.strip.start_with?('{', '[') ? (JSON.parse(raw) rescue raw) : raw
       encrypted = GoSecure::SecureJson.dump(object)
-      connection.execute(
-        "UPDATE licenses SET metadata = #{connection.quote(encrypted)} WHERE id = #{id.to_i}"
-      )
+      License.where(id: id).update_all(metadata: encrypted)
       migrated += 1
     end
     say "encrypted metadata for #{migrated} license row(s)"
@@ -53,9 +53,7 @@ class EncryptLicenseMetadata < ActiveRecord::Migration[7.2]
       next if decrypted.nil?
 
       plaintext = decrypted.is_a?(String) ? decrypted : decrypted.to_json
-      connection.execute(
-        "UPDATE licenses SET metadata = #{connection.quote(plaintext)} WHERE id = #{id.to_i}"
-      )
+      License.where(id: id).update_all(metadata: plaintext)
       reverted += 1
     end
     say "decrypted metadata for #{reverted} license row(s)"

--- a/db/migrate/20260618120000_encrypt_license_metadata.rb
+++ b/db/migrate/20260618120000_encrypt_license_metadata.rb
@@ -1,0 +1,63 @@
+class EncryptLicenseMetadata < ActiveRecord::Migration[7.2]
+  # LL-740bcb10fa: License.metadata moves to secure_serialize (encrypted at
+  # rest). The model's reader now decrypts the column, so any pre-existing
+  # plaintext value must be re-encrypted or reads would choke. metadata has no
+  # writers anywhere in the app today, so this is a defensive backfill and is
+  # expected to touch 0 rows; it is written to be safe and idempotent if data
+  # does exist.
+  #
+  # We operate on the raw column via SQL (not the model) so we are not affected
+  # by the model's decrypting accessor while migrating.
+  disable_ddl_transaction!
+
+  def up
+    migrated = 0
+    rows = connection.select_rows(
+      "SELECT id, metadata FROM licenses WHERE metadata IS NOT NULL AND metadata <> ''"
+    )
+    rows.each do |id, raw|
+      # Already SecureJson-encrypted? load succeeds -> skip (idempotent).
+      already_encrypted =
+        begin
+          GoSecure::SecureJson.load(raw)
+          true
+        rescue StandardError
+          false
+        end
+      next if already_encrypted
+
+      object = raw.strip.start_with?('{', '[') ? (JSON.parse(raw) rescue raw) : raw
+      encrypted = GoSecure::SecureJson.dump(object)
+      connection.execute(
+        "UPDATE licenses SET metadata = #{connection.quote(encrypted)} WHERE id = #{id.to_i}"
+      )
+      migrated += 1
+    end
+    say "encrypted metadata for #{migrated} license row(s)"
+  end
+
+  def down
+    # Best-effort: decrypt back to plaintext JSON so a rollback leaves the
+    # column readable by the (reverted) plain model.
+    reverted = 0
+    rows = connection.select_rows(
+      "SELECT id, metadata FROM licenses WHERE metadata IS NOT NULL AND metadata <> ''"
+    )
+    rows.each do |id, raw|
+      decrypted =
+        begin
+          GoSecure::SecureJson.load(raw)
+        rescue StandardError
+          nil
+        end
+      next if decrypted.nil?
+
+      plaintext = decrypted.is_a?(String) ? decrypted : decrypted.to_json
+      connection.execute(
+        "UPDATE licenses SET metadata = #{connection.quote(plaintext)} WHERE id = #{id.to_i}"
+      )
+      reverted += 1
+    end
+    say "decrypted metadata for #{reverted} license row(s)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_04_193000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_18_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"

--- a/spec/controllers/api/database_contents_controller_spec.rb
+++ b/spec/controllers/api/database_contents_controller_spec.rb
@@ -135,17 +135,17 @@ describe Api::DatabaseContentsController, :type => :controller do
       end
     end
 
-    it 'should serve a no-secure-column allowlisted table (licenses)' do
-      # Exercises the exposable_columns guard for a model that never calls
-      # secure_serialize, so respond_to?(:secure_column) is false.
+    it 'should strip both the encrypted metadata and the plaintext external_reference (licenses)' do
+      # licenses.metadata is now secure_serialize'd (LL-740bcb10fa), so it is
+      # stripped via the secure_column guard; external_reference is a plaintext
+      # PO/Stripe id that go_secure cannot also encrypt (one secure column per
+      # model), so it must still be stripped explicitly via SENSITIVE_COLUMNS.
       make_admin
-      expect(License.respond_to?(:secure_column)).to eq(false)
+      expect(License.secure_column).to eq(:metadata)
       get :index, params: {table: 'licenses'}
       expect(response.successful?).to eq(true)
       json = JSON.parse(response.body)
       columns = json['database_contents']['columns']
-      # licenses has no encrypted column, so its plaintext metadata and the
-      # PO/Stripe external_reference must be stripped explicitly.
       expect(columns).not_to include('metadata')
       expect(columns).not_to include('external_reference')
     end

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require Rails.root.join('db/migrate/20260618120000_encrypt_license_metadata.rb')
+
+describe License, :type => :model do
+  let(:org) { Organization.create(:settings => {'name' => 'Test District'}) }
+
+  describe "secure_serialize :metadata (LL-740bcb10fa)" do
+    it "encrypts metadata at rest and round-trips it" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active',
+                          metadata: {'plan' => 'district', 'note' => 'sensitive'})
+      # raw column is NOT the plaintext
+      raw = License.connection.select_value("SELECT metadata FROM licenses WHERE id = #{l.id}")
+      expect(raw).to_not eq({'plan' => 'district', 'note' => 'sensitive'}.to_json)
+      expect(raw).to_not include('sensitive')
+      # but the model decrypts it back
+      expect(License.find(l.id).metadata).to eq({'plan' => 'district', 'note' => 'sensitive'})
+    end
+
+    it "invokes SecureJson.dump on save" do
+      l = License.new(organization: org, seat_type: 'student', status: 'active')
+      l.metadata = {'a' => 1}
+      expect(GoSecure::SecureJson).to receive(:dump).with({'a' => 1}).and_call_original
+      l.save!
+    end
+
+    it "leaves nil metadata as nil (no read break, no JSON emitted)" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active')
+      expect(License.find(l.id).metadata).to eq(nil)
+      json = JsonApi::License.build_json(l.reload)
+      expect(json).to_not have_key('metadata')
+    end
+
+    it "still reads LEGACY plaintext JSON written before the backfill (reads do not break)" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active')
+      # simulate a pre-migration plaintext row by writing the raw column directly
+      License.where(id: l.id).update_all(metadata: '{"po":"PO-1","tier":"gold"}')
+      expect(License.find(l.id).metadata).to eq({'po' => 'PO-1', 'tier' => 'gold'})
+    end
+  end
+
+  describe "EncryptLicenseMetadata backfill" do
+    it "re-encrypts a legacy plaintext row and is idempotent" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active')
+      License.where(id: l.id).update_all(metadata: '{"po":"PO-9"}')
+
+      migration = EncryptLicenseMetadata.new
+      migration.verbose = false
+      migration.up
+      raw1 = License.connection.select_value("SELECT metadata FROM licenses WHERE id = #{l.id}")
+      expect(raw1).to_not include('PO-9')              # now encrypted
+      expect(License.find(l.id).metadata).to eq({'po' => 'PO-9'})
+
+      # running again must not double-encrypt
+      migration.up
+      raw2 = License.connection.select_value("SELECT metadata FROM licenses WHERE id = #{l.id}")
+      expect(raw2).to eq(raw1)
+      expect(License.find(l.id).metadata).to eq({'po' => 'PO-9'})
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `secure_serialize :metadata` to `License` so the `metadata` catch-all column is encrypted at rest, plus a backfill migration for any existing plaintext rows.

## Design decision (needs your awareness)

`go_secure` allows **only one encrypted column per model** (it literally raises `"only one secure column per record!"`). So I encrypted **`metadata`** (the untyped, free-text catch-all that may hold sensitive district/billing data, which is the real risk and exactly what the finding's prescribed remediation says: "Add `secure_serialize :metadata`").

**`external_reference`** (a PO Number / Stripe ID) is therefore **not** column-encrypted. It stays plaintext and remains stripped from the admin DB-browser API via `SENSITIVE_COLUMNS` (its existing defense-in-depth mitigation). If you want `external_reference` encrypted at rest too, that requires a larger refactor (fold both fields into a single encrypted `settings`-style column with accessors) — say the word and I'll draft it as a follow-up.

## Why this is safe (reads never break)

- `metadata` has **zero writers** anywhere in the app today, so existing rows are effectively empty — the backfill is a defensive safety net and reports `encrypted metadata for 0 license row(s)`.
- The model's decrypting reader (`go_secure` `load_secure_object`) handles legacy plaintext JSON gracefully, so reads keep working in the window between deploy and backfill.
- The migration is **raw-SQL, idempotent, and reversible** (operates on the column directly, not through the decrypting model; running it twice does not double-encrypt; `down` decrypts back to plaintext JSON).

## Tests (`spec/models/license_spec.rb`, new)

- Round-trip: raw DB column is not the plaintext; model decrypts it back.
- `SecureJson.dump` invoked on save.
- `nil` metadata stays `nil` and is omitted from the License JSON.
- Legacy plaintext JSON still reads (proves the no-break claim).
- Backfill re-encrypts a legacy plaintext row and is idempotent.
- Updated the DB-browser contents spec: `licenses` now has `secure_column :metadata`; `external_reference` is stripped explicitly.

59 examples, 0 failures across the License + DB-browser specs. (Three pre-existing `flusher_spec` `flush_board` failures on staging are unrelated — known test-DB orphan-row baseline issue.)

## Finding status

Addresses audit finding **LL-740bcb10fa**. This PR does **NOT** close it. Status stays `open` in `audit-reports/FINDINGS.json` until you verify and attest.

Note: a compliance-touching PR may trigger the n8n DeepSeek adversary pass; this is non-PHI Ruby code, accepted for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)