### PR TITLE
feat(gcp): pre-DNS Render-vs-Cloud-SQL delta-check script (Phase 5 runbook step 7)

### DIFF
--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -323,6 +323,22 @@ Then, BEFORE any DNS change:
   trigger** (it means an external writer or offline replay slipped past the freeze; go fix the
   freeze, do not flip DNS).
 
+  **Script: `scripts/gcp/phase5-delta-check.sh`** (built, strictly read-only - every query runs in
+  `BEGIN READ ONLY`, so it is safe against live prod). Forward (gate) mode exits non-zero on any
+  drift:
+
+  ```
+  cloud-sql-proxy --port 5432 lingolinq-prod:us-central1:lingolinq-prod-pg &
+  RENDER_DATABASE_URL='postgres://USER:PASS@RENDER_HOST:5432/lingolinq_production' \
+  CLOUDSQL_DATABASE_URL='postgres://lingolinq_app:PASS@127.0.0.1:5432/lingolinq_production' \
+    ./scripts/gcp/phase5-delta-check.sh           # add --counts to also compare COUNT(*) (slower)
+  ```
+
+  Default tables are `log_sessions boards board_contents` (override with `TABLES=`). On **rollback**
+  (Rollback step 3), the same script in reverse mode enumerates the cutover-window writes that
+  landed only on Cloud SQL, for replay/merge back into Render:
+  `CLOUDSQL_DATABASE_URL=... ./scripts/gcp/phase5-delta-check.sh --since '<DNS-flip timestamp>'`.
+
 ### 8. Front-end decision gate  (tracker 5.3 - DECIDED 2026-06-23)
 
 The web service currently deploys with `--allow-unauthenticated` straight to the `run.app` URL.
@@ -510,7 +526,11 @@ cold-start / p50 / p95 / memory in tracker 4.2.
       hitting prod, hourly `sync-render-env`, **the outbound webhook notifier**
       (`Webhook.notify_all_with_code`), AND a plan for **inbound webhooks** (Stripe/AWS) 503'd
       during the soak (verified against the LIVE Render dashboard, not this doc).
-- [ ] Pre-DNS Render-vs-Cloud-SQL delta check defined and dry-run (step 7).
+- [x] Pre-DNS Render-vs-Cloud-SQL delta check defined and dry-run (step 7): built as
+      `scripts/gcp/phase5-delta-check.sh` (read-only; forward gate exits non-zero on drift, reverse
+      `--since` mode for rollback reconciliation). Dry-run locally 2026-06-24 (zero-delta exit 0,
+      drift exit 1, reverse report, read-only write-rejection all verified). The live pre-DNS run
+      against Render + Cloud SQL is still a gated cutover step.
 - [ ] `SMS_ENCRYPTION_KEY`: `RemoteTarget` sms-row query run against restored DB; seeded + in
       BOOT_SECRETS if any row exists, else confirmed-empty.
 - [ ] **DNS TTL lowered to 60s** ahead of the window and propagation confirmed.

--- a/scripts/gcp/phase5-delta-check.sh
+++ b/scripts/gcp/phase5-delta-check.sh
@@ -51,11 +51,17 @@
 #   PROJECT_ID         - default 'lingolinq-prod' (only used to print the Cloud SQL connection name).
 #   SQL_INSTANCE       - default 'lingolinq-prod-pg'.
 #
-# DRY-RUN locally (no prod): point both DSNs at local DBs via the unix socket, e.g.
+# DRY-RUN locally (no prod): point both DSNs at local DBs via the unix socket. Forward mode REFUSES
+# two identical endpoints (comparing a DB to itself is always a false "match"), so the dry-run must
+# opt in with ALLOW_SAME_DB=1:
+#   ALLOW_SAME_DB=1 \
 #   RENDER_DATABASE_URL='postgresql:///lingolinq-development?host=/var/run/postgresql' \
 #   CLOUDSQL_DATABASE_URL='postgresql:///lingolinq-development?host=/var/run/postgresql' \
 #     ./scripts/gcp/phase5-delta-check.sh           # same DB both sides => zero delta => exit 0
-# Point the two at DIFFERENT local DBs to exercise the drift/exit-non-zero path.
+# Point the two at DIFFERENT local DBs to exercise the drift/exit-non-zero path (no override needed).
+#
+# DO NOT run this script under `bash -x` / `set -x`: tracing would print the DSNs, which carry the
+# DB password. The script itself never echoes them.
 set -euo pipefail
 
 TABLES="${TABLES:-log_sessions boards board_contents}"
