### PR TITLE
Enforce org AI opt-out at generate_labels + scrub logged model output

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -560,7 +560,10 @@ class Api::BoardsController < ApplicationController
   end
 
   def generate_labels
-    unless FeatureFlags.feature_enabled_for?('ai_board_generation', @api_user)
+    # Gate on the AI-specific check so an org-level AI opt-out (disable_ai_features) is
+    # enforced at the endpoint and returns a clean 403, instead of passing the plain flag
+    # check here and being rejected deeper in the generator as a 503.
+    unless FeatureFlags.ai_feature_enabled_for?('ai_board_generation', @api_user)
       return api_error(403, { error: 'Feature not available' })
     end
     processed_params, json_body_source = board_json_body_params_source

--- a/lib/ai_board_generator.rb
+++ b/lib/ai_board_generator.rb
@@ -660,13 +660,18 @@ module AiBoardGenerator
                     pii_detected: false, pii_findings: [], success: true, error_message: nil,
                     request_type: 'board_generation')
       return unless defined?(AiApiLog)
+      # Scrub the model OUTPUT before it reaches AiApiLog. Generated board names/descriptions
+      # can echo user-supplied sensitive context, so the raw response must never be persisted
+      # unredacted (request_summary is already scrubbed upstream). nil passes through untouched
+      # for the API-error paths that log no response body.
+      safe_response_summary = response_summary.nil? ? nil : PiiScrubber.redact_for_ai(response_summary)[:payload]
       AiApiLog.log_ai_call(
         provider: provider,
         model: model,
         type: request_type,
         user: user,
         request_summary: request_summary,
-        response_summary: response_summary,
+        response_summary: safe_response_summary,
         tokens_sent: tokens_sent,
         tokens_received: tokens_received,
         duration_ms: duration_ms,

--- a/spec/controllers/api/boards_controller_spec.rb
+++ b/spec/controllers/api/boards_controller_spec.rb
@@ -1356,12 +1356,38 @@ describe Api::BoardsController, :type => :controller do
   describe "generate_labels" do
     it "should reject non-object JSON body" do
       token_user
-      expect(FeatureFlags).to receive(:feature_enabled_for?).with('ai_board_generation', anything).and_return(true)
+      expect(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_board_generation', anything).and_return(true)
       request.headers['Content-Type'] = 'application/json'
       post :generate_labels, params: {}, body: '[]'
       expect(response).to have_http_status(:bad_request)
       json = JSON.parse(response.body)
       expect(json['error']).to eq('JSON body must be an object')
+    end
+
+    it "should pass the authenticated user through to the generator" do
+      token_user
+      expect(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_board_generation', anything).and_return(true)
+      captured = nil
+      allow(AiBoardGenerator).to receive(:generate_words) do |**kw|
+        captured = kw
+        { words: %w[apple banana carrot drink], name: 'Snacks', description: 'Snack words', error: nil }
+      end
+      request.headers['Content-Type'] = 'application/json'
+      post :generate_labels, params: {}, body: { prompt: 'snacks', rows: 2, columns: 2 }.to_json
+      expect(response).to be_successful
+      expect(captured[:user]).to be_present
+      expect(captured[:user].global_id).to eq(@user.global_id)
+    end
+
+    it "should return 403 and skip generation when AI is disabled for the org" do
+      token_user
+      expect(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_board_generation', anything).and_return(false)
+      expect(AiBoardGenerator).not_to receive(:generate_words)
+      request.headers['Content-Type'] = 'application/json'
+      post :generate_labels, params: {}, body: { prompt: 'snacks', rows: 2, columns: 2 }.to_json
+      expect(response).to have_http_status(:forbidden)
+      json = JSON.parse(response.body)
+      expect(json['error']).to eq('Feature not available')
     end
   end
   

--- a/spec/lib/ai_board_generator_spec.rb
+++ b/spec/lib/ai_board_generator_spec.rb
@@ -59,6 +59,19 @@ describe AiBoardGenerator do
       expect(AiApiLog).to have_received(:log_ai_call).with(hash_including(provider: 'claude', success: false))
     end
 
+    it "scrubs PII from the model response before it reaches AiApiLog" do
+      logged = nil
+      allow(AiApiLog).to receive(:log_ai_call) { |**kw| logged = kw }
+      raw = "WORDS: apple, banana, carrot, drink\nNAME: Snacks\nDESCRIPTION: Email parent@example.com for help."
+      allow(described_class).to receive(:call_anthropic).and_return(anthropic_response(raw))
+
+      result = described_class.generate_words(prompt: 'snacks', rows: 2, columns: 2)
+
+      expect(result[:error]).to eq(nil)
+      expect(logged[:response_summary]).to include('[REDACTED_EMAIL]')
+      expect(logged[:response_summary]).not_to include('parent@example.com')
+    end
+
     context "COPPA Final Rule hard-gate" do
       it "returns a parental-consent error when coppa_blocks_ai_for? is true" do
         u = User.new(settings: { 'coppa' => { 'pending_parent_consent' => true } })


### PR DESCRIPTION
## Summary
Closes two gaps in the `ai_board_generation` path (feature-flag gated; no behavior change for AI-enabled orgs).

**1. Endpoint-level org AI opt-out.** `generate_labels` gated on `FeatureFlags.feature_enabled_for?`, which does *not* honor the org-level AI opt-out (`disable_ai_features`, FERPA/HIPAA control). Now gated on `ai_feature_enabled_for?`, so an opted-out org is rejected at the door with a clean **403** instead of passing the gate and being rejected deeper in the generator as a confusing **503**. (`user:` is already threaded into `generate_words` on staging, so the generator-level opt-out + audit attribution already engage; this aligns the endpoint gate with it.)

**2. Scrub the logged model OUTPUT.** `log_ai_call` persisted the raw model response (`response_summary`) **unscrubbed** across four call sites (board-gen + focus-words, success + shortfall paths). Generated board names/descriptions can echo user-supplied sensitive context. Fixed once at the chokepoint: `response_summary` now runs through `PiiScrubber.redact_for_ai` before it reaches `AiApiLog`. The request side was already scrubbed upstream; `nil` error-path responses pass through untouched.

## Tests
- `spec/lib/ai_board_generator_spec.rb`: model output containing an email is logged as `[REDACTED_EMAIL]` (raw email absent). **9 examples, 0 failures.**
- `spec/controllers/api/boards_controller_spec.rb`: `generate_labels` passes the authenticated user through to the generator; returns 403 and skips generation when AI is disabled for the org. **3 examples, 0 failures.**

## Notes
- No user-facing strings, so no i18n.
- All changes sit behind the existing `ai_board_generation` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDB9pZmj4BTscjYFbNv58E