### PR TITLE
docs(runbook): close maintenance-message checklist item (no prod users) + fix stale merge notes

### DIFF
--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -158,7 +158,11 @@ The freeze, in order:
 - **Pause Render workers** (the Resque worker writes via background jobs; scale the worker service
   to 0 or stop it). Confirm no in-flight Resque jobs.
 - Announce the window (copy must be i18n'd, calm and concrete for AAC users): "LingoLinq is briefly
-  read-only for scheduled maintenance and will be fully back at <time tz>."
+  read-only for scheduled maintenance and will be fully back at <time tz>." **Skipped at the current
+  cutover: prod has no real users, only internal/fake test accounts, so no proactive announcement is
+  sent (Scot, 2026-06-24; see the maintenance-message checklist item). The reactive WriteFreeze 503
+  page covers the only edge cases. Re-instate this announce step only if real users are onboarded to
+  prod before the window.**
 - **Do NOT scale Render web to 0, and do NOT decommission, until after soak and after Cloud SQL is
   confirmed authoritative** (step 9b). Render web in write-reject mode is the soak-safety guard.
 
@@ -483,7 +487,7 @@ cold-start / p50 / p95 / memory in tracker 4.2.
 - [ ] 0c Redis TLS handshake green against live Memorystore, CA-completeness asserted
       (LL-6619cc1811 verified-closed).
 - [x] W1 worker SIGTERM grace + requeue fix built + dual-reviewed (tracker 4.W1, **PR #473**,
-      pending merge to staging: `RESQUE_PRE_SHUTDOWN_TIMEOUT=4`/`RESQUE_TERM_TIMEOUT=3` + the
+      merged to staging: `RESQUE_PRE_SHUTDOWN_TIMEOUT=4`/`RESQUE_TERM_TIMEOUT=3` + the
       existing BoyBand requeue).
 - [x] **W1 residual DECIDED (Scot, 2026-06-23): pause the outbound-webhook notifier pre-cutover**
       (operational mitigation, step 1) rather than building a per-class selective requeue. The
@@ -494,7 +498,7 @@ cold-start / p50 / p95 / memory in tracker 4.2.
       still to run (gated): provision the LB, validate it + the WAF preview in the rehearsal, flip
       the WAF to enforce, then the ingress lockdown.
 - [x] **Render write-reject mode built + tested + dual-reviewed** (tracker 5.2, **PR #472**,
-      pending merge to staging: `WriteFreeze` middleware, ENV-gated `WRITE_FREEZE`, 503 +
+      merged to staging: `WriteFreeze` middleware, ENV-gated `WRITE_FREEZE`, 503 +
       Retry-After on mutating verbs AND side-effect GETs incl. the `lib/json_api` write paths;
       reads pass; auth allowlist). Re-confirm endpoint coverage in the rehearsal.
 - [ ] **Client 503 re-queue confirmed in the dress rehearsal:** a frozen offline board-save /
@@ -515,4 +519,11 @@ cold-start / p50 / p95 / memory in tracker 4.2.
       BOOT_SECRETS if any row exists, else confirmed-empty.
 - [ ] **DNS TTL lowered to 60s** ahead of the window and propagation confirmed.
 - [ ] Operator holds GCP `lingolinq-prod` + 1Password "LingoLinq Prod" + Render API key.
-- [ ] Maintenance message (i18n) staged.
+- [x] **Maintenance message (i18n): satisfied by the PR #472 503 page; no proactive announcement
+      needed (Scot, 2026-06-24).** Render prod carries no real clients/users at cutover - only a
+      few internal/fake test accounts (prod will be brought up to staging, then migrated to GCP) -
+      so no user-facing window announcement is warranted. The reactive WriteFreeze 503 page
+      (i18n'd `write_freeze.title`/`write_freeze.body`, calm AAC copy, reads still served) is the
+      only maintenance surface and is already built + merged. **Re-open this item only if real
+      users are onboarded to prod before the cutover window;** then add a proactive announcement
+      surface (no in-app banner mechanism exists yet).


### PR DESCRIPTION
## What

Phase 5 cutover runbook (`scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md`) pre-cutover checklist housekeeping. Docs-only, no code.

## Why

Render **prod has no real clients or users** at cutover (only a few internal/fake test accounts; prod will be brought up to staging, then migrated to GCP). So the runbook's *proactive* maintenance-window announcement is unnecessary. The only maintenance surface that matters is the **reactive** WriteFreeze 503 page (PR #472, i18n'd `write_freeze.title`/`write_freeze.body`), which is already built and merged and is sufficient for the fake-account / offline-replay edge cases.

## Changes

- **Maintenance message (i18n) checklist item** → marked `[x]`: satisfied by the #472 503 page; no proactive announcement needed. Records a **re-open condition** if real users are onboarded to prod before the window (no in-app banner mechanism exists yet).
- **Step-1 "announce the window" bullet** → annotated as skipped for this cutover (original copy retained for future use), so the doc is not internally contradictory.
- **Stale merge annotations** → "pending merge to staging" corrected to "merged to staging" on **PR #472** and **PR #473** (both merged). This is the one-line touch-up flagged last session, folded in here.

## Not changed

No code, no i18n strings, no behavior. The reactive 503 copy from #472 is untouched.