### PR TITLE
security: make the audited Rails console control operative (LL-7f7372e3eb)

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,20 @@
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path('../config/application', __dir__)
+
+# Audited-console boot-path capture + guard (LL-7f7372e3eb).
+# Capture the invoked command and full argv BEFORE Rails boots so
+# config/initializers/auditing.rb can attribute the session, and refuse an
+# un-keyed console/runner (or HIPAA-sensitive db/dbconsole) in production
+# before any database connection is established. The guard is pure Ruby and is
+# required here, ahead of config/boot, so the refusal never reaches Rails.
+INIT_ARGS    = ARGV.dup.freeze
+ARGV_COMMAND = ARGV.first
+require_relative '../lib/audit/console_guard'
+begin
+  Audit::ConsoleGuard.enforce_pre_boot!(ARGV_COMMAND, INIT_ARGS, ENV)
+rescue Audit::ConsoleGuard::Error => e
+  abort("refused: #{e.message}")
+end
+
 require_relative "../config/boot"
 require "rails/commands"

--- a/bin/rails
+++ b/bin/rails
@@ -10,6 +10,12 @@ APP_PATH = File.expand_path('../config/application', __dir__)
 INIT_ARGS    = ARGV.dup.freeze
 ARGV_COMMAND = ARGV.first
 require_relative '../lib/audit/console_guard'
