### PR TITLE
compliance(register): reconcile accepted-risk status for LL-92dc570f30, LL-9f83617435

### DIFF
--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -402,7 +402,7 @@
       "severity": "high",
       "confidence": "medium",
       "frameworks": [],
-      "status": "open",
+      "status": "accepted-risk",
       "evidence": {
         "type": "code",
         "file": "app/controllers/api/supervisor_relationships_controller.rb",
@@ -411,7 +411,7 @@
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a"
       },
       "firstSeen": "2026-04-09",
-      "lastSeen": "2026-06-12",
+      "lastSeen": "2026-06-19",
       "owner": "unassigned",
       "remediation": {
         "options": "Standardize to a single token key and a single decision key; or Scot accepts the risk given token_valid? + expiry guards now present.",
@@ -698,7 +698,7 @@
       "severity": "high",
       "confidence": "low",
       "frameworks": [],
-      "status": "open",
+      "status": "accepted-risk",
       "evidence": {
         "type": "code",
         "file": "config/environments/production.rb",
@@ -707,7 +707,7 @@
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a"
       },
       "firstSeen": "2026-04-09",
-      "lastSeen": "2026-06-12",
+      "lastSeen": "2026-06-19",
       "owner": "unassigned",
       "remediation": {
         "options": "Add config.ssl_options = { hsts: { subdomains: true, preload: true, expires_in: 1.year } }.",

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,11 +5,11 @@
 
 **Audited:** `staging` @ `59e20439e005b363ec67f8444d5406848a1c434f` on 2026-06-18  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 7 High
+**Headline (open + remediated-unverified):** 0 Critical / 5 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (46)
+## Open (44)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -18,8 +18,6 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-080a21089f |  | high | FERPA, HIPAA, GDPR | untriaged | audit-run | Account deletion / right-to-erasure path writes no AuditEvent | `app/controllers/api/users_controller.rb`:388 |
 | LL-7acd0e7416 |  | high | FERPA, HIPAA | untriaged | audit-run | Admin-support reads of individual student records (version history, daily usage) write no AuditEvent | `app/controllers/api/users_controller.rb`:485 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
-| LL-9f83617435 | Infra-P1-4 | high |  | **accepted** | audit-run | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
-| LL-92dc570f30 | P1-5 | high |  | **accepted** | audit-run | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | untriaged | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
 | LL-52ff2a9a79 |  | medium | SOC2 | untriaged | audit-run | CI security-scan job (Brakeman SAST, bundle-audit, npm audit, gitleaks) is entirely non-blocking | `.github/workflows/ci.yml`:107 |
 | LL-27d20047db |  | medium |  | untriaged | audit-run | Integration board_render_url is writable but never serialized back (read/write field-name asymmetry) | `app/frontend/app/models/integration.js`:24 |
@@ -88,6 +86,13 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-c5bd616242 | Prior-BAA-AWS | high | HIPAA | untriaged | audit-run | BAA with AWS (S3/SES/Transcoder/SNS) for HIPAA | `docs/legal/AWS_BAA_ACCEPTED.md` |
 | LL-2ea0b804e7 | Infra-P2-1 | medium | HIPAA | untriaged | audit-run | S3 buckets public-read on * (legacy ACL) | `docs/INFRASTRUCTURE.md`:101 |
 | LL-7a8effae8a | P2-9 | medium | FERPA | untriaged | audit-run | user_name exposed for expired licenses during expiration window | `lib/json_api/license.rb`:17 |
+
+## Accepted risk (2)
+
+| ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
+|---|---|---|---|---|---|---|---|
+| LL-9f83617435 | Infra-P1-4 | high |  | **accepted** | audit-run | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
+| LL-92dc570f30 | P1-5 | high |  | **accepted** | audit-run | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
 
 ## Superseded / obsolete (2)
 

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `59e20439e005b363ec67f8444d5406848a1c434f`  
 **Audited ref:** `staging`  
 **Run date:** 2026-06-18  
-**Page generated:** 2026-06-19T05:19:48Z
+**Page generated:** 2026-06-19T12:52:05Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **7** | 23 | 16 |
+| **0** | **5** | 23 | 16 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -30,8 +30,6 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-7acd0e7416 |  | high | FERPA, HIPAA | Admin-support reads of individual student records (version history, daily usage) write no AuditEvent | `app/controllers/api/users_controller.rb`:485 |
 | LL-d1ea8659c3 |  | high |  | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
-| LL-9f83617435 | Infra-P1-4 | high |  | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
-| LL-92dc570f30 | P1-5 | high |  | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
 | LL-0c6e931f47 |  | medium | WCAG | Sentence box (utterance bar) symbol chip images have no alt attribute | `app/frontend/app/templates/components/button-list.hbs`:21 |
 | LL-13ad11eaee |  | medium | WCAG | Loading status text has no aria-live or role=status | `app/frontend/app/templates/bento.hbs`:14 |
 | LL-27d20047db |  | medium |  | Integration board_render_url is writable but never serialized back (read/write field-name asymmetry) | `app/frontend/app/models/integration.js`:24 |


### PR DESCRIPTION
## Register reconciliation (no severity/disposition change)

`LL-92dc570f30` (consent multi-key-param) and `LL-9f83617435` (no HSTS ssl_options) already carried `disposition.state=accepted`, `decidedBy: Scot Wahlquist`, `decidedDate: 2026-06-18` in the register, but their `status` was still `open`, so they inflated the open-High headline.

This PR flips **status only**: `open -> accepted-risk`, matching the acceptance you already recorded. No change to severity, disposition, rationale, or the historical `evidence` anchors.

- `lastSeen` bumped to 2026-06-19
- Regenerated `FINDINGS.md` + `notion/compliance-audit-page.md`
- `citation-check.rb`: PASS 67 / FAIL 0 / SKIP 5
- `compliance-notion-publish.rb --check`: OK

**Open High headline: 7 -> 5.**

Remaining 5 open High after this merges: redis-TLS (gated on Memorystore cutover), bootstrap 3.4.1 EOL (schedule), eval-consent Phase 1B (schedule), and the two new AuditEvent privacy HIGHs (`LL-080a21089f`, `LL-7acd0e7416`) which are being fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)