### PR TITLE
feat(gcp): Phase 5 front-end build - HTTPS LB + Cloud Armor (5.3 Option B)

### DIFF
--- a/scripts/gcp/phase5-frontend-lb.sh
+++ b/scripts/gcp/phase5-frontend-lb.sh
@@ -43,7 +43,11 @@
 #   DOMAIN=... CONFIRM_LB=1 CONFIRM_ARMOR=1 ./scripts/gcp/phase5-frontend-lb.sh  # + Cloud Armor (preview)
 #   DOMAIN=... CONFIRM_LB=1 CONFIRM_ARMOR=1 SET_GH_VARS=1 ...                  # + write repo vars (LB IP/domain)
 #   DOMAIN=... CONFIRM_INGRESS_LOCKDOWN=1 ./scripts/gcp/phase5-frontend-lb.sh  # flip web to LB-only (LAST)
-#   ARMOR_ENFORCE=1 CONFIRM_ARMOR=1 DOMAIN=... ...                             # WAF enforce (after rehearsal)
+#   ARMOR_ENFORCE=1 CONFIRM_ARMOR_ENFORCE=1 CONFIRM_ARMOR=1 DOMAIN=... ...     # WAF enforce (after rehearsal)
+#
+# NOTE: enforce (deny-403) needs BOTH ARMOR_ENFORCE=1 and its own CONFIRM_ARMOR_ENFORCE=1 gate,
+# and the ingress lockdown must be a SEPARATE invocation from the LB build (CONFIRM_LB=1) so the
+# LB path is validated before public run.app access is removed.
 #
 # Optional overrides: PROJECT_ID, REGION, WEB_SERVICE, WAF_SENSITIVITY, RATE_LIMIT_COUNT,
 #   RATE_LIMIT_INTERVAL_SEC, and the resource names below.
@@ -87,6 +91,7 @@ GH_REPO="${GH_REPO:-lingolinq/LingoLinq-AAC}"
 # Gate flags (default 0 = do not run that gated step).
 CONFIRM_LB="${CONFIRM_LB:-0}"
 CONFIRM_ARMOR="${CONFIRM_ARMOR:-0}"
+CONFIRM_ARMOR_ENFORCE="${CONFIRM_ARMOR_ENFORCE:-0}"  # extra gate required to flip the WAF to deny-403
 CONFIRM_INGRESS_LOCKDOWN="${CONFIRM_INGRESS_LOCKDOWN:-0}"
 SET_GH_VARS="${SET_GH_VARS:-0}"
 
@@ -133,7 +138,7 @@ cat <<PLAN
           managed SSL cert $CERT_NAME for DOMAIN='${DOMAIN:-<UNSET - required>}'
           HTTPS proxy + :443 forwarding rule; HTTP :80 -> HTTPS redirect
   [ARMOR] policy $ARMOR_POLICY: OWASP WAF (SQLi/XSS/LFI/RCE) sensitivity=$WAF_SENSITIVITY,
-          mode=$([ "$ARMOR_ENFORCE" = "1" ] && echo ENFORCE || echo PREVIEW); rate-limit
+          mode=$([ "$ARMOR_ENFORCE" = "1" ] && [ "$CONFIRM_ARMOR_ENFORCE" = "1" ] && echo ENFORCE || echo PREVIEW); rate-limit
           ${RATE_LIMIT_COUNT}/${RATE_LIMIT_INTERVAL_SEC}s per IP; attached to $BACKEND_NAME
   [LOCKDOWN] $WEB_SERVICE ingress -> internal-and-cloud-load-balancing (run LAST)
 
@@ -191,15 +196,34 @@ else
     --load-balancing-scheme=EXTERNAL_MANAGED \
     --enable-logging --logging-sample-rate=1.0
 fi
-if gcloud compute backend-services describe "$BACKEND_NAME" --global --project="$PROJECT_ID" \
-     --format='value(backends.group)' | grep -q "$NEG_NAME"; then
+# Match the EXACT NEG resource path, not a bare-name substring (a substring match could
+# false-positive on a different NEG sharing the prefix, or false-NEGATIVE on a transient empty
+# describe and then abort the whole build on add-backend's "already exists"). (dual-review PR #476)
+ATTACHED_GROUPS="$(gcloud compute backend-services describe "$BACKEND_NAME" --global --project="$PROJECT_ID" \
+  --format='value(backends.group)' 2>/dev/null || true)"
+NEG_PATH="projects/$PROJECT_ID/regions/$REGION/networkEndpointGroups/$NEG_NAME"
+if printf '%s' "$ATTACHED_GROUPS" | grep -qF "$NEG_PATH"; then
   skip "NEG already attached to $BACKEND_NAME"
 else
-  gcloud compute backend-services add-backend "$BACKEND_NAME" \
+  set +e
+  ADD_OUT="$(gcloud compute backend-services add-backend "$BACKEND_NAME" \
     --project="$PROJECT_ID" \
     --global \
     --network-endpoint-group="$NEG_NAME" \
-    --network-endpoint-group-region="$REGION"
+    --network-endpoint-group-region="$REGION" 2>&1)"
+  ADD_RC=$?
+  set -e
+  if [ "$ADD_RC" -ne 0 ]; then
+    # Tolerate an "already a backend"/"already exists" race (describe can transiently miss an
+    # existing attachment) so a retried run does not abort mid-build; any other failure stops.
+    if printf '%s' "$ADD_OUT" | grep -qiE 'already (a backend|exists)'; then
+      skip "add-backend reported NEG already attached; continuing"
+    else
+      printf '%s\n' "$ADD_OUT" >&2
+      echo "ERROR: add-backend failed for $BACKEND_NAME (not an already-attached race)." >&2
+      exit 1
+    fi
+  fi
 fi
 
 log "Step 1e: URL map ($URLMAP_NAME) -> $BACKEND_NAME"