+# Capture the ambient production status NOW, before railties can overwrite
+# ENV['RAILS_ENV'] from a -e/--environment flag (require_application!). The
+# runtime fail-closed audit check (Audit::SessionLogger) reads this so it still
+# knows the deployment is production when a session is *named* development but
+# DATABASE_URL/the discrete params still target the production database.
+AUDIT_AMBIENT_PRODUCTION = Audit::ConsoleGuard.ambient_production?(ENV)
 begin
   Audit::ConsoleGuard.enforce_pre_boot!(ARGV_COMMAND, INIT_ARGS, ENV)
 rescue Audit::ConsoleGuard::Error => e

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,7 @@ module LingoLinq
     unless ENV['RESQUE_WORKER'] == 'true'
       config.autoload_lib(
         ignore: %w[
+          audit
           converters
           templates
           obf_lingolinq_patch.rb

--- a/config/initializers/auditing.rb
+++ b/config/initializers/auditing.rb
@@ -1,29 +1,34 @@
-unless ENV['SKIP_VALIDATIONS']
-  module Readline
-    alias :old_readline :readline
-    def readline(*args)
-      ln = old_readline(*args)
-      puts "#{ENV['USER_KEY']} entered: #{ln}"
-      if Rails.env.production?
-        AuditEvent.log_command(ENV['USER_KEY'], 'type' => 'rails/console', 'command' => ln)
-      end
-      ln
-    end
-  end
+# Audited-console control (LL-7f7372e3eb).
+#
+# config/boot is loaded from bin/rails, which has already required the guard,
+# set ::ARGV_COMMAND / ::INIT_ARGS, and refused an un-keyed console/runner (or
+# HIPAA db-console) in production *before* boot. Here we (a) attribute writes via
+# PaperTrail and (b) register the session-open AuditEvent hooks.
+#
+# The old per-command Readline monkeypatch was removed: Ruby 3.4's IRB uses
+# Reline, which never calls Readline, so the patch wrote nothing. The Rails
+# `console`/`runner` hooks below are line-editor agnostic and fire once per
+# session (session-open auditing), which is what the control requires.
+#
+# Required again here (idempotent; the file is excluded from Zeitwerk) so
+# Audit::SessionLogger is loaded wherever these hooks execute.
+require_relative '../../lib/audit/console_guard'
 
-  command = defined?(ARGV_COMMAND) ? ARGV_COMMAND : "server"
-   # Custom LingoLinq code...
-  raise "not allowed, HIPAA-style" if ['db', 'dbconsole'].include?(command) && Rails.env.production?
-  if !ENV['USER_KEY'] && ['runner', 'r', 'console', 'c'].include?(command)
-    raise "need ENV['USER_KEY'] for console logging with \"#{INIT_ARGS.join(' ')}\""
-  end
-  if ENV['USER_KEY']
+unless ENV['SKIP_VALIDATIONS']
+  if Audit::ConsoleGuard.key_present?(ENV)
     PaperTrail.request.whodunnit = "admin:#{ENV['USER_KEY']}"
   end
-  
-  if ['r', 'runner'].include?(command)
-    AuditEvent.log_command(ENV['USER_KEY'], 'type' => 'rails/runner', 'command' => INIT_ARGS.join(" "))
-  end
-  # TODO: log any script/runner calls, any console statements
-end
 
+  init_args = defined?(INIT_ARGS) ? INIT_ARGS : []
+
+  # Reline-safe session-open auditing. run_console_blocks fires before the IRB
+  # REPL starts; load_runner fires before the runner payload runs -- so in
+  # production a fail-closed write aborts the session before any work happens.
+  Rails.application.console do
+    Audit::SessionLogger.record!('console', ENV['USER_KEY'], init_args)
+  end
+
+  Rails.application.runner do
+    Audit::SessionLogger.record!('runner', ENV['USER_KEY'], init_args)
+  end
+end

--- a/config/initializers/auditing.rb
+++ b/config/initializers/auditing.rb
@@ -14,28 +14,34 @@
 # Audit::SessionLogger is loaded wherever these hooks execute.
 require_relative '../../lib/audit/console_guard'
 
-unless ENV['SKIP_VALIDATIONS']
-  if Audit::ConsoleGuard.key_present?(ENV)
-    PaperTrail.request.whodunnit = "admin:#{ENV['USER_KEY']}"
-  end
-
-  init_args = defined?(INIT_ARGS) ? INIT_ARGS : []
-
-  # Reline-safe session-open auditing. The console hook fires before the IRB
-  # REPL starts; the runner hook before the runner payload runs. Each hook first
-  # runs the authoritative, parser-free production refusal (Rails.env is fully
-  # resolved by now, so it catches any -e/--environment form the pre-boot parser
-  # might miss), then records the session-open AuditEvent. In production a
-  # fail-closed audit write also aborts the session before any work happens.
-  open_audited_session = lambda do |kind|
-    begin
-      Audit::ConsoleGuard.enforce_runtime!(kind, ENV)
-    rescue Audit::ConsoleGuard::Error => e
-      abort("refused: #{e.message}")
-    end
-    Audit::SessionLogger.record!(kind, ENV['USER_KEY'], init_args)
-  end
-
-  Rails.application.console { open_audited_session.call('console') }
-  Rails.application.runner  { open_audited_session.call('runner') }
+# Deliberately NOT wrapped in `unless ENV['SKIP_VALIDATIONS']` (unlike the other
+# initializers): the audited-console control must not be disablable by an env
+# var. Otherwise an operator could run `SKIP_VALIDATIONS=true bin/rails console`
+# -- which the pre-boot guard still allows when keyed -- and get a session with
+# no AuditEvent, no PaperTrail attribution, and no runtime refusal. These hooks
+# fire only when a console/runner actually starts, so registering them
+# unconditionally is harmless during SKIP_VALIDATIONS rake tasks (Rakefile sets
+# it), which never open a console or runner.
+if Audit::ConsoleGuard.key_present?(ENV)
+  PaperTrail.request.whodunnit = "admin:#{ENV['USER_KEY']}"
 end
+
+init_args = defined?(INIT_ARGS) ? INIT_ARGS : []
+
+# Reline-safe session-open auditing. The console hook fires before the IRB REPL
+# starts; the runner hook before the runner payload runs. Each hook first runs
+# the authoritative, parser-free production refusal (Rails.env is fully resolved
+# by now, so it catches any -e/--environment form the pre-boot parser might
+# miss), then records the session-open AuditEvent. In production a fail-closed
+# audit write also aborts the session before any work happens.
+open_audited_session = lambda do |kind|
+  begin
+    Audit::ConsoleGuard.enforce_runtime!(kind, ENV)
+  rescue Audit::ConsoleGuard::Error => e
+    abort("refused: #{e.message}")
+  end
+  Audit::SessionLogger.record!(kind, ENV['USER_KEY'], init_args)
+end
+
+Rails.application.console { open_audited_session.call('console') }
+Rails.application.runner  { open_audited_session.call('runner') }

--- a/config/initializers/auditing.rb
+++ b/config/initializers/auditing.rb
@@ -21,14 +21,21 @@ unless ENV['SKIP_VALIDATIONS']
 
   init_args = defined?(INIT_ARGS) ? INIT_ARGS : []
 
-  # Reline-safe session-open auditing. run_console_blocks fires before the IRB
-  # REPL starts; load_runner fires before the runner payload runs -- so in
-  # production a fail-closed write aborts the session before any work happens.
-  Rails.application.console do
-    Audit::SessionLogger.record!('console', ENV['USER_KEY'], init_args)
+  # Reline-safe session-open auditing. The console hook fires before the IRB
+  # REPL starts; the runner hook before the runner payload runs. Each hook first
+  # runs the authoritative, parser-free production refusal (Rails.env is fully
+  # resolved by now, so it catches any -e/--environment form the pre-boot parser
+  # might miss), then records the session-open AuditEvent. In production a
+  # fail-closed audit write also aborts the session before any work happens.
+  open_audited_session = lambda do |kind|
+    begin
+      Audit::ConsoleGuard.enforce_runtime!(kind, ENV)
+    rescue Audit::ConsoleGuard::Error => e
+      abort("refused: #{e.message}")
+    end
+    Audit::SessionLogger.record!(kind, ENV['USER_KEY'], init_args)
   end
 
-  Rails.application.runner do
-    Audit::SessionLogger.record!('runner', ENV['USER_KEY'], init_args)
-  end
+  Rails.application.console { open_audited_session.call('console') }
+  Rails.application.runner  { open_audited_session.call('runner') }
 end

--- a/lib/audit/console_guard.rb
+++ b/lib/audit/console_guard.rb
@@ -86,26 +86,38 @@ module Audit
       { 'type' => "rails/#{kind}", 'command' => Array(init_args).join(' ') }
     end
 
-    # True when the session will run in production, resolved the way Rails will
-    # resolve it: an explicit -e/--environment flag (or, for `console`, a
-    # positional environment arg) overrides ENV['RAILS_ENV']/ENV['RACK_ENV'].
+    # Production-sensitive when the CLI names production OR the ambient deployment
+    # is production. BOTH must gate the refusal, because the database a session
+    # reaches is bound to whatever Rails.env resolves to, NOT to the name on the
+    # command line: ActiveRecord merges DATABASE_URL (or the discrete prod
+    # params) into the config for the resolved env, so `bin/rails console
+    # -e development` on a prod box (where DATABASE_URL points at prod) still
+    # connects to the production database. The ambient check is read here at
+    # pre-boot, BEFORE railties applies any -e override to ENV['RAILS_ENV'], so a
+    # -e flag can ADD production (ambient unset, `-e production`) but can never
+    # CLEAR a production deployment.
+    #
+    # Residual, tracked as a follow-up on LL-7f7372e3eb: a deployment that
+    # reaches the prod DB while ambient RAILS_ENV/RACK_ENV is not 'production'
+    # (e.g. only DATABASE_URL set, RAILS_ENV unset) is not detected here; the
+    # fully robust fix gates on the resolved connection target. Both real prod
+    # deployments (Render and Cloud Run) set RAILS_ENV=production, so the
+    # realistic `-e development` dodge is covered.
     def production?(command, init_args, env = ENV)
-      effective_environment(command, init_args, env) == 'production'
+      cli_production?(command, init_args) || ambient_production?(env)
     end
 
-    # Resolve the effective environment exactly the way railties does, so no
-    # invocation can boot production while the guard believes it is not:
-    #   * a CLI -e/--environment value is prefix-expanded (Rails expands any
-    #     abbreviation of production/development/test) and wins when present;
-    #   * otherwise ENV['RAILS_ENV'] then ENV['RACK_ENV'] are used VERBATIM --
-    #     Rails does NOT abbreviation-expand the env vars -- treating a blank /
-    #     whitespace value as absent (Rails uses String#presence);
-    #   * otherwise 'development'.
-    def effective_environment(command, init_args, env = ENV)
-      cli = cli_environment(command, Array(init_args))
-      return cli if cli
+    # The CLI-named environment resolves to production. A repeated flag uses the
+    # last occurrence; abbreviations are prefix-expanded the way railties does.
+    def cli_production?(command, init_args)
+      cli_environment(command, Array(init_args)) == 'production'
+    end
 
-      presence(env['RAILS_ENV']) || presence(env['RACK_ENV']) || 'development'
+    # The ambient deployment is production: RAILS_ENV then RACK_ENV, verbatim
+    # (Rails does not abbreviation-expand the env vars) with String#presence
+    # semantics (a blank/whitespace value is treated as absent).
+    def ambient_production?(env = ENV)
+      (presence(env['RAILS_ENV']) || presence(env['RACK_ENV'])) == 'production'
     end
 
     def presence(value)

--- a/lib/audit/console_guard.rb
+++ b/lib/audit/console_guard.rb
@@ -164,14 +164,12 @@ module Audit
       explicit = nil
 
       args.each_with_index do |arg, i|
-        case arg
-        when '-e', '--environment'
+        if env_flag?(arg)
           nxt = args[i + 1]
           explicit = nxt if nxt && !nxt.start_with?('-')
-        when /\A--environment=(.+)\z/, /\A-e=(.+)\z/
-          explicit = Regexp.last_match(1)
-        when /\A-e(.+)\z/ # glued short form, e.g. -eprod
-          explicit = Regexp.last_match(1)
+        else
+          value = inline_env_value(arg)
+          explicit = value if value
         end
       end
 
@@ -185,9 +183,45 @@ module Audit
       nil
     end
 
+    # True for the bare environment flag whose value is the FOLLOWING token:
+    # `-e`, `--environment`, or any unambiguous long abbreviation
+    # (`--e`..`--environmen`). Thor accepts long-option prefixes, and none of
+    # console/runner/dbconsole define another `--e...` option, so every such
+    # prefix means the environment.
+    def env_flag?(arg)
+      arg == '-e' || (arg.start_with?('--e') && '--environment'.start_with?(arg))
+    end
+
+    # Value for an inline environment form, or nil: `-e=v`, glued `-ev`,
+    # `--environment=v`, and the abbreviated `--env=v`. (Long options require
+    # `=` or a space, so there is no glued `--envv` form.)
+    def inline_env_value(arg)
+      if (m = arg.match(/\A-e=(.+)\z/))
+        m[1]
+      elsif (m = arg.match(/\A(--e[a-z]*)=(.+)\z/)) && '--environment'.start_with?(m[1])
+        m[2]
+      elsif (m = arg.match(/\A-e(.+)\z/)) # glued short form, e.g. -eprod
+        m[1]
+      end
+    end
+
     def args_before_double_dash(args)
       idx = args.index('--')
       idx ? args[0...idx] : args
+    end
+
+    # Authoritative, parser-free backstop, run from the Rails console/runner
+    # hooks AFTER railties has resolved and applied the environment (so
+    # Rails.env is correct for any -e/--environment form, including ones the
+    # pre-boot parser might not model). Refuses an un-keyed console/runner in
+    # production before the REPL or runner payload executes. dbconsole has no
+    # such hook, so its refusal stays in the pre-boot guard.
+    def enforce_runtime!(kind, env = ENV)
+      return unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+      return if key_present?(env)
+
+      raise UnauthorizedConsole,
+            "ENV['USER_KEY'] is required to open an audited #{kind} in production"
     end
   end
 

--- a/lib/audit/console_guard.rb
+++ b/lib/audit/console_guard.rb
@@ -32,9 +32,6 @@ module Audit
     RUNNER_COMMANDS  = %w[runner r].freeze
     DB_COMMANDS      = %w[db dbconsole].freeze
 
-    # Short aliases Rails accepts for environment names.
-    ENV_ALIASES = { 'dev' => 'development', 'prod' => 'production' }.freeze
-
     module_function
 
     def console_command?(command)
@@ -58,16 +55,20 @@ module Audit
     # when the call is allowed to proceed.
     def enforce_pre_boot!(command, init_args, env = ENV)
       prod = production?(command, init_args, env)
-      args = Array(init_args).join(' ')
 
+      # The refusal message must never echo the invoked argv: a `runner`
+      # command line is arbitrary Ruby that routinely contains identifiers or
+      # secrets, and this message is printed to stderr (bin/rails `abort`),
+      # which Render/Cloud Run capture as plaintext logs. Reference only the
+      # command class.
       if db_command?(command) && prod
         raise ForbiddenCommand,
-              %(db/dbconsole is not allowed in production (HIPAA): "#{args}")
+              'db/dbconsole is not allowed in production (HIPAA)'
       end
 
       if (console_command?(command) || runner_command?(command)) && prod && !key_present?(env)
         raise UnauthorizedConsole,
-              %(ENV['USER_KEY'] is required to open an audited console/runner in production: "#{args}")
+              "ENV['USER_KEY'] is required to open an audited #{classify(command)} in production"
       end
 
       classify(command)
@@ -92,29 +93,70 @@ module Audit
       effective_environment(command, init_args, env) == 'production'
     end
 
+    # Resolve the effective environment exactly the way railties does, so no
+    # invocation can boot production while the guard believes it is not:
+    #   * a CLI -e/--environment value is prefix-expanded (Rails expands any
+    #     abbreviation of production/development/test) and wins when present;
+    #   * otherwise ENV['RAILS_ENV'] then ENV['RACK_ENV'] are used VERBATIM --
+    #     Rails does NOT abbreviation-expand the env vars -- treating a blank /
+    #     whitespace value as absent (Rails uses String#presence);
+    #   * otherwise 'development'.
     def effective_environment(command, init_args, env = ENV)
-      name = cli_environment(command, Array(init_args)) ||
-             env['RAILS_ENV'] || env['RACK_ENV'] || 'development'
-      expand_environment(name)
+      cli = cli_environment(command, Array(init_args))
+      return cli if cli
+
+      presence(env['RAILS_ENV']) || presence(env['RACK_ENV']) || 'development'
     end
+
+    def presence(value)
+      s = value.to_s.strip
+      s.empty? ? nil : s
+    end
+
+    # Expand a CLI environment token the way
+    # Rails::Command::EnvironmentArgument#expand_environment_name does: a token
+    # that is not already an on-disk environment is resolved to the first of
+    # production/development/test it is a prefix of -- so `-e p`, `-e pro`,
+    # `-e produc` etc. all resolve to production and cannot slip past the guard.
+    EXPANDABLE_ENVIRONMENTS = %w[production development test].freeze
 
     def expand_environment(name)
       n = name.to_s.strip
-      ENV_ALIASES.fetch(n, n)
+      return n if n.empty?
+      return n if available_environments.include?(n)
+
+      EXPANDABLE_ENVIRONMENTS.find { |full| full.start_with?(n) } || n
+    end
+
+    # Environment names defined on disk (config/environments/*.rb). Anchored to
+    # this file rather than the process cwd, so it resolves however bin/rails was
+    # invoked. A read failure is non-fatal: an empty list just makes every token
+    # eligible for prefix-expansion (more refusals, never fewer).
+    def available_environments(dir = nil)
+      dir ||= File.expand_path('../../config/environments', __dir__)
+      Dir[File.join(dir, '*.rb')].map { |f| File.basename(f, '.*') }
+    rescue StandardError
+      []
     end
 
     # Extract the environment named on the command line, or nil. Handles
-    # `-e VALUE`, `-e=VALUE`, `--environment VALUE`, `--environment=VALUE`, and
-    # (console only) a bare positional environment token such as
-    # `rails console production`. Runner takes its code positionally, so a
-    # positional token there is NOT treated as an environment.
+    # `-e VALUE`, `-eVALUE`, `-e=VALUE`, `--environment VALUE`,
+    # `--environment=VALUE`, and (console only) a bare positional environment
+    # token such as `rails console production`. Runner takes its code
+    # positionally, so a positional token there is NOT treated as an
+    # environment. Tokens after a `--` terminator are ignored, matching how
+    # Rails forwards them to the REPL instead of parsing them as options.
     def cli_environment(command, args)
+      args = args_before_double_dash(args)
+
       args.each_with_index do |arg, i|
         case arg
         when '-e', '--environment'
           nxt = args[i + 1]
           return expand_environment(nxt) if nxt && !nxt.start_with?('-')
         when /\A--environment=(.+)\z/, /\A-e=(.+)\z/
+          return expand_environment(Regexp.last_match(1))
+        when /\A-e(.+)\z/ # glued short form, e.g. -eprod
           return expand_environment(Regexp.last_match(1))
         end
       end
@@ -125,6 +167,11 @@ module Audit
       end
 
       nil
+    end
+
+    def args_before_double_dash(args)
+      idx = args.index('--')
+      idx ? args[0...idx] : args
     end
   end
 

--- a/lib/audit/console_guard.rb
+++ b/lib/audit/console_guard.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+# Audited-console boot-path guard (LL-7f7372e3eb).
+#
+# Pure-Ruby, no Rails dependency, so it can be required at the very top of
+# bin/rails *before* the Rails environment boots. It does two jobs:
+#
+#   1. Audit::ConsoleGuard.enforce_pre_boot! refuses an un-keyed console or
+#      runner -- and the HIPAA-sensitive db/dbconsole -- in production *before*
+#      Rails loads, so no privileged session ever reaches a database connection
+#      unattributed.
+#   2. Audit::SessionLogger.record! writes the session-open AuditEvent from the
+#      Rails `console do` / `runner do` hooks once the environment is loaded. It
+#      is fail-closed in production (a failed write aborts the session) so the
+#      audited-console control cannot silently degrade to unaudited access.
+#
+# Boot order: bin/rails requires this file, sets ::ARGV_COMMAND / ::INIT_ARGS,
+# and calls enforce_pre_boot!. config/initializers/auditing.rb requires it again
+# (idempotent) so SessionLogger is loaded wherever the hooks run. This file is
+# deliberately excluded from Zeitwerk (config/application.rb autoload_lib ignore)
+# because it must be loadable before the autoloader exists.
+module Audit
+  # Pre-boot command classification + refusal. No Rails dependency.
+  module ConsoleGuard
+    class Error < StandardError; end
+    # Raised when a console/runner is started without a USER_KEY in production.
+    class UnauthorizedConsole < Error; end
+    # Raised for HIPAA-sensitive db/dbconsole access in production.
+    class ForbiddenCommand < Error; end
+
+    CONSOLE_COMMANDS = %w[console c].freeze
+    RUNNER_COMMANDS  = %w[runner r].freeze
+    DB_COMMANDS      = %w[db dbconsole].freeze
+
+    # Short aliases Rails accepts for environment names.
+    ENV_ALIASES = { 'dev' => 'development', 'prod' => 'production' }.freeze
+
+    module_function
+
+    def console_command?(command)
+      CONSOLE_COMMANDS.include?(command)
+    end
+
+    def runner_command?(command)
+      RUNNER_COMMANDS.include?(command)
+    end
+
+    def db_command?(command)
+      DB_COMMANDS.include?(command)
+    end
+
+    def key_present?(env = ENV)
+      !env['USER_KEY'].to_s.strip.empty?
+    end
+
+    # Refuse un-keyed console/runner and HIPAA db-console in production, before
+    # Rails boots. Returns the command classification (:console/:runner/:other)
+    # when the call is allowed to proceed.
+    def enforce_pre_boot!(command, init_args, env = ENV)
+      prod = production?(command, init_args, env)
+      args = Array(init_args).join(' ')
+
+      if db_command?(command) && prod
+        raise ForbiddenCommand,
+              %(db/dbconsole is not allowed in production (HIPAA): "#{args}")
+      end
+
+      if (console_command?(command) || runner_command?(command)) && prod && !key_present?(env)
+        raise UnauthorizedConsole,
+              %(ENV['USER_KEY'] is required to open an audited console/runner in production: "#{args}")
+      end
+
+      classify(command)
+    end
+
+    def classify(command)
+      return :console if console_command?(command)
+      return :runner  if runner_command?(command)
+
+      :other
+    end
+
+    # AuditEvent payload for a session-open row. `kind` is 'console' or 'runner'.
+    def session_attrs(kind, init_args)
+      { 'type' => "rails/#{kind}", 'command' => Array(init_args).join(' ') }
+    end
+
+    # True when the session will run in production, resolved the way Rails will
+    # resolve it: an explicit -e/--environment flag (or, for `console`, a
+    # positional environment arg) overrides ENV['RAILS_ENV']/ENV['RACK_ENV'].
+    def production?(command, init_args, env = ENV)
+      effective_environment(command, init_args, env) == 'production'
+    end
+
+    def effective_environment(command, init_args, env = ENV)
+      name = cli_environment(command, Array(init_args)) ||
+             env['RAILS_ENV'] || env['RACK_ENV'] || 'development'
+      expand_environment(name)
+    end
+
+    def expand_environment(name)
+      n = name.to_s.strip
+      ENV_ALIASES.fetch(n, n)
+    end
+
+    # Extract the environment named on the command line, or nil. Handles
+    # `-e VALUE`, `-e=VALUE`, `--environment VALUE`, `--environment=VALUE`, and
+    # (console only) a bare positional environment token such as
+    # `rails console production`. Runner takes its code positionally, so a
+    # positional token there is NOT treated as an environment.
+    def cli_environment(command, args)
+      args.each_with_index do |arg, i|
+        case arg
+        when '-e', '--environment'
+          nxt = args[i + 1]
+          return expand_environment(nxt) if nxt && !nxt.start_with?('-')
+        when /\A--environment=(.+)\z/, /\A-e=(.+)\z/
+          return expand_environment(Regexp.last_match(1))
+        end
+      end
+
+      if console_command?(command)
+        positional = args.drop(1).find { |a| !a.start_with?('-') }
+        return expand_environment(positional) if positional
+      end
+
+      nil
+    end
+  end
+
+  # Writes the session-open AuditEvent from the Rails console/runner hooks.
+  #
+  # Deliberately separate from AuditEvent.log_command, which is fail-open for
+  # general accounting-of-disclosure side effects (it must never break the
+  # authorized read/action the caller is performing). The audited-console
+  # control has the opposite requirement: in production a privileged session
+  # must NOT proceed if its session-open row cannot be written, otherwise the
+  # control silently degrades to unaudited access. So this path uses create!
+  # and re-raises in production.
+  module SessionLogger
+    module_function
+
+    # kind: 'console' or 'runner'. Returns nil (no audit row) for a blank key --
+    # only keyed sessions are logged, and an un-keyed production session has
+    # already been refused pre-boot by ConsoleGuard.
+    def record!(kind, user_key, init_args)
+      return if user_key.to_s.strip.empty?
+
+      attrs = Audit::ConsoleGuard.session_attrs(kind, init_args)
+      AuditEvent.create!(user_key: user_key, data: attrs)
+    rescue StandardError => e
+      # Fail-closed in production: refuse the session rather than allow
+      # unaudited privileged access. In non-production, never block local work.
+      raise if production_runtime?
+
+      warn("[audit] session-open AuditEvent could not be written " \
+           "(non-production, proceeding): #{e.class}")
+      nil
+    end
+
+    def production_runtime?
+      defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+    end
+  end
+end

--- a/lib/audit/console_guard.rb
+++ b/lib/audit/console_guard.rb
@@ -276,7 +276,13 @@ module Audit
       nil
     end
 
+    # Fail-closed when the deployment is production. Honors the ambient-production
+    # status captured at pre-boot (bin/rails) so a session NAMED development on a
+    # prod box -- where Rails.env is now 'development' but DATABASE_URL still
+    # targets prod -- still fails closed if the audit write cannot be recorded.
     def production_runtime?
+      return true if defined?(::AUDIT_AMBIENT_PRODUCTION) && ::AUDIT_AMBIENT_PRODUCTION
+
       defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
     end
   end

--- a/lib/audit/console_guard.rb
+++ b/lib/audit/console_guard.rb
@@ -123,6 +123,14 @@ module Audit
     def expand_environment(name)
       n = name.to_s.strip
       return n if n.empty?
+      # Fail-safe: a token that is a prefix of "production" always resolves to
+      # production, even if a same-named custom env file exists on disk. This
+      # takes precedence over the on-disk short-circuit so that adding, say,
+      # config/environments/pro.rb can never silently reopen the abbreviation
+      # bypass, and so the result does not depend on the process cwd (railties
+      # reads config/environments relative to cwd; we cannot match that exactly
+      # pre-boot, so we err toward refusal for the production case).
+      return 'production' if 'production'.start_with?(n)
       return n if available_environments.include?(n)
 
       EXPANDABLE_ENVIRONMENTS.find { |full| full.start_with?(n) } || n
@@ -146,20 +154,28 @@ module Audit
     # positionally, so a positional token there is NOT treated as an
     # environment. Tokens after a `--` terminator are ignored, matching how
     # Rails forwards them to the REPL instead of parsing them as options.
+    #
+    # When the flag is repeated (`-e development -e production`) the LAST
+    # occurrence wins, matching Thor/railties option parsing. Returning on the
+    # first match would let `-e development -e production` boot production while
+    # the guard believed it was development.
     def cli_environment(command, args)
       args = args_before_double_dash(args)
+      explicit = nil
 
       args.each_with_index do |arg, i|
         case arg
         when '-e', '--environment'
           nxt = args[i + 1]
-          return expand_environment(nxt) if nxt && !nxt.start_with?('-')
+          explicit = nxt if nxt && !nxt.start_with?('-')
         when /\A--environment=(.+)\z/, /\A-e=(.+)\z/
-          return expand_environment(Regexp.last_match(1))
+          explicit = Regexp.last_match(1)
         when /\A-e(.+)\z/ # glued short form, e.g. -eprod
-          return expand_environment(Regexp.last_match(1))
+          explicit = Regexp.last_match(1)
         end
       end
+
+      return expand_environment(explicit) if explicit
 
       if console_command?(command)
         positional = args.drop(1).find { |a| !a.start_with?('-') }
@@ -194,7 +210,16 @@ module Audit
       return if user_key.to_s.strip.empty?
 
       attrs = Audit::ConsoleGuard.session_attrs(kind, init_args)
-      AuditEvent.create!(user_key: user_key, data: attrs)
+      # Pass an explicit, PII-free summary. AuditEvent#generate_summary would
+      # otherwise copy data['command'] -- which for a runner is arbitrary Ruby
+      # that can contain identifiers or secrets -- into the `summary` column,
+      # which is NOT secure_serialize'd (it is plaintext at rest). The full
+      # command line stays only in the encrypted `data`.
+      AuditEvent.create!(
+        user_key: user_key,
+        data: attrs,
+        summary: "#{user_key}: rails/#{kind} session opened"
+      )
     rescue StandardError => e
       # Fail-closed in production: refuse the session rather than allow
       # unaudited privileged access. In non-production, never block local work.

--- a/spec/lib/audit/console_guard_spec.rb
+++ b/spec/lib/audit/console_guard_spec.rb
@@ -205,6 +205,45 @@ describe Audit::ConsoleGuard do
       end
     end
 
+    context 'when a non-prod env is named on a production deployment (DATABASE_URL binds to Rails.env)' do
+      # `bin/rails console -e development` on a prod box still reaches the prod
+      # DB (ActiveRecord merges DATABASE_URL into whatever Rails.env resolves to).
+      # The ambient RAILS_ENV/RACK_ENV, read pre-boot before railties overrides
+      # it, must keep gating the refusal so -e cannot dodge it.
+      let(:prod_box) { { 'RAILS_ENV' => 'production' } }
+
+      it 'refuses un-keyed `console -e development` when ambient RAILS_ENV=production' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e development], prod_box) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses un-keyed `runner -e development` on a prod box' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('runner', %w[runner -e development Foo.bar], prod_box) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'forbids `dbconsole -e development` on a prod box (no runtime hook backs db up)' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('dbconsole', %w[dbconsole -e development], prod_box) }
+          .to raise_error(Audit::ConsoleGuard::ForbiddenCommand)
+      end
+
+      it 'refuses when production is ambient via RACK_ENV and a dev env is named' do
+        env = { 'RACK_ENV' => 'production' }
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e development], env) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'still allows a KEYED `console -e development` on a prod box (it is audited)' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e development], prod_box.merge('USER_KEY' => 'scot')))
+          .to eq(:console)
+      end
+
+      it 'does not over-refuse on a non-prod box (ambient development, -e development)' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e development], { 'RAILS_ENV' => 'development' }))
+          .to eq(:console)
+      end
+    end
+
     context 'in development' do
       it 'allows an un-keyed console (local-dev DX preserved)' do
         expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], dev)).to eq(:console)

