### PR TITLE
security(audit): AuditEvent for account erasure + admin-support student reads (LL-080a21089f, LL-7acd0e7416)

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -382,9 +382,14 @@ class Api::UsersController < ApplicationController
     return unless allowed?(user, 'delete')
     return api_error(400, {'flushed' => 'false', 'user_name_math' => (user.user_name == params['user_name']), 'user_id_match' => (user.global_id == params['confirm_user_id'])}) unless user.user_name == params['user_name'] && user.global_id == params['confirm_user_id']
     progress = Progress.schedule(Flusher, :flush_user_logs, user.global_id, user.user_name, for_user: @api_user)
+    AuditEvent.log_command(@api_user.global_id, {
+      'type' => 'user_logs_flush_scheduled',
+      'user_id' => user.global_id,
+      'progress_id' => progress.global_id
+    })
     render json: JsonApi::Progress.as_json(progress, :wrapper => true)
   end
-  
+
   def flush_user
     user = User.find_by_path(params['user_id'])
     return unless allowed?(user, 'delete')
@@ -394,6 +399,11 @@ class Api::UsersController < ApplicationController
     Purchasing.cancel_other_subscriptions(user, 'all')
     SubscriptionMailer.deliver_message(:account_deleted, user.global_id)
     AdminMailer.schedule_delivery(:opt_out, user.global_id, 'deleted')
+    AuditEvent.log_command(@api_user.global_id, {
+      'type' => 'user_deletion_scheduled',
+      'user_id' => user.global_id,
+      'scheduled_deletion_at' => user.schedule_deletion_at&.iso8601
+    })
     render json: {flushed: 'pending'}
   end
   
@@ -493,6 +503,14 @@ class Api::UsersController < ApplicationController
       user_id = params['user_id']
     end
     return unless exists?(user_id)
+    # Accounting-of-disclosure: admin-support reads of another user's full version
+    # history are timestamped. Self-reads are not logged.
+    if @api_user && user_id != @api_user.global_id
+      AuditEvent.log_command(@api_user.global_id, {
+        'type' => 'admin_support_history_read',
+        'user_id' => user_id
+      })
+    end
     versions = User.user_versions(user_id)
     render json: JsonApi::UserVersion.paginate(params, versions, {:admin => Organization.admin_manager?(@api_user)})
   end
@@ -814,6 +832,12 @@ class Api::UsersController < ApplicationController
         api_error 400, {error: 'Not authorized', unauthorized: true}
         return
       end
+      # Accounting-of-disclosure: admin-support reads of another user's daily-use
+      # communication log are timestamped.
+      AuditEvent.log_command(@api_user.global_id, {
+        'type' => 'admin_support_daily_use_read',
+        'user_id' => user.global_id
+      })
     end
     log = LogSession.find_by(:user_id => user.id, :log_type => 'daily_use')
     if log

--- a/lib/flusher.rb
+++ b/lib/flusher.rb
@@ -236,6 +236,14 @@ module Flusher
     LogSession.where(:author_id => user.id).each do |note|
       note.update_columns(author_id: nil)
     end
+    gid = user.global_id
     flush_record(user, user.id, 'User')
+    # Accounting-of-disclosure: timestamp the permanent destruction of a user's
+    # education/health records at the async finalization step. No human actor is
+    # in scope here (scheduled flush), so the actor key is 'system'.
+    AuditEvent.log_command('system', {
+      'type' => 'user_permanently_destroyed',
+      'user_id' => gid
+    })
   end
 end

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -1712,8 +1712,19 @@ describe Api::UsersController, :type => :controller do
       expect(progress.settings['method']).to eq('flush_user_logs')
       expect(progress.settings['arguments']).to eq([@user.global_id, @user.user_name])
     end
+
+    it "should log an audit event when scheduling a log flush" do
+      token_user
+      AuditEvent.delete_all
+      post :flush_logs, params: {:user_id => @user.global_id, :confirm_user_id => @user.global_id, :user_name => @user.user_name}
+      expect(response).to be_successful
+      ev = AuditEvent.all.to_a.find { |e| e.data['type'] == 'user_logs_flush_scheduled' }
+      expect(ev).to_not eq(nil)
+      expect(ev.user_key).to eq(@user.global_id)
+      expect(ev.data['user_id']).to eq(@user.global_id)
+    end
   end
-  
+
   describe "flush_user" do
     it "should require api token" do
       post :flush_user, params: {:user_id => 1}
@@ -1752,6 +1763,17 @@ describe Api::UsersController, :type => :controller do
       expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json).to eq({'flushed' => 'pending'})
+    end
+
+    it "should log an audit event when scheduling account deletion" do
+      token_user
+      AuditEvent.delete_all
+      post :flush_user, params: {:user_id => @user.global_id, :confirm_user_id => @user.global_id, :user_name => @user.user_name}
+      expect(response).to be_successful
+      ev = AuditEvent.all.to_a.find { |e| e.data['type'] == 'user_deletion_scheduled' }
+      expect(ev).to_not eq(nil)
+      expect(ev.user_key).to eq(@user.global_id)
+      expect(ev.data['user_id']).to eq(@user.global_id)
     end
   end
 
