### PR TITLE
compliance: backfill accepted-risk attestation lines (LL-92dc570f30, LL-9f83617435)

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "bc06d1eb60718a1d7339e47ec86956a3ac13b0a2c227c0c78b97d618ca53240a",
+      "contentHash": "7e6edf129c73aa25180cadcead6465e67bfc299638ad34a27eaa76a5a1211509",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `bc06d1eb6071` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `7e6edf129c73` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -421,8 +421,8 @@
       },
       "closureEvidence": {
         "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "verifierNote": "No code fix; multi-key param acceptance is residual code-smell behind token_valid? + expiry guards, not a live vuln.",
+        "attestation": "Scot Wahlquist 2026-06-18: accepted as a known risk; token already validated via token_valid? + expiry guards, multi-key param acceptance is residual code-smell not a live vuln. Accepted at current severity; not slated for change."
       },
       "notes": "Verified still open 2026-06-12: multi-key acceptance persists (line 86), though surrounding flow is more defensive (token_valid?, expiry). Candidate for accepted-risk pending Scot.",
       "disposition": {
@@ -728,8 +728,8 @@
       },
       "closureEvidence": {
         "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "verifierNote": "No code fix; force_ssl already emits a default HSTS header (max-age 1yr). includeSubDomains/preload deferred pending a confirmed-safe subdomain inventory.",
+        "attestation": "Scot Wahlquist 2026-06-18: accepted as a known risk; force_ssl already emits a default HSTS header (max-age 1yr). includeSubDomains/preload deferred to avoid the one-way preload commitment until the subdomain inventory is confirmed safe."
       },
       "notes": "Partially mitigated 2026-06-12: force_ssl=true already emits a default HSTS header (max-age 1yr) but without subdomains/preload (production.rb:62). Severity effectively lower than the April P1; left high pending Scot's call.",
       "disposition": {


### PR DESCRIPTION
## What

Backfills the signed `closureEvidence.attestation` string on the two `accepted-risk` High findings that were missing it:

- **LL-92dc570f30** consent_response accepts token/decision from multiple parameter keys
- **LL-9f83617435** No explicit HSTS ssl_options (subdomains/preload)

Both were already `status: accepted-risk` with a signed `disposition` (Scot Wahlquist 2026-06-18), but their `closureEvidence.attestation` string was blank, unlike peer accepted-risk findings (e.g. LL-aacae48768). The attestation text and verifierNote are sourced verbatim from each finding's own recorded disposition rationale.

## Why

Completes closure governance for these two findings so the Notion findings-board "decided by" surface and the publication-status artifact read correctly. No `status`, `severity`, or `disposition` change — this only fills the empty signed-line field.

## Not done (deliberately)

The `status: open` + `disposition: accepted/wontfix` state on the other ~38 open findings is **orthogonal by design** (documented in `scripts/citation-check.rb`) and is NOT drift to "clean up." Left untouched.

## Integrity

Regenerated `DOCUMENT-REGISTER.json`/`.md` (FINDINGS.json contentHash) so the `audit-artifacts-integrity` CI gate stays green. All four `--check` renderers (calendar, notion-publish, document-register, publication-status) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)