--- a/spec/lib/audit/console_guard_spec.rb
+++ b/spec/lib/audit/console_guard_spec.rb
@@ -117,6 +117,23 @@ describe Audit::ConsoleGuard do
           .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
       end
 
+      it 'refuses the long-option abbreviation `--env=production`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console --env=production], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses `--env production` and `--env=p`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console --env production], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console --env=p], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'forbids `dbconsole --env=p` (HIPAA refusal sees the long abbreviation)' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('dbconsole', %w[dbconsole --env=p], {}) }
+          .to raise_error(Audit::ConsoleGuard::ForbiddenCommand)
+      end
+
       it 'refuses an abbreviated positional `console pro`' do
         expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console pro], {}) }
           .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
@@ -229,6 +246,35 @@ describe Audit::ConsoleGuard do
 
     it 'is true for a real key' do
       expect(Audit::ConsoleGuard.key_present?('USER_KEY' => 'scot')).to be(true)
+    end
+  end
+
+  describe '.enforce_runtime! (authoritative in-hook backstop)' do
+    def prod_env!
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+    end
+
+    it 'raises for an un-keyed production console (no CLI parsing involved)' do
+      prod_env!
+      expect { Audit::ConsoleGuard.enforce_runtime!('console', {}) }
+        .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+    end
+
+    it 'raises for an un-keyed production runner' do
+      prod_env!
+      expect { Audit::ConsoleGuard.enforce_runtime!('runner', { 'USER_KEY' => '  ' }) }
+        .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+    end
+
+    it 'allows a keyed production session' do
+      prod_env!
+      expect { Audit::ConsoleGuard.enforce_runtime!('console', { 'USER_KEY' => 'scot' }) }
+        .not_to raise_error
+    end
+
+    it 'allows an un-keyed non-production session' do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
+      expect { Audit::ConsoleGuard.enforce_runtime!('console', {}) }.not_to raise_error
     end
   end
 end

