### PR TITLE
security: bump crass 1.0.6 -> 1.0.7 (GHSA DoS advisories)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     diff-lcs (1.6.2)
     docile (1.4.1)


### PR DESCRIPTION
## What
Bumps `crass` 1.0.6 -> 1.0.7 (one-line `Gemfile.lock` change, conservative update).

## Why
`bundle-audit` started failing the repo-wide **security-scan** CI job on 2026-06-29 because four GHSA advisories for `crass` 1.0.6 landed in the ruby-advisory-db that day:

- GHSA-6jxj-px6v-747w — deeply nested CSS blocks/functions -> `SystemStackError` / excessive memory
- GHSA-6wmf-3r64-vcwv — large numeric exponents -> CPU/memory DoS
- GHSA-8vfg-2r28-hvhj — non-ASCII characters -> superlinear CPU
- GHSA-wwpr-jff3-395c — many adjacent CSS comments -> `SystemStackError`

All fixed in 1.0.7. Criticality "Unknown" (low-severity DoS in a CSS parser), but it red-flags CI on **every** open PR, including the in-flight GCP-migration PR #496.

## Scope / safety
- `crass` is **transitive only** (pulled by `loofah 2.25.0` and `sanitize 7.0.0`, both constrained `~> 1.0.2`, which already permits 1.0.7). No cascade — the diff is a single line.
- Verified locally: `bundle-audit check --update` -> **"No vulnerabilities found"**.

Unblocks the security-scan job repo-wide.