### PR TITLE
security(gcp): cloudrun IAM policy needs KMS for SSE-KMS uploads bucket

### DIFF
--- a/scripts/gcp/iam/lingolinq-cloudrun-s3-ses-policy.json
+++ b/scripts/gcp/iam/lingolinq-cloudrun-s3-ses-policy.json
@@ -29,6 +29,15 @@
       ]
     },
     {
+      "Sid": "KMSForUploadsBucketSSE",
+      "Effect": "Allow",
+      "Action": [
+        "kms:GenerateDataKey",
+        "kms:Decrypt"
+      ],
+      "Resource": "arn:aws:kms:us-west-2:239044785114:key/d5a1a377-8f55-469d-a0ab-4a86481dba67"
+    },
+    {
       "Sid": "SESSendFromUsWest2",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## What
Adds a `kms:GenerateDataKey` + `kms:Decrypt` statement (scoped to one key) to the least-priv Cloud Run IAM policy (`scripts/gcp/iam/lingolinq-cloudrun-s3-ses-policy.json`).

## Why — found by the live clean-DB rehearsal smoke
The `lingolinq-cloudrun-prod` user (4.E1) failed the S3 smoke path with:
```
AccessDenied ... not authorized to perform: kms:GenerateDataKey on resource:
arn:aws:kms:us-west-2:239044785114:key/d5a1a377-8f55-469d-a0ab-4a86481dba67
```
`lingolinq-prod-uploads` is **SSE-KMS** encrypted with that customer-managed key, so `PutObject`/`GetObject` there require KMS data-key permissions — the S3 actions alone aren't enough. The original policy granted S3+SES only. Verified live: `lingolinq-prod-static` is **AES256** (no KMS needed), so KMS is scoped to the single uploads key.

The other four smoke paths passed on the new key: **LOGIN ✓, BOARD ✓, SES ✓** (real MessageId), DB/Redis/boot ✓.

## Live remediation (separate, admin)
The committed file is the reference; the live user's attached policy must be updated too (admin creds — the app user has no IAM). Replace the `lingolinq-cloudrun-s3-ses` policy with this version (`aws iam create-policy-version --set-as-default`), then the S3 smoke re-runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)