### PR TITLE
security(coppa): close org-authored consent bypass + record school-authorization basis

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -267,18 +267,32 @@ class Api::UsersController < ApplicationController
     # under-13 account creation traceable to the authorizing org and manager.
     sa = user.settings && user.settings['school_authorization']
     if sa.is_a?(Hash) && sa['basis'] == 'school_official'
-      AuditEvent.create!(
-        user_key: user.global_id,
-        data: {
-          'type' => 'school_authorization',
-          'basis' => sa['basis'],
-          'organization_id' => sa['organization_id'],
-          'authorized_by' => sa['authorized_by'],
-          'record_id' => sa['record_id']
-        },
-        event_type: 'school_authorization',
-        record_id: sa['record_id']
-      )
+      begin
+        AuditEvent.create!(
+          user_key: user.global_id,
+          data: {
+            'type' => 'school_authorization',
+            'basis' => sa['basis'],
+            'organization_id' => sa['organization_id'],
+            'authorized_by' => sa['authorized_by'],
+            'record_id' => sa['record_id']
+          },
+          event_type: 'school_authorization',
+          record_id: sa['record_id']
+        )
+      rescue => e
+        # Fail-open: the child account is already persisted, so a failed audit insert
+        # must NOT 500 the request (that would orphan the account and invite a
+        # duplicate-creating retry). Log loudly so a missed accounting-of-disclosure
+        # row is caught. e.message can echo DB input, so PII-scrub it (guarded, the
+        # same way AuditEvent.log_command does) rather than logging the raw message.
+        detail = begin
+          PiiScrubber.scrub_log_line(e.message.to_s).truncate(300)
+        rescue ScriptError, StandardError => scrub_err
+          "[unscrubbable:#{scrub_err.class}]"
+        end
+        Rails.logger.error("school_authorization audit failed to persist for #{user.global_id}: #{e.class} #{detail}")
+      end
     end
     coppa_pending = user.coppa_parental_consent_pending?
     unless coppa_pending

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -261,6 +261,25 @@ class Api::UsersController < ApplicationController
       start_progress = res[:progress]
     end
     UserBoardProvisioner.provision_for(user)
