### PR TITLE
compliance(register): attest-close 2 High findings (#434 webhook https, #435/#436 license encryption)

### DIFF
--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -290,7 +290,7 @@
         "GDPR",
         "HIPAA"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/models/license.rb",
@@ -299,16 +299,16 @@
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a"
       },
       "firstSeen": "2026-04-09",
-      "lastSeen": "2026-06-12",
+      "lastSeen": "2026-06-18",
       "owner": "unassigned",
       "remediation": {
         "options": "Add secure_serialize :metadata to License, consistent with Organization/User sensitive-field handling.",
-        "timeframe": "15-30d"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "4071b1c05f4d53c96a6291efcc4dde17cde96346",
+        "verifierNote": "Verified 2026-06-18 on staging: License now includes SecureSerialize with secure_serialize :metadata (#435, 2df67ae10), encrypting metadata at rest; external_reference is encrypted via manual GoSecure::SecureJson accessors (#436, 4071b1c05) because go_secure permits only one secure_serialize column per model, with a reader that tolerates legacy plaintext (rescue -> raw). Idempotent backfill migrations 20260618120000 and 20260618130000 re-encrypt any pre-existing rows (read raw via SQL, write via update_all). external_reference is also stripped from the DB-browser API (schema_explorer.rb).",
+        "attestation": "Scot Wahlquist 2026-06-18: attested verified-closed; metadata encrypted via #435, external_reference via #436."
       },
       "notes": "Verified still open 2026-06-12: License includes only GlobalId; no secure_serialize declared. metadata text + external_reference string remain plaintext.",
       "disposition": {
@@ -626,7 +626,7 @@
         "FERPA",
         "HIPAA"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/models/webhook.rb",
@@ -635,16 +635,16 @@
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a"
       },
       "firstSeen": "2026-04-09",
