### PR TITLE
compliance(docs): index the Notion documents board in the register

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -1466,6 +1466,29 @@
       "bundles": [],
       "mirrors": [],
       "id": "DOC-44080e322c"
+    },
+    {
+      "title": "Notion - Compliance Documents board (LL)",
+      "description": "One-way mirror of the document register itself for board-style viewing of where every compliance doc lives across git/Drive/Notion; human-owned columns (Program notes, Needs Scot decision) live here.",
+      "type": "audit-artifact",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "notion",
+      "canonicalLocation": "https://www.notion.so/3865fe8215c28174aef3ce32239ced5c",
+      "status": "published",
+      "frameworks": [],
+      "lastReviewed": "2026-06-21",
+      "nextReviewDue": "2026-09-21",
+      "attestation": {},
+      "contentHash": null,
+      "bundles": [],
+      "mirrors": [
+        {
+          "system": "git",
+          "location": "audit-reports/DOCUMENT-REGISTER.json"
+        }
+      ],
+      "notes": "Auto-synced from DOCUMENT-REGISTER.json on push to staging via .github/workflows/sync-document-register-to-notion.yml. The team-facing board for the document index.",
+      "id": "DOC-791a05d70e"
     }
   ]
 }

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -4,11 +4,11 @@
 > Do not hand-edit; edit the JSON (the source of truth) and re-render.
 > The codebase copy is canonical; the Notion board is a one-way mirror; Drive docs are linked, never copied.
 >
-> Generated: 2026-06-21 | Documents: 51 (git 26 / drive 22 / notion 3)
+> Generated: 2026-06-21 | Documents: 52 (git 26 / drive 22 / notion 4)
 
 ## Headline
 
-- **Status:** draft 3, approved 9, published 37, superseded 2
+- **Status:** draft 3, approved 9, published 38, superseded 2
 - **Overdue for review** (as of 2026-06-21): none
 - **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); Roadmap - What's Left (2026-06-19)
 
@@ -54,7 +54,7 @@
 | Incident Log (branded) | Drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | published | HIPAA, GDPR | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Security Risk Assessment 2026 Q2 | Drive | [open](https://docs.google.com/document/d/1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 
-### audit-artifact (14)
+### audit-artifact (15)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
@@ -70,6 +70,7 @@
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
 | Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `0e21c9b0ab55` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
+| Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |
 | Roadmap - What's Left (2026-06-19) | Drive | [open](https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit) | draft |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 
@@ -125,4 +126,4 @@ What a US school-district diligence / DPA review asks for (FERPA / COPPA / acces
 
 ---
 
-_51 documents. Re-run `ruby scripts/document-register-render.rb --check` to validate ids, git content hashes, and bundle completeness._
+_52 documents. Re-run `ruby scripts/document-register-render.rb --check` to validate ids, git content hashes, and bundle completeness._


### PR DESCRIPTION
## What

Adds a single `notion` row to `audit-reports/DOCUMENT-REGISTER.json` for the now-live "LingoLinq Compliance Documents (LL)" board, so the register indexes its own mirror (parallel to the existing findings-board notion row).

## Why

The documents Notion board was created and wired up after the register shipped (PR #458). This closes the loop: the register now lists where it is mirrored, just as it does for the findings board.

## Details

- `canonicalSystem: notion`, `canonicalLocation` = the board URL, `contentHash: null` (notion row, advisory by design), `mirrors` -> `audit-reports/DOCUMENT-REGISTER.json`.
- Re-rendered `DOCUMENT-REGISTER.md`; `audit-artifacts-integrity` `--check` green (52 docs).
- One-way only: the board is auto-synced FROM this register via `sync-document-register-to-notion.yml`.

## Compliance note

Compliance content; Claude-only. PII-free (titles, URLs, hashes only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuHK9ERizb1AjoEJ7mpwKA