+    # Org-authored (school-official) creation: emit the immutable authorization audit
+    # now that the user is persisted. process_params recorded the basis in settings
+    # but had no global_id to key the event on. This makes every school-authorized
+    # under-13 account creation traceable to the authorizing org and manager.
+    sa = user.settings && user.settings['school_authorization']
+    if sa.is_a?(Hash) && sa['basis'] == 'school_official'
+      AuditEvent.create!(
+        user_key: user.global_id,
+        data: {
+          'type' => 'school_authorization',
+          'basis' => sa['basis'],
+          'organization_id' => sa['organization_id'],
+          'authorized_by' => sa['authorized_by'],
+          'record_id' => sa['record_id']
+        },
+        event_type: 'school_authorization',
+        record_id: sa['record_id']
+      )
+    end
     coppa_pending = user.coppa_parental_consent_pending?
     unless coppa_pending
       UserMailer.schedule_delivery(:confirm_registration, user.global_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1251,8 +1251,24 @@ class User < ApplicationRecord
       end
       self.settings['email'] = process_string(new_email)
     end
-    # Use blank? so empty string from the client does not skip COPPA (!"" is false in Ruby).
-    if !self.id && JsonApi::Json.coppa_parental_consent_enabled? && params['authored_organization_id'].blank?
+    # Determine up front whether this is a VALID organization-authored creation (a
+    # school/district manager creating a managed user under the FERPA school-official
+    # exception). The COPPA parental-consent gate is skipped ONLY for a validated org
+    # authorization. Previously the skip keyed on the raw authored_organization_id
+    # param being non-blank while the org/author validation ran later (see below), so
+    # a present-but-invalid or unauthorized org id bypassed the COPPA gate AND recorded
+    # nothing. Compute the validated result once and reuse it for both decisions.
+    org_authorized = false
+    authoring_org = nil
+    if !self.id && params['authored_organization_id'].present?
+      authoring_org = Organization.find_by_global_id(params['authored_organization_id'])
+      if authoring_org && non_user_params[:author] && authoring_org.allows?(non_user_params[:author], 'edit')
+        org_authorized = true
+      end
+    end
+    # Use !org_authorized (not authored_organization_id.blank?) so an empty string OR a
+    # present-but-invalid/unauthorized org id both fall through to the COPPA gate.
+    if !self.id && JsonApi::Json.coppa_parental_consent_enabled? && !org_authorized
       # Ember may send snake_case, dasherized, or camelCase JSON keys depending on serializer/version.
       minor_flag = params['coppa_under_13'] || params['coppa-under-13'] || params['coppaUnder13']
       wants_minor = [true, 'true', '1', 1].include?(minor_flag)
@@ -1290,12 +1306,20 @@ class User < ApplicationRecord
     end
     self.settings['referrer'] ||= params['referrer'] if params['referrer']
     self.settings['ad_referrer'] ||= params['ad_referrer'] if params['ad_referrer']
-    if params['authored_organization_id'].present? && !self.id
-      org = Organization.find_by_global_id(params['authored_organization_id'])
-      if org && non_user_params[:author] && org.allows?(non_user_params[:author], 'edit')
-        self.settings['authored_organization_id'] = org.global_id
-        self.settings['pending'] = false
-      end
+    if org_authorized
+      self.settings['authored_organization_id'] = authoring_org.global_id
+      self.settings['pending'] = false
+      # Record the school-authorization basis explicitly so the school-official
+      # exception is auditable (who authorized it, when, and on what basis) instead
+      # of silently skipping COPPA with no record. The matching immutable AuditEvent
+      # is emitted post-save in api/users#create (no global_id exists yet here).
+      self.settings['school_authorization'] = {
+        'basis' => 'school_official',
+        'organization_id' => authoring_org.global_id,
+        'authorized_by' => (non_user_params[:author] && non_user_params[:author].global_id),
+        'authorized_at' => Time.now.utc.iso8601,
+        'record_id' => SecureRandom.uuid
+      }
     end
     if params['last_message_read']
       last_message_read = params['last_message_read'].to_i

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1262,6 +1262,15 @@ class User < ApplicationRecord
     authoring_org = nil
     if !self.id && params['authored_organization_id'].present?
       authoring_org = Organization.find_by_global_id(params['authored_organization_id'])
+      # NOTE: 'edit' is satisfied by assistant-level managers, not only full managers
+      # (Organization adds 'edit' for assistant? at organization.rb:43; 'manage' is the
+      # full-manager-only level at :44). This preserves the pre-existing authoring scope.
+      # Whether the school-official exception should be restricted to full managers, and
+      # gated on a signed-contract/DPA flag, is the Phase 1 decision (see
+      # outputs/plans/2026-06-19-org-coppa-bypass-fix-scope.md); do not silently change
+      # the scope here. Any code path that sets settings['school_authorization'] below
+      # must also emit the school_authorization AuditEvent (today the only creator path
+      # is api/users#create, which does).
       if authoring_org && non_user_params[:author] && authoring_org.allows?(non_user_params[:author], 'edit')
         org_authorized = true
       end

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -786,6 +786,68 @@ describe Api::UsersController, :type => :controller do
         body = JSON.parse(response.body)
         expect(body['coppa_parental_consent_pending']).to eq(true)
       end
+
+      it "treats a present-but-invalid authored_organization_id as NO authorization (COPPA still applies)" do
+        # Regression: a non-blank but invalid org id must NOT skip the COPPA gate.
+        # Under-13 with a bogus org id and no parent email must be rejected, proving
+        # the gate ran despite the non-blank authored_organization_id.
+        post :create, params: {:user => {
+          'name' => 'coppa_kid_bogus_org',
+          'email' => 'kid_bogus_org@example.com',
+          'password' => 'abcdef',
+          'terms_agree' => true,
+          'authored_organization_id' => 'invalid_org_999',
+          'coppa_under_13' => true
+        }}
+        expect(response).not_to be_successful
+        json = JSON.parse(response.body)
+        expect(json['errors']).to include('parent consent email required for under-13 registration')
+      end
+
+      it "treats an unauthorized author's authored_organization_id as NO authorization (COPPA still applies)" do
+        token_user
+        o = Organization.create(:settings => {'total_licenses' => 1})
+        # @user is NOT a manager of o, so the claimed authorization is invalid.
+        post :create, params: {:user => {
+          'name' => 'coppa_kid_unauth_org',
+          'email' => 'kid_unauth_org@example.com',
+          'password' => 'abcdef',
+          'terms_agree' => true,
+          'authored_organization_id' => o.global_id,
+          'coppa_under_13' => true
+        }}
+        expect(response).not_to be_successful
+        json = JSON.parse(response.body)
+        expect(json['errors']).to include('parent consent email required for under-13 registration')
+      end
+
+      it "skips COPPA and records an auditable school_authorization for a valid org-authored minor" do
+        token_user
+        o = Organization.create(:settings => {'total_licenses' => 1})
+        o.add_manager(@user.user_name, true)
+        post :create, params: {:user => {
+          'name' => 'school_kid',
+          'email' => 'school_kid@example.com',
+          'password' => 'abcdef',
+          'terms_agree' => true,
+          'authored_organization_id' => o.global_id,
+          'coppa_under_13' => true
+        }}
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json['meta']['coppa_parental_consent_pending']).to be_falsey
+        u = User.find_by_path(json['user']['id'])
+        expect(u.coppa_parental_consent_pending?).to eq(false)
+        sa = u.settings['school_authorization']
+        expect(sa).to be_a(Hash)
+        expect(sa['basis']).to eq('school_official')
+        expect(sa['organization_id']).to eq(o.global_id)
+        expect(sa['authorized_by']).to eq(@user.global_id)
+        ev = AuditEvent.where(:event_type => 'school_authorization', :record_id => sa['record_id']).first
+        expect(ev).to be_present
+        expect(ev.user_key).to eq(u.global_id)
+        expect(ev.data['organization_id']).to eq(o.global_id)
+      end
     end
 
     it "should error on invalid start code" do

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -848,6 +848,47 @@ describe Api::UsersController, :type => :controller do
         expect(ev.user_key).to eq(u.global_id)
         expect(ev.data['organization_id']).to eq(o.global_id)
       end