@@ -272,9 +296,20 @@ log "Load balancer built. DNS A record for $DOMAIN -> $LB_IP (do NOT flip yet; r
 # 2. [ARMOR GATE] Cloud Armor policy: OWASP WAF (preview, low sensitivity) + rate limit.
 # ---------------------------------------------------------------------------------------
 if [ "$CONFIRM_ARMOR" = "1" ]; then
-  PREVIEW_FLAG="--preview"
-  MODE="PREVIEW (log-only)"
-  if [ "$ARMOR_ENFORCE" = "1" ]; then PREVIEW_FLAG=""; MODE="ENFORCE (deny-403)"; fi
+  # Enforce (deny-403) is a distinct, outage-capable action, so it needs its OWN gate on top of
+  # ARMOR_ENFORCE: a bare ARMOR_ENFORCE=1 must not silently build or flip rules into enforce.
+  # (dual-review PR #476)
+  ENFORCING=0
+  if [ "$ARMOR_ENFORCE" = "1" ]; then
+    [ "$CONFIRM_ARMOR_ENFORCE" = "1" ] || {
+      echo "ERROR: ARMOR_ENFORCE=1 also requires CONFIRM_ARMOR_ENFORCE=1." >&2
+      echo "       Enforce flips the WAF from log-only to deny-403; confirm it deliberately AFTER the" >&2
+      echo "       rehearsal preview logs show no legitimate AAC traffic is flagged." >&2
+      exit 1
+    }
+    ENFORCING=1
+  fi
+  if [ "$ENFORCING" = "1" ]; then PREVIEW_FLAG=""; MODE="ENFORCE (deny-403)"; else PREVIEW_FLAG="--preview"; MODE="PREVIEW (log-only)"; fi
 
   log "Step 2a: Cloud Armor policy $ARMOR_POLICY (WAF mode: $MODE, sensitivity=$WAF_SENSITIVITY)"
   if gcloud compute security-policies describe "$ARMOR_POLICY" --project="$PROJECT_ID" >/dev/null 2>&1; then
@@ -282,10 +317,11 @@ if [ "$CONFIRM_ARMOR" = "1" ]; then
   else
     gcloud compute security-policies create "$ARMOR_POLICY" \
       --project="$PROJECT_ID" --description="LingoLinq edge WAF + rate limiting (front of $WEB_SERVICE)"
-    # Verbose logging so the rehearsal can see what preview-mode WAF rules WOULD have blocked.
-    gcloud compute security-policies update "$ARMOR_POLICY" \
-      --project="$PROJECT_ID" --log-level=VERBOSE
   fi
+  # Verbose logging so the rehearsal can see what preview-mode WAF rules WOULD have blocked.
+  # Re-asserted on EVERY armor run (idempotent) so a policy created out-of-band still gets it.
+  gcloud compute security-policies update "$ARMOR_POLICY" \
+    --project="$PROJECT_ID" --log-level=VERBOSE
 
   # Preconfigured OWASP WAF rule sets (current rule IDs verified 2026-06-23: sqli/xss are the
   # *-v422-stable sets). Low sensitivity + preview so free-text AAC utterances are not blocked
@@ -300,6 +336,14 @@ if [ "$CONFIRM_ARMOR" = "1" ]; then
     RULESET="${WAF_RULES[$PRIO]}"
     if gcloud compute security-policies rules describe "$PRIO" --security-policy="$ARMOR_POLICY" --project="$PROJECT_ID" >/dev/null 2>&1; then
       skip "WAF rule $PRIO ($RULESET) already exists"
+      # Idempotently converge an EXISTING rule to enforce, so the documented preview->enforce flip
+      # actually takes effect on a re-run instead of being silently skipped by the describe check
+      # above and left in preview. (dual-review PR #476)
+      if [ "$ENFORCING" = "1" ]; then
+        log "Step 2b: flip existing WAF rule $PRIO -> ENFORCE (--no-preview)"
+        gcloud compute security-policies rules update "$PRIO" \
+          --project="$PROJECT_ID" --security-policy="$ARMOR_POLICY" --action=deny-403 --no-preview
+      fi
     else
       log "Step 2b: WAF rule $PRIO -> $RULESET (deny-403, $MODE)"
       # shellcheck disable=SC2086
@@ -314,6 +358,11 @@ if [ "$CONFIRM_ARMOR" = "1" ]; then
   # Defense-in-depth on top of the app's Rack::Attack; conservative so normal AAC use is unaffected.
   if gcloud compute security-policies rules describe 2000 --security-policy="$ARMOR_POLICY" --project="$PROJECT_ID" >/dev/null 2>&1; then
     skip "rate-limit rule 2000 already exists"
+    if [ "$ENFORCING" = "1" ]; then
+      log "Step 2c: flip existing rate-limit rule 2000 -> ENFORCE (--no-preview)"
+      gcloud compute security-policies rules update 2000 \
+        --project="$PROJECT_ID" --security-policy="$ARMOR_POLICY" --no-preview
+    fi
   else
     # shellcheck disable=SC2086
     gcloud compute security-policies rules create 2000 \