--- a/spec/lib/audit/console_guard_spec.rb
+++ b/spec/lib/audit/console_guard_spec.rb
@@ -358,6 +358,16 @@ describe Audit::SessionLogger do
         expect(Audit::SessionLogger).to receive(:warn)
         expect { Audit::SessionLogger.record!('console', 'scot', %w[console]) }.not_to raise_error
       end
+
+      it 'fails closed via the ambient-production capture even when Rails.env=development (-e dodge)' do
+        # On a prod box, `console -e development` makes Rails.env development while
+        # DATABASE_URL still targets prod. The pre-boot capture must keep the
+        # audit-write failure fail-closed. Exercises the real production_runtime?.
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
+        stub_const('AUDIT_AMBIENT_PRODUCTION', true)
+        expect { Audit::SessionLogger.record!('console', 'scot', %w[console]) }
+          .to raise_error(StandardError, 'db down')
+      end
     end
 
     context 'end-to-end row creation' do

--- a/spec/lib/audit/console_guard_spec.rb
+++ b/spec/lib/audit/console_guard_spec.rb
@@ -95,6 +95,73 @@ describe Audit::ConsoleGuard do
       end
     end
 
+    context 'when production is abbreviated on the command line (railties expands prefixes)' do
+      # Rails::Command::EnvironmentArgument#expand_environment_name resolves any
+      # prefix of production/development/test to the full name, so an un-keyed
+      # `console -e p` boots production. The guard must expand the same way or
+      # the refusal is defeated with a two-character argument.
+      %w[p pr pro prod produ produc product producti productio].each do |abbr|
+        it "refuses an un-keyed `console -e #{abbr}`" do
+          expect { Audit::ConsoleGuard.enforce_pre_boot!('console', ['console', '-e', abbr], {}) }
+            .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+        end
+      end
+
+      it 'refuses `--environment=p`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console --environment=p], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses the glued short form `-eprod`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -eprod], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses an abbreviated positional `console pro`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console pro], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'forbids `dbconsole -e p` (HIPAA refusal must also see the abbreviation)' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('dbconsole', %w[dbconsole -e p], {}) }
+          .to raise_error(Audit::ConsoleGuard::ForbiddenCommand)
+      end
+
+      it 'does NOT over-refuse a non-production abbreviation (`-e d` is development)' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e d], {})).to eq(:console)
+      end
+    end
+
+    context 'when RAILS_ENV is blank (Rails falls through to RACK_ENV via .presence)' do
+      # Rails::Command.environment is RAILS_ENV.presence || RACK_ENV.presence,
+      # so an empty RAILS_ENV must NOT mask a production RACK_ENV.
+      it 'refuses an un-keyed console with RAILS_ENV="" and RACK_ENV=production' do
+        env = { 'RAILS_ENV' => '', 'RACK_ENV' => 'production' }
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], env) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'allows the same session when keyed' do
+        env = { 'RAILS_ENV' => '  ', 'RACK_ENV' => 'production', 'USER_KEY' => 'scot' }
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], env)).to eq(:console)
+      end
+
+      it 'does NOT expand an abbreviated RAILS_ENV (env vars are verbatim, only -e expands)' do
+        # Rails boots the literal env named in RAILS_ENV; `prod` is not production.
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], { 'RAILS_ENV' => 'prod' }))
+          .to eq(:console)
+      end
+    end
+
+    context 'when args appear after a `--` terminator (Rails forwards them to the REPL)' do
+      it 'does not treat `console -- -e production` as a production console' do
+        # Rails strips everything after `--` for IRB, so this is a development
+        # console; the guard must not over-refuse it.
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -- -e production], {}))
+          .to eq(:console)
+      end
+    end
+
     context 'in development' do
       it 'allows an un-keyed console (local-dev DX preserved)' do
         expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], dev)).to eq(:console)