+
+      it "currently allows an assistant-level manager to author a minor (Phase 1 will decide if a full manager should be required)" do
+        # Documents the preserved authoring scope: 'edit' is satisfied by assistant
+        # managers (add_manager(..., false)), not only full managers. This is the
+        # pre-existing behavior; tightening to full-manager-only is a Phase 1 decision.
+        token_user
+        o = Organization.create(:settings => {'total_licenses' => 1})
+        o.add_manager(@user.user_name, false)
+        post :create, params: {:user => {
+          'name' => 'assistant_authored_kid',
+          'email' => 'assistant_kid@example.com',
+          'password' => 'abcdef',
+          'terms_agree' => true,
+          'authored_organization_id' => o.global_id,
+          'coppa_under_13' => true
+        }}
+        expect(response).to be_successful
+        u = User.find_by_path(JSON.parse(response.body)['user']['id'])
+        expect(u.coppa_parental_consent_pending?).to eq(false)
+        expect(u.settings['school_authorization']['basis']).to eq('school_official')
+      end
+
+      it "does not orphan or 500 the child account when the school_authorization audit fails (fail-open)" do
+        token_user
+        o = Organization.create(:settings => {'total_licenses' => 1})
+        o.add_manager(@user.user_name, true)
+        allow(AuditEvent).to receive(:create!).and_call_original
+        expect(AuditEvent).to receive(:create!).with(hash_including(:event_type => 'school_authorization')).and_raise(StandardError.new('boom'))
+        post :create, params: {:user => {
+          'name' => 'audit_fail_kid',
+          'email' => 'audit_fail_kid@example.com',
+          'password' => 'abcdef',
+          'terms_agree' => true,
+          'authored_organization_id' => o.global_id,
+          'coppa_under_13' => true
+        }}
+        expect(response).to be_successful
+        u = User.find_by_path(JSON.parse(response.body)['user']['id'])
+        expect(u).to be_present
+        expect(u.settings['school_authorization']['basis']).to eq('school_official')
+      end
     end
 
     it "should error on invalid start code" do


### PR DESCRIPTION
## What
Phase 0 of the org-authored COPPA fix. **Narrows** a consent-bypass hole to validated org authorizations and makes those authorizations **auditable**. It does NOT, on its own, require parental involvement or a verified school contract for org-authored under-13 accounts; that is Phase 1 (see Honest scope below).

## The bug (closed)
`User#process_params` skipped the under-13 parental-consent gate whenever `authored_organization_id` was a **non-blank string** (the skip keyed on the raw param), while the org/author validation ran later. So a present-but-**invalid or unauthorized** `authored_organization_id` bypassed the COPPA gate **and recorded nothing**. A client could present any non-blank string and skip the under-13 gate.

## The fix
- Compute the validated org authorization **once** (org resolves AND author is a manager with `edit`) before the COPPA block, and gate the skip on that. Invalid/unauthorized org ids now fall through to the parental-consent gate.
- Record `settings['school_authorization']` (basis, org, authorizing manager, timestamp, `record_id`).
- Emit an immutable `AuditEvent` (`event_type: school_authorization`) post-save in `api/users#create`, **fail-open** so a failed audit insert can never orphan or 500 the child account.

## Adversary review (pre-merge red-team) — addressed
Verdict was MERGE-WITH-FIXES. Applied:
- **High #2 (must-fix):** audit emission is now fail-open with guarded PII-scrubbed loud logging (mirrors `AuditEvent.log_command`). Spec stubs the audit to raise and asserts the account is still created.
- **High #1 (decision flagged):** `allows?('edit')` admits **assistant-level** managers, not only full managers (`organization.rb:43` vs `:44`). This PR **preserves the pre-existing authoring scope** and documents it with a code comment + a spec. **Open decision for Scot:** restrict the school-official exception to full managers (`'manage'`) and/or a signed-contract flag? Deferred to Phase 1.
- **Medium #3:** comment noting any path that sets `school_authorization` must also emit the audit (today only `api/users#create` creates org-authored users).

## Honest scope
With the signed-contract precondition deferred to Phase 1, any org manager or assistant with `edit` can still author under-13 accounts with no parental involvement. This PR makes that **audited and limited to validated authorizations**, not **authorized** in the full COPPA sense. Phase 1 (org contract flag, full-manager scope decision, re-consent on contract change) is tracked in `outputs/plans/2026-06-19-org-coppa-bypass-fix-scope.md`.

## Tests
COPPA controller block: **12 examples, 0 failures** (invalid org → COPPA applies; unauthorized author → COPPA applies; valid org → skips COPPA + records + audits; assistant manager documented; audit-failure fail-open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)