@@ -329,6 +378,16 @@ if [ "$CONFIRM_ARMOR" = "1" ]; then
   log "Step 2d: attach $ARMOR_POLICY to backend $BACKEND_NAME"
   gcloud compute backend-services update "$BACKEND_NAME" \
     --project="$PROJECT_ID" --global --security-policy="$ARMOR_POLICY"
+
+  # Read back and print the ACTUAL preview state of every rule (preview=true => log-only,
+  # preview=false => enforcing), so the operator never trusts the intended MODE banner over the
+  # real policy state before proceeding to lockdown / DNS. (dual-review PR #476)
+  log "Step 2e: actual WAF rule modes (preview=true is log-only, false is enforcing)"
+  for PRIO in "${!WAF_RULES[@]}" 2000; do
+    ACTUAL_PREVIEW="$(gcloud compute security-policies rules describe "$PRIO" \
+      --security-policy="$ARMOR_POLICY" --project="$PROJECT_ID" --format='value(preview)' 2>/dev/null || echo '?')"
+    echo "    rule $PRIO: preview=$ACTUAL_PREVIEW"
+  done
 else
   gate "Step 2 (Cloud Armor) SKIPPED. Re-run with CONFIRM_ARMOR=1 once approved."
 fi
@@ -337,6 +396,15 @@ fi
 # 3. [LOCKDOWN GATE] flip the web service to LB-only ingress. RUN LAST, after LB validated.
 # ---------------------------------------------------------------------------------------
 if [ "$CONFIRM_INGRESS_LOCKDOWN" = "1" ]; then
+  # Refuse to lock down ingress in the SAME run that builds the LB: lockdown must come only AFTER
+  # the LB path is validated in the rehearsal, otherwise the service goes LB-only while the managed
+  # cert is still PENDING (no validated ingress) and the 0a run.app smoke test breaks. (dual-review PR #476)
+  if [ "$CONFIRM_LB" = "1" ] || [ "$CONFIRM_ARMOR" = "1" ]; then
+    echo "ERROR: refusing ingress lockdown in the same invocation as the LB/Armor build." >&2
+    echo "       Validate the LB + WAF path in the rehearsal first, THEN run" >&2
+    echo "       CONFIRM_INGRESS_LOCKDOWN=1 on its own." >&2
+    exit 1
+  fi
   log "Step 3: $WEB_SERVICE ingress -> internal-and-cloud-load-balancing"
   echo "    WARNING: this removes public run.app access; only LB (Cloud Armor) traffic reaches the app."
   echo "    Reverse with: gcloud run services update $WEB_SERVICE --region=$REGION --ingress=all"
@@ -363,14 +431,14 @@ cat <<HANDOFF
   -------------------------------------------------------------------
   Built (when gated): static IP${LB_IP:+ = $LB_IP}, serverless NEG -> $WEB_SERVICE, backend
   $BACKEND_NAME, URL map, managed cert for ${DOMAIN:-<DOMAIN unset>}, HTTPS+HTTP forwarding,
-  and (if CONFIRM_ARMOR) Cloud Armor $ARMOR_POLICY in $([ "$ARMOR_ENFORCE" = "1" ] && echo ENFORCE || echo PREVIEW).
+  and (if CONFIRM_ARMOR) Cloud Armor $ARMOR_POLICY in $([ "$ARMOR_ENFORCE" = "1" ] && [ "$CONFIRM_ARMOR_ENFORCE" = "1" ] && echo ENFORCE || echo PREVIEW).
 
   Next, in order:
    1. Dress rehearsal: validate the LB path via the IP + Host header (cert is PENDING until DNS).
       Review Cloud Armor preview logs; confirm no AAC traffic is flagged, then re-run with
-      ARMOR_ENFORCE=1 CONFIRM_ARMOR=1 to switch the WAF to enforce.
-   2. After the LB is validated, run CONFIRM_INGRESS_LOCKDOWN=1 to take the web service off the
-      public run.app URL (LB-only).
+      ARMOR_ENFORCE=1 CONFIRM_ARMOR_ENFORCE=1 CONFIRM_ARMOR=1 to switch the WAF to enforce.
+   2. After the LB is validated, run CONFIRM_INGRESS_LOCKDOWN=1 ON ITS OWN (no CONFIRM_LB/ARMOR)
+      to take the web service off the public run.app URL (LB-only).
    3. At cutover (runbook step 9): point $DOMAIN DNS A record at the LB IP. The managed cert then
       provisions (up to ~60 min). Do NOT flip DNS before then.
 

