### PR TITLE
compliance(doc-register): attest 10 docs + add human-readable catalog layer

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -198,7 +198,10 @@
       ],
       "lastReviewed": "2026-04-18",
       "nextReviewDue": "2027-04-18",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": "a6e8b0bebcd45451e7d70472d729331d69f6b07b179b2f52e00ff54f4cb1bfba",
       "bundles": [],
       "mirrors": [],
@@ -221,7 +224,10 @@
       ],
       "lastReviewed": "2026-06-18",
       "nextReviewDue": "2027-06-18",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": "5b81ecf7622dd79434d0a23e89b79b774a82926331c42805d54f4e1ceee63377",
       "bundles": [
         "compliance-records-set-2026-06"
@@ -340,7 +346,10 @@
       ],
       "lastReviewed": "2026-06-18",
       "nextReviewDue": "2027-06-18",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": "14563501a6e4347d75affe5ca67c838bdb75413d61ce101298c22642c6228f63",
       "bundles": [
         "soc2-evidence",
@@ -369,7 +378,10 @@
       ],
       "lastReviewed": "2026-06-18",
       "nextReviewDue": "2027-06-18",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": "6aa015915c605ee285e6a13404377f352103c34413d43b7a43385e707f523844",
       "bundles": [
         "school-dpa-package"
@@ -395,7 +407,10 @@
       ],
       "lastReviewed": "2026-04-26",
       "nextReviewDue": "2026-07-26",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": "86da72955ba23901e8acaa518dbded3e59b5eee7328404f56f87deb909564f7c",
       "bundles": [
         "school-dpa-package"
@@ -421,7 +436,10 @@
       ],
       "lastReviewed": "2026-06-11",
       "nextReviewDue": "2027-06-11",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": "9f467478159ca39d862c9a4d5cd209a6f434cd1ca94c7cfb3224cbbae54fa609",
       "bundles": [
         "school-dpa-package"
@@ -449,7 +467,10 @@
       ],
       "lastReviewed": "2026-05-27",
       "nextReviewDue": "2027-05-27",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": "3efcaaf4a7c53016237527a5202a370bf74852f4b3e26e4346db5f418c5e263b",
       "bundles": [
         "soc2-evidence"
@@ -476,7 +497,10 @@
       ],
       "lastReviewed": "2026-05-27",
       "nextReviewDue": "2026-08-27",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": "e4e7c0b98d3fe6992eb33980597be8d1844a408fc8bd1c8205d2f214d59d9073",
       "bundles": [
         "soc2-evidence"
@@ -524,7 +548,10 @@
       ],
       "lastReviewed": "2026-05-11",
       "nextReviewDue": "2027-05-11",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": "dc6a2ba9fa167f3f2bff6ec356bbd2b8bd9f9bafcd680b15362225aeca023f3e",
       "bundles": [],
       "mirrors": [],
@@ -1394,20 +1421,23 @@
     },
     {
       "title": "Roadmap - What's Left (2026-06-19)",
-      "description": "Internal roadmap of remaining compliance work; internal-only, no attestation banner by design.",
+      "description": "Internal roadmap of remaining compliance work; internal-only set, attested by Scot.",
       "type": "audit-artifact",
       "owner": "Scot Wahlquist",
       "canonicalSystem": "drive",
       "canonicalLocation": "https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit",
-      "status": "draft",
+      "status": "approved",
       "frameworks": [],
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
-      "attestation": {},
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-21"
+      },
       "contentHash": null,
       "bundles": [],
       "mirrors": [],
-      "notes": "Internal roadmap; not part of the externally-released set.",
+      "notes": "Internal roadmap; not part of the externally-released set. Attested by Scot Wahlquist 2026-06-21 per CEO direction.",
       "id": "DOC-912b28f375"
     },
     {

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -204,7 +204,12 @@
       },
       "contentHash": "a6e8b0bebcd45451e7d70472d729331d69f6b07b179b2f52e00ff54f4cb1bfba",
       "bundles": [],
