### PR TITLE
fix(gcp): bake real MAPS_KEY + DEFAULT_HOST into globals.js at build (item 4.E2)

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -102,7 +102,8 @@ jobs:
       # are the NEW least-priv IAM user, scripts/gcp/iam/). Every name here is asserted to have a
       # SEEDED VERSION in Secret Manager by the "Assert referenced secrets exist" step before deploy.
       # MAPS_KEY is intentionally NOT here: it is a client-public key emitted at asset-precompile
-      # (globals.js.erb), not read at runtime, so it needs a Docker build ARG, not a runtime mount.
+      # (globals.js.erb), not read at runtime, so it is passed as a Docker build ARG in the
+      # "Build and push image" step (alongside DEFAULT_HOST), not mounted at runtime.
       NON_BOOT_SECRETS: AWS_KEY=AWS_KEY:latest,AWS_SECRET=AWS_SECRET:latest,GOOGLE_TTS_TOKEN=GOOGLE_TTS_TOKEN:latest,GOOGLE_PLACES_TOKEN=GOOGLE_PLACES_TOKEN:latest,GOOGLE_TRANSLATE_TOKEN=GOOGLE_TRANSLATE_TOKEN:latest,GOOGLE_OAUTH_CLIENT_ID=GOOGLE_OAUTH_CLIENT_ID:latest,GOOGLE_OAUTH_CLIENT_SECRET=GOOGLE_OAUTH_CLIENT_SECRET:latest,STRIPE_SECRET_KEY=STRIPE_SECRET_KEY:latest,ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,SENTRY_DSN=SENTRY_DSN:latest,SMS_ENCRYPTION_KEY=SMS_ENCRYPTION_KEY:latest,INTERNAL_API_TOKEN=INTERNAL_API_TOKEN:latest,CACHE_TOKEN=CACHE_TOKEN:latest,OPENSYMBOLS_SECRET=OPENSYMBOLS_SECRET:latest,IPLOCATE_API_KEY=IPLOCATE_API_KEY:latest,YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest
       # Non-secret runtime config (Group B) + perf tuning (Group C), web + worker only. S3 bucket
       # names + AWS/SES regions are not secret. Stripe PUBLISHABLE key, registration email, and the
@@ -133,8 +134,22 @@ jobs:
         run: gcloud auth configure-docker "${{ vars.GCP_REGION }}-docker.pkg.dev" --quiet
 
       - name: Build and push image
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
         run: |
-          docker build -t "$IMAGE" .
+          set -euo pipefail
+          # globals.js.erb bakes window.maps_key + window.default_host at asset-precompile (build
+          # time), so the real client-public values must reach the build as ARGs -- a runtime secret
+          # mount is too late (the asset is already compiled, and on GCP would otherwise bake
+          # default_host=localhost + omit maps_key). Both are fetched from Secret Manager as the
+          # deploy SA (which already reads DEFAULT_HOST for the boot set; MAPS_KEY granted alongside).
+          # Values are client-public (emitted to the browser) and never echoed.
+          MAPS_KEY="$(gcloud secrets versions access latest --secret=MAPS_KEY --project="$GCP_PROJECT_ID")"
+          APP_DEFAULT_HOST="$(gcloud secrets versions access latest --secret=DEFAULT_HOST --project="$GCP_PROJECT_ID")"
+          docker build \
+            --build-arg MAPS_KEY="$MAPS_KEY" \
+            --build-arg APP_DEFAULT_HOST="$APP_DEFAULT_HOST" \
+            -t "$IMAGE" .
           docker push "$IMAGE"
 
       - name: Assert referenced secrets exist + assemble runtime env

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,14 +51,26 @@ COPY . .
 # Copy built Ember assets from the frontend-builder stage
 COPY --from=frontend-builder /app/frontend/dist ./app/frontend/dist
 
