### PR TITLE
compliance(register): close 2 attested Highs; reopen bootstrap from false 'fixed'

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "254cb27b3863ab1726382de61fee594c6b0f01d317759930d975901ade4d8550",
+      "contentHash": "28ff0a88e1e1b1f1b3eaf3f03f4a4541d1d2c585951c7dd9896499215c9d5dec",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `254cb27b3863` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `28ff0a88e1e1` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -1628,10 +1628,10 @@
       },
       "notes": "Surfaced by dependency finder on 2026-06-14. | adversary verifier: CONFIRMED (high); SEVERITY OPINION for Scot = should-be-medium. bootstrap 3.4.1 JS is bundled (ember-cli-build.js:88) and .tooltip()/.popover() are used, but no live untrusted-HTML-into-tooltip sink exists today (all .tooltip() omit html:true; the one html:true popover builds body via escaped innerText), so this is latent supply-chain/XSS hygiene risk, not a currently triggerable XSS. Fix is independent of the pinned Ember 3.28->5 migration. Severity downgrade is Scot's call only.",
       "disposition": {
-        "state": "fixed",
+        "state": "accepted",
         "decidedBy": "Scot Wahlquist",
-        "decidedDate": "2026-06-18",
-        "rationale": "Replace or upgrade bootstrap 3.4.1 (EOL); a larger migration to schedule on its own, not a quick win."
+        "decidedDate": "2026-06-23",
+        "rationale": "Reopened from 'fixed' on verification 2026-06-23: bootstrap 3.4.1 is still bundled (app/frontend/package.json; ember-cli-build.js:52) and .tooltip()/.popover() remain in use, including a data-content=innerHTML popover at utterance.js:840. Not actually remediated; accepted for real remediation (remove/upgrade bootstrap, or sanitize/verify the utterance.js popover path)."
       }
     },
     {
@@ -2246,7 +2246,7 @@
         "FERPA",
         "HIPAA"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/controllers/api/eval_sessions_controller.rb",
@@ -2255,16 +2255,16 @@
         "sha": "922d93b98417692e5fd5b8bc3d64df7b3baab84d"
       },
       "firstSeen": "2026-06-17",
-      "lastSeen": "2026-06-17",
+      "lastSeen": "2026-06-23",
       "owner": "unassigned",
       "remediation": {
         "options": "Persist the eval server-side against the resolved user and verify ownership of the eval content before egress, rather than trusting the client-supplied eval_session payload. Bind the gate-subject (user_id) to the data actually sent.",
-        "timeframe": "server-side-eval-persistence follow-up (Phase 1B)"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "ab426abf50df402abba37ccef8944e6b75ff7c75",
+        "verifierNote": "Verified 2026-06-23: the narrate action gates external-model egress on (a) explicit use_anthropic opt-in (default off -> deterministic local template, no egress), (b) a resolvable supervised student (exists? + allowed?('supervise')), (c) COPPA consent (FeatureFlags.coppa_blocks_ai_for?), and (d) org AI opt-in (ai_enabled_for?); the payload is PII-scrubbed before send. eval_sessions_controller.rb:43-79, eval_narrator.rb:25-73.",
+        "attestation": "Scot Wahlquist 2026-06-23: attested verified-closed. External-model narration is hard-gated on explicit per-request opt-in, supervised-student resolution, COPPA parental-consent, and org-level AI opt-in, with PII scrubbing before egress; default behavior sends no data externally."
       },
       "disposition": {
         "state": "fixed",
@@ -2657,14 +2657,14 @@
         "HIPAA",
         "FERPA"
       ],
