### PR TITLE
compliance(register): attest 9 early closures (backfill Closed/decided by)

### DIFF
--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -75,7 +75,7 @@
       "closureEvidence": {
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a",
         "verifierNote": "Verified 2026-06-12: licenses action now guards sort_by via allowed_sort_columns allowlist (organizations_controller.rb:221-225); only the validated value reaches .order(). sort_order already validated against asc/desc. Remediated in #177.",
-        "attestation": ""
+        "attestation": "Scot Wahlquist 2026-06-20: attested verified-closed; remediated in #177, code-verified 2026-06-12."
       },
       "notes": "April seed showed this as a live P0; remediated since."
     },
@@ -107,7 +107,7 @@
       "closureEvidence": {
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a",
         "verifierNote": "Verified 2026-06-12: flush_user_content now iterates License.where(user_id:) nullifying user_id+granted_at and calling flush_versions (flusher.rb:224-226). Remediated in #177.",
-        "attestation": ""
+        "attestation": "Scot Wahlquist 2026-06-20: attested verified-closed; remediated in #177, code-verified 2026-06-12."
       },
       "notes": ""
     },
@@ -139,7 +139,7 @@
       "closureEvidence": {
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a",
         "verifierNote": "Verified 2026-06-12: claim_user logs AuditEvent.log_command (organizations_controller.rb:238); License#release_user! logs AuditEvent.log_command('system', ...) (license.rb:32). Remediated in #177.",
-        "attestation": ""
+        "attestation": "Scot Wahlquist 2026-06-20: attested verified-closed; remediated in #177, code-verified 2026-06-12."
       },
       "notes": ""
     },
@@ -172,7 +172,7 @@
       "closureEvidence": {
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a",
         "verifierNote": "Verified 2026-06-12: create logs at supervisor_relationships_controller.rb:52, consent_response at :101, destroy at :135. approve/deny route through consent_response. Remediated in #177.",
-        "attestation": ""
+        "attestation": "Scot Wahlquist 2026-06-20: attested verified-closed; remediated in #177, code-verified 2026-06-12."
       },
       "notes": ""
     },
@@ -204,7 +204,7 @@
       "closureEvidence": {
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a",
         "verifierNote": "Verified 2026-06-12: LingoLinq-AAC-Worker (render.yaml:55) now declares all four keys with generateValue (render.yaml:84-91). Note: prod is migrating to GCP Cloud Run with Secret Manager; render.yaml remains the live config until cutover. Remediated in #177.",
-        "attestation": ""
+        "attestation": "Scot Wahlquist 2026-06-20: attested verified-closed; remediated in #177, code-verified 2026-06-12 (live render.yaml until GCP cutover)."
       },
       "notes": ""
     },
@@ -236,7 +236,7 @@
       "closureEvidence": {
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a",
         "verifierNote": "Verified 2026-06-12: status action returns {active: true} for unauthenticated callers (session_controller.rb:948); queue/db introspection runs only when @api_user present (:952-967). Remediated in #177.",
-        "attestation": ""
+        "attestation": "Scot Wahlquist 2026-06-20: attested verified-closed; remediated in #177, code-verified 2026-06-12."
       },
       "notes": ""
     },
@@ -1033,7 +1033,7 @@
       "closureEvidence": {
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a",
         "verifierNote": "Verified 2026-06-12: user_id/user_name serialized only when license.user_id is present (json_api/license.rb:17-19); release_user! nullifies user_id, so an expired/released license exposes no user_name. Remediated in #177.",
-        "attestation": ""
+        "attestation": "Scot Wahlquist 2026-06-20: attested verified-closed; remediated in #177, code-verified 2026-06-12."
       },
       "notes": ""
     },
@@ -1065,7 +1065,7 @@
       "closureEvidence": {
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a",
         "verifierNote": "Verified 2026-06-12 (doc-level): INFRASTRUCTURE.md:101 records ACLs disabled via BucketOwnerEnforced; the app's acl: public-read is a no-op. Bucket-policy posture should still be confirmed in the GCP/AWS infra-audit refresh.",
-        "attestation": ""
+        "attestation": "Scot Wahlquist 2026-06-20: attested verified-closed; S3 ACLs disabled via BucketOwnerEnforced (doc-level, INFRASTRUCTURE.md), verified 2026-06-12."
       },
       "notes": "Doc-level closure; recommend a live AWS bucket-policy spot-check during the next infra-audit run."
     },
@@ -1097,7 +1097,7 @@
       "closureEvidence": {
         "sha": "56da75814c2c88216404f08352e4fe9f6bbbaa8a",
         "verifierNote": "Closed 2026-06-08: AWS hybrid BAA signed via AWS Artifact, covering S3/SES/Transcoder/SNS (docs/legal/AWS_BAA_ACCEPTED.md; project_render_cloud_migration Phase 1). Attestation = external legal artifact, not code.",
-        "attestation": ""
+        "attestation": "Scot Wahlquist 2026-06-20: attested verified-closed; AWS hybrid BAA signed via AWS Artifact 2026-06-08 (external legal artifact, not code)."
       },
       "notes": "Non-code finding; evidence is an executed legal agreement, validated by attestation not citation-check."
     },

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,7 +11,7 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-06-20T03:25:04Z
+**Page generated:** 2026-06-20T16:54:59Z
 
 ## Headline - open findings
 


### PR DESCRIPTION
## What
9 verified-closed findings had a blank **Closed/decided by** cell — they were code-verified (2026-06-12; the AWS BAA 06-08) but never carried a formal attester.

Per Scot's direction, he **attests them as verified-closed today (2026-06-20)** via `closureEvidence.attestation`, matching the convention every other closed finding uses ("Scot Wahlquist YYYY-MM-DD: <note>").

| Group | Findings |
|-------|----------|
| **#177** remediation (code-verified 2026-06-12) | LL-fbe07e6a1b, LL-37caf162eb, LL-3ccbf9b54a, LL-46fd4aa824, LL-c5fe9e2e3e, LL-90137ca466, LL-7a8effae8a |
| doc-level (BucketOwnerEnforced) | LL-2ea0b804e7 |
| external legal artifact (AWS BAA via AWS Artifact 06-08) | LL-c5bd616242 |

## Integrity notes
- **Dated today, not backdated** to the verification date. Each attestation note preserves the original verification/closure provenance (e.g. "code-verified 2026-06-12").
- ISO 8601 dates (matches the rest of the register; the sync's `closed_by()` parser depends on `YYYY-MM-DD`).
- **Status / severity / disposition unchanged** — this only records who/when attested.

## Result
verified-closed with a recorded closer: **18 → 27 of 27.** Notion mirror regenerated; `compliance-notion-publish --check` + `compliance-calendar-render --check` pass; `citation-check` FAIL:0. Merge auto-triggers the sync (touches `FINDINGS.json`), filling the cells on the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)