-      "lastSeen": "2026-06-12",
+      "lastSeen": "2026-06-18",
       "owner": "unassigned",
       "remediation": {
         "options": "Require https:// in the callback URL validation regex.",
-        "timeframe": "15-30d"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "7cb207d988b464ad6bd912f0fecd1bf77b33981e",
+        "verifierNote": "Verified 2026-06-18 on staging (#434, 7cb207d98): all three webhook callback-URL validation sites now require /^https:\\/\\// (app/models/webhook.rb:42 register, :254 process_params url, :264 notification callback), rejecting plaintext http://. Non-breaking: existing stored webhooks (settings is secure_serialize-encrypted) are not re-validated and the send path is unchanged; only new/updated registrations are gated.",
+        "attestation": "Scot Wahlquist 2026-06-18: attested verified-closed; fix merged to staging via #434."
       },
       "notes": "Verified still open 2026-06-12: regex /^http/ matches both http and https (webhook.rb:42).",
       "disposition": {

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,11 +5,11 @@
 
 **Audited:** `staging` @ `59e20439e005b363ec67f8444d5406848a1c434f` on 2026-06-18  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 9 High
+**Headline (open + remediated-unverified):** 0 Critical / 7 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (48)
+## Open (46)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -18,9 +18,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-080a21089f |  | high | FERPA, HIPAA, GDPR | untriaged | audit-run | Account deletion / right-to-erasure path writes no AuditEvent | `app/controllers/api/users_controller.rb`:388 |
 | LL-7acd0e7416 |  | high | FERPA, HIPAA | untriaged | audit-run | Admin-support reads of individual student records (version history, daily usage) write no AuditEvent | `app/controllers/api/users_controller.rb`:485 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
-| LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | **fixed** | audit-run | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |
 | LL-9f83617435 | Infra-P1-4 | high |  | **accepted** | audit-run | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
-| LL-740bcb10fa | P1-2 | high | GDPR, HIPAA | **fixed** | audit-run | License.metadata / external_reference stored unencrypted | `app/models/license.rb`:2 |
 | LL-92dc570f30 | P1-5 | high |  | **accepted** | audit-run | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | untriaged | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
 | LL-52ff2a9a79 |  | medium | SOC2 | untriaged | audit-run | CI security-scan job (Brakeman SAST, bundle-audit, npm audit, gitleaks) is entirely non-blocking | `.github/workflows/ci.yml`:107 |
@@ -62,7 +60,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-a97357136e | P2-2 | low |  | untriaged | audit-run | params.permit! bypasses Strong Parameters | `app/controllers/api/organizations_controller.rb`:866 |
 | LL-ce00c8d3ad | P2-3 | low |  | untriaged | audit-run | License model lacks Processable concern | `app/models/license.rb`:1 |
 
-## Verified closed (22)
+## Verified closed (24)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -77,8 +75,10 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-2967f77e6d |  | high | WCAG | **fixed** | audit-run | Board-tile symbol image has no alt text (fast_html render path) | `app/frontend/app/utils/button.js`:449 |
 | LL-2e4c14d370 |  | high | COPPA, FERPA, HIPAA | untriaged | audit-run | Eval AI narration has no COPPA parental-consent hard-gate before sending under-13 student data to Anthropic | `lib/eval_narrator.rb`:43 |
 | LL-16fef018a0 |  | high | SOC2 | **fixed** | pr-review | Password-reset code verification endpoint (users#password_reset) not rate-limited | `config/initializers/throttling.rb`:41 |
+| LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | **fixed** | audit-run | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |
 | LL-c6dd65a2aa | Infra-P1-3 | high |  | **fixed** | audit-run | Static cache_token='abc' never rotates (stale permission cache) | `config/initializers/resque.rb`:29 |
 | LL-ca38d4d99e | P1-1 | high | FERPA, HIPAA | **fixed** | audit-run | Consent endpoints absent from Rack::Attack protected_paths | `config/initializers/throttling.rb`:18 |
+| LL-740bcb10fa | P1-2 | high | GDPR, HIPAA | **fixed** | audit-run | License.metadata / external_reference stored unencrypted | `app/models/license.rb`:2 |
 | LL-e775d86e6a | P1-3 | high | GDPR | **fixed** | audit-run | License not handled in transfer_user_content (orphaned seats on merge) | `lib/flusher.rb`:156 |
 | LL-e65d34f109 | P1-4 | high | FERPA | **fixed** | audit-run | Sensitive new routes (claim_user) under general throttle only | `config/initializers/throttling.rb`:18 |
 | LL-9a3ee852d5 | P1-6 | high |  | **fixed** | audit-run | forgot_password leaks account existence via response shape and users count | `app/controllers/api/users_controller.rb`:705 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `59e20439e005b363ec67f8444d5406848a1c434f`  
 **Audited ref:** `staging`  
 **Run date:** 2026-06-18  
-**Page generated:** 2026-06-19T04:31:47Z
+**Page generated:** 2026-06-19T05:19:48Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **9** | 23 | 16 |
+| **0** | **7** | 23 | 16 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -30,9 +30,7 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-7acd0e7416 |  | high | FERPA, HIPAA | Admin-support reads of individual student records (version history, daily usage) write no AuditEvent | `app/controllers/api/users_controller.rb`:485 |
 | LL-d1ea8659c3 |  | high |  | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
-| LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |
 | LL-9f83617435 | Infra-P1-4 | high |  | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
-| LL-740bcb10fa | P1-2 | high | GDPR, HIPAA | License.metadata / external_reference stored unencrypted | `app/models/license.rb`:2 |
 | LL-92dc570f30 | P1-5 | high |  | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
 | LL-0c6e931f47 |  | medium | WCAG | Sentence box (utterance bar) symbol chip images have no alt attribute | `app/frontend/app/templates/components/button-list.hbs`:21 |
 | LL-13ad11eaee |  | medium | WCAG | Loading status text has no aria-live or role=status | `app/frontend/app/templates/bento.hbs`:14 |


### PR DESCRIPTION
## What

Register-only PR. Attest-closes 2 High findings whose fixes merged to staging this session, each verified against live staging code before flipping status:

| Finding | Fix | Verified |
|---|---|---|
| LL-740bcb10fa License.metadata/external_reference unencrypted | #435 + #436 | `secure_serialize :metadata` (encrypted at rest) + manual `GoSecure::SecureJson` accessors for `external_reference` (one-secure-column limit); idempotent backfill migrations re-encrypt existing rows; `external_reference` also stripped from the DB-browser API |
| LL-1085e59d29 webhook accepts plaintext http:// | #434 | all 3 validation sites now require `/^https:\/\//`; non-breaking for existing stored webhooks |

## Impact

Open High **9 → 7**. Remaining open High: LL-6619cc1811 (redis TLS, gated on GCP Memorystore cutover), LL-d1ea8659c3 (bootstrap EOL, schedule), LL-11db0dc848 (eval consent, Phase 1B), plus the 2 new audit-run privacy HIGHs (LL-080a21089f, LL-7acd0e7416, untriaged).

Historical `evidence` anchors + their shas left untouched; `closureEvidence` carries the merge sha, verifierNote, and attestation per finding.

## Checks

- `ruby scripts/citation-check.rb` -> PASS 69 / FAIL 0
- `ruby scripts/compliance-notion-publish.rb --check` -> OK

Attested in-thread by Scot Wahlquist 2026-06-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)