### PR TITLE
compliance(notion): drop stale 'unattested/DRAFT' posture-report comment

### DIFF
--- a/scripts/compliance-notion-publish.rb
+++ b/scripts/compliance-notion-publish.rb
@@ -18,8 +18,8 @@
 #   * Publishes: headline counts, and an open / remediated-unverified findings table with
 #     id, legacyId, severity, frameworks, title, and the evidence file:line ANCHOR.
 #   * Does NOT publish: evidence snippets, finding notes, closed/accepted/superseded findings,
-#     remediation prose, or the unattested Compliance Posture Report (that stays DRAFT until
-#     Scot attests; it is linked, never embedded). No student/patient data ever - the register
+#     remediation prose, or the Compliance Posture Report itself (CEO-attested; it is linked
+#     from the Notes section, never embedded). No student/patient data ever - the register
 #     carries code-only evidence, and this render drops even the code snippet.
 #
 # Pure stdlib (json, time). Safe in CI. Usage:


### PR DESCRIPTION
## What

One-line comment fix in `scripts/compliance-notion-publish.rb`. The header comment still called the Compliance Posture Report "the unattested Compliance Posture Report (that stays DRAFT until Scot attests)." That is no longer accurate.

## Why

The Posture Report has been **CEO-attested since 2026-06-19** (`docs/legal/COMPLIANCE_POSTURE_REPORT.md`; DOCUMENT-REGISTER status `published`). The script's generated output already reflects this (the Notes section reads "CEO-attested (Scot Wahlquist, 2026-06-19)"). Commit `2755a041c` updated the output but left this descriptive comment stale, so the file contradicted itself.

## Scope

- **Comment-only.** The generated Notion page content is byte-identical (the regen only bumps the volatile "Page generated" timestamp, which the `--check` masks). No register, doc, or rendered artifact changes.
- All artifact integrity checks green locally: citation-check 76/0, calendar, notion-publish, document-register, publication-status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)