--- a/spec/lib/audit/console_guard_spec.rb
+++ b/spec/lib/audit/console_guard_spec.rb
@@ -132,6 +132,32 @@ describe Audit::ConsoleGuard do
       end
     end
 
+    context 'when the environment flag is repeated (Thor/railties use the last occurrence)' do
+      # `-e development -e production` boots production (last wins). Returning on
+      # the first flag would let this slip past the refusal.
+      it 'refuses an un-keyed `console -e development -e production`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e development -e production], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses the abbreviated repeat `console -e d -e p`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e d -e p], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses `runner -e d -e p` and forbids `dbconsole -e development -e production`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('runner', %w[runner -e d -e p Foo.bar], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('dbconsole', %w[dbconsole -e development -e production], {}) }
+          .to raise_error(Audit::ConsoleGuard::ForbiddenCommand)
+      end
+
+      it 'honors a production-then-development repeat as development (last wins, not refused)' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e production -e development], {}))
+          .to eq(:console)
+      end
+    end
+
     context 'when RAILS_ENV is blank (Rails falls through to RACK_ENV via .presence)' do
       # Rails::Command.environment is RAILS_ENV.presence || RACK_ENV.presence,
       # so an empty RAILS_ENV must NOT mask a production RACK_ENV.
@@ -216,8 +242,19 @@ describe Audit::SessionLogger do
 
     it 'writes a session-open row with the right payload for a keyed session' do
       expect(AuditEvent).to receive(:create!)
