### PR TITLE
security(license): encrypt external_reference at rest (LL-740bcb10fa follow-up)

### DIFF
--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -5,10 +5,32 @@ class License < ApplicationRecord
   belongs_to :user, optional: true
 
   # LL-740bcb10fa: metadata is an untyped catch-all that may hold sensitive
-  # district/billing data, so it is encrypted at rest. go_secure permits only
-  # one secure column per model; external_reference (a PO/Stripe id) stays
-  # plaintext and is excluded from the DB-browser API in schema_explorer.rb.
+  # district/billing data, so it is encrypted at rest via secure_serialize.
+  # go_secure permits only one secure_serialize column per model, so the
+  # second sensitive field (external_reference) is encrypted manually below.
   secure_serialize :metadata
+
+  # LL-740bcb10fa (follow-up): external_reference is a PO Number / Stripe id.
+  # secure_serialize is already taken by :metadata, so this column is encrypted
+  # manually with the same GoSecure::SecureJson primitive used for device and
+  # user_integration secrets. The reader tolerates legacy plaintext (rescue ->
+  # raw) so existing rows keep reading correctly before the backfill runs; the
+  # writer encrypts at assignment.
+  def external_reference
+    raw = read_attribute(:external_reference)
+    return raw if raw.blank?
+    GoSecure::SecureJson.load(raw)
+  rescue StandardError
+    raw
+  end
+
+  def external_reference=(value)
+    if value.blank?
+      write_attribute(:external_reference, value)
+    else
+      write_attribute(:external_reference, GoSecure::SecureJson.dump(value))
+    end
+  end
 
   validates :organization_id, presence: true
   validates :seat_type, inclusion: { in: %w[student supervisor] }

--- a/db/migrate/20260618130000_encrypt_license_external_reference.rb
+++ b/db/migrate/20260618130000_encrypt_license_external_reference.rb
@@ -1,0 +1,58 @@
+class EncryptLicenseExternalReference < ActiveRecord::Migration[7.2]
+  # LL-740bcb10fa (follow-up): License.external_reference is now encrypted at
+  # rest via manual GoSecure::SecureJson accessors on the model. Re-encrypt any
+  # pre-existing plaintext value so the model's decrypting reader returns the
+  # right thing. external_reference has no writers anywhere in the app today, so
+  # this is a defensive backfill expected to touch 0 rows; it is idempotent.
+  #
+  # Operates on the raw column via SQL (not the model) so the model's accessor
+  # does not interfere while migrating.
+  disable_ddl_transaction!
+
+  def up
+    migrated = 0
+    rows = connection.select_rows(
+      "SELECT id, external_reference FROM licenses WHERE external_reference IS NOT NULL AND external_reference <> ''"
+    )
+    rows.each do |id, raw|
+      already_encrypted =
+        begin
+          GoSecure::SecureJson.load(raw)
+          true
+        rescue StandardError
+          false
+        end
+      next if already_encrypted
+
+      encrypted = GoSecure::SecureJson.dump(raw)
+      connection.execute(
+        "UPDATE licenses SET external_reference = #{connection.quote(encrypted)} WHERE id = #{id.to_i}"
+      )
+      migrated += 1
+    end
+    say "encrypted external_reference for #{migrated} license row(s)"
+  end
+
+  def down
+    reverted = 0
+    rows = connection.select_rows(
+      "SELECT id, external_reference FROM licenses WHERE external_reference IS NOT NULL AND external_reference <> ''"
+    )
+    rows.each do |id, raw|
+      decrypted =
+        begin
+          GoSecure::SecureJson.load(raw)
+        rescue StandardError
+          nil
+        end
+      next if decrypted.nil?
+
+      plaintext = decrypted.is_a?(String) ? decrypted : decrypted.to_json
+      connection.execute(
+        "UPDATE licenses SET external_reference = #{connection.quote(plaintext)} WHERE id = #{id.to_i}"
+      )
+      reverted += 1
+    end
+    say "decrypted external_reference for #{reverted} license row(s)"
+  end
+end

--- a/db/migrate/20260618130000_encrypt_license_external_reference.rb
+++ b/db/migrate/20260618130000_encrypt_license_external_reference.rb
@@ -5,8 +5,10 @@ class EncryptLicenseExternalReference < ActiveRecord::Migration[7.2]
   # right thing. external_reference has no writers anywhere in the app today, so
   # this is a defensive backfill expected to touch 0 rows; it is idempotent.
   #
-  # Operates on the raw column via SQL (not the model) so the model's accessor
-  # does not interfere while migrating.
+  # Reads the raw column via SQL (not the model) so the decrypting accessor does
+  # not interfere, and writes back through update_all (quoted by ActiveRecord, no
+  # string interpolation; update_all bypasses the encrypting setter so the
+  # pre-encrypted blob lands in the column verbatim).
   disable_ddl_transaction!
 
   def up
@@ -25,9 +27,7 @@ class EncryptLicenseExternalReference < ActiveRecord::Migration[7.2]
       next if already_encrypted
 
       encrypted = GoSecure::SecureJson.dump(raw)
-      connection.execute(
-        "UPDATE licenses SET external_reference = #{connection.quote(encrypted)} WHERE id = #{id.to_i}"
-      )
+      License.where(id: id).update_all(external_reference: encrypted)
       migrated += 1
     end
     say "encrypted external_reference for #{migrated} license row(s)"
