### PR TITLE
compliance(register): attest-close 4 High findings fixed by #425/#427/#428/#429

### DIFF
--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -328,7 +328,7 @@
       "frameworks": [
         "GDPR"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "lib/flusher.rb",
@@ -341,12 +341,12 @@
       "owner": "unassigned",
       "remediation": {
         "options": "Add License.where(user_id: source.id).update_all(user_id: target.id) to transfer_user_content.",
-        "timeframe": "15-30d"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "dc82c5df7bfc28ecb049d13ee79e367bcf257d5e",
+        "verifierNote": "Verified 2026-06-18 on staging (#429, dc82c5df): Flusher.transfer_user_content now transfers License rows (License.where(user_id: source.id).update_all(user_id: target.id)) alongside the other transferred content, so org seats are no longer orphaned on user merge; the existing transfer spec was updated and a new behavioral spec added.",
+        "attestation": "PENDING Scot Wahlquist sign-off (draft prepared by Claude 2026-06-18; merging this PR constitutes attestation)."
       },
       "notes": "Verified still open 2026-06-12: transfer_user_content transfers NfcTag/UserIntegration/UserGoal/UserBadge/Webhook/UserBoardConnection/UserLink/ButtonSound/ButtonImage/UserVideo but not License (flusher.rb:156-190). License IS handled in flush_user_content (see P0-2), only the transfer path is missing it.",
       "disposition": {
@@ -438,7 +438,7 @@
       "severity": "high",
       "confidence": "high",
       "frameworks": [],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/controllers/api/users_controller.rb",
@@ -451,12 +451,12 @@
       "owner": "unassigned",
       "remediation": {
         "options": "Return a uniform {email_sent: true} regardless of existence; drop the users count.",
-        "timeframe": "15-30d"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "91319512a1989784d1650e8d9dbe7a15d79c7695",
+        "verifierNote": "Verified 2026-06-18 on staging (#427, 91319512): forgot_password now always renders {email_sent: true} (no users count, no distinguishing message, no 400 status), collapsing every path to a uniform response. The Ember forgot_password/forgot-login controllers render the email_sent branch (\"Email sent!\") for all cases, so no frontend dependency on users.length remains. users_controller_spec asserts identical responses for real vs bogus keys.",
+        "attestation": "PENDING Scot Wahlquist sign-off (draft prepared by Claude 2026-06-18; merging this PR constitutes attestation)."
       },
       "notes": "Verified still open 2026-06-12: forgot_password (users_controller.rb:692) returns users: users.length on success (:705/:708) and a 400 with users: 0 (:714), enabling enumeration.",
       "disposition": {
@@ -513,7 +513,7 @@
       "severity": "high",
       "confidence": "medium",
       "frameworks": [],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/controllers/api/callbacks_controller.rb",
@@ -526,12 +526,12 @@
       "owner": "unassigned",
       "remediation": {
         "options": "Apply Aws::SNS::MessageVerifier to the transcoding callback path as already done for the SMS-inbound path.",
-        "timeframe": "15-30d"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "eb563e8dc9b5e9b8d9b76ccaca1b6ba4dfeaf203",
+        "verifierNote": "Verified 2026-06-18 on staging (#425, eb563e8d): the SNS transcoding branch (audio_conversion_events/video_conversion_events) now calls Aws::SNS::MessageVerifier.new.authentic?(body) and returns 401 {error: 'inauthentic message'} on failure, mirroring the SMS-inbound path; specs cover all three transcoding paths.",
+        "attestation": "PENDING Scot Wahlquist sign-off (draft prepared by Claude 2026-06-18; merging this PR constitutes attestation)."
       },
       "notes": "Reduced-scope 2026-06-12: SMS-inbound path now verifies via Aws::SNS::MessageVerifier.authentic? (callbacks_controller.rb:37-38), but the general transcoding TODO at :8 remains. Originally scoped to all SNS callbacks.",
       "disposition": {
@@ -1554,7 +1554,7 @@
       "frameworks": [
         "WCAG"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/frontend/app/utils/button.js",
@@ -1567,12 +1567,12 @@
       "owner": "unassigned",
       "remediation": {
         "options": "In the fast_html symbol <img> string, concatenate an alt attribute (button label, or empty when the label is rendered). Keep parity with the template path fix so both grid render paths agree.",
-        "timeframe": "30 days"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "abb09fcf1a789af51be463943aeb97270cb8cffc",
+        "verifierNote": "Verified 2026-06-18 on staging (#428, abb09fcf): the board-tile symbol image now carries alt text on all three independent render paths (board.js fast-render string and button.js fast_html string via Button.clean_text escaping, plus board/index.hbs alt={{button.label}} with Handlebars auto-escaping); resolves WCAG 1.1.1 / 4.1.2 for AAC symbols.",
+        "attestation": "PENDING Scot Wahlquist sign-off (draft prepared by Claude 2026-06-18; merging this PR constitutes attestation)."
       },
       "notes": "Surfaced by accessibility finder on 2026-06-16. WCAG 1.1.1 / 4.1.2 (EN 301 549 9.1.1). Second of the two board-grid render paths: button.js builds the tile symbol <img> as a raw HTML string with no alt attribute (the action_image at button.js:442 does include alt). Mirror of the templates/board/index.hbs finding; a fix in one path is not automatically in the other. | adversary: confirmed (2026-06-16): the fast_html symbol <img> (button.js:449) has no alt on a LIVE render path ({{button.fast_html}} / {{board.fast_html.html}}); the action_image <img> at button.js:442 DOES include alt, so the omission is specific not global. Escalation verified: when button.hide_label is set, the label span (button.js:479) is display:none via .hide-label (app.scss:9167), so it leaves the accessibility tree and the tile has NO accessible name at all -- supports high/critical. The parallel board.js render_fast_html builder repeats the same pattern (a third render path).",
       "disposition": {

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,25 +5,21 @@
 
 **Audited:** `staging` @ `59e20439e005b363ec67f8444d5406848a1c434f` on 2026-06-18  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 11 High
+**Headline (open + remediated-unverified):** 0 Critical / 7 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (43)
+## Open (39)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
 | LL-d1ea8659c3 |  | high |  | **fixed** | audit-run | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
-| LL-2967f77e6d |  | high | WCAG | **fixed** | audit-run | Board-tile symbol image has no alt text (fast_html render path) | `app/frontend/app/utils/button.js`:449 |
 | LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | **fixed** | audit | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | **fixed** | audit-run | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |
 | LL-9f83617435 | Infra-P1-4 | high |  | **accepted** | audit-run | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
 | LL-740bcb10fa | P1-2 | high | GDPR, HIPAA | **fixed** | audit-run | License.metadata / external_reference stored unencrypted | `app/models/license.rb`:2 |
-| LL-e775d86e6a | P1-3 | high | GDPR | **fixed** | audit-run | License not handled in transfer_user_content (orphaned seats on merge) | `lib/flusher.rb`:156 |
 | LL-92dc570f30 | P1-5 | high |  | **accepted** | audit-run | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
-| LL-9a3ee852d5 | P1-6 | high |  | **fixed** | audit-run | forgot_password leaks account existence via response shape and users count | `app/controllers/api/users_controller.rb`:705 |
-| LL-6d8314e37b | P1-8 | high |  | **fixed** | audit-run | SNS transcoding callbacks accepted without signature verification | `app/controllers/api/callbacks_controller.rb`:8 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | untriaged | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
 | LL-52ff2a9a79 |  | medium | SOC2 | untriaged | audit-run | CI security-scan job (Brakeman SAST, bundle-audit, npm audit, gitleaks) is entirely non-blocking | `.github/workflows/ci.yml`:107 |
 | LL-27d20047db |  | medium |  | untriaged | audit-run | Integration board_render_url is writable but never serialized back (read/write field-name asymmetry) | `app/frontend/app/models/integration.js`:24 |
@@ -57,7 +53,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-a97357136e | P2-2 | low |  | untriaged | audit-run | params.permit! bypasses Strong Parameters | `app/controllers/api/organizations_controller.rb`:866 |
 | LL-ce00c8d3ad | P2-3 | low |  | untriaged | audit-run | License model lacks Processable concern | `app/models/license.rb`:1 |
 
-## Verified closed (18)
+## Verified closed (22)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -69,12 +65,16 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-3ccbf9b54a | P0-3 | critical | FERPA | untriaged | audit-run | No AuditEvent on license claim/release (FERPA access-log gap) | `app/controllers/api/organizations_controller.rb`:238 |
 | LL-46fd4aa824 | P0-4 | critical | FERPA, HIPAA | untriaged | audit-run | No AuditEvent on supervisor consent create/respond/revoke | `app/controllers/api/supervisor_relationships_controller.rb`:52 |
 | LL-ef5ac1b2a5 |  | high | FERPA, HIPAA | untriaged | audit-run | Eval AI narration creates no AiApiLog entry (no record student eval data was sent to an LLM) | `lib/eval_narrator.rb`:58 |
+| LL-2967f77e6d |  | high | WCAG | **fixed** | audit-run | Board-tile symbol image has no alt text (fast_html render path) | `app/frontend/app/utils/button.js`:449 |
 | LL-2e4c14d370 |  | high | COPPA, FERPA, HIPAA | untriaged | audit-run | Eval AI narration has no COPPA parental-consent hard-gate before sending under-13 student data to Anthropic | `lib/eval_narrator.rb`:43 |
 | LL-16fef018a0 |  | high | SOC2 | **fixed** | pr-review | Password-reset code verification endpoint (users#password_reset) not rate-limited | `config/initializers/throttling.rb`:41 |
 | LL-c6dd65a2aa | Infra-P1-3 | high |  | **fixed** | audit-run | Static cache_token='abc' never rotates (stale permission cache) | `config/initializers/resque.rb`:29 |
 | LL-ca38d4d99e | P1-1 | high | FERPA, HIPAA | **fixed** | audit-run | Consent endpoints absent from Rack::Attack protected_paths | `config/initializers/throttling.rb`:18 |
+| LL-e775d86e6a | P1-3 | high | GDPR | **fixed** | audit-run | License not handled in transfer_user_content (orphaned seats on merge) | `lib/flusher.rb`:156 |
 | LL-e65d34f109 | P1-4 | high | FERPA | **fixed** | audit-run | Sensitive new routes (claim_user) under general throttle only | `config/initializers/throttling.rb`:18 |
+| LL-9a3ee852d5 | P1-6 | high |  | **fixed** | audit-run | forgot_password leaks account existence via response shape and users count | `app/controllers/api/users_controller.rb`:705 |
 | LL-747bb0e02d | P1-7 | high | FERPA, HIPAA | **fixed** | audit-run | Password changes (incl. admin resets) generate no AuditEvent | `app/models/user.rb`:2255 |
+| LL-6d8314e37b | P1-8 | high |  | **fixed** | audit-run | SNS transcoding callbacks accepted without signature verification | `app/controllers/api/callbacks_controller.rb`:8 |
 | LL-4e243f3e16 | P1-9 | high |  | **fixed** | audit-run | start_code_lookup uses a brute-forceable 5-char verification hash | `app/controllers/api/organizations_controller.rb`:128 |
 | LL-c5bd616242 | Prior-BAA-AWS | high | HIPAA | untriaged | audit-run | BAA with AWS (S3/SES/Transcoder/SNS) for HIPAA | `docs/legal/AWS_BAA_ACCEPTED.md` |
 | LL-2ea0b804e7 | Infra-P2-1 | medium | HIPAA | untriaged | audit-run | S3 buckets public-read on * (legacy ACL) | `docs/INFRASTRUCTURE.md`:101 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `59e20439e005b363ec67f8444d5406848a1c434f`  
 **Audited ref:** `staging`  
 **Run date:** 2026-06-18  
-**Page generated:** 2026-06-19T00:27:02Z
+**Page generated:** 2026-06-19T04:07:26Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **11** | 18 | 14 |
+| **0** | **7** | 18 | 14 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -26,16 +26,12 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | ID | Legacy | Severity | Frameworks | Title | Evidence |
 |---|---|---|---|---|---|
 | LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
-| LL-2967f77e6d |  | high | WCAG | Board-tile symbol image has no alt text (fast_html render path) | `app/frontend/app/utils/button.js`:449 |
 | LL-d1ea8659c3 |  | high |  | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |
 | LL-9f83617435 | Infra-P1-4 | high |  | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
 | LL-740bcb10fa | P1-2 | high | GDPR, HIPAA | License.metadata / external_reference stored unencrypted | `app/models/license.rb`:2 |
-| LL-e775d86e6a | P1-3 | high | GDPR | License not handled in transfer_user_content (orphaned seats on merge) | `lib/flusher.rb`:156 |
 | LL-92dc570f30 | P1-5 | high |  | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
-| LL-9a3ee852d5 | P1-6 | high |  | forgot_password leaks account existence via response shape and users count | `app/controllers/api/users_controller.rb`:705 |
-| LL-6d8314e37b | P1-8 | high |  | SNS transcoding callbacks accepted without signature verification | `app/controllers/api/callbacks_controller.rb`:8 |
 | LL-0c6e931f47 |  | medium | WCAG | Sentence box (utterance bar) symbol chip images have no alt attribute | `app/frontend/app/templates/components/button-list.hbs`:21 |
 | LL-13ad11eaee |  | medium | WCAG | Loading status text has no aria-live or role=status | `app/frontend/app/templates/bento.hbs`:14 |
 | LL-27d20047db |  | medium |  | Integration board_render_url is writable but never serialized back (read/write field-name asymmetry) | `app/frontend/app/models/integration.js`:24 |


### PR DESCRIPTION
Marks four High findings **verified-closed** now that their remediating PRs merged to `staging`. Sibling to #432 (which closed the #420/#421/#433 set).

| Finding | Fix PR | Merge SHA | What was verified |
|---|---|---|---|
| LL-6d8314e37b | #425 | `eb563e8d` | SNS transcoding branch now verifies signature (`Aws::SNS::MessageVerifier`), 401 on failure; specs cover all 3 paths |
| LL-9a3ee852d5 | #427 | `91319512` | `forgot_password` always returns `{email_sent: true}` (no count/message/400); Ember frontend renders uniform "Email sent!"; spec asserts identical real-vs-bogus responses |
| LL-2967f77e6d | #428 | `abb09fcf` | board-tile symbol alt text on all 3 render paths (board.js, button.js fast_html, index.hbs); WCAG 1.1.1/4.1.2 |
| LL-e775d86e6a | #429 | `dc82c5df` | `Flusher.transfer_user_content` transfers License rows; seats no longer orphaned on merge; behavioral spec added |

### Mechanics
- `status: open -> verified-closed`; `closureEvidence{sha, verifierNote}` added per the documented closure mechanic.
- Historical `evidence` anchors left untouched so `citation-check.rb` still validates each snippet at its pinned SHA.
- `FINDINGS.md` + Notion mirror regenerated. `citation-check.rb` → **PASS: 60, FAIL: 0**. `compliance-notion-publish.rb --check` → **OK**.
- Headline: **11 High → 7 High**.

### ⚠️ Attestation is PENDING your sign-off
Each `closureEvidence.attestation` reads `PENDING Scot Wahlquist sign-off`. The verifier notes and evidence SHAs are Claude's and factual; **only you attest**. Merging this PR constitutes your attestation. If you'd rather I write an explicit attestation line instead of the placeholder, say so and I'll amend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)