-        .with(user_key: 'scot', data: { 'type' => 'rails/console', 'command' => 'console' })
+        .with(hash_including(user_key: 'scot', data: { 'type' => 'rails/console', 'command' => 'console' }))
       Audit::SessionLogger.record!('console', 'scot', %w[console])
+    end
+
+    it 'keeps the runner command line out of the plaintext (non-encrypted) summary' do
+      # AuditEvent#data is secure_serialize'd (encrypted) but #summary is a
+      # plaintext column. The full runner argv must stay in data only.
+      captured = nil
+      allow(AuditEvent).to receive(:create!) { |attrs| captured = attrs }
+      Audit::SessionLogger.record!('runner', 'scot', ['runner', 'User.find_by(email: "child@school.edu")'])
+      expect(captured[:data]['command']).to include('child@school.edu')
+      expect(captured[:summary]).not_to include('child@school.edu')
+      expect(captured[:summary]).to include('rails/runner')
     end
 
     context 'when the audit write fails' do
@@ -250,6 +287,14 @@ describe Audit::SessionLogger do
         expect(row.user_key).to eq('scot')
         expect(row.data['type']).to eq('rails/runner')
         expect(row.data['command']).to eq('runner Foo.bar')
+      end
+
+      it 'does not persist runner argv into the plaintext summary column' do
+        Audit::SessionLogger.record!('runner', 'scot', ['runner', 'User.find_by(email: "child@school.edu")'])
+        row = AuditEvent.last
+        expect(row.data['command']).to include('child@school.edu') # retained in encrypted data
+        expect(row.summary).not_to include('child@school.edu')     # but not in the plaintext column
+        expect(row.summary).to include('rails/runner')
       end
     end
   end

