### PR TITLE
fix(cutover): worker SIGTERM grace within Cloud Run's fixed 10s window (4.W1)

### DIFF
--- a/bin/docker-worker-entrypoint
+++ b/bin/docker-worker-entrypoint
@@ -23,22 +23,40 @@ set -e
 #      in-flight job NATURALLY (no interruption), then
 #   2. send TERM to the child, which raises Resque::TermException in the job, then
 #   3. wait RESQUE_TERM_TIMEOUT seconds, then SIGKILL if still alive.
-# Worst case = PRE_SHUTDOWN + TERM_TIMEOUT, kept safely below the 10s grace.
+# Worst case = PRE_SHUTDOWN + TERM_TIMEOUT = 4 + 3 = 7s. We deliberately keep ~3s
+# of headroom under the fixed 10s rather than maxing it out: the resque wait is a
+# sleep(0.1)+waitpid poll loop (drift), and in step 2 the child's requeue
+# (Resque.enqueue = an LPUSH to Memorystore over rediss:// TLS) must itself finish
+# inside RESQUE_TERM_TIMEOUT or the child is SIGKILLed mid-requeue and the job IS
+# lost. If the parent's total shutdown wall-clock ever exceeds 10s, Cloud Run
+# SIGKILLs the parent and any requeueing child dies with it. Re-measure the real
+# wall-clock under TLS Redis in the dress rehearsal (4.1/4.2) before raising these.
 #
-# When the job IS interrupted (step 2), it is NOT lost: BoyBand::WorkerMethods#perform_at
-# rescues Resque::TermException and re-enqueues the job (Resque.enqueue), so it is
-# re-run after a new instance comes up. (Note: that requeue is blanket across all
-# job classes; a non-idempotent slow-queue class such as Webhook.notify_all_with_code
-# can therefore double-run on interrupt. The pre-shutdown grace below mitigates this
-# by letting short jobs finish cleanly before any TERM is sent; a per-class
-# idempotency audit to make the requeue selective is a documented follow-up.)
+# When the job is interrupted DURING EXECUTION (step 2), it is re-enqueued, not
+# dropped: BoyBand::WorkerMethods#perform_at rescues Resque::TermException and
+# re-enqueues (Resque.enqueue), so it re-runs after a new instance comes up.
+# Caveats (NOT a blanket "no job is ever lost"):
+#   - SIGKILL (Cloud Run's hard kill at 10s, or a too-slow requeue) and any TERM
+#     that lands OUTSIDE perform_at's klass.send (between jobs, in the cache-clear
+#     ensure, or in resque framework code) bypass the rescue; resque records those
+#     as DirtyExit in the FAILED queue. Monitor the failed queue during cutover.
+#   - The requeue is blanket across all job classes. A non-idempotent long job
+#     (e.g. Webhook.notify_all_with_code, ~20 min, sends outbound webhooks per
+#     recipient) re-runs from the top on interrupt -> duplicate webhooks. The
+#     pre-shutdown grace does NOT help multi-minute jobs. Mitigation for cutover
+#     is operational: pause/drain such writers before the window (pre-cutover
+#     checklist); making the requeue selective (per-class idempotency) is a
+#     documented follow-up, tracked as a cutover decision.
+#   - An interrupted :slow job re-enqueues onto the DEFAULT queue (BoyBand's rescue
+#     uses `self` = Worker), so on re-run Worker.current_speed is :normal, not
+#     :slow; code that branches on current_speed == 'slow' (e.g.
+#     BoardDownstreamButtonSet.update_for) then fans out instead of recursing inline.
+#     The job still completes; the scheduling path differs. Follow-up with the above.
 #
-# Both values are overridable so the cutover dress rehearsal (tracker 4.1/4.2) can
-# tune them to the measured slow-queue job durations without a code change. Long
-# slow-queue jobs (minutes) cannot finish inside 10s regardless; those rely on the
-# requeue safety net above, not on the grace.
-: "${RESQUE_PRE_SHUTDOWN_TIMEOUT:=5}"
-: "${RESQUE_TERM_TIMEOUT:=4}"
+# Both values are overridable so the dress rehearsal can tune them to measured
+# job durations without a code change.
+: "${RESQUE_PRE_SHUTDOWN_TIMEOUT:=4}"
+: "${RESQUE_TERM_TIMEOUT:=3}"
 
 export QUEUES INTERVAL TERM_CHILD RESQUE_PRE_SHUTDOWN_TIMEOUT RESQUE_TERM_TIMEOUT
 

--- a/bin/docker-worker-entrypoint
+++ b/bin/docker-worker-entrypoint
@@ -9,6 +9,37 @@ set -e
 : "${QUEUES:=priority,default,slow}"
 : "${INTERVAL:=0.1}"
 : "${TERM_CHILD:=1}"
