### PR TITLE
security(frontend): harden bootstrap 3 speak-mode popover XSS sink (LL-d1ea8659c3)

### DIFF
--- a/app/frontend/app/components/stats/goal-statuses-over-time.js
+++ b/app/frontend/app/components/stats/goal-statuses-over-time.js
@@ -10,6 +10,7 @@ export default Component.extend({
   },
   draw: observer('goal.draw_id', function() {
     var $elem = $(this.get('element'));
+    // `title` is app-controlled stats data; do not enable html:true or pass untrusted strings (bootstrap 3 EOL, LL-d1ea8659c3).
     $elem.find(".time_block,.time_block_left").tooltip({container: 'body'});
   })
 });

--- a/app/frontend/app/components/stats/time-of-day.js
+++ b/app/frontend/app/components/stats/time-of-day.js
@@ -38,6 +38,7 @@ export default Component.extend({
         this.set('usage_stats.ref_max_combined_modeled_time_block', this.get('ref_stats.max_combined_modeled_time_block'));
       }
       runLater(function() {
+        // `title` is app-controlled stats data; do not enable html:true or pass untrusted strings (bootstrap 3 EOL, LL-d1ea8659c3).
         $elem.find(".time_block").tooltip({container: 'body'});
       }, 1000);
     }

--- a/app/frontend/app/components/stats/trial-bar.js
+++ b/app/frontend/app/components/stats/trial-bar.js
@@ -9,6 +9,7 @@ export default Component.extend({
   },
   draw: function() {
     var $elem = $(this.get('element'));
+    // `title` is app-controlled stats data; do not enable html:true or pass untrusted strings (bootstrap 3 EOL, LL-d1ea8659c3).
     $elem.find(".bar_holder").tooltip({container: 'body'});
   }
 });