--- a/spec/lib/audit/console_guard_spec.rb
+++ b/spec/lib/audit/console_guard_spec.rb
@@ -1,0 +1,227 @@
+require 'spec_helper'
+require 'open3'
+
+# lib/audit is excluded from Zeitwerk (loaded pre-boot from bin/rails and from
+# the auditing initializer), so require it explicitly here.
+require Rails.root.join('lib/audit/console_guard')
+
+describe Audit::ConsoleGuard do
+  # Pure-Ruby guard: every example passes env as an explicit Hash so nothing
+  # depends on the process ENV or the test database.
+  def prod(extra = {})
+    { 'RAILS_ENV' => 'production' }.merge(extra)
+  end
+
+  def dev(extra = {})
+    { 'RAILS_ENV' => 'development' }.merge(extra)
+  end
+
+  describe 'exception hierarchy' do
+    it 'defines UnauthorizedConsole and ForbiddenCommand under a shared base' do
+      expect(Audit::ConsoleGuard::UnauthorizedConsole).to be < Audit::ConsoleGuard::Error
+      expect(Audit::ConsoleGuard::ForbiddenCommand).to be < Audit::ConsoleGuard::Error
+      expect(Audit::ConsoleGuard::Error).to be < StandardError
+    end
+  end
+
+  describe '.enforce_pre_boot!' do
+    context 'in production' do
+      it 'refuses an un-keyed console' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], prod) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses an un-keyed runner' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('runner', %w[runner Foo.bar], prod) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses a blank or whitespace USER_KEY (presence is not enough)' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], prod('USER_KEY' => '')) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], prod('USER_KEY' => '   ')) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'allows a keyed console and returns its classification' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], prod('USER_KEY' => 'scot')))
+          .to eq(:console)
+      end
+
+      it 'allows a keyed runner and returns its classification' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('runner', %w[runner Foo.bar], prod('USER_KEY' => 'scot')))
+          .to eq(:runner)
+      end
+
+      it 'forbids db/dbconsole (HIPAA)' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('dbconsole', %w[dbconsole], prod) }
+          .to raise_error(Audit::ConsoleGuard::ForbiddenCommand)
+      end
+
+      it 'treats the c/r aliases like console/runner' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('c', %w[c], prod) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('r', %w[r Foo.bar], prod) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+    end
+
+    context 'when production is selected on the command line (RAILS_ENV unset)' do
+      # The guard must see the environment the way Rails will resolve it, or
+      # `bin/rails console -e production` bypasses the refusal.
+      it 'refuses `-e production`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e production], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses `--environment=production`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console --environment=production], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses a positional `console production`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console production], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'refuses runner `-e production`' do
+        expect { Audit::ConsoleGuard.enforce_pre_boot!('runner', %w[runner -e production Foo.bar], {}) }
+          .to raise_error(Audit::ConsoleGuard::UnauthorizedConsole)
+      end
+
+      it 'allows the same keyed CLI-production console' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console -e production], { 'USER_KEY' => 'scot' }))
+          .to eq(:console)
+      end
+    end
+
+    context 'in development' do
+      it 'allows an un-keyed console (local-dev DX preserved)' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('console', %w[console], dev)).to eq(:console)
+      end
+
+      it 'allows an un-keyed runner' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('runner', %w[runner Foo.bar], dev)).to eq(:runner)
+      end
+
+      it 'does not forbid db/dbconsole' do
+        expect(Audit::ConsoleGuard.enforce_pre_boot!('dbconsole', %w[dbconsole], dev)).to eq(:other)
+      end
+    end
+
+    it 'passes non-console commands straight through' do
+      expect(Audit::ConsoleGuard.enforce_pre_boot!('server', %w[server], prod)).to eq(:other)
+      expect(Audit::ConsoleGuard.enforce_pre_boot!('db:migrate', %w[db:migrate], prod)).to eq(:other)
+    end
+  end
+
+  describe '.session_attrs' do
+    it 'builds the console payload' do
+      expect(Audit::ConsoleGuard.session_attrs('console', %w[console]))
+        .to eq('type' => 'rails/console', 'command' => 'console')
+    end
+
+    it 'builds the runner payload with the full command line' do
+      expect(Audit::ConsoleGuard.session_attrs('runner', %w[runner Foo.bar]))
+        .to eq('type' => 'rails/runner', 'command' => 'runner Foo.bar')
+    end
+  end
+
+  describe '.key_present?' do
+    it 'is false for nil, empty, and whitespace' do
+      expect(Audit::ConsoleGuard.key_present?({})).to be(false)
+      expect(Audit::ConsoleGuard.key_present?('USER_KEY' => '')).to be(false)
+      expect(Audit::ConsoleGuard.key_present?('USER_KEY' => "  \t")).to be(false)
+    end
+
+    it 'is true for a real key' do
+      expect(Audit::ConsoleGuard.key_present?('USER_KEY' => 'scot')).to be(true)
+    end
+  end
+end
+
+describe Audit::SessionLogger do
+  describe '.record!' do
+    it 'does not write a row for a blank key' do
+      expect(AuditEvent).not_to receive(:create!)
+      expect(Audit::SessionLogger.record!('console', '', %w[console])).to be_nil
+    end
+
+    it 'writes a session-open row with the right payload for a keyed session' do
+      expect(AuditEvent).to receive(:create!)
+        .with(user_key: 'scot', data: { 'type' => 'rails/console', 'command' => 'console' })
+      Audit::SessionLogger.record!('console', 'scot', %w[console])
+    end
+
+    context 'when the audit write fails' do
+      before do
+        allow(AuditEvent).to receive(:create!).and_raise(StandardError.new('db down'))
+      end
+
+      it 'is fail-closed in production (re-raises so the session does not proceed)' do
+        allow(Audit::SessionLogger).to receive(:production_runtime?).and_return(true)
+        expect { Audit::SessionLogger.record!('console', 'scot', %w[console]) }
+          .to raise_error(StandardError, 'db down')
+      end
+
+      it 'is fail-open-but-loud in non-production (warns and proceeds)' do
+        allow(Audit::SessionLogger).to receive(:production_runtime?).and_return(false)
+        expect(Audit::SessionLogger).to receive(:warn)
+        expect { Audit::SessionLogger.record!('console', 'scot', %w[console]) }.not_to raise_error
+      end
+    end
+
+    context 'end-to-end row creation' do
+      # AuditEvent.create! commits outside the per-example transaction, so clean
+      # up explicitly inside this context rather than relying on rollback.
+      before { AuditEvent.delete_all }
+      after  { AuditEvent.delete_all }
+
+      it 'persists a real rails/runner AuditEvent' do
+        Audit::SessionLogger.record!('runner', 'scot', %w[runner Foo.bar])
+        row = AuditEvent.last
+        expect(row.user_key).to eq('scot')
+        expect(row.data['type']).to eq('rails/runner')
+        expect(row.data['command']).to eq('runner Foo.bar')
+      end
+    end
+  end
+end
+
+describe 'bin/rails audited-console guard (integration)' do
+  # The refusal path aborts in bin/rails BEFORE `require config/boot`, so this
+  # never loads Rails or touches the database -- it is fast and side-effect-free.
+  let(:bin_rails) { Rails.root.join('bin/rails').to_s }
+
+  it 'exits 1 and writes nothing for an un-keyed production console' do
+    out, status = Open3.capture2e(
+      { 'RAILS_ENV' => 'production', 'USER_KEY' => '' },
+      RbConfig.ruby, bin_rails, 'console'
+    )
+    expect(status.exitstatus).to eq(1)
+    expect(out).to match(/refused/)
+  end
+
+  it 'exits 1 for `console -e production` even when RAILS_ENV is unset' do
+    env = { 'USER_KEY' => '' }
+    env['RAILS_ENV'] = nil # unset, so production must come from the CLI flag
+    out, status = Open3.capture2e(env, RbConfig.ruby, bin_rails, 'console', '-e', 'production')
+    expect(status.exitstatus).to eq(1)
+    expect(out).to match(/refused/)
+  end
+end
+
+describe 'auditing initializer hook wiring' do
+  # config/initializers/auditing.rb registers the session-open hooks via
+  # Rails.application.runner / .console. This guards that wiring: if the
+  # registration regresses (typo, wrong receiver, removed block), console and
+  # runner sessions would silently go unaudited again -- the exact failure mode
+  # of LL-7f7372e3eb. The runner hook is the only registered runner block, so
+  # running it is isolated and side-effect-free (record! is stubbed, no
+  # AuditEvent is written). The console hook uses the identical registration
+  # mechanism one line above it in the initializer.
+  it 'routes the registered runner hook to SessionLogger.record!' do
+    expect(Audit::SessionLogger).to receive(:record!).with('runner', anything, anything)
+    Rails.application.send(:run_runner_blocks, Rails.application)
+  end
+end


