### PR TITLE
compliance(register): attest-close LL-d1ea8659c3 (bootstrap popover XSS) after #481

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "28ff0a88e1e1b1f1b3eaf3f03f4a4541d1d2c585951c7dd9896499215c9d5dec",
+      "contentHash": "bc06d1eb60718a1d7339e47ec86956a3ac13b0a2c227c0c78b97d618ca53240a",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `28ff0a88e1e1` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `bc06d1eb6071` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -1606,7 +1606,7 @@
       "frameworks": [
         "SOC2"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/frontend/package.json",
@@ -1615,23 +1615,23 @@
         "sha": "1aa5d2db60e2f0eed9489445b2a37b5e1ad6fc3c"
       },
       "firstSeen": "2026-06-14",
-      "lastSeen": "2026-06-14",
+      "lastSeen": "2026-06-24",
       "owner": "unassigned",
       "remediation": {
         "options": "Bootstrap 3.x is EOL since 2019 with no security patches; GHSA XSS advisories (Tooltip/Popover sanitizer bypass, data-* injection) have no 3.x backport. The app ships bootstrap.min.js (ember-cli-build.js:109) and calls .tooltip()/.popover() (app-state, utterance, stats components), so the vector is reachable. INDEPENDENT of the pinned Ember 3.28 -> 5.x migration. Options: (1) migrate to Bootstrap 5.x behind a feature flag (AAC UI-disruptive); (2) if deferred, ensure no untrusted HTML reaches title/data-content of tooltip/popover call sites and audit those sites; (3) Scot accepts risk with call sites confirmed to use only app-controlled sanitized strings.",
-        "timeframe": "advisory"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "6f4cf9a79165a3d84b139342c1d2c6c7bc7cfb0a",
+        "verifierNote": "Verified 2026-06-24: XSS dimension remediated in PR #481 (merged to staging at 6f4cf9a79). silent_speak_button now passes the prebuilt popover body as a DOM node via content:()=>_this._popover_dom (utterance.js) and no longer sets the data-content innerHTML string, so bootstrap 3.4.1 Popover.setContent takes the .append() branch and never parses the body as HTML -- the EOL sanitizer is no longer load-bearing. Popover init made idempotent ($(selector).popover(opts)) so it survives app-state.js popover('destroy') (adversary-found regression, fixed + re-verified). The 4 imperative .tooltip() inits in components/stats/* carry app-controlled-only comments. Behaviorally verified against real jQuery 3.7.1 + bootstrap 3.4.1 headless (XSS payload renders as a literal text node even with sanitize:false); passed /review-pr and /adversary-review. Note: bootstrap 3.4.1 is INTENTIONALLY still bundled (load-bearing for dropdowns, keyboard a11y, alert-close), so the package.json evidence anchor remains true; the residual EOL supply-chain exposure is a separate concern, not this XSS finding, and remains Scot's risk-accept/upgrade call.",
+        "attestation": "Scot Wahlquist 2026-06-24: attested verified-closed for the reachable XSS vector; remediated in PR #481, code-verified behaviorally 2026-06-24. Bootstrap retention is a deliberate, separately-tracked decision."
       },
       "notes": "Surfaced by dependency finder on 2026-06-14. | adversary verifier: CONFIRMED (high); SEVERITY OPINION for Scot = should-be-medium. bootstrap 3.4.1 JS is bundled (ember-cli-build.js:88) and .tooltip()/.popover() are used, but no live untrusted-HTML-into-tooltip sink exists today (all .tooltip() omit html:true; the one html:true popover builds body via escaped innerText), so this is latent supply-chain/XSS hygiene risk, not a currently triggerable XSS. Fix is independent of the pinned Ember 3.28->5 migration. Severity downgrade is Scot's call only.",
       "disposition": {
-        "state": "accepted",
+        "state": "fixed",
         "decidedBy": "Scot Wahlquist",
-        "decidedDate": "2026-06-23",
-        "rationale": "Reopened from 'fixed' on verification 2026-06-23: bootstrap 3.4.1 is still bundled (app/frontend/package.json; ember-cli-build.js:52) and .tooltip()/.popover() remain in use, including a data-content=innerHTML popover at utterance.js:840. Not actually remediated; accepted for real remediation (remove/upgrade bootstrap, or sanitize/verify the utterance.js popover path)."
+        "decidedDate": "2026-06-24",
+        "rationale": "Remediated via PR #481 (merged to staging 6f4cf9a79): popover body rendered as a DOM node (bootstrap .append() path, no HTML parse), init made idempotent to survive popover('destroy'), 4 stats .tooltip() sinks documented app-controlled-only. Code-verified behaviorally + /review-pr + /adversary-review. Bootstrap kept intentionally; residual EOL supply-chain exposure tracked separately, not this XSS finding."
       }
     },
     {

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,15 +5,14 @@
 
 **Audited:** `scot/security/audit-erasure-admin-reads` @ `445336592ddaf838689df7e578829e94e140890d` on 2026-06-19  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 3 High
+**Headline (open + remediated-unverified):** 0 Critical / 2 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (43)
+## Open (42)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
-| LL-d1ea8659c3 |  | high | SOC2 | **accepted** | audit-run | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | **accepted** | audit-review | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | **accepted** | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
@@ -57,7 +56,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-a97357136e | P2-2 | low | SOC2 | **wontfix** | audit-run | params.permit! bypasses Strong Parameters | `app/controllers/api/organizations_controller.rb`:866 |
 | LL-ce00c8d3ad | P2-3 | low |  | **wontfix** | audit-run | License model lacks Processable concern | `app/models/license.rb`:1 |
 
-## Verified closed (34)
+## Verified closed (35)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -69,6 +68,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-3ccbf9b54a | P0-3 | critical | FERPA | untriaged | audit-run | No AuditEvent on license claim/release (FERPA access-log gap) | `app/controllers/api/organizations_controller.rb`:238 |
 | LL-46fd4aa824 | P0-4 | critical | FERPA, HIPAA | untriaged | audit-run | No AuditEvent on supervisor consent create/respond/revoke | `app/controllers/api/supervisor_relationships_controller.rb`:52 |
 | LL-ef5ac1b2a5 |  | high | FERPA, HIPAA | untriaged | audit-run | Eval AI narration creates no AiApiLog entry (no record student eval data was sent to an LLM) | `lib/eval_narrator.rb`:58 |
+| LL-d1ea8659c3 |  | high | SOC2 | **fixed** | audit-run | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-2967f77e6d |  | high | WCAG | **fixed** | audit-run | Board-tile symbol image has no alt text (fast_html render path) | `app/frontend/app/utils/button.js`:449 |
 | LL-2e4c14d370 |  | high | COPPA, FERPA, HIPAA | untriaged | audit-run | Eval AI narration has no COPPA parental-consent hard-gate before sending under-13 student data to Anthropic | `lib/eval_narrator.rb`:43 |
 | LL-11db0dc848 |  | high | COPPA, FERPA, HIPAA | **fixed** | audit | Eval narration gates on caller-asserted user_id but egresses an independent, unbound eval_session payload | `app/controllers/api/eval_sessions_controller.rb`:57 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-06-24T00:38:32Z
+**Page generated:** 2026-06-24T19:47:40Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **3** | 24 | 16 |
+| **0** | **2** | 24 | 16 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -26,7 +26,6 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | ID | Legacy | Severity | Frameworks | Title | Evidence |
 |---|---|---|---|---|---|
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
-| LL-d1ea8659c3 |  | high | SOC2 | bootstrap 3.4.1 (EOL/abandoned) bundled into shipped app; reachable Tooltip/Popover & data-* XSS | `app/frontend/package.json`:31 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-0c6e931f47 |  | medium | WCAG | Sentence box (utterance bar) symbol chip images have no alt attribute | `app/frontend/app/templates/components/button-list.hbs`:21 |
 | LL-13ad11eaee |  | medium | WCAG | Loading status text has no aria-live or role=status | `app/frontend/app/templates/bento.hbs`:14 |


### PR DESCRIPTION
## What

Attest-closes finding **LL-d1ea8659c3** (bootstrap 3.4.1 EOL/XSS, High, SOC2) in the findings register now that its remediation has merged to `staging` via **#481** (`6f4cf9a79`). This is the separate register PR for the closure + attestation; the code lives in #481.

## Register change (`audit-reports/FINDINGS.json`)

- `status`: `open` -> `verified-closed`
- `closureEvidence`: `sha` `6f4cf9a79`, a `verifierNote` describing the DOM-node `.append()` fix + idempotent init + behavioral verification, and an `attestation` line (Scot Wahlquist, 2026-06-24)
- `disposition.state`: `accepted` -> `fixed`; `remediation.timeframe`: `advisory` -> `done`

## Derived artifacts regenerated (deterministic, stdlib-only)

- `FINDINGS.md` (`citation-check.rb --render`)
- `notion/compliance-audit-page.md` (`compliance-notion-publish.rb`)
- `DOCUMENT-REGISTER.{json,md}` (`document-register-render.rb` -> refreshed the `FINDINGS.json` content hash)
- `COMPLIANCE-PUBLICATION-STATUS.md`: re-run, no change (aggregate counts unchanged)

## Validation (mirrors the `audit-artifacts-integrity` CI gate)

- `citation-check.rb`: **76 PASS / 0 FAIL** / 6 SKIP. LL-d1ea8659c3 still PASSes its evidence anchor because bootstrap is intentionally retained, so `package.json:31` remains true.
- `compliance-calendar-render --check`, `compliance-notion-publish --check`, `document-register-render --check`, `compliance-publication-status --check`: all OK.

## Effect

Headline open **High** count drops **3 -> 2**. The remaining two are migration-gated and untouched here: Redis TLS `LL-6619cc1811` and Postgres sslmode `LL-ba0585ab93` (Render -> GCP thread).

## Notes

- Compliance content: Claude-only. This PR was **not** routed to the Codex reviewer.
- Bootstrap 3.4.1 stays bundled by design (load-bearing for dropdowns, keyboard a11y, alert-close). The residual EOL supply-chain exposure is a separate concern, not this XSS finding, and remains a risk-accept/upgrade decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yFB3bkGB5xGpnFeDP9Gf7
