### PR TITLE
fix(flags): gate supervisor-consent UI and eval/quick route behind their flags

### DIFF
--- a/app/frontend/app/routes/eval/quick.js
+++ b/app/frontend/app/routes/eval/quick.js
@@ -1,11 +1,23 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
+import { inject as service } from '@ember/service';
 import LingoLinq from '../../app';
 import EvalSession from '../../utils/eval_session';
 import i18n from '../../utils/i18n';
 
 export default Route.extend({
   title: i18n.t('quick_screen_eval_title', "Quick Screen"),
+  appState: service('app-state'),
+  router: service('router'),
+
+  beforeModel(/* transition */) {
+    // Defense-in-depth: entry links and the API already gate quick_screen_eval, but
+    // guard the route too so a direct URL does not render the eval shell before the
+    // API rejects it. Redirect home when the flag is off for this user.
+    if(!this.appState.get('feature_flags.quick_screen_eval')) {
+      this.router.transitionTo('index');
+    }
+  },
 
   model(params) {
     if (params.user_id) {

--- a/app/frontend/app/templates/components/supervision-settings.hbs
+++ b/app/frontend/app/templates/components/supervision-settings.hbs
@@ -65,7 +65,7 @@
         <p>{{t "None found" key="none_found"}}</p>
       {{/unless}}
     {{/if}}
-    {{pending-consent-requests user=this.model}}
+    {{#if this.appState.feature_flags.supervisor_consent_flow}}{{pending-consent-requests user=this.model}}{{/if}}
     {{#if this.model.permissions.manage_supervision}}
       {{#if this.model.permissions.delete}}
         <button type='button' class='md-btn md-btn--primary' {{action "add_supervisor"}}>{{t "Add Supervisor" key="add_supervisor"}}</button>
@@ -267,7 +267,7 @@
       <p class="md-modal-hint">{{t "None found" key="none_found"}}</p>
     {{/if}}
 
-    {{pending-consent-requests user=this.model}}
+    {{#if this.appState.feature_flags.supervisor_consent_flow}}{{pending-consent-requests user=this.model}}{{/if}}
 
     {{#if this.model.permissions.manage_supervision}}
       <div class="md-modal-field" style="display: flex; gap: 8px; flex-wrap: wrap;">


### PR DESCRIPTION
## What
Two feature-flag coverage quick wins from the audit (`outputs/docs/2026-06-19-feature-flag-coverage-audit.md`). No data exposure in either; these close disruptive-UI / defense-in-depth gaps where the backend already enforced the flag.

## GAP B: supervisor-consent UI ungated on the frontend
`pending-consent-requests` rendered unconditionally in `supervision-settings` (component template lines 68 and 270) even though the backend enforces `supervisor_consent_flow` (OFF by default). A supervisor in an org without the flow saw a dead-end "pending consent requests" UI whose actions fail server-side.

Both include sites are now wrapped in `{{#if this.appState.feature_flags.supervisor_consent_flow}}`.

The `/consent/:token` route is **intentionally left reachable** so any already-sent consent-email links keep working. Only the settings-page UI is gated.

## GAP C: `eval/quick` route had no route-level guard
Entry links and the API already gate `quick_screen_eval`, but a direct URL rendered the eval shell before the API rejected it. Added a `beforeModel` guard (via the `app-state` + `router` services) that redirects home when the flag is off. Defense-in-depth only.

## Validation
- ESLint (project v5.16.0) and ember-template-lint clean on both files under Node 20.
- Diff against the pristine baseline: **no new rule violations introduced**.
- Note: `ember test` only runs lint in this repo (AMD loader defect, issue #314); no behavioral unit run is possible for template/route guards.

## Not included (needs a product decision)
GAP A (board-import flag mismatch, `paste_html_import` vs `multi_user_board_import`) is held for a product call, per the audit. GAP D (four TEMPORARY-ON flags) is a release-gate checklist item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)