### PR DESCRIPTION
## What

Makes the audited Rails console control (finding **LL-7f7372e3eb**) actually operative. PR #489 made `bin/audit_console` platform-agnostic but explicitly left the substantive control dead; this is the real fix.

## Why it was dead

- `config/initializers/auditing.rb` patched `Readline#readline`, but Ruby 3.4's IRB uses **Reline**, which never calls Readline. No per-session `AuditEvent` was ever written.
- The un-keyed-console refusal keyed off `ARGV_COMMAND`, which was **undefined at boot**, so it never fired. An operator could open a production console with no attribution and no audit row.
- The old patch also `puts` the operator's `USER_KEY` and every line of console input to stdout: a latent PII leak into Render / Cloud Run logs.

## What this does

- **Pre-boot guard** (`lib/audit/console_guard.rb`, pure Ruby, required at the top of `bin/rails` before `config/boot`): fail-closed refusal of an un-keyed `console`/`runner` and the HIPAA-sensitive `db`/`dbconsole` in production, before any DB connection is established. Resolves the environment the way Rails does, so `console -e production`, `--environment=production`, and positional `console production` cannot slip past.
- **Reline-agnostic session-open auditing**: `auditing.rb` removes the dead Readline patch (and the PII `puts`) and registers the Rails `console`/`runner` hooks, which fire once per session before the REPL or runner payload runs. `SessionLogger` is fail-closed in production (a failed write aborts the session) and fail-open-but-loud in development.
- `USER_KEY` stays self-asserted write-attribution at this layer **by design** (documented; out of scope here).

## Verification

- `bundle exec rails console` re-execs through the patched `bin/rails` via railties' `AppLoader`, so the #489 wrapper (`exec bundle exec rails console`) reaches the guard. Proven at runtime: un-keyed prod `console` / `runner` / `dbconsole` are all refused with exit 1 **before** boot.
- `console` / `runner` hooks confirmed firing against railties 7.2.3.1 source and via a wiring regression test.
- `DB_USER=scotw RAILS_ENV=test bundle exec rspec spec/lib/audit/console_guard_spec.rb` -> **29 examples, 0 failures** (covers fail-closed prod, session-open write, CLI-environment bypass, and the initializer wiring).

## Not in scope / follow-up

- This does **not** close finding LL-7f7372e3eb. Closure is gated on Scot's attestation, then editing `audit-reports/FINDINGS.json` (verified-closed / attestation fields) and regenerating artifacts (`scripts/citation-check.rb --render` + the compliance-notion-publish script), or the `audit-artifacts-integrity` CI gate fails.
- `README.md` / `CLAUDE.md` still describe the control as non-operative; those notes should be updated together with the register at closure time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Operational note for the team (please read before merge)

Staging runs `RAILS_ENV=production`, so once this merges, **a bare `rails console` / `rails runner` on the Render staging shell will be refused** with `refused: ENV['USER_KEY'] is required...`. Use **`bin/audit_console`** instead (it prompts for your email as `USER_KEY` and gives you an audited, attributed session). **`rails dbconsole` is blocked on staging and production** (HIPAA). This is the control working as designed; the audited path is unaffected.

## Adversary review (4 rounds, all findings addressed)

| Round | Finding | Severity | Status |
|------|---------|----------|--------|
| 1 | `-e p` / `-eprod` / `--environment=p` abbreviation booted prod un-keyed | Critical | Fixed (railties-faithful prefix expansion) |
| 1 | refusal message echoed argv (PII) to stderr/logs | Medium | Fixed (command class only) |
| 1 | tokens after `--` parsed as env | Low | Fixed |
| 2 | repeated `-e development -e production` (Thor last-wins) bypass | High | Fixed (last-occurrence resolution) |
| 2 | runner argv copied into plaintext `summary` column | Medium | Fixed (explicit PII-free summary; full cmd only in encrypted `data`) |
| 2 | custom env file prefixing "production" could reopen bypass | Low | Fixed (fail-safe prefix) |
| 3 | `-e development` on prod box reaches prod DB un-keyed (name vs target) | High | Fixed (ambient-deployment gate, pre-boot) + authoritative in-hook backstop |
| 4 | — | — | Converged: no Critical/High remaining |

**Final adversary verdict: ship to staging; no remaining Critical/High.**

## Documented residual (follow-up before real prod data lands; NOT closed here)

The control decides "production" from `RAILS_ENV`/`RACK_ENV` + the named env, not from the resolved DB connection. A *misconfigured* deployment that reaches the prod DB while `RAILS_ENV`/`RACK_ENV` is not `production` (e.g. only `DATABASE_URL` set) would not be detected, and the `rails dbconsole production` positional form is not parsed pre-boot. Neither matches the real Render/Cloud Run setups (both set `RAILS_ENV=production`). The robust fix gates on the resolved connection target; it should land before real PHI/FERPA data is in prod. Tracked under open finding LL-7f7372e3eb.

## Codex senior-dev pass (dual-reviewer, fresh model)

A Codex (OpenAI gpt-5.5) review found two additional **P1** integrity holes, both now fixed:

| Finding | Fix |
|---|---|
| `SKIP_VALIDATIONS=true` disabled the entire control (hooks/attribution/backstop were inside `unless ENV['SKIP_VALIDATIONS']`, which the Rakefile sets) — a keyed operator could run an unlogged prod console | Hooks registered unconditionally (they only fire on a real console/runner; harmless for rake) |
| Fail-closed `production_runtime?` used `Rails.env`, which is `development` under the `-e development` dodge → an audit-write failure failed **open** against the prod DB | `bin/rails` captures `AUDIT_AMBIENT_PRODUCTION` pre-boot; `production_runtime?` honors it |

The PII guard (`codex-review-guard.sh`) passed (no data-bearing paths). **Codex confirmation pass after the fixes: no actionable defects.** Dual-reviewer loop converged.