-      "status": "open",
+      "status": "accepted-risk",
       "evidence": {
         "type": "runtime",
         "source": "render-mcp:list_postgres_instances",
         "snippet": "Both Render Postgres instances (incl. the prod DB and the dev/staging DB) report ipAllowList = a single all-addresses /0 entry ('everywhere'), i.e. the database accepts TCP connections from any source IP on the public internet. No source-IP restriction is in effect. render.yaml databases block (render.yaml:101-105) declares no ipAllowList, so the public-everywhere default is the effective committed posture and is not documented as intentional in render.yaml or docs/INFRASTRUCTURE.md. Checked: ipAllowList field only; no secrets/connection strings/PII read or echoed."
       },
       "firstSeen": "2026-06-19",
-      "lastSeen": "2026-06-21",
+      "lastSeen": "2026-06-23",
       "owner": "Scot Wahlquist",
       "remediation": {
         "options": "Restrict the Render Postgres ipAllowList to known egress sources (the Render service private network / specific NAT egress CIDRs) instead of the all-addresses /0 default, via the database's Access Control settings or an ipAllowList block in render.yaml. Combined with sslmode=require (LL-ba0585ab93, no cert verification), a public-reachable DB is a real network attack surface for a credential-stuffing / brute-force path against the DB. The GCP Cloud SQL cutover removes public DB exposure entirely (private VPC + Cloud SQL connector), so for prod this reconciles with the migration rather than being fixed twice; the dev/staging DB should be restricted now regardless. Until cutover, set an allowlist or accept-risk with a dated note.",
@@ -2672,15 +2672,15 @@
       },
       "closureEvidence": {
         "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "verifierNote": "No code fix; network-allowlist remediation is owned by the Render-to-GCP migration workstream and lands with the private-VPC Cloud SQL cutover.",
+        "attestation": "Scot Wahlquist 2026-06-23: accepted as a known risk on the interim Render environment; superseded by the private-VPC Cloud SQL cutover."
       },
       "notes": "Surfaced by infra finder on 2026-06-19. Net-new infra finding (runtime). Distinct from LL-ba0585ab93 (DB sslmode=require, encryption/cert-verification, not network reachability), LL-6619cc1811 (Redis TLS), and LL-9f83617435 (HSTS). The register has no finding covering DB network-level public exposure. Re-verify by re-running render-mcp:list_postgres_instances (workspace-independent). The prod-DB closure is gated on the GCP Memorystore/Cloud SQL cutover per project_render_cloud_migration; the dev/staging DB exposure is independently restrictable now. | adversary: confirmed (committed-config: render.yaml databases block declares no ipAllowList and INFRASTRUCTURE.md does not document the open posture as intentional). Live single-/0 runtime detail flagged uncertain pending a render-MCP re-pull. | triaged 2026-06-19: disposition=accepted (real, to remediate), owner Scot, at Scot's direction in the audit session. | LIVE CHECK 2026-06-21 (render-MCP list_postgres_instances): CONFIRMED both lingolinq-prod-db (dpg-d64c5i1r0fns73c5jcp0-a) and lingolinq-dev-staging-db (dpg-d64c53v5r7bs73acj600-a) have ipAllowList=[0.0.0.0/0 \"everywhere\"]. The prior \"uncertain pending re-pull\" note is resolved: the /0 exposure is real and current on both. dev/staging is restrictable now; prod gated on the Memorystore/Cloud SQL cutover. Remains open (live state cannot close it). | DECISION 2026-06-21 (Scot, /lingo session): remediate via the GCP migration, NOT an interim Render allowlist edit. Prod + dev/staging move to Cloud SQL (private-IP-only, NO public IP - confirmed in the Phase-4 dry-run plan Step 2 \"no public IP\" verify) over the next ~2 weeks, eliminating the public endpoint entirely (strictly better than a 0.0.0.0/0 -> /32 narrowing). Interim 0.0.0.0/0 exposure ACCEPTED for the cutover window (DB stays credential-gated; creds in Render env/1Password, not in repo); no interim infra change so prod is not poked right before cutover. CLOSE when: prod data is live on private-IP Cloud SQL AND the Render prod + dev-staging DBs are decommissioned/restricted (re-run render-MCP list_postgres_instances to confirm). TRIPWIRE: if the cutover has not landed by ~2026-07-05, revisit and apply the interim restriction drafted at ~/ai-company-brain/outputs/plans/2026-06-21-dev-staging-db-allowlist-restriction-plan.md.",
       "disposition": {
         "state": "accepted",
         "decidedBy": "Scot Wahlquist",
-        "decidedDate": "2026-06-19",
-        "rationale": "Confirmed real network-exposure finding. Accepted as a remediation item (not a risk-acceptance). Production DB closure folds into the Render->GCP Cloud SQL cutover (private VPC, no public DB exposure) per the migration; the dev/staging DB ipAllowList should be restricted independently and now, since it does not depend on the cutover. Adversary confirmed the committed-config half; live single-/0 detail to re-confirm via a render-MCP re-pull at remediation time."
+        "decidedDate": "2026-06-23",
+        "rationale": "Accepted as a known risk. The production Postgres network allowlist is managed in the Render-to-GCP migration workstream; the interim public-reachability exposure on Render is accepted and is superseded by the private-VPC Cloud SQL cutover."
       }
     },
     {

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,17 +5,15 @@
 
 **Audited:** `scot/security/audit-erasure-admin-reads` @ `445336592ddaf838689df7e578829e94e140890d` on 2026-06-19  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 5 High
+**Headline (open + remediated-unverified):** 0 Critical / 3 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (45)
+## Open (43)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
-| LL-d1ea8659c3 |  | high | SOC2 | **fixed** | audit-run | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
-| LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | **fixed** | audit | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
-| LL-aacae48768 |  | high | SOC2, HIPAA, FERPA | **accepted** | audit-run | Production Postgres (lingolinq-prod-db) reachable from an all-addresses /0 allowlist (public internet) | (attestation) |
+| LL-d1ea8659c3 |  | high | SOC2 | **accepted** | audit-run | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | **accepted** | audit-review | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | **accepted** | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
@@ -59,7 +57,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-a97357136e | P2-2 | low | SOC2 | **wontfix** | audit-run | params.permit! bypasses Strong Parameters | `app/controllers/api/organizations_controller.rb`:866 |
 | LL-ce00c8d3ad | P2-3 | low |  | **wontfix** | audit-run | License model lacks Processable concern | `app/models/license.rb`:1 |
 
-## Verified closed (33)
+## Verified closed (34)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -73,6 +71,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-ef5ac1b2a5 |  | high | FERPA, HIPAA | untriaged | audit-run | Eval AI narration creates no AiApiLog entry (no record student eval data was sent to an LLM) | `lib/eval_narrator.rb`:58 |
 | LL-2967f77e6d |  | high | WCAG | **fixed** | audit-run | Board-tile symbol image has no alt text (fast_html render path) | `app/frontend/app/utils/button.js`:449 |
 | LL-2e4c14d370 |  | high | COPPA, FERPA, HIPAA | untriaged | audit-run | Eval AI narration has no COPPA parental-consent hard-gate before sending under-13 student data to Anthropic | `lib/eval_narrator.rb`:43 |
+| LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | **fixed** | audit | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
 | LL-16fef018a0 |  | high | SOC2 | **fixed** | pr-review | Password-reset code verification endpoint (users#password_reset) not rate-limited | `config/initializers/throttling.rb`:41 |
 | LL-080a21089f |  | high | FERPA, HIPAA, GDPR | untriaged | audit-run | Account deletion / right-to-erasure path writes no AuditEvent | `app/controllers/api/users_controller.rb`:388 |
 | LL-7acd0e7416 |  | high | FERPA, HIPAA | untriaged | audit-run | Admin-support reads of individual student records (version history, daily usage) write no AuditEvent | `app/controllers/api/users_controller.rb`:485 |
@@ -97,10 +96,11 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-a25d930f21 |  | low | SOC2 | untriaged | audit-run | ember-cli-mirage 2.4.0 is abandoned for Ember 3.x (no active maintenance, last meaningful release 2021) | `app/frontend/package-lock.json`:12501 |
 | LL-53ab4ea456 |  | low | SOC2 | untriaged | audit-run | serialize-javascript 4.0.0 vulnerable to CVE-2024-11831 (XSS); dev toolchain only | `app/frontend/package-lock.json`:26437 |
 
-## Accepted risk (2)
+## Accepted risk (3)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
+| LL-aacae48768 |  | high | SOC2, HIPAA, FERPA | **accepted** | audit-run | Production Postgres (lingolinq-prod-db) reachable from an all-addresses /0 allowlist (public internet) | (attestation) |
 | LL-9f83617435 | Infra-P1-4 | high | SOC2 | **accepted** | audit-run | No explicit HSTS ssl_options (subdomains/preload) | `config/environments/production.rb`:62 |
 | LL-92dc570f30 | P1-5 | high | SOC2 | **accepted** | audit-run | consent_response accepts token/decision from multiple parameter keys | `app/controllers/api/supervisor_relationships_controller.rb`:86 |
 

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-06-23T23:52:06Z
+**Page generated:** 2026-06-24T00:38:32Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **5** | 24 | 16 |
+| **0** | **3** | 24 | 16 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -25,9 +25,7 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 
 | ID | Legacy | Severity | Frameworks | Title | Evidence |
 |---|---|---|---|---|---|
-| LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
-| LL-aacae48768 |  | high | SOC2, HIPAA, FERPA | Production Postgres (lingolinq-prod-db) reachable from an all-addresses /0 allowlist (public internet) | (attestation) |
 | LL-d1ea8659c3 |  | high | SOC2 | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-0c6e931f47 |  | medium | WCAG | Sentence box (utterance bar) symbol chip images have no alt attribute | `app/frontend/app/templates/components/button-list.hbs`:21 |


### PR DESCRIPTION
## What

Applies Scot's 2026-06-23 closure decisions (from the closure proposal, grounded in code verification). **Headline drops 0C/5H to 0C/3H/24M/16L.**

| Finding | Change | Basis |
|---|---|---|
| `LL-aacae48768` Postgres reachable from `/0` | open -> **accepted-risk** | Accepted interim-Render risk; allowlist remediation owned by the migration workstream, superseded by the private-VPC Cloud SQL cutover. Attested by Scot 2026-06-23. |
| `LL-11db0dc848` eval narration PHI egress | open -> **verified-closed** | Code-verified: egress hard-gated on explicit `use_anthropic` opt-in (default = local template, no egress), supervised-student resolution, COPPA consent, and org AI opt-in, with PII scrubbing (`eval_sessions_controller.rb:43-79`, `eval_narrator.rb:25-73`). Attested by Scot 2026-06-23. |
| `LL-d1ea8659c3` bootstrap 3.4.1 XSS surface | disposition `fixed` -> `accepted`, **stays open** | Verification showed `fixed` was inaccurate: bootstrap 3.4.1 still bundled (`ember-cli-build.js:52`), `.tooltip()`/`.popover()` still used incl. a `data-content=innerHTML` popover at `utterance.js:840`. Reopened for real remediation. |

`LL-6619cc1811` (Redis TLS) deliberately left open/fixed: migration-gated, not a clean close.

## Governance

- Closures carry Scot's attestation in `closureEvidence.attestation` (verified-closed) / acceptance rationale (accepted-risk); only Scot attests, and he did.
- Diff touches exactly these 3 findings; no severity or evidence tampering; no other findings altered (Claude-only diff review confirmed).
- Compliance content reviewed Claude-only.

## Verification

All integrity checks green locally: `citation-check` 76/0, `compliance-calendar`, `compliance-notion-publish` (0C/3H/24M/16L), `document-register`, `compliance-publication-status`.

## Follow-up (not in this PR)

`LL-d1ea8659c3` bootstrap now needs real remediation (remove/upgrade bootstrap, or sanitize/verify the `utterance.js:840` popover path). Tracked as open/accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)