@@ -48,9 +48,7 @@ class EncryptLicenseExternalReference < ActiveRecord::Migration[7.2]
       next if decrypted.nil?
 
       plaintext = decrypted.is_a?(String) ? decrypted : decrypted.to_json
-      connection.execute(
-        "UPDATE licenses SET external_reference = #{connection.quote(plaintext)} WHERE id = #{id.to_i}"
-      )
+      License.where(id: id).update_all(external_reference: plaintext)
       reverted += 1
     end
     say "decrypted external_reference for #{reverted} license row(s)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_18_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_18_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require Rails.root.join('db/migrate/20260618120000_encrypt_license_metadata.rb')
+require Rails.root.join('db/migrate/20260618130000_encrypt_license_external_reference.rb')
 
 describe License, :type => :model do
   let(:org) { Organization.create(:settings => {'name' => 'Test District'}) }
@@ -35,6 +36,56 @@ describe License, :type => :model do
       # simulate a pre-migration plaintext row by writing the raw column directly
       License.where(id: l.id).update_all(metadata: '{"po":"PO-1","tier":"gold"}')
       expect(License.find(l.id).metadata).to eq({'po' => 'PO-1', 'tier' => 'gold'})
+    end
+  end
+
+  describe "external_reference manual encryption (LL-740bcb10fa follow-up)" do
+    it "encrypts external_reference at rest and round-trips it" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active',
+                          external_reference: 'PO-12345')
+      raw = License.connection.select_value("SELECT external_reference FROM licenses WHERE id = #{l.id}")
+      expect(raw).to_not eq('PO-12345')
+      expect(raw).to_not include('PO-12345')
+      expect(License.find(l.id).external_reference).to eq('PO-12345')
+    end
+
+    it "leaves a blank external_reference untouched" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active')
+      expect(License.find(l.id).external_reference).to eq(nil)
+      json = JsonApi::License.build_json(l.reload)
+      expect(json['external_reference']).to eq(nil)
+    end
+
+    it "still reads LEGACY plaintext external_reference (reads do not break)" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active')
+      License.where(id: l.id).update_all(external_reference: 'cus_legacyPlain')
+      expect(License.find(l.id).external_reference).to eq('cus_legacyPlain')
+    end
+
+    it "is serialized correctly through JsonApi::License" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active',
+                          external_reference: 'PO-777')
+      json = JsonApi::License.build_json(l.reload)
+      expect(json['external_reference']).to eq('PO-777')
+    end
+  end
+
+  describe "EncryptLicenseExternalReference backfill" do
+    it "re-encrypts a legacy plaintext external_reference and is idempotent" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active')
+      License.where(id: l.id).update_all(external_reference: 'PO-BACKFILL')
+
+      migration = EncryptLicenseExternalReference.new
+      migration.verbose = false
+      migration.up
+      raw1 = License.connection.select_value("SELECT external_reference FROM licenses WHERE id = #{l.id}")
+      expect(raw1).to_not include('PO-BACKFILL')
+      expect(License.find(l.id).external_reference).to eq('PO-BACKFILL')
+
+      migration.up
+      raw2 = License.connection.select_value("SELECT external_reference FROM licenses WHERE id = #{l.id}")
+      expect(raw2).to eq(raw1)
+      expect(License.find(l.id).external_reference).to eq('PO-BACKFILL')
     end
   end
 


### PR DESCRIPTION
## What

Follow-up to **#435**: also encrypts `License.external_reference` (a PO Number / Stripe ID) at rest, so **both** sensitive License columns are now encrypted.

**Stacked on #435** (`scot/security/license-metadata-encryption`). Review/merge #435 first; this PR's diff is only the `external_reference` changes.

## How (and why it's a separate mechanism)

`go_secure` allows only **one** `secure_serialize` column per model, and #435 used that slot for `metadata`. So `external_reference` is encrypted **manually** with the same `GoSecure::SecureJson` primitive already used for `device.settings` and `user_integration` secrets — a custom getter/setter on the model:
- **Reader** decrypts, and tolerates legacy plaintext (`rescue -> raw`) so rows written before the backfill still read correctly.
- **Writer** encrypts at assignment.
- **Backfill** (`20260618130000`) re-encrypts any pre-existing plaintext value; raw-SQL, idempotent, reversible, touches **0 rows** today (no writers exist yet).

This is the additive path you approved ("draft the external_reference follow-up"). It does leave License with two encryption mechanisms (secure_serialize for `metadata`, manual for `external_reference`). If you'd rather consolidate to a single encrypted column holding both (architecturally cleaner, but supersedes #435 rather than stacking), say so and I'll draft that instead.

## Tests

`spec/models/license_spec.rb`: round-trip (raw column is not plaintext; model decrypts back), blank stays blank + omitted from JSON, legacy plaintext still reads, `JsonApi::License` serializes it correctly, backfill re-encrypts + idempotent. License spec 10 examples, DB-browser specs 54 examples, 0 failures.

## Finding status

Addresses audit finding **LL-740bcb10fa** (completing both columns). Does **NOT** close it — status stays `open` until you verify and attest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)