-      "mirrors": [],
+      "mirrors": [
+        {
+          "system": "drive",
+          "location": "https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit"
+        }
+      ],
       "id": "DOC-9b299a785b"
     },
     {
@@ -681,7 +686,12 @@
       "attestation": {},
       "contentHash": "",
       "bundles": [],
-      "mirrors": [],
+      "mirrors": [
+        {
+          "system": "notion",
+          "location": "https://www.notion.so/3865fe8215c28174aef3ce32239ced5c"
+        }
+      ],
       "id": "DOC-2d4e00befa"
     },
     {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -8,9 +8,9 @@
 
 ## Headline
 
-- **Status:** draft 3, approved 9, published 38, superseded 2
+- **Status:** draft 2, approved 10, published 38, superseded 2
 - **Overdue for review** (as of 2026-06-21): none
-- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); Roadmap - What's Left (2026-06-19)
+- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded)
 
 ## Documents by type
 
@@ -20,10 +20,10 @@
 |---|---|---|---|---|---|---|---|---|---|---|
 | Access Control Policy | Drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | published | SOC2, HIPAA, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Business Continuity and Disaster Recovery Plan | Drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
-| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-04-18 | 2027-04-18 | no | `a6e8b0bebcd4` |  |
-| Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | approved | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | no | `14563501a6e4` | soc2-evidence, school-dpa-package |
+| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-04-18 | 2027-04-18 | 2026-06-21 | `a6e8b0bebcd4` |  |
+| Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | approved | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `14563501a6e4` | soc2-evidence, school-dpa-package |
 | Data Retention Schedule (branded) | Drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | published | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence, school-dpa-package |
-| Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | approved | GDPR, FERPA, HIPAA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | no | `6aa015915c60` | school-dpa-package |
+| Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | approved | GDPR, FERPA, HIPAA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `6aa015915c60` | school-dpa-package |
 | Subprocessor Register (branded) | Drive | [open](https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit) | published | GDPR, FERPA, HIPAA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
 | Vendor and Subprocessor Management Policy | Drive | [open](https://docs.google.com/document/d/1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM/edit) | published | SOC2, GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Written Information Security Program (WISP) | Drive | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | published | SOC2, HIPAA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
@@ -40,17 +40,17 @@
 | Compliance & Security Program v1.0 (Attested) | Drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | published | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 | Compliance Posture Report | git | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-20 | 2026-09-20 | 2026-06-20 | `a81f72f13bef` | school-dpa-package |
 | Compliance Posture Report (branded) | Drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-18 | 2027-06-18 | no | `5b81ecf7622d` | compliance-records-set-2026-06 |
+| Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `5b81ecf7622d` | compliance-records-set-2026-06 |
 | Records of Processing Activities (RoPA) and Data Map | Drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | published | GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 
 ### evidence (6)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
-| AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | approved | HIPAA | Scot Wahlquist | 2026-05-11 | 2027-05-11 | no | `dc6a2ba9fa16` |  |
-| COPPA Final-Rule Verification | git | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | approved | COPPA | Scot Wahlquist | 2026-04-26 | 2026-07-26 | no | `86da72955ba2` | school-dpa-package |
+| AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | approved | HIPAA | Scot Wahlquist | 2026-05-11 | 2027-05-11 | 2026-06-21 | `dc6a2ba9fa16` |  |
+| COPPA Final-Rule Verification | git | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | approved | COPPA | Scot Wahlquist | 2026-04-26 | 2026-07-26 | 2026-06-21 | `86da72955ba2` | school-dpa-package |
 | COPPA Final-Rule Verification (branded) | Drive | [open](https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit) | published | COPPA | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| Incident Log | git | `docs/legal/INCIDENT_LOG.md` | approved | HIPAA, GDPR | Scot Wahlquist | 2026-05-27 | 2026-08-27 | no | `e4e7c0b98d3f` | soc2-evidence |
+| Incident Log | git | `docs/legal/INCIDENT_LOG.md` | approved | HIPAA, GDPR | Scot Wahlquist | 2026-05-27 | 2026-08-27 | 2026-06-21 | `e4e7c0b98d3f` | soc2-evidence |
 | Incident Log (branded) | Drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | published | HIPAA, GDPR | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Security Risk Assessment 2026 Q2 | Drive | [open](https://docs.google.com/document/d/1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 
@@ -72,14 +72,14 @@
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |
-| Roadmap - What's Left (2026-06-19) | Drive | [open](https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit) | draft |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
+| Roadmap - What's Left (2026-06-19) | Drive | [open](https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit) | approved |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-21 | (supplied) |  |
 
 ### runbook (4)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | published |  | Scot Wahlquist | 2026-06-21 | 2027-06-21 | no | `2ba6af7f0dd9` |  |
-| Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | approved | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-05-27 | 2027-05-27 | no | `3efcaaf4a7c5` | soc2-evidence |
+| Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | approved | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-05-27 | 2027-05-27 | 2026-06-21 | `3efcaaf4a7c5` | soc2-evidence |
 | Incident Response and Breach Runbook (branded) | Drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | published | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Notion - Compliance Engineering Onboarding/Handoff | Notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | published |  | Scot Wahlquist | 2026-06-19 | 2026-12-19 | no | (supplied) |  |
 
@@ -88,7 +88,7 @@
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Parental Consent (COPPA / under-13) (branded) | Drive | [open](https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit) | published | COPPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | approved | COPPA | Scot Wahlquist | 2026-06-11 | 2027-06-11 | no | `9f467478159c` | school-dpa-package |
+| Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | approved | COPPA | Scot Wahlquist | 2026-06-11 | 2027-06-11 | 2026-06-21 | `9f467478159c` | school-dpa-package |
 
 ### agent-config (6)
 

--- a/scripts/document-register-notion-sync.rb
+++ b/scripts/document-register-notion-sync.rb
@@ -25,7 +25,8 @@
 #   Doc ID (title), Title (rich_text), Type (select), System (select), Owner (rich_text),
 #   Canonical location (rich_text), Status (select), Frameworks (multi_select),
 #   Bundles (multi_select), Last reviewed (date), Next due (date), Attested (rich_text),
-#   Content hash (rich_text), Mirrors (rich_text).
+#   Content hash (rich_text), Readable copy (rich_text; renamed from "Mirrors" 2026-06-21
+#   for non-dev clarity - holds the human-readable Drive/Notion copy of a git-canonical doc).
 #
 # Select-property note: Type/System/Status (select) and Frameworks/Bundles (multi_select) are
 # sent as plain option names; Notion auto-creates a missing option on write. Leave option
@@ -103,7 +104,7 @@ def properties_for(doc)
     'Next due'           => date_prop(doc['nextReviewDue']),
     'Attested'           => { 'rich_text' => rich(attested_str(doc)) },
     'Content hash'       => { 'rich_text' => rich(doc['contentHash'].to_s[0, 16]) },
-    'Mirrors'            => { 'rich_text' => rich(mirrors_str(doc)) }
+    'Readable copy'      => { 'rich_text' => rich(mirrors_str(doc)) }
   }
 end
 


### PR DESCRIPTION
Doc-register usability pass (3 commits):

**1. Attestations** — Scot attested 10 docs as of 2026-06-21: the 9 approved git docs whose branded Drive copies were already attested 2026-06-19, plus the internal Roadmap (draft -> approved). Both ACR/VPAT entries deliberately held at draft pending assistive-technology testing.

**2. Readable-copy cross-links** — added `mirrors` so the catalog surfaces a human-readable copy beside the two substantive git docs that lacked one:
- `COMPLIANCE.md` -> branded "Compliance & Security Program v1.0 (Attested)" Doc
- Document Register -> the Notion Compliance Documents board

Most git docs were already cross-linked; internal-only docs (auditor agent defs, runbook, superseded snapshots) correctly have no branded twin.

**3. Notion column rename** — the documents-board property `Mirrors` -> `Readable copy` for non-dev clarity, sync script repointed, surfaced in the By Topic / By Package / By Framework / Where It Lives views.

Render `--check` green. Notion already reflects this state (synced via workflow_dispatch on this branch: 52 updated, 0 created, 0 archived).