### PR TITLE
compliance: COMPLIANCE.md AI PII overclaim fix + publication status queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Verify document register render + git content hashes + bundle completeness
         run: ruby scripts/document-register-render.rb --check
 
+      - name: Verify compliance publication status report
+        run: ruby scripts/compliance-publication-status.rb --check
+
   security-scan:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -33,7 +33,7 @@ LingoLinq is an Augmentative and Alternative Communication (AAC) application. It
 - Opt-in content-based word prediction (de-identified before any ML processing)
 - SSO identity data (managed by the identity provider; LingoLinq stores only opaque tokens and display names)
 
-**Core principle: LLMs and ML models NEVER see who users are.** Every AI-powered feature operates exclusively on anonymized or de-identified data. The Rails backend is the single enforcement point for this guarantee.
+**Core principle: AI models never receive direct user identifiers.** Before any AI API call, the Rails backend strips direct identifiers (names, emails, SSO subject IDs) and replaces user references with opaque tokens, so AI features operate on de-identified data rather than user identities. The `lib/pii_scrubber.rb` layer is the single enforcement point. De-identified user-authored content (for example board labels and sentences) is still sent to the model; free-text is scrubbed of known direct identifiers and name patterns on a best-effort basis, so this is a strong de-identification guarantee, not a claim that no user-authored text ever reaches a model.
 
 ---
 
@@ -190,7 +190,7 @@ This module is responsible for:
 |------------------------------|---------------------|--------------------------|------------------------------------------|
 | Rails application            | Yes                 | N/A                      | Primary application; handles all user data |
 | PostgreSQL / Redis / S3      | Yes                 | N/A                      | Storage layer; encrypted at rest          |
-| AI APIs (Anthropic, etc.)    | **NEVER**           | Yes                      | Only receives scrubbed/de-identified data |
+| AI APIs (Anthropic, etc.)    | No (identifiers stripped) | Yes                | Receives de-identified content only; direct identifiers stripped before egress, free-text scrubbed best-effort |
 | MCPs (dev environment)       | **NEVER** (prod)    | Yes (dev/seed data)      | MCPs only connect to dev DB with test data |
 | Notion / HubSpot / Slack     | **NEVER**           | No                       | Business operations only                  |
 

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,4 +1,4 @@
-# LingoLinq AAC -- Compliance & Data Governance
+# LingoLinq AAC: Compliance & Data Governance
 
 **Last updated:** 2026-04-18
 **Owner:** Scott W.
@@ -71,7 +71,7 @@ Payment card data is handled entirely by Stripe. LingoLinq never sees, stores, o
 
 All systems, services, and tools used in LingoLinq development and operations are classified into three zones based on their potential exposure to user data.
 
-### SAFE ZONE -- No User Data
+### SAFE ZONE: No User Data
 
 These tools and services never contain, process, or have access to user data. They operate exclusively on source code, public information, or developer-only content.
 
@@ -87,7 +87,7 @@ These tools and services never contain, process, or have access to user data. Th
 | Chrome DevTools        | Browser debugging              | Used against local dev environment only              |
 | Jotform                | Form building                  | Marketing/feedback forms; no user data collected     |
 
-### CAUTION ZONE -- May Contain PII in Context
+### CAUTION ZONE: May Contain PII in Context
 
 These services are used for business operations and may contain business contact information (names, emails of school administrators, sales contacts). They must **never** be used to store student, patient, or end-user data.
 
@@ -99,7 +99,7 @@ These services are used for business operations and may contain business contact
 | n8n            | Workflow automation    | Workflows could be configured to move user data   | Self-hosted on Render; workflows reviewed in audit  |
 | Slack          | Team communication     | Screenshots or pastes could contain user data     | Policy: NEVER paste user data into Slack           |
 
-### RESTRICTED ZONE -- Contains FERPA/HIPAA-Protected Data
+### RESTRICTED ZONE: Contains FERPA/HIPAA-Protected Data
 
 These systems store or process actual user data. They require the highest level of protection, access control, and (where applicable) BAAs.
 
@@ -122,9 +122,9 @@ This table maps every external service to the data it receives, its BAA status, 
 | **Anthropic (Claude)** | Developer queries only; code assistance           | No BAA needed               | Max plan; no user data ever sent; dev use only  |
 | **Google (Gemini)**  | Developer queries only; code assistance             | No BAA needed               | No user data ever sent; dev use only            |
 | **HubSpot**          | Business contacts: admin names, school/hospital emails, deal info | No BAA needed | Business contacts only; never student/patient data |
-| **Stripe**           | Institutional payment data (org name, billing email, card via Stripe.js) | N/A -- PCI-DSS handled by Stripe | LingoLinq never handles raw card data; Stripe is PCI Level 1 |
+| **Stripe**           | Institutional payment data (org name, billing email, card via Stripe.js) | N/A: PCI-DSS handled by Stripe | LingoLinq never handles raw card data; Stripe is PCI Level 1 |
 | **Notion**           | Project plans, specs, internal notes                | No BAA needed               | Policy: NEVER put user/student/patient data in Notion |
-| **n8n (self-hosted)**| Workflow definitions; data depends on workflow config | N/A -- self-hosted on Render | Covered by Render BAA; audit workflows quarterly |
+| **n8n (self-hosted)**| Workflow definitions; data depends on workflow config | N/A: self-hosted on Render | Covered by Render BAA; audit workflows quarterly |
 | **Slack**            | Team chat, notifications                            | No BAA needed               | Policy: NEVER paste user data; use DM links to Rails admin instead |
 | **GitHub**           | Source code, issues, PRs                            | No BAA needed               | No user data in repos; .gitignore enforced for data files |
 | **Perplexity**       | Web search queries (research only)                  | No BAA needed               | Never submit user data as search queries        |
