### PR TITLE
fix(gcp): deploy-SA secret presence-check (workflow cutover-readiness)

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -168,12 +168,16 @@ jobs:
           missing=""
           for pair in $(printf '%s,%s' "$BOOT_SECRETS" "$NON_BOOT_SECRETS" | tr ',' '\n'); do
             name="${pair%%=*}"
-            # Check a VERSION resolves, not just that the container exists: phase1-setup.sh creates all
+            # Verify an ENABLED version EXISTS, without reading its value. phase1-setup.sh creates all
             # secrets EMPTY, and `--set-secrets NAME:latest` crash-loops the revision if NAME has no
-            # version. `describe` would pass an empty container; `versions access latest` does not.
-            # Output is discarded (never logged) - this is a presence probe, not a value read.
-            gcloud secrets versions access latest --secret="$name" --project="$GCP_PROJECT_ID" >/dev/null 2>&1 \
-              || missing="$missing $name"
+            # enabled version. `describe` would pass an empty container; listing enabled versions does not.
+            # This deliberately uses `versions list` (needs only secretmanager.viewer) instead of
+            # `versions access` (needs secretAccessor / reads the value): the deploy SA is least-privilege
+            # and must NOT be able to read every app secret just to run this presence probe. `|| true`
+            # keeps a NOT_FOUND (missing container) from tripping `set -e`; empty output -> flagged below.
+            v="$(gcloud secrets versions list "$name" --project="$GCP_PROJECT_ID" \
+                   --filter='state:ENABLED' --format='value(name)' --limit=1 2>/dev/null || true)"
+            [ -n "$v" ] || missing="$missing $name"
           done
           if [ -n "$missing" ]; then
             echo "::error::Secret(s) missing or unseeded (no version) in Secret Manager (project $GCP_PROJECT_ID):$missing"

--- a/scripts/gcp/phase1-setup.sh
+++ b/scripts/gcp/phase1-setup.sh
@@ -218,7 +218,12 @@ done
 # ---------------------------------------------------------------------------------------
 log "Step 5: IAM bindings (machine identities)"
 # Deploy SA: deploy Cloud Run + push images. project-level.
-for role in roles/run.admin roles/artifactregistry.writer; do
+# secretmanager.viewer (list/metadata, NOT value-read) lets the deploy workflow's "Assert referenced
+# secrets exist" step probe every boot/app secret for an enabled version via `gcloud secrets versions
+# list` WITHOUT granting it read access to the secret values (least privilege: only the runtime SA reads
+# values). The build step still needs to READ two client-public build-arg secrets (MAPS_KEY,
+# DEFAULT_HOST) -- those get scoped per-secret secretAccessor in Step 8 below, not a project-wide grant.
+for role in roles/run.admin roles/artifactregistry.writer roles/secretmanager.viewer; do
   gcloud projects add-iam-policy-binding "$PROJECT_ID" \
     --member="serviceAccount:${DEPLOY_SA}" --role="$role" --condition=None --quiet >/dev/null
 done
@@ -228,7 +233,7 @@ gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA" \
   --project="$PROJECT_ID" \
   --member="serviceAccount:${DEPLOY_SA}" \
   --role="roles/iam.serviceAccountUser" --condition=None --quiet >/dev/null
-echo "    deploy SA -> run.admin, artifactregistry.writer, serviceAccountUser(on runtime SA)"
+echo "    deploy SA -> run.admin, artifactregistry.writer, secretmanager.viewer, serviceAccountUser(on runtime SA)"
 # NOTE (Phase 3): grant the RUNTIME SA roles/cloudsql.client once the Cloud SQL instance
 # exists. Intentionally NOT granted here - see the handoff block. Redis needs no IAM (VPC).
 
@@ -395,6 +400,27 @@ for secret in "${ALL_SECRETS[@]}"; do
     --role="roles/secretmanager.secretAccessor" --quiet >/dev/null
 done
 echo "    Created/verified ${#ALL_SECRETS[@]} empty secrets (no versions yet)."