@@ -91,6 +97,13 @@ bad()  { printf "${C_BAD}%s${C_OFF}" "$*"; }
 
 command -v psql >/dev/null 2>&1 || { echo "ERROR: psql not found." >&2; exit 1; }
 
+# Validate every table name against a strict identifier pattern BEFORE it is interpolated into SQL.
+# TABLES is operator-supplied, but a stray quote/space/`;` could break out of the read-only
+# transaction (e.g. an injected COMMIT), defeating the script's read-only-against-prod guarantee.
+for _t in $TABLES; do
+  [[ "$_t" =~ ^[a-z_][a-z0-9_]*$ ]] || { echo "ERROR: invalid table name '$_t' (expected ^[a-z_][a-z0-9_]*\$)." >&2; exit 1; }
+done
+
 # A NULL marker that compares cleanly when a table is empty on BOTH sides (both -> same marker).
 NULLMARK='(none)'
 
@@ -110,7 +123,9 @@ build_forward_sql() {
   for t in $TABLES; do
     [ $first -eq 1 ] || printf "UNION ALL\n"; first=0
     if [ "$WITH_COUNTS" = 1 ]; then cnt="COUNT(*)::text"; else cnt="'-'"; fi
-    printf "SELECT '%s' AS tbl, COALESCE(MAX(id)::text,'%s') AS max_id, COALESCE(MAX(updated_at)::text,'%s') AS max_upd, %s AS n FROM \"%s\"\n" \
+    # to_char with an explicit pattern renders identically regardless of each server's DateStyle /
+    # fractional-second defaults (Render PG vs Cloud SQL PG18), so equal timestamps never read as DRIFT.
+    printf "SELECT '%s' AS tbl, COALESCE(MAX(id)::text,'%s') AS max_id, COALESCE(to_char(MAX(updated_at),'YYYY-MM-DD HH24:MI:SS.US'),'%s') AS max_upd, %s AS n FROM \"%s\"\n" \
       "$t" "$NULLMARK" "$NULLMARK" "$cnt" "$t"
   done
   printf "ORDER BY tbl;\nCOMMIT;\n"
@@ -123,7 +138,7 @@ build_reverse_sql() {
   local first=1 t
   for t in $TABLES; do
     [ $first -eq 1 ] || printf "UNION ALL\n"; first=0
-    printf "SELECT '%s' AS tbl, COUNT(*)::text AS n, COALESCE(MAX(id)::text,'%s') AS max_id, COALESCE(MAX(updated_at)::text,'%s') AS max_upd FROM \"%s\" WHERE updated_at > %s\n" \
+    printf "SELECT '%s' AS tbl, COUNT(*)::text AS n, COALESCE(MAX(id)::text,'%s') AS max_id, COALESCE(to_char(MAX(updated_at),'YYYY-MM-DD HH24:MI:SS.US'),'%s') AS max_upd FROM \"%s\" WHERE updated_at > %s\n" \
       "$t" "$NULLMARK" "$NULLMARK" "$t" "$(printf "'%s'" "${SINCE//\'/\'\'}")"
   done
   printf "ORDER BY tbl;\nCOMMIT;\n"
@@ -143,14 +158,21 @@ if [ -n "$SINCE" ]; then
   echo "    Tables    : $TABLES"
   echo "    Since     : $SINCE  (rows NEWER than this exist only on Cloud SQL)"
 
-  total=0; rows="$(probe build_reverse_sql "$CLOUDSQL_DATABASE_URL")"
+  total=0; seen=0; rows="$(probe build_reverse_sql "$CLOUDSQL_DATABASE_URL")"
   log "Cloud SQL rows written after the DNS-flip timestamp (replay-or-accept-loss candidates)"
   printf "    %-22s %10s  %-12s  %s\n" "TABLE" "ROWS" "MAX_ID" "MAX_UPDATED_AT"
   while IFS='|' read -r tbl n max_id max_upd; do
     [ -z "$tbl" ] && continue
+    # COUNT(*) is always a non-negative integer; anything else means a malformed/partial probe -
+    # abort rather than silently under-count the rows that must be reconciled on rollback.
+    [[ "$n" =~ ^[0-9]+$ ]] || { echo "ERROR: non-numeric row count for '$tbl': [$n] - aborting (do not trust this report)." >&2; exit 3; }
     printf "    %-22s %10s  %-12s  %s\n" "$tbl" "$n" "$max_id" "$max_upd"
-    total=$(( total + n ))
+    total=$(( total + n )); seen=$(( seen + 1 ))
   done <<< "$rows"
+  # Coverage: every requested table must have produced exactly one row, else a table silently
+  # dropped out and the reconciliation total is understated.
+  want=$(echo $TABLES | wc -w)
+  [ "$seen" = "$want" ] || { echo "ERROR: reverse probe returned $seen of $want requested tables - aborting (incomplete reconciliation)." >&2; exit 3; }
 
   echo
   if [ "$total" -gt 0 ]; then
@@ -166,10 +188,20 @@ fi
 [ -n "${RENDER_DATABASE_URL:-}" ] || { echo "ERROR: RENDER_DATABASE_URL is required for the forward (pre-DNS) check." >&2; exit 1; }
 
 log "Phase 5 pre-DNS delta check (Render vs Cloud SQL)"
-echo "    Render    : $(safe_conn "$RENDER_DATABASE_URL")"
-echo "    Cloud SQL : $(safe_conn "$CLOUDSQL_DATABASE_URL")"
+ren_conn="$(safe_conn "$RENDER_DATABASE_URL")"
+cs_conn="$(safe_conn "$CLOUDSQL_DATABASE_URL")"
+echo "    Render    : $ren_conn"
+echo "    Cloud SQL : $cs_conn"
 echo "    Tables    : $TABLES"
 echo "    Counts    : $([ "$WITH_COUNTS" = 1 ] && echo 'comparing COUNT(*) too' || echo 'MAX(id) + MAX(updated_at) only (add --counts for COUNT(*))')"
+
+# Comparing a database to ITSELF always reports a (meaningless) match. In the live pre-DNS gate the
+# two endpoints MUST differ; refuse identical db+host unless explicitly overridden for a dry-run.
+if [ "$ren_conn" = "$cs_conn" ] && [ "${ALLOW_SAME_DB:-0}" != "1" ]; then
+  echo "ERROR: Render and Cloud SQL resolve to the same db+host ($ren_conn)." >&2
+  echo "       Comparing a DB to itself is a false 'match'. Set ALLOW_SAME_DB=1 only for a local dry-run." >&2
+  exit 1
+fi
 
 ren="$(probe build_forward_sql "$RENDER_DATABASE_URL")"
 cs="$(probe build_forward_sql "$CLOUDSQL_DATABASE_URL")"
@@ -182,12 +214,17 @@ while IFS='|' read -r tbl id up n; do [ -z "$tbl" ] && continue; C_ID["$tbl"]="$
 log "Per-table comparison"
 drift=0
 for t in $TABLES; do
-  t_drift=0
+  t_drift=0; absent=0
+  # A table absent from EITHER probe is never "OK" - that is exactly the silent-drop case the gate
+  # must not pass. Treat absence as drift (not a both-MISSING==MISSING match).
+  if [ -z "${R_ID[$t]+x}" ] || [ -z "${C_ID[$t]+x}" ]; then t_drift=1; absent=1; fi
   [ "${R_ID[$t]:-MISSING}" = "${C_ID[$t]:-MISSING}" ] || t_drift=1
   [ "${R_UP[$t]:-MISSING}" = "${C_UP[$t]:-MISSING}" ] || t_drift=1
   if [ "$WITH_COUNTS" = 1 ]; then [ "${R_N[$t]:-MISSING}" = "${C_N[$t]:-MISSING}" ] || t_drift=1; fi
 
-  if [ "$t_drift" = 0 ]; then status="$(ok '[OK]')"; else status="$(bad '[DRIFT]')"; drift=1; fi
+  if [ "$t_drift" = 0 ]; then status="$(ok '[OK]')"
+  elif [ "$absent" = 1 ]; then status="$(bad '[ABSENT]')"; drift=1
+  else status="$(bad '[DRIFT]')"; drift=1; fi
   printf "\n  %s  %s\n" "$t" "$status"
   printf "      max_id          render=%-14s cloudsql=%-14s\n" "${R_ID[$t]:-MISSING}" "${C_ID[$t]:-MISSING}"
   printf "      max_updated_at  render=%-26s cloudsql=%-26s\n" "${R_UP[$t]:-MISSING}" "${C_UP[$t]:-MISSING}"

--- a/scripts/gcp/phase5-delta-check.sh
+++ b/scripts/gcp/phase5-delta-check.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# phase5-delta-check.sh - LingoLinq Render -> GCP Cloud Run migration, Phase 5 (cutover).
+#
+# The PRE-DNS delta check (PHASE5-CUTOVER-RUNBOOK.md step 7). Immediately before the DNS flip,
+# compare MAX(id) and MAX(updated_at) on the high-traffic tables between the LIVE Render prod
+# database and the freshly-restored Cloud SQL database. The step-0a/3 reconciliation only compares
+# dump-to-restore, so it CANNOT see writes that reached Render after the fresh dump. This script is
+# the only thing that catches a writer that slipped past the freeze.
+#
+#   ANY non-zero delta is a ROLLBACK TRIGGER: it means an external writer or an offline replay
+#   wrote to Render after the dump (or something wrote to Cloud SQL early). Go fix the freeze; do
+#   NOT flip DNS. The script exits non-zero on drift so it gates an automated cutover step.
+#
+# It is STRICTLY READ-ONLY: every query runs inside `BEGIN READ ONLY` with
+# `default_transaction_read_only = on`, so it physically cannot write to either database. Safe to
+# run against live prod (this is the one place the runbook has you touch live Render during the
+# window, and it only SELECTs MAX/COUNT).
+#
+# ---------------------------------------------------------------------------------------------
+# MODES
+#
+#   Forward (default) - the pre-DNS gate:
+#     RENDER_DATABASE_URL=...  CLOUDSQL_DATABASE_URL=...  ./scripts/gcp/phase5-delta-check.sh
+#       Compares Render vs Cloud SQL per table. Exit 0 = match (safe to proceed to DNS).
+#       Exit non-zero = DRIFT (rollback trigger). Add --counts to also compare COUNT(*) (slower).
+#
+#   Reverse - the rollback reconciliation report (runbook Rollback step 3):
+#     CLOUDSQL_DATABASE_URL=...  ./scripts/gcp/phase5-delta-check.sh --since '2026-07-12 06:00:00 UTC'
+#       After a rollback, enumerate Cloud SQL rows newer than the DNS-flip timestamp - the
+#       cutover-window writes that exist ONLY on GCP and must be replayed/merged back into Render
+#       or accepted as lost. Report-only (exit 0) unless --fail-on-rows is given.
+#
+# ---------------------------------------------------------------------------------------------
+# CONNECTIONS  (point each at a TCP DSN; never echoed - the password lives only inside the DSN)
+#
+#   CLOUDSQL_DATABASE_URL - reach Cloud SQL through the cloud-sql-proxy (the /cloudsql unix socket
+#                           only exists inside Cloud Run, not on an operator laptop), e.g.:
+#       cloud-sql-proxy --port 5432 lingolinq-prod:us-central1:lingolinq-prod-pg &
+#       CLOUDSQL_DATABASE_URL='postgres://lingolinq_app:PASSWORD@127.0.0.1:5432/lingolinq_production'
+#   RENDER_DATABASE_URL   - the live Render prod Postgres connection string (forward mode only).
+#                           A read-only Render DB user is preferred but not required (this script
+#                           is read-only regardless).
+#
+# ---------------------------------------------------------------------------------------------
+# KNOBS (env)
+#   TABLES             - space-separated table list. Default: "log_sessions boards board_contents"
+#                        (the three the runbook names; offline replay + external writers hit these).
+#   STATEMENT_TIMEOUT  - per-statement timeout. Default '60s'. MAX(id) is instant (PK); MAX(updated_at)
+#                        may seq-scan a large table - raise this if it times out, do not skip it.
+#   PROJECT_ID         - default 'lingolinq-prod' (only used to print the Cloud SQL connection name).
+#   SQL_INSTANCE       - default 'lingolinq-prod-pg'.
+#
+# DRY-RUN locally (no prod): point both DSNs at local DBs via the unix socket, e.g.
+#   RENDER_DATABASE_URL='postgresql:///lingolinq-development?host=/var/run/postgresql' \
+#   CLOUDSQL_DATABASE_URL='postgresql:///lingolinq-development?host=/var/run/postgresql' \
+#     ./scripts/gcp/phase5-delta-check.sh           # same DB both sides => zero delta => exit 0
+# Point the two at DIFFERENT local DBs to exercise the drift/exit-non-zero path.
+set -euo pipefail
+
+TABLES="${TABLES:-log_sessions boards board_contents}"
+STATEMENT_TIMEOUT="${STATEMENT_TIMEOUT:-60s}"
+PROJECT_ID="${PROJECT_ID:-lingolinq-prod}"
+SQL_INSTANCE="${SQL_INSTANCE:-lingolinq-prod-pg}"
+
+WITH_COUNTS=0
+SINCE=""
+FAIL_ON_ROWS=0
+
+usage() {
+  sed -n '2,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --counts)       WITH_COUNTS=1; shift ;;
+    --since)        SINCE="${2:?--since needs a timestamp}"; shift 2 ;;
+    --fail-on-rows) FAIL_ON_ROWS=1; shift ;;
+    -h|--help)      usage 0 ;;
+    *) echo "ERROR: unknown argument '$1'" >&2; usage 1 ;;
+  esac
+done
+
+# Colors only when stdout is a TTY.
+if [ -t 1 ]; then C_HEAD='\033[1;34m'; C_OK='\033[0;32m'; C_BAD='\033[1;31m'; C_OFF='\033[0m'
+else C_HEAD=''; C_OK=''; C_BAD=''; C_OFF=''; fi
+log()  { printf "\n${C_HEAD}==>${C_OFF} %s\n" "$*"; }
+ok()   { printf "${C_OK}%s${C_OFF}"  "$*"; }
+bad()  { printf "${C_BAD}%s${C_OFF}" "$*"; }
+
+command -v psql >/dev/null 2>&1 || { echo "ERROR: psql not found." >&2; exit 1; }
+
+# A NULL marker that compares cleanly when a table is empty on BOTH sides (both -> same marker).
+NULLMARK='(none)'
+
+# Print a DSN's resolved db/host/user (NEVER the password) as a sanity check before querying.
+safe_conn() {
+  PGCONNECT_TIMEOUT=8 psql "$1" -tAc \
+    "select 'db='||current_database()||' host='||coalesce(host(inet_server_addr()),'local')||' user='||current_user;" 2>&1 || true
+}
+
+# Build the read-only probe SQL for forward mode. One round-trip: a UNION ALL over the table list,
+# wrapped in a read-only transaction with a statement timeout. Emits pipe-separated tuples:
+#   tbl|max_id|max_updated_at|count_or_dash
+build_forward_sql() {
+  printf "SET statement_timeout = '%s';\n" "$STATEMENT_TIMEOUT"
+  printf "SET default_transaction_read_only = on;\nBEGIN READ ONLY;\n"
+  local first=1 t cnt
+  for t in $TABLES; do
+    [ $first -eq 1 ] || printf "UNION ALL\n"; first=0
+    if [ "$WITH_COUNTS" = 1 ]; then cnt="COUNT(*)::text"; else cnt="'-'"; fi
+    printf "SELECT '%s' AS tbl, COALESCE(MAX(id)::text,'%s') AS max_id, COALESCE(MAX(updated_at)::text,'%s') AS max_upd, %s AS n FROM \"%s\"\n" \
+      "$t" "$NULLMARK" "$NULLMARK" "$cnt" "$t"
+  done
+  printf "ORDER BY tbl;\nCOMMIT;\n"
+}
+
+# Build the read-only reverse SQL: per table, rows on Cloud SQL with updated_at > SINCE.
+build_reverse_sql() {
+  printf "SET statement_timeout = '%s';\n" "$STATEMENT_TIMEOUT"
+  printf "SET default_transaction_read_only = on;\nBEGIN READ ONLY;\n"
+  local first=1 t
+  for t in $TABLES; do
+    [ $first -eq 1 ] || printf "UNION ALL\n"; first=0
+    printf "SELECT '%s' AS tbl, COUNT(*)::text AS n, COALESCE(MAX(id)::text,'%s') AS max_id, COALESCE(MAX(updated_at)::text,'%s') AS max_upd FROM \"%s\" WHERE updated_at > %s\n" \
+      "$t" "$NULLMARK" "$NULLMARK" "$t" "$(printf "'%s'" "${SINCE//\'/\'\'}")"
+  done
+  printf "ORDER BY tbl;\nCOMMIT;\n"
+}
+
+# Run a probe SQL against a DSN, returning only the data tuples (tuples-only, pipe-separated).
+probe() { build="$1"; dsn="$2"; "$build" | psql "$dsn" -v ON_ERROR_STOP=1 -qtA -F '|'; }
+
+# ---------------------------------------------------------------------------------------------
+
+[ -n "${CLOUDSQL_DATABASE_URL:-}" ] || { echo "ERROR: CLOUDSQL_DATABASE_URL is required." >&2; exit 1; }
+
+if [ -n "$SINCE" ]; then
+  # ---- REVERSE / rollback-reconciliation report ----
+  log "Phase 5 reverse delta check (rollback reconciliation)"
+  echo "    Cloud SQL : $(safe_conn "$CLOUDSQL_DATABASE_URL")"
+  echo "    Tables    : $TABLES"
+  echo "    Since     : $SINCE  (rows NEWER than this exist only on Cloud SQL)"
+
+  total=0; rows="$(probe build_reverse_sql "$CLOUDSQL_DATABASE_URL")"
+  log "Cloud SQL rows written after the DNS-flip timestamp (replay-or-accept-loss candidates)"
+  printf "    %-22s %10s  %-12s  %s\n" "TABLE" "ROWS" "MAX_ID" "MAX_UPDATED_AT"
+  while IFS='|' read -r tbl n max_id max_upd; do
+    [ -z "$tbl" ] && continue
+    printf "    %-22s %10s  %-12s  %s\n" "$tbl" "$n" "$max_id" "$max_upd"
+    total=$(( total + n ))
+  done <<< "$rows"
+
+  echo
+  if [ "$total" -gt 0 ]; then
+    printf "    %s %s row(s) on Cloud SQL are newer than the flip timestamp; replay/merge into Render or accept as lost.\n" "$(bad '!!')" "$total"
+    [ "$FAIL_ON_ROWS" = 1 ] && exit 2
+  else
+    printf "    %s No Cloud SQL rows newer than the flip timestamp; nothing to reconcile.\n" "$(ok 'OK')"
+  fi
+  exit 0
+fi
+
+# ---- FORWARD / pre-DNS gate ----
+[ -n "${RENDER_DATABASE_URL:-}" ] || { echo "ERROR: RENDER_DATABASE_URL is required for the forward (pre-DNS) check." >&2; exit 1; }
+
+log "Phase 5 pre-DNS delta check (Render vs Cloud SQL)"
+echo "    Render    : $(safe_conn "$RENDER_DATABASE_URL")"
+echo "    Cloud SQL : $(safe_conn "$CLOUDSQL_DATABASE_URL")"
+echo "    Tables    : $TABLES"
+echo "    Counts    : $([ "$WITH_COUNTS" = 1 ] && echo 'comparing COUNT(*) too' || echo 'MAX(id) + MAX(updated_at) only (add --counts for COUNT(*))')"
+
+ren="$(probe build_forward_sql "$RENDER_DATABASE_URL")"
+cs="$(probe build_forward_sql "$CLOUDSQL_DATABASE_URL")"
+
+# Index both result sets by table name.
+declare -A R_ID R_UP R_N C_ID C_UP C_N
+while IFS='|' read -r tbl id up n; do [ -z "$tbl" ] && continue; R_ID["$tbl"]="$id"; R_UP["$tbl"]="$up"; R_N["$tbl"]="$n"; done <<< "$ren"
+while IFS='|' read -r tbl id up n; do [ -z "$tbl" ] && continue; C_ID["$tbl"]="$id"; C_UP["$tbl"]="$up"; C_N["$tbl"]="$n"; done <<< "$cs"
+
+log "Per-table comparison"
+drift=0
+for t in $TABLES; do
+  t_drift=0
+  [ "${R_ID[$t]:-MISSING}" = "${C_ID[$t]:-MISSING}" ] || t_drift=1
+  [ "${R_UP[$t]:-MISSING}" = "${C_UP[$t]:-MISSING}" ] || t_drift=1
+  if [ "$WITH_COUNTS" = 1 ]; then [ "${R_N[$t]:-MISSING}" = "${C_N[$t]:-MISSING}" ] || t_drift=1; fi
+
+  if [ "$t_drift" = 0 ]; then status="$(ok '[OK]')"; else status="$(bad '[DRIFT]')"; drift=1; fi
+  printf "\n  %s  %s\n" "$t" "$status"
+  printf "      max_id          render=%-14s cloudsql=%-14s\n" "${R_ID[$t]:-MISSING}" "${C_ID[$t]:-MISSING}"
+  printf "      max_updated_at  render=%-26s cloudsql=%-26s\n" "${R_UP[$t]:-MISSING}" "${C_UP[$t]:-MISSING}"
+  [ "$WITH_COUNTS" = 1 ] && printf "      count           render=%-14s cloudsql=%-14s\n" "${R_N[$t]:-MISSING}" "${C_N[$t]:-MISSING}"
+done
+
+echo
+if [ "$drift" = 0 ]; then
+  printf "%s All %s table(s) match. No post-dump drift detected; safe to proceed to the DNS flip.\n" "$(ok '==> OK:')" "$(echo $TABLES | wc -w)"
+  exit 0
+else
+  printf "%s Drift detected. A writer reached Render after the dump (or Cloud SQL was written early).\n" "$(bad '==> ROLLBACK TRIGGER:')"
+  printf "    Do NOT flip DNS. Fix the freeze (find the writer), re-dump/re-restore, and re-run this check.\n"
+  exit 1
+fi


### PR DESCRIPTION
## What

Adds `scripts/gcp/phase5-delta-check.sh` - the **pre-DNS delta check** from the Phase 5 cutover runbook (step 7), plus the runbook references that name it. No app code; operator tooling only.

## Why

Immediately before the DNS flip, the only thing that catches a writer that slipped past the write-freeze is comparing the **live Render** DB against the **freshly-restored Cloud SQL** DB. The step-0a/3 reconciliation only compares dump-to-restore, so it cannot see writes that reached Render *after* the fresh dump. **Any non-zero delta is a rollback trigger.**

## Behavior

- **Forward (gate, default):** compares `MAX(id)` + `MAX(updated_at)` (optionally `COUNT(*)` with `--counts`) on `log_sessions`, `boards`, `board_contents` (override via `TABLES=`). Exit `0` = match (safe to flip); exit non-zero = drift (do NOT flip DNS).
- **Reverse (`--since <flip-ts>`):** enumerates Cloud SQL rows newer than the DNS-flip time - the cutover-window writes that exist only on GCP, for replay/merge back to Render on rollback (Rollback step 3). Report-by-default; `--fail-on-rows` to gate.
- **Strictly read-only:** every query runs in `BEGIN READ ONLY` + `default_transaction_read_only=on` - verified the transaction *physically rejects* an INSERT - so it is safe against live prod (HIPAA). Never echoes the DSN/password. Models `phase4-setval-sequences.sh` conventions.

## Review

Claude adversary red-team pass (Claude-only - HIPAA-adjacent cutover tooling, **not** Codex). Verdict **SHIP-WITH-FIXES**; all merge-blockers addressed in commit `d2b4a9b`:
- forward mode refuses identical Render/Cloud SQL endpoints (false-OK) unless `ALLOW_SAME_DB=1`
- `to_char` timestamp normalization (Render PG vs Cloud SQL PG18 format-divergence false-DRIFT)
- absent-table = drift `[ABSENT]`; reverse-mode table-coverage + numeric-count assertions (no silent under-report)
- `TABLES` identifier validation (can't escape the read-only transaction)
- header warns never to run under `bash -x` (DSN/password leak)

Pushed back on the adversary's "reverse should default to fail-on-rows": runbook Rollback step 3 is explicitly replay-or-accept-loss (operator judgment), so the report stays report-by-default; the real risk is closed by the coverage assertion.

## Dry-run evidence (local, dev/test DBs, 2026-06-24)

| Scenario | Result |
|---|---|
| same-DB without override | refused, exit 1 |
| `ALLOW_SAME_DB=1`, identical data (`--counts`) | all `[OK]`, exit 0 |
| distinct DBs | `[DRIFT]`/`ROLLBACK TRIGGER`, exit 1 |
| empty table both sides | `(none)` -> `[OK]` |
| reverse, rows newer (+`--fail-on-rows`) | reports total, exit 2 |
| reverse, none newer | "nothing to reconcile", exit 0 |
| read-only write attempt | `cannot execute INSERT in a read-only transaction` |
| invalid `TABLES` / missing env | refused |

The **live** pre-DNS run against Render + Cloud SQL remains a gated cutover step.

## Note

Touches `PHASE5-CUTOVER-RUNBOOK.md` step 7 + checklist; no line overlap with open PR #483 (runbook housekeeping), so both auto-merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiZM2j7J1bYAMTc2Ug9wjL