-# Precompile assets with dummy keys
+# Client-public config baked into globals.js.erb AT asset-precompile (build time), not read at
+# runtime: window.maps_key (Google Maps embed) and window.default_host. These are emitted to the
+# browser, so they are NOT secrets. They must be present during precompile or the compiled
+# /assets/globals.js bakes dummy values (default_host=localhost, maps_key omitted). On Render this
+# worked implicitly because the build env carried the real values; the GCP build must be told via
+# --build-arg (see .github/workflows/deploy-cloudrun.yml "Build and push image"). Defaults keep the
+# old dummy behavior so a bare `docker build` (local/dev) still succeeds.
+ARG MAPS_KEY=""
+ARG APP_DEFAULT_HOST="localhost"
+
+# Precompile assets. Server secrets stay dummy (the asset pipeline never reads them); the two
+# client-public build args above carry their real values into globals.js.erb.
 RUN export SECRET_KEY_BASE=dummy_key_at_least_30_characters_long_for_build && \
     export COOKIE_KEY=dummy_key_at_least_30_characters_long_for_build && \
     export SECURE_ENCRYPTION_KEY=dummy_key_at_least_30_characters_long_for_build && \
     export SECURE_NONCE_KEY=dummy_key_at_least_30_characters_long_for_build && \
     export DATABASE_URL=postgres://postgres@localhost/dummy && \
     export REDIS_URL=redis://localhost:6379/0 && \
-    export DEFAULT_HOST=localhost && \
+    export DEFAULT_HOST="$APP_DEFAULT_HOST" && \
+    export MAPS_KEY="$MAPS_KEY" && \
     bundle exec rake extras:assert_js && \
     bundle exec rake extras:copy_terms && \
     bundle exec rake assets:precompile && \


### PR DESCRIPTION
## Why

`globals.js.erb` is compiled at `assets:precompile` and served as a **static** `/assets/globals.js` (verified: no runtime route/controller serves it). So `window.maps_key` and `window.default_host` are baked at **build time**, not resolved per-request.

The GCP `Dockerfile` precompiles with dummy values:
```
export DEFAULT_HOST=localhost   # baked into window.default_host
# MAPS_KEY unset                # <% if ENV['MAPS_KEY'] %> false -> window.maps_key omitted
```
So the GCP image ships `window.default_host="localhost"` and no maps key. Render never hit this because its build env carries the real values during `assets:precompile`.

Severity is low (the `default_host` consumers fall back to `capabilities.fallback_host` and it is not the main API origin; maps is a peripheral embed), but it is a real correctness gap surfaced during the clean-DB rehearsal env reconciliation.

## What

- **Dockerfile**: add `ARG MAPS_KEY=""` + `ARG APP_DEFAULT_HOST="localhost"` (defaults preserve the old dummy behavior for a bare local `docker build`) and export them into the precompile step. Server secrets stay dummy (the asset pipeline never reads them).
- **deploy-cloudrun.yml**: the "Build and push image" step fetches `MAPS_KEY` + `DEFAULT_HOST` from Secret Manager (as the deploy SA, which already reads `DEFAULT_HOST` for the boot set) and passes both via `--build-arg`. Values are client-public (emitted to the browser) and never echoed.

## Live prerequisites already applied
- `MAPS_KEY` seeded to Secret Manager in `lingolinq-prod` (value sourced from Render prod, 39 chars).
- `roles/secretmanager.secretAccessor` on `MAPS_KEY` granted to the deploy SA `cloud-run-deployer@`.

## Scope notes (verified against live Render prod)
- The other `globals.js` client keys (`SYMBOL_PROXY_KEY`, `PIXABAY_KEY`, `FLICKR_KEY`, `GCSE_KEY`, `GIPHY_KEY`) are **not** set on Render prod, so there is no parity gap for them — intentionally left out.
- Transcoder/SNS IAM was a candidate pre-cutover item but is **not** needed: neither the web nor worker Render service carries any `TRANSCODER_*`/`SNS_*` env vars, so that pipeline is inactive on prod today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)