@@ -2704,6 +2726,29 @@ describe Api::UsersController, :type => :controller do
       expect(json['log']).to_not eq(nil)
     end
 
+    it "should log an admin-support audit event for a cross-user daily_use read" do
+      token_user
+      o = Organization.create(:admin => true)
+      o.add_manager(@user.user_name, true)
+      u = User.create
+      AuditEvent.delete_all
+      get :daily_use, params: {:user_id => u.global_id}
+      expect(response).to be_successful
+      ev = AuditEvent.all.to_a.find { |e| e.data['type'] == 'admin_support_daily_use_read' }
+      expect(ev).to_not eq(nil)
+      expect(ev.user_key).to eq(@user.global_id)
+      expect(ev.data['user_id']).to eq(u.global_id)
+    end
+
+    it "should not log an admin-support audit event for a self daily_use read" do
+      token_user
+      AuditEvent.delete_all
+      get :daily_use, params: {:user_id => @user.global_id}
+      expect(response).to be_successful
+      ev = AuditEvent.all.to_a.find { |e| e.data['type'] == 'admin_support_daily_use_read' }
+      expect(ev).to eq(nil)
+    end
+
     it 'should return data if available' do
       token_user
       d = Device.create(:user => @user)
@@ -2753,6 +2798,20 @@ describe Api::UsersController, :type => :controller do
       expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json['userversion']).to eq([])
+    end
+
+    it 'should log an admin-support audit event for a cross-user history read' do
+      token_user
+      o = Organization.create(:admin => true)
+      o.add_manager(@user.user_name, true)
+      u = User.create
+      AuditEvent.delete_all
+      get 'history', :params => {'user_id' => u.global_id}
+      expect(response).to be_successful
+      ev = AuditEvent.all.to_a.find { |e| e.data['type'] == 'admin_support_history_read' }
+      expect(ev).to_not eq(nil)
+      expect(ev.user_key).to eq(@user.global_id)
+      expect(ev.data['user_id']).to eq(u.global_id)
     end
   end
   

--- a/spec/lib/flusher_spec.rb
+++ b/spec/lib/flusher_spec.rb
@@ -407,6 +407,17 @@ describe Flusher do
       expect(Flusher).to receive(:flush_record).with(u, u.id, u.class.to_s)
       Flusher.flush_user_completely(u.global_id, u.user_name)
     end
+
+    it "should log an audit event recording the permanent destruction" do
+      u = User.create
+      gid = u.global_id
+      AuditEvent.delete_all
+      Flusher.flush_user_completely(u.global_id, u.user_name)
+      ev = AuditEvent.all.to_a.find { |e| e.data['type'] == 'user_permanently_destroyed' }
+      expect(ev).to_not eq(nil)
+      expect(ev.user_key).to eq('system')
+      expect(ev.data['user_id']).to eq(gid)
+    end
   end
 
   describe "flush_deleted_users" do


### PR DESCRIPTION
## Audit-trail gaps for account erasure + admin-support student reads

Fixes the two new privacy HIGHs surfaced by the 2026-06-18 `/audit-run` (FERPA accounting-of-disclosure / GDPR Art. 30). Both paths handled student/patient records but wrote **no `AuditEvent`**.

### `LL-080a21089f` — erasure path writes no AuditEvent
- `users_controller#flush_logs` -> `user_logs_flush_scheduled` (actor `@api_user`)
- `users_controller#flush_user` -> `user_deletion_scheduled` (actor `@api_user`)
- `Flusher.flush_user_completely` -> `user_permanently_destroyed` (actor `'system'`, captured `global_id` before the record is destroyed) so the **async permanent destruction** of education/health records is timestamped

### `LL-7acd0e7416` — cross-user admin-support reads write no AuditEvent
- `users_controller#history` -> `admin_support_history_read` (full UserVersion change history)
- `users_controller#daily_use` -> `admin_support_daily_use_read` (daily-use communication log)
- Both scoped to the **cross-user branch** so self-reads are not logged

### Safety / conventions
- `AuditEvent.log_command` is best-effort (rescues + Sentry-alerts on persist failure), so audit logging never breaks the authorized action or read.
- Mirrors the existing `log_command` pattern in `organizations` / `supervisor_relationships` / `database_contents` controllers.
- No PII in the audit payloads — only opaque `global_id`s and an event type.

### Tests
6 new RSpec examples (2 flush, 1 finalize, 2 daily_use incl. a negative self-read, 1 history). Targeted run: **45 examples, 0 failures** (1 unrelated pre-existing pending). Block-scoped `AuditEvent.delete_all` per the known commit-outside-txn accumulation gotcha.

Register closures for both findings will be staged in a follow-up register PR (with this PR's merge SHA) for Scot's attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)