+
+# Build-arg secrets: globals.js.erb bakes these into /assets/globals.js AT docker build
+# (asset-precompile, see Dockerfile + deploy-cloudrun.yml "Build and push image"), so the DEPLOY SA
+# (which runs the build) must READ them to pass --build-arg. They are CLIENT-PUBLIC (emitted to the
+# browser as window.maps_key / window.default_host), never PHI. MAPS_KEY is build-only (no runtime
+# mount, so it is NOT in ALL_SECRETS and gets no runtime-SA accessor); DEFAULT_HOST is also a boot
+# secret (already created + runtime-accessor'd above), but the build needs deploy-SA read too.
+BUILD_ARG_SECRETS=(MAPS_KEY DEFAULT_HOST)
+for secret in "${BUILD_ARG_SECRETS[@]}"; do
+  if ! gcloud secrets describe "$secret" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    gcloud secrets create "$secret" \
+      --project="$PROJECT_ID" \
+      --replication-policy="user-managed" \
+      --locations="$REGION"
+  fi
+  gcloud secrets add-iam-policy-binding "$secret" \
+    --project="$PROJECT_ID" \
+    --member="serviceAccount:${DEPLOY_SA}" \
+    --role="roles/secretmanager.secretAccessor" --quiet >/dev/null
+done
+echo "    deploy SA -> secretAccessor on build-arg secrets: ${BUILD_ARG_SECRETS[*]} (client-public, build-time)"
 
 # ---------------------------------------------------------------------------------------
 # 9. [FREE] GitHub repo variables the workflow reads. GCP_PROJECT_ID is DELIBERATELY


### PR DESCRIPTION
## Why

The clean-DB rehearsal ran all deploys **manually as an admin identity**, which masked a gap in the **workflow-driven** path: the deploy SA `cloud-run-deployer` has only `run.admin` + `artifactregistry.writer` — **no secret access at all**.

But `deploy-cloudrun.yml`'s "Assert referenced secrets exist" step runs `gcloud secrets versions access` for **every** boot + non-boot secret *as that deploy SA*. So a real `workflow_dispatch` cutover would fail the assert step, reporting all ~30 secrets as missing. (Surfaced while rebuilding the prod image, which failed first try on exactly this: `PermissionDenied` reading `DEFAULT_HOST`.)

## What

- **`deploy-cloudrun.yml`**: the assert step now uses `gcloud secrets versions list --filter='state:ENABLED' --limit=1` — it verifies an **enabled version exists without reading the value**, which needs only `secretmanager.viewer`. The build step keeps `versions access` for the two client-public build-arg secrets (`MAPS_KEY`, `DEFAULT_HOST`) it genuinely must read. `|| true` keeps a `NOT_FOUND` from tripping `set -e`.
- **`scripts/gcp/phase1-setup.sh`**: codifies the matching grants for a reproducible project —
  - deploy SA gets `roles/secretmanager.viewer` (list/metadata only, no value reads),
  - new `BUILD_ARG_SECRETS=(MAPS_KEY DEFAULT_HOST)` block grants the deploy SA per-secret `secretAccessor` (the only values it may read).

## Least-privilege outcome
The deploy SA can now *enumerate* every secret's version state but can only *read* the two client-public build-arg values. It still cannot read `DB_PASSWORD`, `SECRET_KEY_BASE`, Stripe/AI keys, etc. — those stay readable only by the runtime SA.

## Live grants already applied (mirrored by the phase1 edit)
- `roles/secretmanager.viewer` → `cloud-run-deployer@` (project-level).
- per-secret `secretAccessor` on `MAPS_KEY` + `DEFAULT_HOST` → `cloud-run-deployer@`.

## Validation
- YAML parses; `bash -n` clean on the script.
- Ran the new probe loop live against `DEFAULT_HOST`, `MAPS_KEY`, and a bogus name → flagged only the bogus one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)