-export QUEUES INTERVAL TERM_CHILD
+
+# Graceful worker shutdown on SIGTERM (Cloud Run worker-pool replacement: deploy,
+# scale, or cutover). Tracker 4.W1.
+#
+# Cloud Run sends SIGTERM and then SIGKILL after a FIXED 10s grace period that is
+# NOT configurable for services, jobs, or worker pools (verified against the
+# Cloud Run container runtime contract; there is no gcloud flag for it). So the
+# entire graceful-shutdown budget must fit inside 10s.
+#
+# With TERM_CHILD set, Resque's new_kill_child (resque worker.rb) does, on TERM:
+#   1. wait RESQUE_PRE_SHUTDOWN_TIMEOUT seconds for the child to finish the
+#      in-flight job NATURALLY (no interruption), then
+#   2. send TERM to the child, which raises Resque::TermException in the job, then
+#   3. wait RESQUE_TERM_TIMEOUT seconds, then SIGKILL if still alive.
+# Worst case = PRE_SHUTDOWN + TERM_TIMEOUT, kept safely below the 10s grace.
+#
+# When the job IS interrupted (step 2), it is NOT lost: BoyBand::WorkerMethods#perform_at
+# rescues Resque::TermException and re-enqueues the job (Resque.enqueue), so it is
+# re-run after a new instance comes up. (Note: that requeue is blanket across all
+# job classes; a non-idempotent slow-queue class such as Webhook.notify_all_with_code
+# can therefore double-run on interrupt. The pre-shutdown grace below mitigates this
+# by letting short jobs finish cleanly before any TERM is sent; a per-class
+# idempotency audit to make the requeue selective is a documented follow-up.)
+#
+# Both values are overridable so the cutover dress rehearsal (tracker 4.1/4.2) can
+# tune them to the measured slow-queue job durations without a code change. Long
+# slow-queue jobs (minutes) cannot finish inside 10s regardless; those rely on the
+# requeue safety net above, not on the grace.
+: "${RESQUE_PRE_SHUTDOWN_TIMEOUT:=5}"
+: "${RESQUE_TERM_TIMEOUT:=4}"
+
+export QUEUES INTERVAL TERM_CHILD RESQUE_PRE_SHUTDOWN_TIMEOUT RESQUE_TERM_TIMEOUT
 
 exec bundle exec rake environment resque:work

--- a/spec/lib/worker_sigterm_requeue_spec.rb
+++ b/spec/lib/worker_sigterm_requeue_spec.rb
@@ -41,4 +41,17 @@ describe 'worker SIGTERM requeue safety net' do
 
     Worker.perform(*job_args)
   end
+
+  it 'preserves trailing domain:: / chain:: routing args on requeue' do
+    # Real jobs carry appended domain::/chain:: markers; perform_at strips them
+    # from the dispatch args but the requeue must re-enqueue the ORIGINAL args so
+    # the marker context survives the interrupt.
+    full_args = ['BoardDownstreamButtonSet', 'update_for', '1_2', true, 'domain::1_5', 'chain::abc']
+    expect(BoardDownstreamButtonSet).to receive(:update_for)
+      .with('1_2', true)
+      .and_raise(Resque::TermException.new('SIGTERM'))
+    expect(Resque).to receive(:enqueue).with(Worker, *full_args)
+
+    Worker.perform(*full_args)
+  end
 end

--- a/spec/lib/worker_sigterm_requeue_spec.rb
+++ b/spec/lib/worker_sigterm_requeue_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+# Locks in the SIGTERM requeue safety net relied on by the Cloud Run cutover
+# (tracker 4.W1). When a worker-pool instance is replaced, Cloud Run sends
+# SIGTERM and SIGKILLs after a FIXED, unconfigurable 10s grace, so any
+# long-running slow-queue job WILL be interrupted. Resque (with TERM_CHILD)
+# raises Resque::TermException in the interrupted child; BoyBand::WorkerMethods
+# #perform_at must rescue it and re-enqueue the job rather than drop it. This
+# spec guards that behavior so a future boy_band bump cannot silently regress
+# it into lost background work.
+describe 'worker SIGTERM requeue safety net' do
+  # A representative slow-queue job class+method (see app/models/remote_action.rb,
+  # board.rb -> Board(Set) recompute work on the :slow queue).
+  let(:job_args) { ['BoardDownstreamButtonSet', 'update_for', '1_2', true] }
+
+  it 're-enqueues a slow-queue job interrupted by SIGTERM instead of dropping it' do
+    expect(BoardDownstreamButtonSet).to receive(:update_for)
+      .with('1_2', true)
+      .and_raise(Resque::TermException.new('SIGTERM'))
+    # SlowWorker.perform delegates to Worker.perform_at(:slow, ...), so the
+    # rescue's `self` is Worker: the interrupted slow job re-enqueues onto the
+    # Worker (default) queue. The important guarantee is that it re-enqueues at
+    # all (no lost work), not which queue it lands on.
+    expect(Resque).to receive(:enqueue).with(Worker, *job_args)
+
+    SlowWorker.perform(*job_args)
+  end
+
+  it 're-enqueues a default-queue job interrupted by SIGTERM instead of dropping it' do
+    expect(BoardDownstreamButtonSet).to receive(:update_for)
+      .with('1_2', true)
+      .and_raise(Resque::TermException.new('SIGTERM'))
+    expect(Resque).to receive(:enqueue).with(Worker, *job_args)
+
+    Worker.perform(*job_args)
+  end
+
+  it 'does NOT requeue when the job completes normally (no spurious re-run)' do
+    expect(BoardDownstreamButtonSet).to receive(:update_for).with('1_2', true).and_return(true)
+    expect(Resque).not_to receive(:enqueue)
+
+    Worker.perform(*job_args)
+  end
+end