@@ -175,14 +175,14 @@ User Device  -->  Rails Backend  -->  [PII Scrubber]  -->  Anthropic Claude API 
 
 All data leaving the Rails application passes through a centralized de-identification layer:
 
-**`lib/pii_scrubber.rb`** -- the single enforcement point for PII removal.
+**`lib/pii_scrubber.rb`**: the single enforcement point for PII removal.
 
 This module is responsible for:
 
-1. **Stripping direct identifiers** -- Removes names, emails, SSO subject IDs, and any other directly identifying fields before data is sent to any AI API.
-2. **Replacing with opaque tokens** -- Where context requires a notion of "this user" vs. "that user" (e.g., for usage-pattern analysis), the scrubber replaces real IDs with opaque, non-reversible tokens (SHA-256 hash with a rotating salt).
-3. **Scrubbing board content** -- Family names that appear in board labels or custom vocabulary are detected and replaced with generic placeholders (e.g., "[FAMILY_NAME]") before any content-based prediction request.
-4. **Audit logging** -- Every scrub operation is logged (what was removed, which AI API call it was for, timestamp) without recording the original PII values.
+1. **Stripping direct identifiers**: Removes names, emails, SSO subject IDs, and any other directly identifying fields before data is sent to any AI API.
+2. **Replacing with opaque tokens**: Where context requires a notion of "this user" vs. "that user" (e.g., for usage-pattern analysis), the scrubber replaces real IDs with opaque, non-reversible tokens (SHA-256 hash with a rotating salt).
+3. **Scrubbing board content**: Family names that appear in board labels or custom vocabulary are detected and replaced with generic placeholders (e.g., "[FAMILY_NAME]") before any content-based prediction request.
+4. **Audit logging**: Every scrub operation is logged (what was removed, which AI API call it was for, timestamp) without recording the original PII values.
 
 ### What Each Layer Sees
 
@@ -203,10 +203,10 @@ This module is responsible for:
 
 All AI-powered features that analyze user behavior or content are:
 
-1. **Off by default** -- Every AI feature is behind a feature flag.
-2. **Opt-in at the organization level** -- A school district or hospital must explicitly enable each AI feature.
-3. **Explained in plain language** -- The opt-in screen describes what data is used, how it is de-identified, and what the feature does.
-4. **Reversible** -- Disabling a feature purges any cached de-identified data associated with that organization.
+1. **Off by default**: Every AI feature is behind a feature flag.
+2. **Opt-in at the organization level**: A school district or hospital must explicitly enable each AI feature.
+3. **Explained in plain language**: The opt-in screen describes what data is used, how it is de-identified, and what the feature does.
+4. **Reversible**: Disabling a feature purges any cached de-identified data associated with that organization.
 
 ---
 
@@ -242,7 +242,7 @@ These rules are **non-negotiable**. Any violation is treated as a security incid
 
 Each AI platform used in LingoLinq development or research has specific guardrails.
 
-### Claude Code (Anthropic) -- Primary Development Tool
+### Claude Code (Anthropic): Primary Development Tool
 
 - **Role:** Primary AI coding assistant for all development work.
 - **MCP access:** All local MCPs (GitHub, Render, Notion, n8n, Filesystem, Sequential-thinking, Perplexity, DeepWiki, Chrome DevTools, Mermaid Chart, Jotform, Slack).
@@ -250,26 +250,26 @@ Each AI platform used in LingoLinq development or research has specific guardrai
 - **Plan:** Anthropic Max plan. No BAA needed because no user data is ever sent.
 - **Database access:** Dev database only (via MCPs connected to dev environment).
 
-### Gemini CLI (Google) -- Secondary Development Tool
+### Gemini CLI (Google): Secondary Development Tool
 
 - **Role:** Secondary AI coding assistant; used for the same development tasks as Claude Code.
 - **MCP access:** Same MCP set as Claude Code for development purposes.
 - **Data rule:** NEVER send user data. Same restrictions as Claude Code.
 - **Database access:** Dev database only.
 
-### Genspark -- Research
+### Genspark: Research
 
 - **Role:** Research tool for exploring AAC domain, competitor analysis, regulatory guidance.
 - **Data rule:** Research queries only. NEVER submit student names, patient information, or any data from the LingoLinq user database.
 - **Access:** Web-based; no MCP integration; no access to any LingoLinq system.
 
-### Manus -- Browser Automation
+### Manus: Browser Automation
 
 - **Role:** Browser automation for testing and research tasks.
 - **Data rule:** NEVER automate authenticated LingoLinq sessions (dev or production). NEVER interact with pages that display user data.
 - **Permitted use:** Automating public web research, testing public-facing marketing pages, generating screenshots of competitor products.
 
-### Perplexity -- Web Research (MCP-Integrated)
+### Perplexity: Web Research (MCP-Integrated)
 
 - **Role:** Web research via MCP integration.
 - **Data rule:** No user data in search queries. Queries must be about technology, AAC practices, compliance requirements, or general research topics.

