### PR TITLE
compliance(tooling): widen Notion sync PR scan to notes + disposition.rationale

### DIFF
--- a/scripts/compliance-findings-notion-sync.rb
+++ b/scripts/compliance-findings-notion-sync.rb
@@ -70,8 +70,11 @@ def closed_by(f)
 end
 
 def prs(f)
+  # Scan every register field a PR number is recorded in. PRs land in the closure
+  # note/attestation (closures), in disposition.rationale (accepted/decided risks),
+  # and in the top-level `notes` field (enabler/tracking PRs on still-open findings).
   src = [(f['closureEvidence'] || {})['verifierNote'], (f['closureEvidence'] || {})['attestation'],
-         (f['remediation'] || {})['options']].join(' ')
+         (f['remediation'] || {})['options'], (f['disposition'] || {})['rationale'], f['notes']].join(' ')
   src.scan(/#\d{3,4}/).uniq.join(' ')
 end
 


### PR DESCRIPTION
## What
The register->Notion findings sync (`scripts/compliance-findings-notion-sync.rb`) only scanned three fields for PR numbers (`closureEvidence.verifierNote`, `closureEvidence.attestation`, `remediation.options`). PR numbers also live in the top-level `notes` field and in `disposition.rationale`, so 7 findings showed a **blank "PRs" cell** on the Notion board even though the data was in the register.

## Fix
Add `disposition.rationale` and `notes` to the PR-scan source. Findings with a populated PR cell: **17 -> 24** (e.g. LL-6619cc1811 -> #410, LL-11db0dc848 -> #412, five more -> #380).

## Scope / safety
- One-line change to the `prs()` extractor; no other behavior change.
- Still one-way (register -> Notion), still writes only register-owned columns, never touches human-owned columns (Owner / Target date / Program notes / Needs Scot decision).
- Merge to staging auto-triggers the "Sync findings to Notion" Action, which re-runs the sync and fills the cells.

## Not covered (separate pass)
~11 early (2026-06-12) verified-closed findings were closed by commit SHA + a "Verified <date>" note with **no PR number and no attester** in the register. Their "PRs"/"Closed by" cells stay blank because that data isn't in the register; their Closure SHA cell is populated. Backfilling those needs the actual PR numbers + attestation (governance-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)