### PR TITLE
fix(a11y): working accessible name + i18n placeholder for find-button input (LL-9b5d0f1381)

### DIFF
--- a/app/frontend/app/components/focus-input.js
+++ b/app/frontend/app/components/focus-input.js
@@ -3,6 +3,11 @@ import { TextField } from '@ember/legacy-built-in-components';
 import $ from 'jquery';
 
 export default TextField.extend({
+  // `aria-label` is not in TextField's default attributeBindings, so an aria-label
+  // passed to a focus-input would set a property but never reach the DOM. Bind it here
+  // (concatenated with the inherited bindings) so callers can give the input an
+  // accessible name. Only renders when an aria-label is actually provided.
+  attributeBindings: ['aria-label'],
   didInsertElement() {
     this._super(...arguments);
     if (!capabilities.mobile || this.get('force')) {

--- a/app/frontend/app/templates/components/find-button.hbs
+++ b/app/frontend/app/templates/components/find-button.hbs
@@ -6,7 +6,7 @@
     </div>
     <div class="la-find-button-body">
       <label for="button_search_string" class="sr-only">{{t "Search for buttons" key="search_for_buttons"}}</label>
-      {{focus-input force="true" type="text" id="button_search_string" value=this.searchString class="la-find-button-input" select="pick_result" placeholder="Word or phrase you're looking for" autocomplete="off" aria-label=(t "Search for buttons" key="search_for_buttons")}}
+      {{focus-input force="true" type="text" id="button_search_string" value=this.searchString class="la-find-button-input" select="pick_result" placeholder=(t "Word or phrase you're looking for" key="word_or_phrase_youre_looking_for") autocomplete="off" aria-label=(t "Search for buttons" key="search_for_buttons")}}
       {{#if this.searchString}}
         <div class="la-find-button-results" role="region" aria-live="polite" aria-atomic="false" aria-label={{t "Search results" key="search_results"}}>
           {{#if this.results}}

--- a/app/frontend/app/templates/find-button.hbs
+++ b/app/frontend/app/templates/find-button.hbs
@@ -5,7 +5,8 @@
       <button type="button" class="la-modal-close" {{action "close"}} aria-label={{t "Close" key="close"}}>✕</button>
     </div>
     <div class="la-find-button-body">
-      {{focus-input force="true" type="text" id="button_search_string" value=this.searchString class="la-find-button-input" select="pick_result" placeholder="Word or phrase you're looking for"}}
+      <label for="button_search_string" class="sr-only">{{t "Search for buttons" key="search_for_buttons"}}</label>
+      {{focus-input force="true" type="text" id="button_search_string" value=this.searchString class="la-find-button-input" select="pick_result" placeholder=(t "Word or phrase you're looking for" key="word_or_phrase_youre_looking_for") autocomplete="off" aria-label=(t "Search for buttons" key="search_for_buttons")}}
       {{#if this.searchString}}
         <div class="la-find-button-results">
           {{#if this.results}}

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -5078,6 +5078,7 @@
   "add_color_set": "Add Color Set",
   "modify": "Modify",
   "search_for_buttons": "Search for buttons",
+  "word_or_phrase_youre_looking_for": "Word or phrase you're looking for",
   "search_results": "Search results",
   "get_there_through": "Get there through: ",
   "on_this_board": "On this board",


### PR DESCRIPTION
Resolves finding **LL-9b5d0f1381** (find-a-button search input accessible name).

## What I found (RULE #0 diagnosis)
The finding was anchored to `templates/find-button.hbs:8`, which is the **dead Phase-1 route template** (no `find-button` route exists; `modal-container.hbs` renders the `{{find-button}}` component, whose template is `templates/components/find-button.hbs`).

The **live** find-a-button input was already accessible: it has an associated `<label for="button_search_string" class="sr-only">`. So there was no user-facing "no accessible name" bug on the live path. The live input did, however, have a **raw non-i18n placeholder**, and its `aria-label` was a no-op (see below).

## Changes
- **`focus-input.js`** — `focus-input` extends a classic `TextField` whose `attributeBindings` do **not** include `aria-label`, so any `aria-label` passed to it was silently dropped before reaching the DOM. Added `attributeBindings: ['aria-label']` (concatenated with the inherited list; renders only when provided). Matches the existing `label-field.js` pattern.
- **`templates/components/find-button.hbs`** (live) — converted the raw `placeholder` to the `{{t}}` helper. The existing sr-only `<label>` and the now-functional `aria-label` give a solid accessible name.
- **`templates/find-button.hbs`** (dead anchor) — aligned to the live component (sr-only label + i18n placeholder + aria-label) so the finding's literal location is resolved and the template is safe if ever revived.
- **`public/locales/en.json`** — added `word_or_phrase_youre_looking_for`.

`lint:hbs` and `lint:js` both clean.

## Note for review
`templates/find-button.hbs` + `controllers/find-button.js` look like **dead Phase-1 leftovers** superseded by the Phase-2 component. A cleaner follow-up would be to delete them outright rather than maintain two copies; I aligned instead of deleting to keep this PR scoped to the finding. Flagging for a decision.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)