--- a/app/frontend/app/components/stats/user-weeks.js
+++ b/app/frontend/app/components/stats/user-weeks.js
@@ -13,6 +13,7 @@ export default Component.extend({
   },
   draw: function() {
     var $elem = $(this.get('element'));
+    // `title` is app-controlled stats data; do not enable html:true or pass untrusted strings (bootstrap 3 EOL, LL-d1ea8659c3).
     $elem.find(".week,.profile_box").tooltip({container: 'body'});
   },
   communicators_with_stats: computed(

--- a/app/frontend/app/utils/utterance.js
+++ b/app/frontend/app/utils/utterance.js
@@ -818,9 +818,12 @@ var utterance = EmberObject.extend({
       opts.placement = 'bottom';
       selector = '#home_button';
     }
-    if(!$(selector).attr('data-popover')) {
-      $(selector).attr('data-popover', true).popover(opts);
-    }
+    // Initialize idempotently: bootstrap no-ops `.popover(opts)` when this element already
+    // has an instance, and re-creates it with these hardened opts after a `popover('destroy')`
+    // (app-state.js fires that on leaving a board). The previous `data-popover` attr guard
+    // could survive a destroy and skip re-init, so `.popover('show')` would rebuild a bare
+    // default popover with no `content` fn -- an empty bubble.
+    $(selector).popover(opts);
     runCancel(this._popoverHide);
     var div = document.createElement('div');
     div.innerText = "\"" + (button.vocalization || button.label) + "\"";

--- a/app/frontend/app/utils/utterance.js
+++ b/app/frontend/app/utils/utterance.js
@@ -798,8 +798,20 @@ var utterance = EmberObject.extend({
     return u.map(function(b) { return b.vocalization || b.label; }).join(" ");
   },
   silent_speak_button: function(button) {
+    var _this = this;
     var selector = '#speak_mode';
-    var opts = {html: true};
+    // Render the popover body as a prebuilt DOM node (set on `_this._popover_dom`
+    // below), NOT as an HTML string. Bootstrap 3.4.1 Popover.setContent takes the
+    // `.append()` branch for non-string content, so the node is inserted as-is and
+    // nothing is ever parsed as HTML. This keeps the body XSS-safe by construction
+    // (button text goes through `.innerText`, images through `img.src`) instead of
+    // depending on the EOL sanitizer. Any future `title`/`content` STRING passed to
+    // a tooltip/popover here must be app-controlled and pre-escaped.
+    var opts = {
+      html: true,
+      sanitize: true, // defense-in-depth for the title path / future string content; never disable
+      content: function() { return _this._popover_dom || ''; }
+    };
     var timeout = 2000;
     if(app_state.get('speak_mode')) {
       opts.container = 'body';
@@ -837,7 +849,11 @@ var utterance = EmberObject.extend({
       img.src = button.avatar_url;
       div.prepend(img);
     }
-    $(selector).attr('data-content', div.innerHTML).popover('show');
+    // Hand bootstrap the actual DOM node (consumed by the `content` fn above), not a
+    // `data-content` HTML string. Do NOT set the `data-content` attr: Popover.getContent
+    // reads that attr first and would re-introduce the string (.html()) path.
+    _this._popover_dom = div;
+    $(selector).popover('show');
 
     this._popoverHide = runLater(this, function() {
       $(selector).popover('hide');

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -5526,3 +5526,15 @@ bootstrap the NODE via the `content` function; do not set `data-content` to an H
 in `utils/utterance.js:silent_speak_button` (LL-d1ea8659c3). Note bootstrap JS is also load-bearing
 for `data-toggle="dropdown"` (incl. keyboard a11y in `controllers/caseload.js`) and
 `data-dismiss="alert"`, so the EOL lib cannot simply be dropped without replacing those too.
+
+## Gotcha: bootstrap 3 popover('destroy') is async; home-grown init guards go stale after it
+Bootstrap 3's `Tooltip/Popover.destroy` defers `removeData('bs.popover')` into the `hide()`
+animation callback (~150ms, `animation:true` is the default), so the instance is still present
+synchronously right after `destroy` but gone a moment later. A home-grown "init once" guard keyed
+on a custom attribute (e.g. `if(!$el.attr('data-popover')){ ...popover(opts) }`) does NOT get
+cleared by destroy, so a later `.popover('show')` finds no instance, skips re-init, and bootstrap's
+`Plugin` rebuilds a DEFAULT popover (`html:false`, `content:''`, no `content` fn) -- an empty/blank
+widget that silently drops your configured options. Prefer bootstrap's own idempotency: call
+`$el.popover(opts)` unconditionally before `show` (no-op when an instance exists, re-creates with
+your opts after a destroy). Seen in `utils/utterance.js:silent_speak_button` where
+`services/app-state.js:2336` destroys `#speak_mode`'s popover on leaving a board (LL-d1ea8659c3).

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -5512,3 +5512,17 @@ Two wrong tries proved it: (a) `height:auto` + cell `min-height:96px`, (b) grid
 `min-height: calc(--board-rows*104px)` — both forced rows taller than the squares → gaps. The
 only gap-free path is the grid collapsing to the squares' own height. `computeHeight()` is
 EMPTY (board-detail.js:1920) so sizing is pure CSS; `--board-rows` is set by JS (board-detail.js:3044).
+
+## Gotcha: bootstrap 3 tooltip/popover is XSS-safe only via DOM-node content, not data-content strings
+Bootstrap 3.4.1 (`node_modules/bootstrap/dist/js/bootstrap.js`) `Popover.getContent` reads the
+`data-content` attribute FIRST, then falls back to the `content` option. `Popover.setContent`
+branches `typeof content === 'string' ? 'html' : 'append'` and runs `sanitizeHtml` ONLY on string
+content. So `$(el).attr('data-content', node.innerHTML).popover('show')` round-trips through a
+parsed+sanitized HTML string (safety depends on the EOL sanitizer), whereas passing
+`content: () => domNode` makes bootstrap `.append()` the real node, never parsing HTML at all
+(sanitizer irrelevant). When building popover/tooltip bodies, construct a DOM node with
+`document.createElement` + `.innerText` (escapes) + `img.src` (property, no attr injection) and hand
+bootstrap the NODE via the `content` function; do not set `data-content` to an HTML string. Verified
+in `utils/utterance.js:silent_speak_button` (LL-d1ea8659c3). Note bootstrap JS is also load-bearing
+for `data-toggle="dropdown"` (incl. keyboard a11y in `controllers/caseload.js`) and
+`data-dismiss="alert"`, so the EOL lib cannot simply be dropped without replacing those too.


### PR DESCRIPTION
## What

Remediates the XSS dimension of finding **LL-d1ea8659c3** (bootstrap 3.4.1 EOL/XSS, High) by making the speak-mode popover safe **by construction**, independent of bootstrap's EOL HTML sanitizer. Bootstrap JS/CSS are intentionally retained (load-bearing for dropdowns, keyboard a11y, and the bare alert-close).

## Why

`silent_speak_button` in `app/frontend/app/utils/utterance.js` built its popover body safely (escaped `innerText` + `img.src` property assignment) but then round-tripped it through an HTML string into `data-content`, re-parsed and re-sanitized by bootstrap 3.4.1's EOL sanitizer. That made XSS-safety depend on an unpatched, end-of-life library.

Verified bootstrap 3.4.1 internals (`node_modules/bootstrap/dist/js/bootstrap.js`): `Popover.setContent` branches on `typeof content === 'string' ? 'html' : 'append'`. A **DOM-node** content takes the `.append()` branch and is never parsed as HTML, so the sanitizer is irrelevant.

## Change

`app/frontend/app/utils/utterance.js` (`silent_speak_button`):
- Pass the prebuilt `div` as the popover `content` function (`content: () => _this._popover_dom`); stop setting the `data-content` innerHTML string. DOM construction unchanged.
- `sanitize: true` retained as defense-in-depth for the title/string path.
- Made popover init idempotent (`$(selector).popover(opts)`), replacing the stale `data-popover` attr guard. The old guard could survive `app-state.js`'s `popover('destroy')` (bootstrap defers `removeData` into the async hide callback), so a later `.popover('show')` rebuilt a bare default popover with no `content` fn (empty bubble). This was caught by the adversary review.

Plus one-line "title is app-controlled; never enable html:true or pass untrusted strings" comments at the 4 imperative `.tooltip()` inits in `app/frontend/app/components/stats/*.js`, and two LEARNINGS.md gotchas.

## Verification (behavioral)

`ember test` only lints in this repo (unit specs do not execute behaviorally, issue #314), so verification was done by reading the vendored bootstrap source and by driving the **actual** jQuery 3.7.1 + bootstrap 3.4.1 headless:
- XSS payload in `button.label` renders as a literal text node; 0 `<img>` created, `onerror` never fires, **even with `sanitize:false`**.
- Image reaction / avatar / sound glyph / auto-hide timeouts unchanged.
- Async-aware repro confirmed the post-`destroy` regression and confirmed the idempotent-init fix resolves it.

`lint:js` clean (0 errors; 6 pre-existing warnings on unchanged lines). No `.hbs` touched.

## Reviews

- `/review-pr` (senior-dev pass): Approve with comments (no Critical/High).
- `/adversary-review`: 1 High (post-destroy empty bubble) **fixed + re-verified**; 1 Medium (singleton aliasing) verified not reachable (synchronous set+show, single-threaded); 1 Low (`sanitize:true` is the default) kept as documented defense-in-depth.

## Out of scope

Bootstrap removal/upgrade; the 78 dropdown sites and alert plugin; migration-gated findings (`LL-6619cc1811`, `LL-ba0585ab93`). Register closure + attestation for `LL-d1ea8659c3` is a separate Scot-only register PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yFB3bkGB5xGpnFeDP9Gf7
