### PR TITLE
security: platform-agnostic audit_console wrapper (prereq for LL-7f7372e3eb, finding stays open)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,14 +105,17 @@ bundle exec rspec spec/models/user_spec.rb:42
 
 **Console access:**
 ```bash
-# Audited console wrapper (currently legacy Heroku-backed)
+# Audited console wrapper (platform-agnostic; run from any app shell)
 bin/audit_console
 ```
 
-> Note: this script was previously named `bin/heroku_console`. It was renamed
-> for clarity; the body still invokes the Heroku CLI and needs a follow-up
-> rewrite to target Render's shell. Until then, the wrapper records an
-> `AuditEvent` per session but only works against the legacy Heroku environment.
+> Note: this script was previously named `bin/heroku_console`. It no longer
+> invokes the Heroku CLI; it sets `USER_KEY` and `exec`s `bundle exec rails
+> console`, so it works from the Render Shell tab, a Cloud Run exec shell, or a
+> local checkout. `USER_KEY` provides self-asserted PaperTrail write-attribution
+> only (see the Security section); the wrapper does NOT currently record a
+> per-session `AuditEvent` (the Reline-bypassed Readline hook is non-operative),
+> a gap tracked under open finding LL-7f7372e3eb.
 
 **Scheduled tasks (run periodically in production):**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ New user-facing features MUST be added behind a feature flag (`lib/feature_flags
 
 - Avoid OWASP Top 10 vulnerabilities (XSS, SQL injection, command injection, etc.)
 - User data is privacy-regulated - use `secure_serialize` concern for sensitive fields
-- Console access audited via `AuditEvent` model (use `bin/audit_console`, not `rails console`)
+- Console access audited via `AuditEvent` model: use `bin/audit_console` (it sets `USER_KEY` and opens the console in the current shell, so it works from the Render Shell tab, a Cloud Run exec shell, or locally), not a bare `rails console`
 - Protected IDs require nonce to prevent snooping
 
 ## Environment Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ New user-facing features MUST be added behind a feature flag (`lib/feature_flags
 
 - Avoid OWASP Top 10 vulnerabilities (XSS, SQL injection, command injection, etc.)
 - User data is privacy-regulated - use `secure_serialize` concern for sensitive fields
-- Console access audited via `AuditEvent` model: use `bin/audit_console` (it sets `USER_KEY` and opens the console in the current shell, so it works from the Render Shell tab, a Cloud Run exec shell, or locally), not a bare `rails console`
+- Console access: use `bin/audit_console` (sets `USER_KEY` so console record-writes are attributed to you via PaperTrail, and works from the Render Shell tab, a Cloud Run exec shell, or locally), not a bare `rails console`. NOTE: the per-session `AuditEvent` logging this is meant to feed is currently non-operative on the Ruby 3.4 / Reline stack (Readline hook bypassed; `ARGV_COMMAND` undefined at boot so the un-keyed-console refusal never fires) -- tracked as open finding LL-7f7372e3eb
 - Protected IDs require nonce to prevent snooping
 
 ## Environment Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ New user-facing features MUST be added behind a feature flag (`lib/feature_flags
 
 - Avoid OWASP Top 10 vulnerabilities (XSS, SQL injection, command injection, etc.)
 - User data is privacy-regulated - use `secure_serialize` concern for sensitive fields
-- Console access: use `bin/audit_console` (sets `USER_KEY` so console record-writes are attributed to you via PaperTrail, and works from the Render Shell tab, a Cloud Run exec shell, or locally), not a bare `rails console`. NOTE: the per-session `AuditEvent` logging this is meant to feed is currently non-operative on the Ruby 3.4 / Reline stack (Readline hook bypassed; `ARGV_COMMAND` undefined at boot so the un-keyed-console refusal never fires) -- tracked as open finding LL-7f7372e3eb
+- Console access: use `bin/audit_console` (sets `USER_KEY` so console record-writes are attributed to you via PaperTrail, and works from the Render Shell tab, a Cloud Run exec shell, or locally), not a bare `rails console`. NOTE: `USER_KEY` is self-asserted free text, not derived from an authenticated principal, so the attributed actor is spoofable and the wrapper is opt-in (a bare `rails console` bypasses it with no attribution). The per-session `AuditEvent` logging this is meant to feed is also currently non-operative on the Ruby 3.4 / Reline stack (Readline hook bypassed; `ARGV_COMMAND` undefined at boot so the un-keyed-console refusal never fires). All three gaps are tracked as open finding LL-7f7372e3eb
 - Protected IDs require nonce to prevent snooping
 
 ## Environment Setup

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Additionally, the admin organization has a special importing tool, "Word Data Im
 
 ##### Troubleshooting
 
-Need console access? Use `bin/audit_console` from wherever you already have a shell on the app (the Render Shell tab, a Cloud Run exec shell, or a local checkout). It sets `USER_KEY` so any record changes you make during the session are attributed to you via PaperTrail. Prefer this wrapper over a bare `bundle exec rails console` for write attribution. It does not yet provide per-session `AuditEvent` logging or enforce refusal of an un-keyed console; that open control gap is tracked as LL-7f7372e3eb.
+Need console access? Use `bin/audit_console` from wherever you already have a shell on the app (the Render Shell tab, a Cloud Run exec shell, or a local checkout). It sets `USER_KEY` so any record changes you make during the session are attributed to you via PaperTrail. Prefer this wrapper over a bare `bundle exec rails console` for write attribution. Note that `USER_KEY` is self-asserted: the value you type is recorded verbatim and is not verified against the platform principal, so attribution is spoofable by anyone with shell access and is not yet a tamper-evident actor record. The wrapper is also opt-in; a bare `bundle exec rails console` bypasses it entirely with no attribution. It does not yet provide per-session `AuditEvent` logging or enforce refusal of an un-keyed console; both that bypass and the self-asserted-actor gap are tracked as LL-7f7372e3eb.
 
 ```
 b = Board.find_by_path('example/keyboard')

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Additionally, the admin organization has a special importing tool, "Word Data Im
 
 ##### Troubleshooting
 
-Need console access? On Render, use the Shell tab in your service dashboard, or run `bundle exec rails console` locally. Since LingoLinq needs to ensure user data remains protected, all production requests need to be audited (see the model `AuditEvent`), so there are some safeguards to prevent unaudited console access.
+Need console access? Use `bin/audit_console` from wherever you already have a shell on the app (the Render Shell tab, a Cloud Run exec shell, or a local checkout). It sets `USER_KEY` and opens the Rails console so the session is recorded via the `AuditEvent` model. Since LingoLinq needs to ensure user data remains protected, a bare `bundle exec rails console` is deliberately refused unless `USER_KEY` is set, which keeps privileged console access audited.
 
 ```
 b = Board.find_by_path('example/keyboard')

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Additionally, the admin organization has a special importing tool, "Word Data Im
 
 ##### Troubleshooting
 
-Need console access? Use `bin/audit_console` from wherever you already have a shell on the app (the Render Shell tab, a Cloud Run exec shell, or a local checkout). It sets `USER_KEY` so any record changes you make during the session are attributed to you via PaperTrail. Since LingoLinq needs to ensure user data remains protected, prefer this wrapper over a bare `bundle exec rails console` so privileged access stays accountable (see the `AuditEvent` model).
+Need console access? Use `bin/audit_console` from wherever you already have a shell on the app (the Render Shell tab, a Cloud Run exec shell, or a local checkout). It sets `USER_KEY` so any record changes you make during the session are attributed to you via PaperTrail. Prefer this wrapper over a bare `bundle exec rails console` for write attribution. It does not yet provide per-session `AuditEvent` logging or enforce refusal of an un-keyed console; that open control gap is tracked as LL-7f7372e3eb.
 
 ```
 b = Board.find_by_path('example/keyboard')

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Additionally, the admin organization has a special importing tool, "Word Data Im
 
 ##### Troubleshooting
 
-Need console access? Use `bin/audit_console` from wherever you already have a shell on the app (the Render Shell tab, a Cloud Run exec shell, or a local checkout). It sets `USER_KEY` and opens the Rails console so the session is recorded via the `AuditEvent` model. Since LingoLinq needs to ensure user data remains protected, a bare `bundle exec rails console` is deliberately refused unless `USER_KEY` is set, which keeps privileged console access audited.
+Need console access? Use `bin/audit_console` from wherever you already have a shell on the app (the Render Shell tab, a Cloud Run exec shell, or a local checkout). It sets `USER_KEY` so any record changes you make during the session are attributed to you via PaperTrail. Since LingoLinq needs to ensure user data remains protected, prefer this wrapper over a bare `bundle exec rails console` so privileged access stays accountable (see the `AuditEvent` model).
 
 ```
 b = Board.find_by_path('example/keyboard')

--- a/bin/audit_console
+++ b/bin/audit_console
@@ -1,8 +1,31 @@
 #!/bin/sh
-# TODO: this wrapper still invokes the Heroku CLI (`heroku auth:whoami`,
-# `heroku run -a lingolinq`). LingoLinq runs on Render now, so this script
-# only works against the legacy Heroku environment. Follow-up: rewrite the
-# body to attach to a Render service shell while still exporting USER_KEY
-# so the Rails console records an AuditEvent per session.
-heroku_id=`heroku auth:whoami`
-heroku run "export USER_KEY=$heroku_id && bundle exec rails console" -a lingolinq
+# Audited Rails console launcher.
+#
+# Opens a Rails console with USER_KEY set so config/initializers/auditing.rb
+# records an AuditEvent for the session (every console command in production)
+# and tags PaperTrail changes with the operator's identity. Console and runner
+# access is refused outright when USER_KEY is unset, so this wrapper is the
+# supported way to get an audited console.
+#
+# Platform-agnostic by design: it runs the console in the CURRENT shell instead
+# of shelling out to a hosting-provider CLI, so it works wherever you already
+# have a shell on the app -- the Render Shell tab, a GCP Cloud Run exec shell,
+# or a local checkout. (It replaced an older Heroku-CLI-only version; the legacy
+# Heroku app is gone.)
+set -e
+
+# Identity for the audit trail. Honor an already-exported USER_KEY (e.g. one set
+# in a local .env); otherwise prompt, mirroring setup_env.sh. It must be
+# non-empty -- the auditing initializer raises a console without it.
+if [ -z "$USER_KEY" ]; then
+  printf 'Enter your email for console auditing (USER_KEY): '
+  read -r USER_KEY || true
+fi
+
+if [ -z "$USER_KEY" ]; then
+  echo 'audit_console: USER_KEY is required so console access stays audited; aborting.' >&2
+  exit 1
+fi
+
+export USER_KEY
+exec bundle exec rails console "$@"

--- a/bin/audit_console
+++ b/bin/audit_console
@@ -1,29 +1,31 @@
 #!/bin/sh
-# Audited Rails console launcher.
+# Rails console launcher with operator identity.
 #
-# Opens a Rails console with USER_KEY set so config/initializers/auditing.rb
-# records an AuditEvent for the session (every console command in production)
-# and tags PaperTrail changes with the operator's identity. Console and runner
-# access is refused outright when USER_KEY is unset, so this wrapper is the
-# supported way to get an audited console.
+# Sets USER_KEY and opens a Rails console in the CURRENT shell, so it works
+# wherever you already have a shell on the app -- the Render Shell tab, a GCP
+# Cloud Run exec shell, or a local checkout. (It replaced an older
+# Heroku-CLI-only version; the legacy Heroku app is gone.)
 #
-# Platform-agnostic by design: it runs the console in the CURRENT shell instead
-# of shelling out to a hosting-provider CLI, so it works wherever you already
-# have a shell on the app -- the Render Shell tab, a GCP Cloud Run exec shell,
-# or a local checkout. (It replaced an older Heroku-CLI-only version; the legacy
-# Heroku app is gone.)
+# USER_KEY tags PaperTrail changes with the operator's identity
+# (config/initializers/auditing.rb), which attributes record WRITES made during
+# the session. NOTE: the per-session / per-command AuditEvent logging this
+# wrapper is meant to feed is NOT currently operative -- the Readline hook is
+# bypassed by Reline on Ruby 3.4, and the un-keyed-console refusal never fires
+# because ARGV_COMMAND is undefined at boot. That control gap is tracked as
+# finding LL-7f7372e3eb; this platform-agnostic wrapper is a prerequisite for
+# that fix, not the whole fix. USER_KEY is still requested so write-attribution
+# works and the path is ready once the control is restored.
 set -e
 
-# Identity for the audit trail. Honor an already-exported USER_KEY (e.g. one set
-# in a local .env); otherwise prompt, mirroring setup_env.sh. It must be
-# non-empty -- the auditing initializer raises a console without it.
+# Identity for attribution. Honor an already-exported USER_KEY (e.g. one set in
+# a local .env); otherwise prompt, mirroring setup_env.sh.
 if [ -z "$USER_KEY" ]; then
   printf 'Enter your email for console auditing (USER_KEY): '
   read -r USER_KEY || true
 fi
 
 if [ -z "$USER_KEY" ]; then
-  echo 'audit_console: USER_KEY is required so console access stays audited; aborting.' >&2
+  echo 'audit_console: USER_KEY is required for console attribution; aborting.' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What

Rewrites `bin/audit_console` (the documented console entry point) from a Heroku-CLI wrapper into a **platform-agnostic** launcher. The old version shelled to `heroku auth:whoami` + `heroku run -a lingolinq`; Heroku is gone, so it was inoperative on Render. The new version sets `USER_KEY` and runs `bundle exec rails console` **in the current shell**, so it works unchanged from the Render Shell tab, a GCP Cloud Run exec shell, or locally, and is not coupled to the Render-to-GCP migration. It also removes the string-interpolation injection vector the old `heroku run "export USER_KEY=$heroku_id && ..."` form carried.

## This does NOT close finding LL-7f7372e3eb

The adversary pass empirically confirmed the audited-console **control this wrapper feeds is itself non-operative** on the current Ruby 3.4 / Rails 7.2 stack, independent of platform:

1. **Enforcement guard dead.** `config/initializers/auditing.rb:14` reads `command = defined?(ARGV_COMMAND) ? ARGV_COMMAND : "server"`, but `ARGV_COMMAND`/`INIT_ARGS` are **never assigned anywhere in the repo**. So `command` is always `"server"` and the un-keyed-console refusal (`:17-19`), the `rails/runner` AuditEvent (`:25`), and the `"not allowed, HIPAA-style"` db-console block (`:16`) can never fire. Runtime-confirmed: `USER_KEY= RAILS_ENV=test rails runner ...` ran with `ARGV_COMMAND` = `nil`, **not refused**.
2. **Per-command console log dead.** The only `AuditEvent.log_command` for the console (`:8`) lives in a stdlib `Readline` monkeypatch (`:2-12`), which **Reline 0.6.3** (the IRB line editor on Ruby 3.4) bypasses.

**Net:** zero `AuditEvent` rows are produced even via `bin/audit_console`; only `PaperTrail.whodunnit` write-attribution survives. The finding's gap (no per-session AuditEvent) therefore still stands.

This PR is a **prerequisite** (it makes the launcher work and kills the injection vector), but the actual remediation lives in the boot path (`auditing.rb` + restoring `ARGV_COMMAND`/`INIT_ARGS` capture + a Reline-compatible session-open AuditEvent + tests). That is intentionally **out of scope here** (boot-path risk), and **LL-7f7372e3eb stays open** for it.

## Honesty of the docs

The script header, `CLAUDE.md`, and `README.md` describe only what holds **today** (USER_KEY-based write attribution via PaperTrail). They do **not** claim per-session AuditEvent recording or un-keyed-console refusal, since neither currently happens. `CLAUDE.md` references LL-7f7372e3eb as the tracking item for the boot-path gap.

## Scope

- **Files:** `bin/audit_console`, `CLAUDE.md`, `README.md`. No code calls the script; only docs referenced it.
- No DB migration, no deploy/config change, no env-var-handling change, no new dependency, no gem/npm bump.
- No fixtures/seeds/factories/data-migrations; no secrets; no real student/patient data.

## Verification

- `sh -n bin/audit_console` clean; guard path tested (no `USER_KEY`, aborts exit 1, no Rails boot).
- `DB_USER=scotw RAILS_ENV=test bundle exec rspec spec/models/audit_event_spec.rb` gives **8 examples, 0 failures**.
- `/review-pr` (senior-dev): Approve. `/adversary-review`: the two boot-path findings above (which is why this is not labeled a remediation).

## Register

`audit-reports/FINDINGS.json` is intentionally untouched. **Do not** move LL-7f7372e3eb to verified-closed on this PR.
