### PR TITLE
compliance(register): attest-close LL-9b5d0f1381 (find-button a11y)

### DIFF
--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -2531,7 +2531,7 @@
       "frameworks": [
         "WCAG"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/frontend/app/templates/find-button.hbs",
@@ -2544,12 +2544,12 @@
       "owner": "Scot Wahlquist",
       "remediation": {
         "options": "Give the find-a-button search input a programmatic accessible name: add an i18n aria-label (aria-label={{t \"Search for a button\" key='...'}}). A placeholder is not a reliable accessible name and disappears on input; the sibling .la-modal-header-label span (find-button.hbs:4) is not programmatically associated. Also convert the raw placeholder to the i18n helper per the double-quote/{{t}} convention.",
-        "timeframe": "15-30d"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "dd194540640bcb4e6bcf71343b97e41b6a6f33d8",
+        "verifierNote": "Find-a-button search input given a working accessible name + i18n placeholder in #448 (dd1945406); vestigial Phase-1 find-button route template removed in #450. Verified against merged staging.",
+        "attestation": "Scot Wahlquist 2026-06-19: attested verified-closed; instructed in-thread to close after #448 shipped the accessible-name fix."
       },
       "notes": "Surfaced by accessibility finder on 2026-06-19. WCAG Labels-or-Instructions and Name-Role-Value criteria, mapped in EN 301 549 clauses 9.3 and 9.4. Find-a-button is a core AAC navigation surface (reachable in scanning). focus-input (components/focus-input.js) extends TextField and renders a bare input with the passed attributes, injecting no aria-label, so the input is named only by a placeholder. Distinct (ruleKey, file) from the registered search-overlay-input-missing-label finding, which is the authenticated-view Home dashboard overlay in a different file. i18n cross-ref: placeholder is a raw English string, not {{t}} -- also an i18n defect. | adversary: confirmed (focus-input injects no aria-label; input named by placeholder only; distinct from LL-35e6b7a3d6, the authenticated-view overlay input in a different file). HIGH leans on a find-a-button scan-reachability assumption not independently traced; the defect itself is solid. | triaged 2026-06-19: disposition=accepted (real, to remediate), owner Scot, at Scot's direction in the audit session. | fixed 2026-06-19 in PR #448 (commit dd1945406, merged to staging): root cause was focus-input (components/focus-input.js) extending classic TextField, whose attributeBindings do not include aria-label, so a passed aria-label set a property that never reached the DOM -- fixed by adding attributeBindings:['aria-label'] to focus-input. The live component template (templates/components/find-button.hbs) already carried an sr-only <label for=button_search_string>, so its input had an accessible name; the cited route-style templates/find-button.hbs had neither label nor i18n placeholder, both added. Raw placeholder converted to the {{t}} helper in both. Status remains open pending a verified-closed attestation batch.",
       "disposition": {

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,18 +5,17 @@
 
 **Audited:** `scot/security/audit-erasure-admin-reads` @ `445336592ddaf838689df7e578829e94e140890d` on 2026-06-19  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 5 High
+**Headline (open + remediated-unverified):** 0 Critical / 4 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (49)
+## Open (48)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
 | LL-d1ea8659c3 |  | high |  | **fixed** | audit-run | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | **fixed** | audit | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
 | LL-aacae48768 |  | high | SOC2, HIPAA, FERPA | **accepted** | audit-run | Production Postgres (lingolinq-prod-db) reachable from an all-addresses /0 allowlist (public internet) | (attestation) |
-| LL-9b5d0f1381 |  | high | WCAG | **fixed** | audit-run | Find-a-button search input has no accessible name (placeholder-only, non-i18n) | `app/frontend/app/templates/find-button.hbs`:8 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | untriaged | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
 | LL-52ff2a9a79 |  | medium | SOC2 | untriaged | audit-run | CI security-scan job (Brakeman SAST, bundle-audit, npm audit, gitleaks) is entirely non-blocking | `.github/workflows/ci.yml`:107 |
@@ -63,7 +62,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-a97357136e | P2-2 | low |  | untriaged | audit-run | params.permit! bypasses Strong Parameters | `app/controllers/api/organizations_controller.rb`:866 |
 | LL-ce00c8d3ad | P2-3 | low |  | untriaged | audit-run | License model lacks Processable concern | `app/models/license.rb`:1 |
 
-## Verified closed (26)
+## Verified closed (27)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -80,6 +79,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-16fef018a0 |  | high | SOC2 | **fixed** | pr-review | Password-reset code verification endpoint (users#password_reset) not rate-limited | `config/initializers/throttling.rb`:41 |
 | LL-080a21089f |  | high | FERPA, HIPAA, GDPR | untriaged | audit-run | Account deletion / right-to-erasure path writes no AuditEvent | `app/controllers/api/users_controller.rb`:388 |
 | LL-7acd0e7416 |  | high | FERPA, HIPAA | untriaged | audit-run | Admin-support reads of individual student records (version history, daily usage) write no AuditEvent | `app/controllers/api/users_controller.rb`:485 |
+| LL-9b5d0f1381 |  | high | WCAG | **fixed** | audit-run | Find-a-button search input has no accessible name (placeholder-only, non-i18n) | `app/frontend/app/templates/find-button.hbs`:8 |
 | LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | **fixed** | audit-run | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |
 | LL-c6dd65a2aa | Infra-P1-3 | high |  | **fixed** | audit-run | Static cache_token='abc' never rotates (stale permission cache) | `config/initializers/resque.rb`:29 |
 | LL-ca38d4d99e | P1-1 | high | FERPA, HIPAA | **fixed** | audit-run | Consent endpoints absent from Rack::Attack protected_paths | `config/initializers/throttling.rb`:18 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-06-19T18:00:46Z
+**Page generated:** 2026-06-19T20:42:42Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **5** | 25 | 19 |
+| **0** | **4** | 25 | 19 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -26,7 +26,6 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | ID | Legacy | Severity | Frameworks | Title | Evidence |
 |---|---|---|---|---|---|
 | LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
-| LL-9b5d0f1381 |  | high | WCAG | Find-a-button search input has no accessible name (placeholder-only, non-i18n) | `app/frontend/app/templates/find-button.hbs`:8 |
 | LL-aacae48768 |  | high | SOC2, HIPAA, FERPA | Production Postgres (lingolinq-prod-db) reachable from an all-addresses /0 allowlist (public internet) | (attestation) |
 | LL-d1ea8659c3 |  | high |  | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |


### PR DESCRIPTION
Attest-closes `LL-9b5d0f1381` (find-a-button search input had no accessible name). Fixed in #448 (`dd1945406`, working accessible name + i18n placeholder); vestigial Phase-1 find-button template removed in #450.

- status `open` -> `verified-closed`, closureEvidence stamped with the fix SHA; historical `evidence` anchor untouched.
- citation-check PASS (FAIL 0); notion mirror OK.
- **Open High: 5 -> 4.**

When this merges, the Sync-findings-to-Notion Action fires and the board updates automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)