### PR DESCRIPTION
## What

Gives in-flight Resque jobs a chance to finish (or requeue) when a Cloud Run worker-pool instance is replaced (deploy, scale, **or the Phase 5 cutover**). Sets `RESQUE_PRE_SHUTDOWN_TIMEOUT=4` and `RESQUE_TERM_TIMEOUT=3` (both overridable) in `bin/docker-worker-entrypoint` — total 7s, with ~3s of deliberate headroom under Cloud Run's fixed 10s grace.

> **Correction (post dual-review):** an earlier draft of this description quoted `5`/`4` (9s). The committed values are `4`/`3` (7s). The extra headroom is intentional: in step 2 the interrupted child's requeue is an `Resque.enqueue` LPUSH to Memorystore over `rediss://` TLS that must itself complete inside `RESQUE_TERM_TIMEOUT`, and the resque wait is a `sleep(0.1)`+`waitpid` poll loop with drift — so maxing the budget to 9s risks a mid-requeue SIGKILL (lost job). Re-measure under live TLS Redis in the dress rehearsal before raising.

Tracker 4.W1. Plan: `~/ai-company-brain/outputs/plans/2026-06-23-cloudrun-w1-worker-shutdown-plan.md`.

## Diagnosis corrected two premises of the plan

Building the branch surfaced two evidence-based findings that **changed the deliverable** (RULE #0: the fix follows the verified cause):

1. **Cloud Run's SIGTERM→SIGKILL grace is a FIXED 10s and is NOT configurable** for services, jobs, *or* worker pools — verified against the [Cloud Run container runtime contract](https://docs.cloud.google.com/run/docs/container-contract); [`gcloud beta run worker-pools deploy`](https://docs.cloud.google.com/sdk/gcloud/reference/beta/run/worker-pools/deploy) exposes no grace/shutdown/timeout flag. So the plan's "set a generous SIGTERM grace on the worker-pool deploy" step is **impossible** — the deploy workflow is left unchanged, and the whole shutdown budget must fit inside 10s.

2. **Requeue-on-interrupt already exists.** `BoyBand::WorkerMethods#perform_at` does `rescue Resque::TermException; Resque.enqueue(self, *args)` (boy_band 0.1.16). With `TERM_CHILD` set (it is), Resque 3.0.0's `new_kill_child` raises `Resque::TermException` in the interrupted child, so the job is **re-enqueued today**. No `resque-retry` and no new rescue are needed.

## How it works (verified against resque 3.0.0 `worker.rb`)

On SIGTERM, with `TERM_CHILD` set, `new_kill_child`:
1. waits `RESQUE_PRE_SHUTDOWN_TIMEOUT` (4s) for the child to finish the in-flight job **naturally** (no interruption);
2. sends TERM → child raises `Resque::TermException` → BoyBand re-enqueues the job;
3. waits `RESQUE_TERM_TIMEOUT` (3s), then SIGKILL.

Worst case `4 + 3 = 7s < 10s`. The pre-shutdown grace lets short jobs complete cleanly, which reduces requeue churn during the cutover's many worker restarts **and** mitigates the blanket-requeue double-run risk for non-idempotent long jobs (more finish before any TERM).

## Tests

`spec/lib/worker_sigterm_requeue_spec.rb` (4 examples, 0 failures): asserts an interrupted slow-queue and default-queue job each re-enqueue (no lost work), that a normally-completing job does **not** spuriously requeue, and that trailing `domain::`/`chain::` routing args survive the requeue. Locks in the existing safety net so a future boy_band bump can't silently regress it.

> The spec exercises BoyBand's real `rescue Resque::TermException` branch (it is not a tautology — the raise and `Resque.enqueue` are stubbed independently). It guards "rescue re-enqueues original args", not the end-to-end "no lost work under a real signal", which is a dress-rehearsal item.

## Out of scope / follow-ups

- **Per-class idempotency audit** to make the blanket requeue selective. The worst case is `Webhook.notify_all_with_code` (~20 min, sends outbound webhooks per recipient): note it runs on the **default** queue (`Webhook.notify_all` → `schedule_for(:default, …)`), **not** the slow queue — so the pre-cutover drain checklist must cover long default-queue writers, not only slow. For the cutover the mitigation is operational (pause the notifier; runbook step 1).
- **Dress rehearsal (tracker 4.1/4.2):** kill a worker mid slow-job and confirm it re-runs after the new instance comes up; **measure the real requeue LPUSH wall-clock under TLS Redis** and tune the two timeouts to measured durations if needed (env-overridable, no code change). Long jobs (minutes) cannot finish in 10s and rely on the requeue, not the grace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