--- a/scripts/gcp/phase5-frontend-lb.sh
+++ b/scripts/gcp/phase5-frontend-lb.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+#
+# phase5-frontend-lb.sh - LingoLinq Render -> GCP Cloud Run migration, Phase 5 (5.3 front end).
+#
+# Builds the DECIDED Option B front end (decision memo
+# ~/ai-company-brain/outputs/docs/2026-06-23-cloudrun-frontend-5-3-decision.md; runbook step 8):
+# an external global HTTPS Application Load Balancer + Cloud Armor (WAF) in front of the
+# lingolinq-web Cloud Run service, instead of mapping the domain straight to the run.app URL.
+#
+# Builds, in order (each behind a fail-closed gate):
+#   [LB]       reserve a global static anycast IP   (DNS A-record target for the cutover)
+#              serverless NEG -> lingolinq-web  +  EXTERNAL_MANAGED backend service
+#              URL map + Google-managed SSL cert + target HTTPS proxy + :443 forwarding rule
+#              HTTP :80 -> HTTPS redirect (url-map + proxy + forwarding rule)
+#   [ARMOR]    Cloud Armor policy: preconfigured OWASP WAF rules (SQLi/XSS/LFI/RCE) in
+#              PREVIEW (log-only) at LOW sensitivity + an edge rate-limit rule, attached to
+#              the backend service. Preview + low sensitivity so the dress rehearsal can prove
+#              it does NOT false-positive on AAC traffic before it is switched to enforce.
+#   [LOCKDOWN] flip lingolinq-web ingress to internal-and-cloud-load-balancing so the public
+#              run.app URL no longer bypasses Cloud Armor. RUN LAST, after the LB is validated.
+#
+# It does NOT flip DNS (runbook step 9, a separate gated cutover action) and does NOT enforce
+# the WAF rules (they ship in preview; flip to enforce after the rehearsal proves them clean).
+#
+# Design rules (same contract as scripts/gcp/phase3-data-layer.sh):
+#   - Idempotent: every create is guarded by a describe check, so re-runs are safe.
+#   - Fail-closed gates: each step runs ONLY when its CONFIRM_* flag is 1. A bare run prints
+#     the plan + a rough cost estimate and stops before creating anything billable.
+#   - Auditable: every command is commented with what it does and why (HIPAA evidence).
+#   - Reversible: the ingress lockdown is undoable with `gcloud run services update
+#     lingolinq-web --ingress=all`; teardown notes are in the handoff block at the end.
+#
+# IMPORTANT - SSL cert provisioning needs DNS: a Google-managed cert does NOT provision until
+# the domain's DNS resolves to this LB's IP. So at cutover the cert is PENDING until step 9
+# (DNS flip), and HTTPS on the custom domain only goes green after propagation. For the dress
+# rehearsal, validate the LB path via the LB IP with a Host header / a hosts-file override (or a
+# throwaway test subdomain pointed at the LB IP), not the production domain. Plan ~up to 60 min
+# for the cert to provision after DNS.
+#
+# Usage:
+#   DOMAIN=app.example.com ./scripts/gcp/phase5-frontend-lb.sh                 # plan + cost, stop
+#   DOMAIN=... CONFIRM_LB=1 ./scripts/gcp/phase5-frontend-lb.sh                # + IP/NEG/BE/cert/proxy/FR
+#   DOMAIN=... CONFIRM_LB=1 CONFIRM_ARMOR=1 ./scripts/gcp/phase5-frontend-lb.sh  # + Cloud Armor (preview)
+#   DOMAIN=... CONFIRM_LB=1 CONFIRM_ARMOR=1 SET_GH_VARS=1 ...                  # + write repo vars (LB IP/domain)
+#   DOMAIN=... CONFIRM_INGRESS_LOCKDOWN=1 ./scripts/gcp/phase5-frontend-lb.sh  # flip web to LB-only (LAST)
+#   ARMOR_ENFORCE=1 CONFIRM_ARMOR=1 DOMAIN=... ...                             # WAF enforce (after rehearsal)
+#
+# Optional overrides: PROJECT_ID, REGION, WEB_SERVICE, WAF_SENSITIVITY, RATE_LIMIT_COUNT,
+#   RATE_LIMIT_INTERVAL_SEC, and the resource names below.
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------------------
+# CONFIG (override via env)
+# ---------------------------------------------------------------------------------------
+PROJECT_ID="${PROJECT_ID:-lingolinq-prod}"
+REGION="${REGION:-us-central1}"
+WEB_SERVICE="${WEB_SERVICE:-lingolinq-web}"            # the Cloud Run service to front (deploy-cloudrun.yml)
+
+# The production domain the LB serves. REQUIRED for the managed cert; no safe default, so we
+# refuse to guess it. Set DOMAIN=... on the command line.
+DOMAIN="${DOMAIN:-}"
+
+# Resource names (all global except the regional serverless NEG).
+LB_IP_NAME="${LB_IP_NAME:-lingolinq-lb-ip}"
+NEG_NAME="${NEG_NAME:-lingolinq-web-neg}"
+BACKEND_NAME="${BACKEND_NAME:-lingolinq-web-be}"
+URLMAP_NAME="${URLMAP_NAME:-lingolinq-url-map}"
+CERT_NAME="${CERT_NAME:-lingolinq-cert}"
+HTTPS_PROXY_NAME="${HTTPS_PROXY_NAME:-lingolinq-https-proxy}"
+HTTPS_FR_NAME="${HTTPS_FR_NAME:-lingolinq-https-fr}"
+REDIRECT_URLMAP_NAME="${REDIRECT_URLMAP_NAME:-lingolinq-http-redirect}"
+HTTP_PROXY_NAME="${HTTP_PROXY_NAME:-lingolinq-http-proxy}"
+HTTP_FR_NAME="${HTTP_FR_NAME:-lingolinq-http-fr}"
+ARMOR_POLICY="${ARMOR_POLICY:-lingolinq-armor}"
+
+# Cloud Armor tuning. Low sensitivity + preview by default so the WAF does NOT block real AAC
+# traffic (free-text utterances can resemble SQLi/XSS signatures) until proven in the rehearsal.
+WAF_SENSITIVITY="${WAF_SENSITIVITY:-1}"               # 1 = fewest signatures/false positives; default GCP is 4
+RATE_LIMIT_COUNT="${RATE_LIMIT_COUNT:-600}"          # requests per interval per client IP at the edge
+RATE_LIMIT_INTERVAL_SEC="${RATE_LIMIT_INTERVAL_SEC:-60}"
+ARMOR_ENFORCE="${ARMOR_ENFORCE:-0}"                  # 0 = WAF rules in PREVIEW (log-only); 1 = enforce (deny-403)
+
+# GitHub repo for repo-variable writes (needs `gh` CLI authed).
+GH_REPO="${GH_REPO:-lingolinq/LingoLinq-AAC}"
+
+# Gate flags (default 0 = do not run that gated step).
+CONFIRM_LB="${CONFIRM_LB:-0}"
+CONFIRM_ARMOR="${CONFIRM_ARMOR:-0}"
+CONFIRM_INGRESS_LOCKDOWN="${CONFIRM_INGRESS_LOCKDOWN:-0}"
+SET_GH_VARS="${SET_GH_VARS:-0}"
+
+log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+skip() { printf '    \033[1;33m(skip)\033[0m %s\n' "$*"; }
+gate() { printf '\n\033[1;31m[GATE]\033[0m %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------------------
+# 0. PREFLIGHT - right operator, project exists, billing live, web service deployed.
+# ---------------------------------------------------------------------------------------
+log "Preflight: gcloud auth, project, billing, web service"
+command -v gcloud >/dev/null 2>&1 || { echo "ERROR: gcloud CLI not found." >&2; exit 1; }
+ACTIVE_ACCT="$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null || true)"
+[ -n "$ACTIVE_ACCT" ] || { echo "ERROR: no active gcloud account. Run: gcloud auth login" >&2; exit 1; }
+echo "    Active account: $ACTIVE_ACCT"
+
+gcloud projects describe "$PROJECT_ID" >/dev/null 2>&1 \
+  || { echo "ERROR: project $PROJECT_ID not found. Run Phase 1/3 first." >&2; exit 1; }
+echo "    Project: $PROJECT_ID, region $REGION"
+
+set +e
+BILLING_ENABLED="$(gcloud billing projects describe "$PROJECT_ID" --format='value(billingEnabled)' 2>/dev/null)"
+BILLING_RC=$?
+set -e
+[ "$BILLING_RC" -eq 0 ] || { echo "ERROR: cannot read billing for $PROJECT_ID." >&2; exit 1; }
+[ "$BILLING_ENABLED" = "True" ] || { echo "ERROR: billing not enabled on $PROJECT_ID." >&2; exit 1; }
+
+# The web service must already be deployed (it is the NEG backend). The deploy workflow creates
+# it; if it is missing, run the deploy first (runbook step 7).
+gcloud run services describe "$WEB_SERVICE" --region="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1 \
+  || { echo "ERROR: Cloud Run service $WEB_SERVICE not found in $REGION. Deploy it first (runbook step 7)." >&2; exit 1; }
+echo "    Web service present: $WEB_SERVICE ($REGION)"
+
+# ---------------------------------------------------------------------------------------
+# 0b. PLAN + COST ESTIMATE. Printed every run before any gate.
+# ---------------------------------------------------------------------------------------
+cat <<PLAN
+
+  PHASE 5 (5.3) FRONT-END PLAN for $PROJECT_ID  (Option B: external HTTPS ALB + Cloud Armor)
+  -------------------------------------------------------------------
+  [LB]    static IP $LB_IP_NAME (global) -> DNS A-record target for cutover
+          serverless NEG $NEG_NAME -> Cloud Run $WEB_SERVICE
+          backend $BACKEND_NAME (EXTERNAL_MANAGED) + URL map $URLMAP_NAME
+          managed SSL cert $CERT_NAME for DOMAIN='${DOMAIN:-<UNSET - required>}'
+          HTTPS proxy + :443 forwarding rule; HTTP :80 -> HTTPS redirect
+  [ARMOR] policy $ARMOR_POLICY: OWASP WAF (SQLi/XSS/LFI/RCE) sensitivity=$WAF_SENSITIVITY,
+          mode=$([ "$ARMOR_ENFORCE" = "1" ] && echo ENFORCE || echo PREVIEW); rate-limit
+          ${RATE_LIMIT_COUNT}/${RATE_LIMIT_INTERVAL_SEC}s per IP; attached to $BACKEND_NAME
+  [LOCKDOWN] $WEB_SERVICE ingress -> internal-and-cloud-load-balancing (run LAST)
+
+  ROUGH cost estimate (VERIFY against current GCP pricing before approving):
+    Global forwarding rule + LB ........... ~\$18-25 / mo + data processing
+    Cloud Armor policy + rules ............ ~\$5 / mo + \$1/rule + per-request
+    Static anycast IP (in use) ............ included while attached
+    -------------------------------------------------------------------
+    Estimated steady-state ................ ~\$30-45 / mo
+  -------------------------------------------------------------------
+  NOTE: the managed SSL cert stays PENDING until DNS points DOMAIN at the LB IP (step 9).
+  Validate the LB in the rehearsal via the IP + Host header, not the production domain.
+PLAN
+
+# ---------------------------------------------------------------------------------------
+# 1. [LB GATE] static IP + serverless NEG + backend + URL map + cert + proxies + forwarding.
+# ---------------------------------------------------------------------------------------
+if [ "$CONFIRM_LB" != "1" ]; then
+  gate "Step 1 (load balancer) SKIPPED. Re-run with CONFIRM_LB=1 (and DOMAIN=...) once approved. Stopping."
+  exit 0
+fi
+[ -n "$DOMAIN" ] || { echo "ERROR: DOMAIN is required for the managed SSL cert. Set DOMAIN=app.example.com." >&2; exit 1; }
+
+log "Step 1a: enable compute API (load balancing lives here)"
+gcloud services enable compute.googleapis.com --project="$PROJECT_ID"
+
+log "Step 1b: reserve global static anycast IP ($LB_IP_NAME) - the DNS A-record target"
+if gcloud compute addresses describe "$LB_IP_NAME" --global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "address $LB_IP_NAME already exists"
+else
+  gcloud compute addresses create "$LB_IP_NAME" --global --project="$PROJECT_ID"
+fi
+LB_IP="$(gcloud compute addresses describe "$LB_IP_NAME" --global --project="$PROJECT_ID" --format='value(address)')"
+echo "    LB IP: $LB_IP   (use this as the DNS A record for $DOMAIN at cutover)"
+
+log "Step 1c: serverless NEG ($NEG_NAME) -> Cloud Run $WEB_SERVICE"
+if gcloud compute network-endpoint-groups describe "$NEG_NAME" --region="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "NEG $NEG_NAME already exists"
+else
+  gcloud compute network-endpoint-groups create "$NEG_NAME" \
+    --project="$PROJECT_ID" \
+    --region="$REGION" \
+    --network-endpoint-type=serverless \
+    --cloud-run-service="$WEB_SERVICE"
+fi
+
+log "Step 1d: backend service ($BACKEND_NAME, EXTERNAL_MANAGED) + attach NEG"
+# Serverless NEG backends do NOT take a health check (managed by Cloud Run), so none is added.
+if gcloud compute backend-services describe "$BACKEND_NAME" --global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "backend service $BACKEND_NAME already exists"
+else
+  gcloud compute backend-services create "$BACKEND_NAME" \
+    --project="$PROJECT_ID" \
+    --global \
+    --load-balancing-scheme=EXTERNAL_MANAGED \
+    --enable-logging --logging-sample-rate=1.0
+fi
+if gcloud compute backend-services describe "$BACKEND_NAME" --global --project="$PROJECT_ID" \
+     --format='value(backends.group)' | grep -q "$NEG_NAME"; then
+  skip "NEG already attached to $BACKEND_NAME"
+else
+  gcloud compute backend-services add-backend "$BACKEND_NAME" \
+    --project="$PROJECT_ID" \
+    --global \
+    --network-endpoint-group="$NEG_NAME" \
+    --network-endpoint-group-region="$REGION"
+fi
+
+log "Step 1e: URL map ($URLMAP_NAME) -> $BACKEND_NAME"
+if gcloud compute url-maps describe "$URLMAP_NAME" --global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "url map $URLMAP_NAME already exists"
+else
+  gcloud compute url-maps create "$URLMAP_NAME" \
+    --project="$PROJECT_ID" --global --default-service="$BACKEND_NAME"
+fi
+
+log "Step 1f: Google-managed SSL cert ($CERT_NAME) for $DOMAIN"
+# Provisions only AFTER DNS points $DOMAIN at $LB_IP (so it stays PENDING until step 9).
+if gcloud compute ssl-certificates describe "$CERT_NAME" --global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "ssl cert $CERT_NAME already exists"
+else
+  gcloud compute ssl-certificates create "$CERT_NAME" \
+    --project="$PROJECT_ID" --global --domains="$DOMAIN"
+fi
+
+log "Step 1g: target HTTPS proxy ($HTTPS_PROXY_NAME) + :443 forwarding rule ($HTTPS_FR_NAME)"
+if gcloud compute target-https-proxies describe "$HTTPS_PROXY_NAME" --global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "https proxy $HTTPS_PROXY_NAME already exists"
+else
+  gcloud compute target-https-proxies create "$HTTPS_PROXY_NAME" \
+    --project="$PROJECT_ID" --global \
+    --url-map="$URLMAP_NAME" --ssl-certificates="$CERT_NAME"
+fi
+if gcloud compute forwarding-rules describe "$HTTPS_FR_NAME" --global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "forwarding rule $HTTPS_FR_NAME already exists"
+else
+  gcloud compute forwarding-rules create "$HTTPS_FR_NAME" \
+    --project="$PROJECT_ID" --global \
+    --load-balancing-scheme=EXTERNAL_MANAGED \
+    --address="$LB_IP_NAME" --target-https-proxy="$HTTPS_PROXY_NAME" --ports=443
+fi
+
+log "Step 1h: HTTP :80 -> HTTPS redirect (so plain http doesn't dead-end)"
+if gcloud compute url-maps describe "$REDIRECT_URLMAP_NAME" --global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "redirect url map $REDIRECT_URLMAP_NAME already exists"
+else
+  # url-maps import reads a redirect spec from stdin (no create-time flag for a pure redirect).
+  gcloud compute url-maps import "$REDIRECT_URLMAP_NAME" \
+    --project="$PROJECT_ID" --global --quiet <<YAML
+name: $REDIRECT_URLMAP_NAME
+defaultUrlRedirect:
+  httpsRedirect: true
+  redirectResponseCode: MOVED_PERMANENTLY_DEFAULT
+  stripQuery: false
+YAML
+fi
+if gcloud compute target-http-proxies describe "$HTTP_PROXY_NAME" --global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "http proxy $HTTP_PROXY_NAME already exists"
+else
+  gcloud compute target-http-proxies create "$HTTP_PROXY_NAME" \
+    --project="$PROJECT_ID" --global --url-map="$REDIRECT_URLMAP_NAME"
+fi
+if gcloud compute forwarding-rules describe "$HTTP_FR_NAME" --global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  skip "forwarding rule $HTTP_FR_NAME already exists"
+else
+  gcloud compute forwarding-rules create "$HTTP_FR_NAME" \
+    --project="$PROJECT_ID" --global \
+    --load-balancing-scheme=EXTERNAL_MANAGED \
+    --address="$LB_IP_NAME" --target-http-proxy="$HTTP_PROXY_NAME" --ports=80
+fi
+
+echo
+log "Load balancer built. DNS A record for $DOMAIN -> $LB_IP (do NOT flip yet; runbook step 9)."
+
+# ---------------------------------------------------------------------------------------
+# 2. [ARMOR GATE] Cloud Armor policy: OWASP WAF (preview, low sensitivity) + rate limit.
+# ---------------------------------------------------------------------------------------
+if [ "$CONFIRM_ARMOR" = "1" ]; then
+  PREVIEW_FLAG="--preview"
+  MODE="PREVIEW (log-only)"
+  if [ "$ARMOR_ENFORCE" = "1" ]; then PREVIEW_FLAG=""; MODE="ENFORCE (deny-403)"; fi
+
+  log "Step 2a: Cloud Armor policy $ARMOR_POLICY (WAF mode: $MODE, sensitivity=$WAF_SENSITIVITY)"
+  if gcloud compute security-policies describe "$ARMOR_POLICY" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    skip "security policy $ARMOR_POLICY already exists"
+  else
+    gcloud compute security-policies create "$ARMOR_POLICY" \
+      --project="$PROJECT_ID" --description="LingoLinq edge WAF + rate limiting (front of $WEB_SERVICE)"
+    # Verbose logging so the rehearsal can see what preview-mode WAF rules WOULD have blocked.
+    gcloud compute security-policies update "$ARMOR_POLICY" \
+      --project="$PROJECT_ID" --log-level=VERBOSE
+  fi
+
+  # Preconfigured OWASP WAF rule sets (current rule IDs verified 2026-06-23: sqli/xss are the
+  # *-v422-stable sets). Low sensitivity + preview so free-text AAC utterances are not blocked
+  # until the rehearsal proves the rules clean; flip to enforce with ARMOR_ENFORCE=1 afterward.
+  declare -A WAF_RULES=(
+    [1001]="sqli-v422-stable"
+    [1002]="xss-v422-stable"
+    [1003]="lfi-v422-stable"
+    [1004]="rce-v422-stable"
+  )
+  for PRIO in "${!WAF_RULES[@]}"; do
+    RULESET="${WAF_RULES[$PRIO]}"
+    if gcloud compute security-policies rules describe "$PRIO" --security-policy="$ARMOR_POLICY" --project="$PROJECT_ID" >/dev/null 2>&1; then
+      skip "WAF rule $PRIO ($RULESET) already exists"
+    else
+      log "Step 2b: WAF rule $PRIO -> $RULESET (deny-403, $MODE)"
+      # shellcheck disable=SC2086
+      gcloud compute security-policies rules create "$PRIO" \
+        --project="$PROJECT_ID" --security-policy="$ARMOR_POLICY" \
+        --expression="evaluatePreconfiguredWaf('$RULESET', {'sensitivity': $WAF_SENSITIVITY})" \
+        --action=deny-403 $PREVIEW_FLAG
+    fi
+  done
+
+  log "Step 2c: edge rate-limit rule 2000 (throttle ${RATE_LIMIT_COUNT}/${RATE_LIMIT_INTERVAL_SEC}s per IP)"
+  # Defense-in-depth on top of the app's Rack::Attack; conservative so normal AAC use is unaffected.
+  if gcloud compute security-policies rules describe 2000 --security-policy="$ARMOR_POLICY" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    skip "rate-limit rule 2000 already exists"
+  else
+    # shellcheck disable=SC2086
+    gcloud compute security-policies rules create 2000 \
+      --project="$PROJECT_ID" --security-policy="$ARMOR_POLICY" \
+      --src-ip-ranges="*" \
+      --action=throttle \
+      --rate-limit-threshold-count="$RATE_LIMIT_COUNT" \
+      --rate-limit-threshold-interval-sec="$RATE_LIMIT_INTERVAL_SEC" \
+      --conform-action=allow --exceed-action=deny-429 \
+      --enforce-on-key=IP $PREVIEW_FLAG
+  fi
+
+  log "Step 2d: attach $ARMOR_POLICY to backend $BACKEND_NAME"
+  gcloud compute backend-services update "$BACKEND_NAME" \
+    --project="$PROJECT_ID" --global --security-policy="$ARMOR_POLICY"
+else
+  gate "Step 2 (Cloud Armor) SKIPPED. Re-run with CONFIRM_ARMOR=1 once approved."
+fi
+
+# ---------------------------------------------------------------------------------------
+# 3. [LOCKDOWN GATE] flip the web service to LB-only ingress. RUN LAST, after LB validated.
+# ---------------------------------------------------------------------------------------
+if [ "$CONFIRM_INGRESS_LOCKDOWN" = "1" ]; then
+  log "Step 3: $WEB_SERVICE ingress -> internal-and-cloud-load-balancing"
+  echo "    WARNING: this removes public run.app access; only LB (Cloud Armor) traffic reaches the app."
+  echo "    Reverse with: gcloud run services update $WEB_SERVICE --region=$REGION --ingress=all"
+  gcloud run services update "$WEB_SERVICE" \
+    --project="$PROJECT_ID" --region="$REGION" \
+    --ingress=internal-and-cloud-load-balancing
+else
+  gate "Step 3 (ingress lockdown) SKIPPED. Run with CONFIRM_INGRESS_LOCKDOWN=1 ONLY after the LB path is validated in the rehearsal (otherwise the 0a run.app smoke test breaks)."
+fi
+
+# ---------------------------------------------------------------------------------------
+# 4. [GH VARS] write the LB IP + domain as repo variables for the runbook / DNS step.
+# ---------------------------------------------------------------------------------------
+if [ "$SET_GH_VARS" = "1" ] && [ "$CONFIRM_LB" = "1" ]; then
+  command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI not found (needed for SET_GH_VARS)." >&2; exit 1; }
+  log "Step 4: write repo variables to $GH_REPO (LB_IP, FRONTEND_DOMAIN)"
+  gh variable set FRONTEND_LB_IP --repo "$GH_REPO" --body "$LB_IP"
+  gh variable set FRONTEND_DOMAIN --repo "$GH_REPO" --body "$DOMAIN"
+fi
+
+cat <<HANDOFF
+
+  PHASE 5 (5.3) FRONT END - handoff
+  -------------------------------------------------------------------
+  Built (when gated): static IP${LB_IP:+ = $LB_IP}, serverless NEG -> $WEB_SERVICE, backend
+  $BACKEND_NAME, URL map, managed cert for ${DOMAIN:-<DOMAIN unset>}, HTTPS+HTTP forwarding,
+  and (if CONFIRM_ARMOR) Cloud Armor $ARMOR_POLICY in $([ "$ARMOR_ENFORCE" = "1" ] && echo ENFORCE || echo PREVIEW).
+
+  Next, in order:
+   1. Dress rehearsal: validate the LB path via the IP + Host header (cert is PENDING until DNS).
+      Review Cloud Armor preview logs; confirm no AAC traffic is flagged, then re-run with
+      ARMOR_ENFORCE=1 CONFIRM_ARMOR=1 to switch the WAF to enforce.
+   2. After the LB is validated, run CONFIRM_INGRESS_LOCKDOWN=1 to take the web service off the
+      public run.app URL (LB-only).
+   3. At cutover (runbook step 9): point $DOMAIN DNS A record at the LB IP. The managed cert then
+      provisions (up to ~60 min). Do NOT flip DNS before then.
+
+  Teardown (reverse order): forwarding-rules -> proxies -> url-maps -> ssl-certificates ->
+  backend-services -> network-endpoint-groups -> addresses; detach + delete the Cloud Armor
+  policy; restore ingress with --ingress=all.
+HANDOFF


### PR DESCRIPTION
## What

Implements the decided **5.3 Option B** front end (external global HTTPS Application Load Balancer + Cloud Armor in front of `lingolinq-web`) as a gated, idempotent provisioning script: `scripts/gcp/phase5-frontend-lb.sh`. Authoring only — **nothing runs against `lingolinq-prod`** without the `CONFIRM_*` gates and your go. Matches the `scripts/gcp/phase3-data-layer.sh` contract (plan-first + cost, fail-closed gates, describe-guarded idempotency, audit comments).

Decision context: `~/ai-company-brain/outputs/docs/2026-06-23-cloudrun-frontend-5-3-decision.md`; runbook step 8.

## Gates (a bare run prints the plan + cost estimate and stops)

- **`CONFIRM_LB=1`** (needs `DOMAIN=...`): global static anycast IP (the DNS A-record target), serverless NEG → Cloud Run, `EXTERNAL_MANAGED` backend, URL map, Google-managed SSL cert, HTTPS proxy + :443 forwarding rule, HTTP :80 → HTTPS redirect.
- **`CONFIRM_ARMOR=1`**: Cloud Armor policy — preconfigured OWASP WAF (SQLi/XSS/LFI/RCE, current `*-v422-stable` sets) in **PREVIEW (log-only) at LOW sensitivity**, plus an edge rate-limit rule, attached to the backend. Preview + low sensitivity so the rehearsal proves the WAF doesn't false-positive on free-text AAC utterances before flipping to enforce (`ARMOR_ENFORCE=1`). Directly addresses the memo's "a bad Cloud Armor rule can block AAC users" risk.
- **`CONFIRM_INGRESS_LOCKDOWN=1`**: flips `lingolinq-web` to `internal-and-cloud-load-balancing` so the public `run.app` URL no longer bypasses Cloud Armor. Documented to run **LAST** (the 0a rehearsal smoke-tests `run.app`); reversible with `--ingress=all`.

## Correctness notes (verified against current GCP docs, 2026-06-23)

- Serverless-NEG backends take **no health check** (Cloud Run manages it) — none is added.
- The managed cert stays **PENDING until DNS points the domain at the LB IP** (cutover step 9), so the rehearsal validates via the LB IP + Host header, not the prod domain.
- `DOMAIN` is a **required override** (no guessed default).
- Cloud Armor rule IDs corrected to the current `sqli-v422-stable` / `xss-v422-stable` sets (training-era `v33` names are stale).

## Scope

- Does **not** modify `.github/workflows/deploy-cloudrun.yml` (run.app stays public for the rehearsal smoke test; the ingress lockdown is the explicit final gated step in the script).
- Does **not** flip DNS (runbook step 9, a separate gated action).
- Runbook step-8 pointer to this script will be added on the #475 branch (which rewrote step 8) to avoid a merge conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)