### PR TITLE
compliance(register): file audit_console Heroku-not-Render finding (LL-7f7372e3eb)

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "a2b6d15d032068fcc72e5f21e390da989294368f4057cd59320e4bf9cbdaf026",
+      "contentHash": "7ff6ed9d0f7615da6a826b470db2496d552267a1abbb47e05dc1ad621da3787b",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `a2b6d15d0320` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `7ff6ed9d0f76` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -2721,6 +2721,50 @@
         "timeframe": "with toolchain modernization"
       },
       "notes": "Successor to LL-257c696fe0 (eol-eslint-5x, closed 2026-06-21). The v5 EOL was fixed by the v8 upgrade, but v8 reached end-of-life; tracked here so the register stays honest. Low: dev-toolchain only."
+    },
+    {
+      "id": "LL-7f7372e3eb",
+      "ruleKey": "audit-console-targets-heroku-not-render",
+      "title": "Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited",
+      "severity": "high",
+      "confidence": "high",
+      "frameworks": [
+        "SOC2",
+        "HIPAA"
+      ],
+      "status": "open",
+      "evidence": {
+        "type": "code",
+        "file": "bin/audit_console",
+        "line": 7,
+        "snippet": "heroku_id=`heroku auth:whoami`",
+        "sha": "3e59c0543daa29efe9d5b5512853be0ded030fab"
+      },
+      "firstSeen": "2026-06-23",
+      "lastSeen": "2026-06-23",
+      "owner": "scot",
+      "remediation": {
+        "options": "Rewrite bin/audit_console to attach to a Render service shell while still exporting USER_KEY so the Rails console records an AuditEvent per session, or replace it with a Render-native audited console path; until then, privileged console access on Render is not captured by this wrapper.",
+        "timeframe": "60d"
+      },
+      "closureEvidence": {
+        "sha": "",
+        "verifierNote": "",
+        "attestation": ""
+      },
+      "disposition": {
+        "state": "untriaged",
+        "decidedBy": "",
+        "decidedDate": "",
+        "rationale": ""
+      },
+      "source": {
+        "kind": "audit-review",
+        "pr": null,
+        "reviewer": "claude-compliance-officer",
+        "promotedDate": "2026-06-23"
+      },
+      "notes": "Promoted from claude-compliance-officer review on 2026-06-23. bin/audit_console is the documented audited-console wrapper (CLAUDE.md Security section: console access audited via AuditEvent). It still shells to the Heroku CLI (heroku auth:whoami; heroku run -a lingolinq). LingoLinq runs on Render and the legacy Heroku app is gone, so the wrapper cannot attach a console in the live environment and the per-session AuditEvent it is meant to record is not produced on Render. Net effect: the audited-console control is not operative on the current platform; privileged console access to a system holding regulated student/patient data is not captured by this path. Code/path evidence only."
     }
   ]
 }

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,17 +5,18 @@
 
 **Audited:** `scot/security/audit-erasure-admin-reads` @ `445336592ddaf838689df7e578829e94e140890d` on 2026-06-19  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 4 High
+**Headline (open + remediated-unverified):** 0 Critical / 5 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (44)
+## Open (45)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
 | LL-d1ea8659c3 |  | high | SOC2 | **fixed** | audit-run | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | **fixed** | audit | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
 | LL-aacae48768 |  | high | SOC2, HIPAA, FERPA | **accepted** | audit-run | Production Postgres (lingolinq-prod-db) reachable from an all-addresses /0 allowlist (public internet) | (attestation) |
+| LL-7f7372e3eb |  | high | SOC2, HIPAA | untriaged | audit-review | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | untriaged | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
 | LL-52ff2a9a79 |  | medium | SOC2 | untriaged | audit-run | CI security-scan job (Brakeman SAST, bundle-audit, npm audit, gitleaks) is entirely non-blocking | `.github/workflows/ci.yml`:107 |
@@ -112,4 +113,4 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 
 ---
 
-_81 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._
+_82 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-06-21T22:19:24Z
+**Page generated:** 2026-06-23T21:30:13Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **4** | 24 | 16 |
+| **0** | **5** | 24 | 16 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -26,6 +26,7 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | ID | Legacy | Severity | Frameworks | Title | Evidence |
 |---|---|---|---|---|---|
 | LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
+| LL-7f7372e3eb |  | high | SOC2, HIPAA | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
 | LL-aacae48768 |  | high | SOC2, HIPAA, FERPA | Production Postgres (lingolinq-prod-db) reachable from an all-addresses /0 allowlist (public internet) | (attestation) |
 | LL-d1ea8659c3 |  | high | SOC2 | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |


### PR DESCRIPTION
## What

Files a new findings-register entry for a real compliance gap: **`bin/audit_console` (the documented audited-console wrapper) still invokes the Heroku CLI, so it is not operative on Render.**

| | |
|---|---|
| id | `LL-7f7372e3eb` |
| ruleKey | `audit-console-targets-heroku-not-render` |
| severity / confidence | high / high |
| frameworks | SOC2, HIPAA |
| status / disposition | open / untriaged |
| evidence | `bin/audit_console:7` (`heroku auth:whoami`) @ staging `3e59c054` |
| owner | scot |

## Why it matters

`CLAUDE.md` documents the control: "Console access audited via `AuditEvent` (use `bin/audit_console`, not `rails console`)." The wrapper shells to `heroku auth:whoami` and `heroku run ... -a lingolinq`. LingoLinq runs on Render and the legacy Heroku app is gone, so the wrapper cannot attach a console in the live environment and the per-session `AuditEvent` it is meant to record is not produced. The audited-console control is not operative on the current platform, leaving privileged console access to a system holding regulated student/patient data uncaptured by this path.

The code already carries a TODO acknowledging the rewrite is owed (`bin/audit_console:2-6`); this lands it in the register so it gets tracked and triaged instead of living only as a code comment.

## How

Filed through the governed `scripts/promote-finding.rb` path (the `/promote-finding` flow), **not** a hand-edit of `FINDINGS.json`. The script adds it as `open`/`untriaged` only; it refuses PII/secrets and verifies the snippet resolves at its sha. Code/path evidence only.

Regenerated all derived artifacts and re-ran every integrity check (the `audit-artifacts-integrity` gate set), all green locally:

- `citation-check` 76 PASS / 0 FAIL
- `compliance-calendar --check` OK
- `compliance-notion-publish --check` OK (headline now **0C / 5H / 24M / 16L**)
- `document-register --check` OK
- `compliance-publication-status --check` OK

## Triage note (Scot owns this)

This lands `open` / `untriaged`. Headline High count moves 4 to 5, which is the correct effect of filing a genuine High, not a regression. I rated it **high** because a documented audit control is inoperative on the live platform. If you prefer it at medium, that is a triage/severity call only you make. Remediation (rewrite the wrapper for a Render service shell) is **infra work that belongs to the Render-to-GCP migration thread**, not this compliance thread; this PR only tracks the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)