--- a/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
+++ b/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
@@ -1,0 +1,138 @@
+# Compliance Publication Status
+
+> Generated from `audit-reports/FINDINGS.json` and `audit-reports/DOCUMENT-REGISTER.json` by `scripts/compliance-publication-status.rb`.
+> Do not hand-edit; update the registers and re-render.
+
+**Generated:** 2026-06-21
+
+**Latest source date:** 2026-06-21
+
+**Findings audited date:** 2026-06-19
+
+**Document register generated date:** 2026-06-21
+
+## What Updates Automatically
+
+| Surface | Source | Automation | Scope |
+|---|---|---|---|
+| Notion findings board | `audit-reports/FINDINGS.json` | configured | Register-owned finding facts only. Human-owned Notion columns are preserved. |
+| Notion documents board | `audit-reports/DOCUMENT-REGISTER.json` | configured | Register-owned document-index facts only. Human-owned Notion columns are preserved. |
+
+## What Does Not Auto-Update
+
+- Google Docs bodies are not rewritten by the current repo workflows. Drive rows are tracked by URL, review date, and optional content hash only.
+- Frozen branded records can stay point-in-time, but living Drive docs must be refreshed by an operator or a future Google Docs publisher.
+- Notion page content is not rewritten here. The document board can be synced; individual Notion pages need either canonical git sources or an explicit publisher.
+
+## Stale Review Queue
+
+| Title | System | Location | Last reviewed | Status | Why |
+|---|---|---|---|---|---|
+| AI Governance Memo (branded) | drive | [open](https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Access Control Policy | drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Accessibility Conformance Report (ACR / VPAT) (branded) | drive | [open](https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit) | 2026-06-19 | draft | Review date is older than 2026-06-21. |
+| Audit Results Report | drive | [open](https://docs.google.com/document/d/1n6z-76-awsAtWq-2clQ340vfcn_gAtJbkCmVnIxL4tY/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Business Continuity and Disaster Recovery Plan | drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| COPPA Final-Rule Verification (branded) | drive | [open](https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Compliance & Security - Semi-Annual Program Report (H1 2026) | drive | [open](https://docs.google.com/document/d/1VKTOxmGjLiRYy9U3_Y4gzQ2gsmfnZZTeq5RZ7mkHAIM/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Compliance & Security Overhaul - Completion Report | drive | [open](https://docs.google.com/document/d/1en3MCE47qKj1nwg6wb_MA7h3TwwsDMs33oUM-0GhdEM/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Compliance & Security Program v1.0 (Attested) | drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Compliance Calendar (branded) | drive | [open](https://docs.google.com/document/d/19IT_GKK1PzC7zLnGNr-RNT0Rw1fFR68syUvnuBBA2CI/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Compliance Posture Report (branded) | drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Compliance Program - Claim vs Code Review | drive | [open](https://docs.google.com/document/d/1IHQ5yFkoU39N01wyTt5SRXM-Q71aKa9wuXvnGVWnbRg/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Data Retention Schedule (branded) | drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Incident Log (branded) | drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Incident Response and Breach Runbook (branded) | drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Parental Consent (COPPA / under-13) (branded) | drive | [open](https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Records of Processing Activities (RoPA) and Data Map | drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Roadmap - What's Left (2026-06-19) | drive | [open](https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit) | 2026-06-19 | approved | Review date is older than 2026-06-21. |
+| Security Risk Assessment 2026 Q2 | drive | [open](https://docs.google.com/document/d/1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Subprocessor Register (branded) | drive | [open](https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Vendor and Subprocessor Management Policy | drive | [open](https://docs.google.com/document/d/1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Written Information Security Program (WISP) | drive | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| AI Governance Memo | git | `docs/legal/AI_GOVERNANCE_MEMO.md` | 2026-06-20 | published | Review date is older than 2026-06-21. |
+| AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | 2026-05-11 | approved | Review date is older than 2026-06-21. |
+| AWS Business Associate Agreement (signed PDF) | git | `docs/legal/AWS_BAA_2026-02.pdf` | 2026-05-11 | published | Review date is older than 2026-06-21. |
+| Accessibility Conformance Report (ACR / VPAT) | git | `docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md` | 2026-06-16 | draft | Review date is older than 2026-06-21. |
+| Audit Reports Index (audit-reports/README.md) | git | `audit-reports/README.md` | 2026-06-16 | published | Review date is older than 2026-06-21. |
+| COPPA Final-Rule Verification | git | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | 2026-04-26 | approved | Review date is older than 2026-06-21. |
+| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | 2026-04-18 | approved | Review date is older than 2026-06-21. |
+| Compliance Calendar (compliance-calendar.json) | git | `audit-reports/compliance-calendar.json` | 2026-06-16 | published | Review date is older than 2026-06-21. |
+| Compliance Posture Report | git | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | 2026-06-20 | published | Review date is older than 2026-06-21. |
+| Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | 2026-06-18 | approved | Review date is older than 2026-06-21. |
+| Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | 2026-06-18 | approved | Review date is older than 2026-06-21. |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Incident Log | git | `docs/legal/INCIDENT_LOG.md` | 2026-05-27 | approved | Review date is older than 2026-06-21. |
+| Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | 2026-05-27 | approved | Review date is older than 2026-06-21. |
+| Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | 2026-06-11 | approved | Review date is older than 2026-06-21. |
+| Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | 2026-06-18 | approved | Review date is older than 2026-06-21. |
+| Notion - Compliance & Audits hub | notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Notion - Compliance Engineering Onboarding/Handoff | notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | 2026-06-19 | published | Review date is older than 2026-06-21. |
+| Notion - Compliance Findings board (LL) | notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | 2026-06-20 | published | Review date is older than 2026-06-21. |
+
+## Drive Refresh Queue
+
+| Title | Location | Last reviewed | Status | Action |
+|---|---|---|---|---|
+| AI Governance Memo (branded) | [open](https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Access Control Policy | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Accessibility Conformance Report (ACR / VPAT) (branded) | [open](https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit) | 2026-06-19 | draft | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Audit Results Report | [open](https://docs.google.com/document/d/1n6z-76-awsAtWq-2clQ340vfcn_gAtJbkCmVnIxL4tY/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Business Continuity and Disaster Recovery Plan | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| COPPA Final-Rule Verification (branded) | [open](https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Compliance & Security - Semi-Annual Program Report (H1 2026) | [open](https://docs.google.com/document/d/1VKTOxmGjLiRYy9U3_Y4gzQ2gsmfnZZTeq5RZ7mkHAIM/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Compliance & Security Overhaul - Completion Report | [open](https://docs.google.com/document/d/1en3MCE47qKj1nwg6wb_MA7h3TwwsDMs33oUM-0GhdEM/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Compliance & Security Program v1.0 (Attested) | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Compliance Calendar (branded) | [open](https://docs.google.com/document/d/19IT_GKK1PzC7zLnGNr-RNT0Rw1fFR68syUvnuBBA2CI/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Compliance Posture Report (branded) | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Compliance Program - Claim vs Code Review | [open](https://docs.google.com/document/d/1IHQ5yFkoU39N01wyTt5SRXM-Q71aKa9wuXvnGVWnbRg/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Data Retention Schedule (branded) | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Incident Log (branded) | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Incident Response and Breach Runbook (branded) | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Parental Consent (COPPA / under-13) (branded) | [open](https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Records of Processing Activities (RoPA) and Data Map | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Roadmap - What's Left (2026-06-19) | [open](https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit) | 2026-06-19 | approved | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Security Risk Assessment 2026 Q2 | [open](https://docs.google.com/document/d/1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Subprocessor Register (branded) | [open](https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Vendor and Subprocessor Management Policy | [open](https://docs.google.com/document/d/1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+| Written Information Security Program (WISP) | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
+
+## External Hash Gaps
+
+| Title | System | Location | Action |
+|---|---|---|---|
+| AI Governance Memo (branded) | drive | [open](https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Access Control Policy | drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Accessibility Conformance Report (ACR / VPAT) (branded) | drive | [open](https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Audit Results Report | drive | [open](https://docs.google.com/document/d/1n6z-76-awsAtWq-2clQ340vfcn_gAtJbkCmVnIxL4tY/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Business Continuity and Disaster Recovery Plan | drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| COPPA Final-Rule Verification (branded) | drive | [open](https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Compliance & Security - Semi-Annual Program Report (H1 2026) | drive | [open](https://docs.google.com/document/d/1VKTOxmGjLiRYy9U3_Y4gzQ2gsmfnZZTeq5RZ7mkHAIM/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Compliance & Security Overhaul - Completion Report | drive | [open](https://docs.google.com/document/d/1en3MCE47qKj1nwg6wb_MA7h3TwwsDMs33oUM-0GhdEM/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Compliance & Security Program v1.0 (Attested) | drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Compliance Calendar (branded) | drive | [open](https://docs.google.com/document/d/19IT_GKK1PzC7zLnGNr-RNT0Rw1fFR68syUvnuBBA2CI/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Compliance Posture Report (branded) | drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Compliance Program - Claim vs Code Review | drive | [open](https://docs.google.com/document/d/1IHQ5yFkoU39N01wyTt5SRXM-Q71aKa9wuXvnGVWnbRg/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Data & Compliance Pipeline - Build Inventory (dated) | drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Data Retention Schedule (branded) | drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Incident Log (branded) | drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Incident Response and Breach Runbook (branded) | drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Parental Consent (COPPA / under-13) (branded) | drive | [open](https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Records of Processing Activities (RoPA) and Data Map | drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Roadmap - What's Left (2026-06-19) | drive | [open](https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Security Risk Assessment 2026 Q2 | drive | [open](https://docs.google.com/document/d/1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Subprocessor Register (branded) | drive | [open](https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Vendor and Subprocessor Management Policy | drive | [open](https://docs.google.com/document/d/1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Written Information Security Program (WISP) | drive | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Notion - Compliance & Audits hub | notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | Run `ruby scripts/document-register-notion-sync.rb --refresh-notion-hashes` with `NOTION_TOKEN`. |
+| Notion - Compliance Documents board (LL) | notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | Run `ruby scripts/document-register-notion-sync.rb --refresh-notion-hashes` with `NOTION_TOKEN`. |
+| Notion - Compliance Engineering Onboarding/Handoff | notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | Run `ruby scripts/document-register-notion-sync.rb --refresh-notion-hashes` with `NOTION_TOKEN`. |
+| Notion - Compliance Findings board (LL) | notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | Run `ruby scripts/document-register-notion-sync.rb --refresh-notion-hashes` with `NOTION_TOKEN`. |
+
+## Next Automation Gap
+
+The missing layer is a Google Docs publisher/refresh workflow. Until that exists, the compliance agent should use this report as its work queue: update canonical registers, sync Notion boards, then refresh or explicitly freeze affected Drive documents.
+
+---
+
+_53 documents tracked. 41 stale review item(s). 22 Drive refresh item(s). 4 Notion hash item(s)._

--- a/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
+++ b/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
@@ -56,7 +56,6 @@
 | Accessibility Conformance Report (ACR / VPAT) | git | `docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md` | 2026-06-16 | draft | Review date is older than 2026-06-21. |
 | Audit Reports Index (audit-reports/README.md) | git | `audit-reports/README.md` | 2026-06-16 | published | Review date is older than 2026-06-21. |
 | COPPA Final-Rule Verification | git | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | 2026-04-26 | approved | Review date is older than 2026-06-21. |
-| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | 2026-04-18 | approved | Review date is older than 2026-06-21. |
 | Compliance Calendar (compliance-calendar.json) | git | `audit-reports/compliance-calendar.json` | 2026-06-16 | published | Review date is older than 2026-06-21. |
 | Compliance Posture Report | git | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | 2026-06-20 | published | Review date is older than 2026-06-21. |
 | Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | 2026-06-18 | approved | Review date is older than 2026-06-21. |
@@ -135,4 +134,4 @@ The missing layer is a Google Docs publisher/refresh workflow. Until that exists
 
 ---
 
-_53 documents tracked. 41 stale review item(s). 22 Drive refresh item(s). 4 Notion hash item(s)._
+_53 documents tracked. 40 stale review item(s). 22 Drive refresh item(s). 4 Notion hash item(s)._

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -199,7 +199,7 @@
       "lastReviewed": "2026-04-18",
       "nextReviewDue": "2027-04-18",
       "attestation": {},
-      "contentHash": "40a93f8e93ac21f3f66b0b4e0272965bd3d0e7b562cc8f80c4a3f0f56168f69e",
+      "contentHash": "2823383621e2e5162bdfb8388b15f1840d9654185194cf3569190941b82d7999",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -188,7 +188,7 @@
       "owner": "Scot Wahlquist",
       "canonicalSystem": "git",
       "canonicalLocation": "COMPLIANCE.md",
-      "status": "draft",
+      "status": "approved",
       "frameworks": [
         "FERPA",
         "COPPA",
@@ -196,9 +196,12 @@
         "GDPR",
         "SOC2"
       ],
-      "lastReviewed": "2026-04-18",
-      "nextReviewDue": "2027-04-18",
-      "attestation": {},
+      "lastReviewed": "2026-06-23",
+      "nextReviewDue": "2027-06-23",
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-06-23"
+      },
       "contentHash": "2823383621e2e5162bdfb8388b15f1840d9654185194cf3569190941b82d7999",
       "bundles": [],
       "mirrors": [

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -188,7 +188,7 @@
       "owner": "Scot Wahlquist",
       "canonicalSystem": "git",
       "canonicalLocation": "COMPLIANCE.md",
-      "status": "approved",
+      "status": "draft",
       "frameworks": [
         "FERPA",
         "COPPA",
@@ -198,11 +198,8 @@
       ],
       "lastReviewed": "2026-04-18",
       "nextReviewDue": "2027-04-18",
-      "attestation": {
-        "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-06-21"
-      },
-      "contentHash": "a6e8b0bebcd45451e7d70472d729331d69f6b07b179b2f52e00ff54f4cb1bfba",
+      "attestation": {},
+      "contentHash": "40a93f8e93ac21f3f66b0b4e0272965bd3d0e7b562cc8f80c4a3f0f56168f69e",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -706,7 +706,7 @@
       "lastReviewed": "2026-06-21",
       "nextReviewDue": "2027-06-21",
       "attestation": {},
-      "contentHash": "2ba6af7f0dd9f2aafa4528b3af70fbdcbdf21da34926bfd6cfb94caea1c6835e",
+      "contentHash": "05c98f8f40f85ddbdae308e2a8721467377f92b9a286cf51501111ff66f5d5c5",
       "bundles": [],
       "mirrors": [],
       "id": "DOC-a936b01d6a"
@@ -1449,6 +1449,29 @@
       "mirrors": [],
       "notes": "Internal roadmap; not part of the externally-released set. Attested by Scot Wahlquist 2026-06-21 per CEO direction.",
       "id": "DOC-912b28f375"
+    },
+    {
+      "title": "Data & Compliance Pipeline - Build Inventory (dated)",
+      "description": "Dated Drive inventory of the compliance/data pipeline build-out; tracked so downstream docs that cite the pipeline inventory do not drift invisibly.",
+      "type": "audit-artifact",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "drive",
+      "canonicalLocation": "https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit",
+      "status": "approved",
+      "frameworks": [],
+      "lastReviewed": "2026-06-22",
+      "nextReviewDue": "2026-09-22",
+      "attestation": {},
+      "contentHash": null,
+      "bundles": [],
+      "mirrors": [
+        {
+          "system": "drive",
+          "location": "https://docs.google.com/document/d/1ZcYdaCc2eo5EGoaqlOgTLo9IXsbAvb-myw6pgO9Urtw/edit"
+        }
+      ],
+      "notes": "Current Drive search also shows an undated companion document, LingoLinq Data & Compliance Pipeline - Build Inventory, at 1ZcYdaCc2eo5EGoaqlOgTLo9IXsbAvb-myw6pgO9Urtw. Treat this dated row as the tracked review artifact until the living/frozen ownership split is reconciled.",
+      "id": "DOC-71d0861ff9"
     },
     {
       "title": "Notion - Compliance Findings board (LL)",

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -204,12 +204,7 @@
       },
       "contentHash": "2823383621e2e5162bdfb8388b15f1840d9654185194cf3569190941b82d7999",
       "bundles": [],
-      "mirrors": [
-        {
-          "system": "drive",
-          "location": "https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit"
-        }
-      ],
+      "mirrors": [],
       "id": "DOC-9b299a785b"
     },
     {
@@ -237,12 +232,7 @@
       "bundles": [
         "compliance-records-set-2026-06"
       ],
-      "mirrors": [
-        {
-          "system": "drive",
-          "location": "https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit"
-        }
-      ],
+      "mirrors": [],
       "id": "DOC-b61994933c"
     },
     {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -8,9 +8,9 @@
 
 ## Headline
 
-- **Status:** draft 2, approved 11, published 38, superseded 2
+- **Status:** draft 3, approved 10, published 38, superseded 2
 - **Overdue for review** (as of 2026-06-21): none
-- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded)
+- **Drafts awaiting attestation:** Compliance & Data Governance (COMPLIANCE.md); Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded)
 
 ## Documents by type
 
@@ -20,7 +20,7 @@
 |---|---|---|---|---|---|---|---|---|---|---|
 | Access Control Policy | Drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | published | SOC2, HIPAA, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Business Continuity and Disaster Recovery Plan | Drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
-| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-04-18 | 2027-04-18 | 2026-06-21 | `a6e8b0bebcd4` |  |
+| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-04-18 | 2027-04-18 | no | `40a93f8e93ac` |  |
 | Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | approved | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `14563501a6e4` | soc2-evidence, school-dpa-package |
 | Data Retention Schedule (branded) | Drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | published | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence, school-dpa-package |
 | Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | approved | GDPR, FERPA, HIPAA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `6aa015915c60` | school-dpa-package |

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -20,7 +20,7 @@
 |---|---|---|---|---|---|---|---|---|---|---|
 | Access Control Policy | Drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | published | SOC2, HIPAA, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Business Continuity and Disaster Recovery Plan | Drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
-| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-04-18 | 2027-04-18 | no | `40a93f8e93ac` |  |
+| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-04-18 | 2027-04-18 | no | `2823383621e2` |  |
 | Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | approved | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `14563501a6e4` | soc2-evidence, school-dpa-package |
 | Data Retention Schedule (branded) | Drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | published | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence, school-dpa-package |
 | Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | approved | GDPR, FERPA, HIPAA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `6aa015915c60` | school-dpa-package |

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -4,11 +4,11 @@
 > Do not hand-edit; edit the JSON (the source of truth) and re-render.
 > The codebase copy is canonical; the Notion board is a one-way mirror; Drive docs are linked, never copied.
 >
-> Generated: 2026-06-21 | Documents: 52 (git 26 / drive 22 / notion 4)
+> Generated: 2026-06-21 | Documents: 53 (git 26 / drive 23 / notion 4)
 
 ## Headline
 
-- **Status:** draft 2, approved 10, published 38, superseded 2
+- **Status:** draft 2, approved 11, published 38, superseded 2
 - **Overdue for review** (as of 2026-06-21): none
 - **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded)
 
@@ -54,7 +54,7 @@
 | Incident Log (branded) | Drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | published | HIPAA, GDPR | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Security Risk Assessment 2026 Q2 | Drive | [open](https://docs.google.com/document/d/1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 
-### audit-artifact (15)
+### audit-artifact (16)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
@@ -67,6 +67,7 @@
 | Compliance Program - Claim vs Code Review | Drive | [open](https://docs.google.com/document/d/1IHQ5yFkoU39N01wyTt5SRXM-Q71aKa9wuXvnGVWnbRg/edit) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) |  |
 | Compliance Status Snapshot (2026-04-23) | git | `docs/legal/COMPLIANCE_STATUS_2026-04-23.md` | superseded |  | Scot Wahlquist | 2026-04-23 |  | no | `0cacd835e906` |  |
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
+| Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
 | Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `a2b6d15d0320` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
@@ -78,7 +79,7 @@
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
-| Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | published |  | Scot Wahlquist | 2026-06-21 | 2027-06-21 | no | `2ba6af7f0dd9` |  |
+| Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | published |  | Scot Wahlquist | 2026-06-21 | 2027-06-21 | no | `05c98f8f40f8` |  |
 | Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | approved | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-05-27 | 2027-05-27 | 2026-06-21 | `3efcaaf4a7c5` | soc2-evidence |
 | Incident Response and Breach Runbook (branded) | Drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | published | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Notion - Compliance Engineering Onboarding/Handoff | Notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | published |  | Scot Wahlquist | 2026-06-19 | 2026-12-19 | no | (supplied) |  |
@@ -126,4 +127,4 @@ What a US school-district diligence / DPA review asks for (FERPA / COPPA / acces
 
 ---
 
-_52 documents. Re-run `ruby scripts/document-register-render.rb --check` to validate ids, git content hashes, and bundle completeness._
+_53 documents. Re-run `ruby scripts/document-register-render.rb --check` to validate ids, git content hashes, and bundle completeness._

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -8,9 +8,9 @@
 
 ## Headline
 
-- **Status:** draft 3, approved 10, published 38, superseded 2
+- **Status:** draft 2, approved 11, published 38, superseded 2
 - **Overdue for review** (as of 2026-06-21): none
-- **Drafts awaiting attestation:** Compliance & Data Governance (COMPLIANCE.md); Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded)
+- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded)
 
 ## Documents by type
 
@@ -20,7 +20,7 @@
 |---|---|---|---|---|---|---|---|---|---|---|
 | Access Control Policy | Drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | published | SOC2, HIPAA, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Business Continuity and Disaster Recovery Plan | Drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
-| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-04-18 | 2027-04-18 | no | `2823383621e2` |  |
+| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-23 | 2027-06-23 | 2026-06-23 | `2823383621e2` |  |
 | Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | approved | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `14563501a6e4` | soc2-evidence, school-dpa-package |
 | Data Retention Schedule (branded) | Drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | published | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence, school-dpa-package |
 | Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | approved | GDPR, FERPA, HIPAA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `6aa015915c60` | school-dpa-package |

--- a/docs/legal/COMPLIANCE_DOCS_GUIDE.md
+++ b/docs/legal/COMPLIANCE_DOCS_GUIDE.md
@@ -36,6 +36,8 @@ copy; never hand-edit a mirror to "fix" a difference.
 | The index (readable render) | `audit-reports/DOCUMENT-REGISTER.md` |
 | Render / validate tool | `scripts/document-register-render.rb` |
 | Notion mirror tool | `scripts/document-register-notion-sync.rb` |
+| Publication status / stale-doc queue | `audit-reports/COMPLIANCE-PUBLICATION-STATUS.md` |
+| Publication status tool | `scripts/compliance-publication-status.rb` |
 | Living legal/policy docs | `docs/legal/*.md` (+ the signed BAA PDF) |
 | Findings register (status SSOT) | `audit-reports/FINDINGS.json` |
 | Branded external records set | Google Drive "Branded Records Set" folder |
@@ -92,6 +94,38 @@ index notices a document changed but its row did not.
 - **If a git hash-drift check fails:** it means a doc's content and its register
   row disagree. Re-render to reconcile, then sanity-check the review date and
   status while you are there.
+
+## Publication status
+
+The findings and document registers do not automatically rewrite every downstream
+Google Doc or Notion page. They do automatically keep the two team-facing Notion
+boards current:
+
+- `FINDINGS.json` -> "LingoLinq Compliance Findings (LL)" via
+  `.github/workflows/sync-findings-to-notion.yml`.
+- `DOCUMENT-REGISTER.json` -> "LingoLinq Compliance Documents (LL)" via
+  `.github/workflows/sync-document-register-to-notion.yml` when the
+  `NOTION_DOCS_DB_ID` repo variable is configured.
+
+Everything else is tracked through the publication status report:
+
+```bash
+ruby scripts/compliance-publication-status.rb
+ruby scripts/compliance-publication-status.rb --check
+```
+
+That report is the compliance-agent work queue. It lists which surfaces update
+automatically, which Drive docs need an operator refresh, which Notion rows need
+hash refresh, and which active documents have a `lastReviewed` date older than
+the latest register source date. CI blocks if the committed report drifts from
+the registers.
+
+Until a Google Docs publisher exists, Drive-canonical docs are either:
+
+- **Frozen point-in-time records:** keep the body as-is, and say so in `notes`.
+- **Living docs:** refresh the Google Doc body manually or through a future
+  Google Docs workflow, then update `lastReviewed` and `contentHash` when
+  available.
 
 ## bundles (completeness reporting)
 

--- a/scripts/compliance-publication-status.rb
+++ b/scripts/compliance-publication-status.rb
@@ -1,0 +1,185 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# compliance-publication-status.rb - render the compliance publication queue.
+#
+# The findings register and document register are the source-of-truth inputs. This report
+# answers "what updates automatically, and what still needs a human or agent publish step?"
+# It is intentionally network-free and deterministic so CI can block when the committed
+# markdown drifts from the registers.
+#
+# Usage:
+#   ruby scripts/compliance-publication-status.rb
+#   ruby scripts/compliance-publication-status.rb --check
+
+require 'json'
+require 'date'
+require 'optparse'
+
+FINDINGS_PATH = 'audit-reports/FINDINGS.json'
+DOCS_PATH = 'audit-reports/DOCUMENT-REGISTER.json'
+REPORT_PATH = 'audit-reports/COMPLIANCE-PUBLICATION-STATUS.md'
+
+options = { mode: :render }
+OptionParser.new do |o|
+  o.banner = 'Usage: ruby scripts/compliance-publication-status.rb [--check]'
+  o.on('--check', 'Exit 1 if the committed publication report is stale') { options[:mode] = :check }
+end.parse!(ARGV)
+
+def read_json(path)
+  abort "compliance-publication-status: missing #{path}" unless File.file?(path)
+
+  JSON.parse(File.read(path))
+end
+
+def parse_date(value)
+  return nil if value.nil? || value.to_s.strip.empty?
+
+  Date.parse(value.to_s)
+rescue ArgumentError
+  nil
+end
+
+def esc(value)
+  value.to_s.gsub('|', '\\|')
+end
+
+def link_for(doc)
+  loc = doc['canonicalLocation'].to_s
+  doc['canonicalSystem'].to_s == 'git' ? "`#{loc}`" : "[open](#{loc})"
+end
+
+def workflow_state(path)
+  File.file?(path) ? 'configured' : 'missing'
+end
+
+findings = read_json(FINDINGS_PATH)
+doc_register = read_json(DOCS_PATH)
+
+finding_meta = findings['meta'] || {}
+doc_meta = doc_register['meta'] || {}
+docs = doc_register['documents'] || []
+
+generated_date = parse_date(doc_meta['generatedDate']) ||
+                 parse_date(finding_meta['auditedDate']) ||
+                 Date.today
+generated = generated_date.strftime('%Y-%m-%d')
+
+finding_date = parse_date(finding_meta['auditedDate'])
+doc_date = parse_date(doc_meta['generatedDate'])
+latest_source_date = [finding_date, doc_date].compact.max || generated_date
+latest_source = latest_source_date.strftime('%Y-%m-%d')
+
+findings_auto = workflow_state('.github/workflows/sync-findings-to-notion.yml')
+docs_auto = workflow_state('.github/workflows/sync-document-register-to-notion.yml')
+
+drive_docs = docs.select { |d| d['canonicalSystem'].to_s == 'drive' }
+notion_docs = docs.select { |d| d['canonicalSystem'].to_s == 'notion' }
+
+review_stale = docs.select do |d|
+  last = parse_date(d['lastReviewed'])
+  status = d['status'].to_s
+  next false if %w[superseded archived].include?(status)
+  next true if last.nil?
+
+  last < latest_source_date
+end
+
+missing_external_hash = docs.select do |d|
+  %w[drive notion].include?(d['canonicalSystem'].to_s) && d['contentHash'].to_s.empty?
+end
+
+drive_needs_refresh = drive_docs.select do |d|
+  last = parse_date(d['lastReviewed'])
+  status = d['status'].to_s
+  next false if %w[superseded archived].include?(status)
+  next true if last.nil?
+
+  last < latest_source_date
+end
+
+notion_needs_hash = notion_docs.select do |d|
+  d['contentHash'].to_s.empty?
+end
+
+out = +''
+out << "# Compliance Publication Status\n\n"
+out << "> Generated from `#{FINDINGS_PATH}` and `#{DOCS_PATH}` by `scripts/compliance-publication-status.rb`.\n"
+out << "> Do not hand-edit; update the registers and re-render.\n\n"
+
+out << "**Generated:** #{generated}\n\n"
+out << "**Latest source date:** #{latest_source}\n\n"
+out << "**Findings audited date:** #{finding_meta['auditedDate']}\n\n"
+out << "**Document register generated date:** #{doc_meta['generatedDate']}\n\n"
+
+out << "## What Updates Automatically\n\n"
+out << "| Surface | Source | Automation | Scope |\n"
+out << "|---|---|---|---|\n"
+out << "| Notion findings board | `audit-reports/FINDINGS.json` | #{findings_auto} | Register-owned finding facts only. Human-owned Notion columns are preserved. |\n"
+out << "| Notion documents board | `audit-reports/DOCUMENT-REGISTER.json` | #{docs_auto} | Register-owned document-index facts only. Human-owned Notion columns are preserved. |\n\n"
+
+out << "## What Does Not Auto-Update\n\n"
+out << "- Google Docs bodies are not rewritten by the current repo workflows. Drive rows are tracked by URL, review date, and optional content hash only.\n"
+out << "- Frozen branded records can stay point-in-time, but living Drive docs must be refreshed by an operator or a future Google Docs publisher.\n"
+out << "- Notion page content is not rewritten here. The document board can be synced; individual Notion pages need either canonical git sources or an explicit publisher.\n\n"
+
+out << "## Stale Review Queue\n\n"
+if review_stale.empty?
+  out << "_No active documents have a `lastReviewed` date older than the latest register source date._\n\n"
+else
+  out << "| Title | System | Location | Last reviewed | Status | Why |\n"
+  out << "|---|---|---|---|---|---|\n"
+  review_stale.sort_by { |d| [d['canonicalSystem'].to_s, d['title'].to_s] }.each do |d|
+    out << "| #{esc(d['title'])} | #{d['canonicalSystem']} | #{link_for(d)} | #{d['lastReviewed']} | #{d['status']} | Review date is older than #{latest_source}. |\n"
+  end
+  out << "\n"
+end
+
+out << "## Drive Refresh Queue\n\n"
+if drive_needs_refresh.empty?
+  out << "_No Drive-canonical documents are stale against the latest register source date._\n\n"
+else
+  out << "| Title | Location | Last reviewed | Status | Action |\n"
+  out << "|---|---|---|---|---|\n"
+  drive_needs_refresh.sort_by { |d| d['title'].to_s }.each do |d|
+    out << "| #{esc(d['title'])} | #{link_for(d)} | #{d['lastReviewed']} | #{d['status']} | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |\n"
+  end
+  out << "\n"
+end
+
+out << "## External Hash Gaps\n\n"
+if missing_external_hash.empty?
+  out << "_All Drive/Notion canonical rows have supplied content hashes._\n\n"
+else
+  out << "| Title | System | Location | Action |\n"
+  out << "|---|---|---|---|\n"
+  missing_external_hash.sort_by { |d| [d['canonicalSystem'].to_s, d['title'].to_s] }.each do |d|
+    action = d['canonicalSystem'].to_s == 'notion' ? 'Run `ruby scripts/document-register-notion-sync.rb --refresh-notion-hashes` with `NOTION_TOKEN`.' : 'Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet.'
+    out << "| #{esc(d['title'])} | #{d['canonicalSystem']} | #{link_for(d)} | #{esc(action)} |\n"
+  end
+  out << "\n"
+end
+
+out << "## Next Automation Gap\n\n"
+out << "The missing layer is a Google Docs publisher/refresh workflow. Until that exists, the compliance agent should use this report as its work queue: update canonical registers, sync Notion boards, then refresh or explicitly freeze affected Drive documents.\n\n"
+
+out << "---\n\n"
+out << "_#{docs.size} documents tracked. #{review_stale.size} stale review item(s). #{drive_needs_refresh.size} Drive refresh item(s). #{notion_needs_hash.size} Notion hash item(s)._\n"
+
+if options[:mode] == :check
+  unless File.file?(REPORT_PATH)
+    warn "compliance-publication-status: missing #{REPORT_PATH}"
+    exit 1
+  end
+
+  if File.read(REPORT_PATH) == out
+    puts 'compliance-publication-status: OK'
+    exit 0
+  end
+
+  warn 'compliance-publication-status: DRIFT - run `ruby scripts/compliance-publication-status.rb`'
+  exit 1
+end
+
+File.write(REPORT_PATH, out)
+puts "compliance-publication-status: wrote #{REPORT_PATH} (#{review_stale.size} stale, #{drive_needs_refresh.size} Drive refresh)"


### PR DESCRIPTION
## Summary

Two compliance-register follow-ups that landed on this branch after PR #463 merged (its remote head was auto-deleted; these commits were left ahead of `staging`):

1. **COMPLIANCE.md AI PII overclaim fix** (`01a09082d`) — the doc asserted AI/ML models "NEVER see who users are" and that the AI-APIs layer NEVER sees real user data. Corrected to match `lib/pii_scrubber.rb` reality: direct identifiers (names, emails, SSO subject IDs) are stripped and user references tokenized before AI egress, but de-identified user-authored content (board labels, sentences) is still sent and free-text is scrubbed of known identifiers/name patterns on a **best-effort** basis. Framed as a strong de-identification guarantee, not "no user text ever reaches a model." Surfaced by the 2026-06-23 external (Cursor) posture-report review.
2. **Publication status queue** (`1ffb09c63`) — earlier compliance-records publication-status tracking.

## Governance / register

- COMPLIANCE.md is a `contentHash`-tracked, attested policy doc. Because the wording changed, its register row is flipped `approved -> draft` with empty attestation (Scot's 2026-06-21 attestation covered the prior text).
- `audit-reports/DOCUMENT-REGISTER.json` + `.md` regenerated via `document-register-render.rb`; `--check` passes, so the `audit-artifacts-integrity` CI gate stays green.
- Compliance-only change; reviewed Claude-only (`/code-review`), never routed to Codex/DeepSeek.

## Owed after merge (Scot)

- Re-attest COMPLIANCE.md to restore `approved` (or adjust wording first).
- Re-sync the Google Drive mirror (`...1bvVQClf...`), now stale vs. the git canonical.

## Test plan

- `ruby scripts/document-register-render.rb --check` -> OK (53 docs consistent).
- No application code changed (`.rb`/`.js`/`.hbs` untouched); Brakeman/Semgrep N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4esjfHTi4sf4UZNe4TDXi
