### PR TITLE
compliance: EU AI Act Article 50(2) machine-readable marking of AI board output (slice 1: backend)

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -608,9 +608,13 @@ class Api::BoardsController < ApplicationController
       fallback_board_name(prompt)
     end
     response[:description] = result[:description].presence || prompt
-    # EU AI Act Article 50(2): surface the signed AI-generated marker so the client
-    # can carry it into the board-save payload, where it is verified and persisted
-    # onto board.settings (and propagated on copy). Unconditional; not flag-gated.
+    # EU AI Act Article 50(2): surface the signed AI-generated marker on the
+    # generation response (unconditional; not flag-gated). NOTE: durable persistence
+    # of this marker onto board.settings at save time, and its propagation through
+    # relinking copy_for, are NOT yet implemented -- they are the follow-up
+    # persistence slice. Until then the marker exists only on this transient
+    # response, so saved/exported/shared boards are not yet marked. The Art. 50
+    # register entry stays OPEN until persistence lands.
     response[:ai_generated] = result[:ai_generated] if result[:ai_generated]
     render json: response
   end

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -608,6 +608,10 @@ class Api::BoardsController < ApplicationController
       fallback_board_name(prompt)
     end
     response[:description] = result[:description].presence || prompt
+    # EU AI Act Article 50(2): surface the signed AI-generated marker so the client
+    # can carry it into the board-save payload, where it is verified and persisted
+    # onto board.settings (and propagated on copy). Unconditional; not flag-gated.
+    response[:ai_generated] = result[:ai_generated] if result[:ai_generated]
     render json: response
   end
 

--- a/app/models/ai_api_log.rb
+++ b/app/models/ai_api_log.rb
@@ -100,7 +100,27 @@ class AiApiLog < ApplicationRecord
     log.save!
     log
   rescue ActiveRecord::RecordInvalid => e
-    Rails.logger.error "AiApiLog: failed to persist audit log: #{e.message}"
+    # Alert-but-continue: a failed AI compliance audit write (incl. EU AI Act
+    # Article 50 fields) must be LOUD so the gap surfaces in monitoring, but it
+    # must NOT fail the user's AI generation on an audit-DB hiccup. Mirror
+    # AuditEvent: scrub the message, log it, and Sentry the scrubbed MESSAGE (not
+    # the raw exception, which CoppaSentryScrub#before_send does not scrub for
+    # non-child users), guarded so alerting can never raise. Previously this was
+    # a silent Rails.logger.error -> audit loss looked like success (finding P3).
+    detail = begin
+      PiiScrubber.scrub_log_line(e.message.to_s).truncate(300)
+    rescue ScriptError, StandardError => scrub_err
+      "[unscrubbable:#{scrub_err.class}]"
+    end
+    message = "AiApiLog: failed to persist audit log: #{detail}"
+    Rails.logger.error(message)
+    begin
+      if defined?(Sentry) && Sentry.respond_to?(:initialized?) && Sentry.initialized?
+        Sentry.capture_message(message, level: 'error', tags: { audit: 'ai_api_log_persist_failed' })
+      end
+    rescue StandardError
+      nil
+    end
     log
   end
 

--- a/app/models/ai_api_log.rb
+++ b/app/models/ai_api_log.rb
@@ -99,11 +99,16 @@ class AiApiLog < ApplicationRecord
     log.ai_generated_content_id = params[:ai_generated_content_id]
     log.save!
     log
-  rescue ActiveRecord::RecordInvalid => e
+  rescue ActiveRecord::ActiveRecordError => e
     # Alert-but-continue: a failed AI compliance audit write (incl. EU AI Act
     # Article 50 fields) must be LOUD so the gap surfaces in monitoring, but it
-    # must NOT fail the user's AI generation on an audit-DB hiccup. Mirror
-    # AuditEvent: scrub the message, log it, and Sentry the scrubbed MESSAGE (not
+    # must NOT fail the user's AI generation on an audit-DB hiccup. Catch the whole
+    # ActiveRecordError tree (RecordInvalid for validation bugs AND StatementInvalid
+    # / ConnectionNotEstablished / lock+timeout for real DB incidents) -- the
+    # operational "audit loss looks like success" case is a DB hiccup, not a
+    # validation failure, so rescuing only RecordInvalid would have left exactly
+    # that case silent. Mirror AuditEvent: scrub the message, log it, and Sentry the
+    # scrubbed MESSAGE (not
     # the raw exception, which CoppaSentryScrub#before_send does not scrub for
     # non-child users), guarded so alerting can never raise. Previously this was
     # a silent Rails.logger.error -> audit loss looked like success (finding P3).

--- a/lib/ai_board_generator.rb
+++ b/lib/ai_board_generator.rb
@@ -4,6 +4,7 @@ require 'anthropic'
 require 'openai'
 require 'set'
 require_relative 'pii_scrubber'
+require_relative 'art50_marker'
 
 module AiBoardGenerator
   # Default model for board generation — Haiku is fast and cheap for structured output
@@ -132,11 +133,20 @@ module AiBoardGenerator
               log_params[:tokens_sent] = last_response.dig('usage', 'prompt_tokens')
               log_params[:tokens_received] = last_response.dig('usage', 'completion_tokens')
             end
+            # EU AI Act Article 50(2): mark the AI-generated output (unconditional,
+            # not feature-flag-gated). The signed marker travels with the content so
+            # a saved board can persist it (see relinking copy_for) and detection
+            # tools can verify provenance. ai_generated_content_id links this output
+            # to its audit row in AiApiLog.
+            marker = Art50Marker.build(provider: provider.to_s, model: model)
+            log_params[:ai_content_marked] = true
+            log_params[:ai_generated_content_id] = marker['content_id']
             log_ai_call(**log_params)
             return {
               words: words.first(cell_count),
               name: last_payload[:name].presence,
               description: last_payload[:description].presence,
+              ai_generated: marker,
               error: nil
             }
           end
@@ -658,7 +668,8 @@ module AiBoardGenerator
     def log_ai_call(provider:, model:, user:, request_summary:, response_summary:,
                     tokens_sent: nil, tokens_received: nil, duration_ms: nil,
                     pii_detected: false, pii_findings: [], success: true, error_message: nil,
-                    request_type: 'board_generation')
+                    request_type: 'board_generation',
+                    ai_content_marked: false, ai_generated_content_id: nil)
       return unless defined?(AiApiLog)
       # Scrub the model OUTPUT before it reaches AiApiLog. Generated board names/descriptions
       # can echo user-supplied sensitive context, so the raw response must never be persisted
@@ -679,7 +690,11 @@ module AiBoardGenerator
         pii_findings: pii_findings,
         success: success,
         error_message: error_message,
-        feature_flag: 'ai_board_generation'
+        feature_flag: 'ai_board_generation',
+        # EU AI Act Article 50(2): record that the output was machine-readable marked
+        # and link this audit row to the marked content via its content_id.
+        ai_content_marked: ai_content_marked,
+        ai_generated_content_id: ai_generated_content_id
       )
     rescue StandardError => e
       Rails.logger.warn "AiBoardGenerator: failed to log AI API call: #{e.message}"

--- a/lib/ai_board_generator.rb
+++ b/lib/ai_board_generator.rb
@@ -133,11 +133,19 @@ module AiBoardGenerator
               log_params[:tokens_sent] = last_response.dig('usage', 'prompt_tokens')
               log_params[:tokens_received] = last_response.dig('usage', 'completion_tokens')
             end
-            # EU AI Act Article 50(2): mark the AI-generated output (unconditional,
-            # not feature-flag-gated). The signed marker travels with the content so
-            # a saved board can persist it (see relinking copy_for) and detection
-            # tools can verify provenance. ai_generated_content_id links this output
-            # to its audit row in AiApiLog.
+            # EU AI Act Article 50(2): mark the board-generation output. The marking
+            # is NOT feature-flag-gated (only the Article 50(1) disclosure is); within
+            # this path every successful AI output is marked. SCOPE: this slice marks
+            # board generation only. Other AI-output surfaces are NOT yet marked and are
+            # tracked follow-up: generate_focus_words (below; persists via AiFocusWordSet
+            # cache), AiWordPredictor.predict, eval narration, AiPredictionGenerator.
+            # Durable persistence of this marker (board.settings + relinking copy_for)
+            # is also follow-up; see boards_controller#generate_labels. Until those land,
+            # do not record the Article 50(2) obligation as closed.
+            # ai_generated_content_id is a best-effort link to this output's AiApiLog
+            # row; under alert-but-continue an audit-write failure is alerted (loud) but
+            # the marker is still returned, so a valid marker does not by itself prove a
+            # persisted audit row.
             marker = Art50Marker.build(provider: provider.to_s, model: model)
             log_params[:ai_content_marked] = true
             log_params[:ai_generated_content_id] = marker['content_id']

--- a/lib/art50_marker.rb
+++ b/lib/art50_marker.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'go_secure'
 require 'active_support/security_utils'
 
@@ -17,6 +18,14 @@ require 'active_support/security_utils'
 #   content-bound signature would falsely invalidate the moment a user edits a word.
 #   Provenance binding keeps the marker valid through legitimate editing while still
 #   being unforgeable by a client.
+# - CONSEQUENCE (state it, do not gloss it): because the signature does not cover the
+#   words, the marker is a server-issued PROVENANCE/BEARER attestation, not a binding
+#   to specific content. `marked?` proves "an AI-generation event occurred on this
+#   server," NOT "these exact words are that output." A valid marker could be lifted
+#   onto unrelated content. This is the accepted tradeoff against post-edit
+#   invalidation; it must be documented in the compliance record, not over-claimed as
+#   content integrity. A future hardening could co-sign a normalized, edit-tolerant
+#   digest of the delivered words if content binding becomes required.
 # - The signature is a keyed HMAC-SHA512 (GoSecure.lite_hmac) over a canonical
 #   serialization of the signed fields, keyed by the app encryption secret. A client
 #   cannot mint or alter a marker without the server secret, so a forged or stripped
@@ -82,9 +91,15 @@ module Art50Marker
   # Computes the signature over the canonical serialization of the signed fields.
   # Extra (unsigned) keys on the input are ignored, so #verify can pass the full
   # marker hash here without stripping marked/sig_alg/signature first.
+  #
+  # The canonical form is a JSON array of [key, value] pairs in fixed SIGNED_KEYS
+  # order. JSON escaping makes it injective: no field value (even one containing a
+  # delimiter) can collide with a different field assignment, so two distinct field
+  # sets can never produce the same signing input. (Today provider/model come from
+  # server config and the rest are hex/ISO8601, but signing must not depend on that.)
   def sign(payload)
     p = stringify(payload)
-    canonical = SIGNED_KEYS.map { |k| "#{k}=#{p[k]}" }.join('&')
+    canonical = JSON.generate(SIGNED_KEYS.map { |k| [k, p[k]] })
     GoSecure.lite_hmac(canonical, SIG_SALT, 1)
   end
 

--- a/lib/art50_marker.rb
+++ b/lib/art50_marker.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'go_secure'
+require 'active_support/security_utils'
+
+# EU AI Act Article 50(2) machine-readable marking of AI-generated output.
+#
+# When LingoLinq generates AAC board content with an external model, Article 50(2)
+# requires the output be marked in a machine-readable, detectable way that travels
+# with the content. This module produces a tamper-evident, server-verifiable
+# metadata marker for that purpose.
+#
+# Design notes:
+# - The marker attests PROVENANCE (this content originated from AI generation at a
+#   time, by a named provider/model), NOT the exact bytes of the words. AAC boards
+#   are routinely human-edited after generation (an SLP tweaks a label), so a
+#   content-bound signature would falsely invalidate the moment a user edits a word.
+#   Provenance binding keeps the marker valid through legitimate editing while still
+#   being unforgeable by a client.
+# - The signature is a keyed HMAC-SHA512 (GoSecure.lite_hmac) over a canonical
+#   serialization of the signed fields, keyed by the app encryption secret. A client
+#   cannot mint or alter a marker without the server secret, so a forged or stripped
+#   marker fails #verify. This is the codebase's strongest existing MAC primitive;
+#   an asymmetric / C2PA provenance signature is a documented future hardening.
+# - The marker is UNCONDITIONAL: it is emitted whenever AI produced the content,
+#   independent of any feature flag or jurisdiction. Only the Article 50(1)
+#   user-facing disclosure is gated; the 50(2) marking is not.
+module Art50Marker
+  # Bump SPEC / SIG_ALG (never silently) if the signed shape or algorithm changes,
+  # so older markers remain verifiable against the version that produced them.
+  SPEC = 'eu-ai-act-art50-2'
+  SIG_ALG = 'GoSecure.lite_hmac.v1'
+  SIG_SALT = 'art50_marker'
+
+  # Fields covered by the signature, in canonical order. Order is fixed so the
+  # canonical string is deterministic across Ruby versions and hash orderings.
+  SIGNED_KEYS = %w[spec provider model generated_at content_id].freeze
+
+  module_function
+
+  # Builds a signed marker for one AI generation. provider/model identify the
+  # system that produced the output; generated_at defaults to now (UTC ISO8601).
+  # Returns a string-keyed Hash safe to embed in JSON responses and board.settings.
+  def build(provider:, model:, generated_at: nil)
+    payload = {
+      'spec' => SPEC,
+      'provider' => provider.to_s,
+      'model' => model.to_s,
+      'generated_at' => (generated_at || Time.now.utc).iso8601,
+      'content_id' => GoSecure.nonce('art50_content')
+    }
+    payload.merge(
+      'marked' => true,
+      'sig_alg' => SIG_ALG,
+      'signature' => sign(payload)
+    )
+  end
+
+  # Verifies a marker's signature against the current server secret. Returns true
+  # only for a well-formed, untampered, server-issued marker. Any malformed input,
+  # missing field, or signature mismatch returns false (never raises).
+  def verify(marker)
+    return false unless marker.is_a?(Hash)
+    m = stringify(marker)
+    return false unless m['marked'] == true || m['marked'] == 'true'
+    return false unless m['sig_alg'] == SIG_ALG
+    sig = m['signature']
+    return false unless sig.is_a?(String) && !sig.empty?
+    return false unless SIGNED_KEYS.all? { |k| m[k].is_a?(String) && !m[k].empty? }
+
+    ActiveSupport::SecurityUtils.secure_compare(sig, sign(m))
+  rescue StandardError
+    false
+  end
+
+  # Convenience: is the ai_generated key on a board.settings-style hash a valid marker?
+  def marked?(settings)
+    return false unless settings.is_a?(Hash)
+    verify(settings['ai_generated'] || settings[:ai_generated])
+  end
+
+  # Computes the signature over the canonical serialization of the signed fields.
+  # Extra (unsigned) keys on the input are ignored, so #verify can pass the full
+  # marker hash here without stripping marked/sig_alg/signature first.
+  def sign(payload)
+    p = stringify(payload)
+    canonical = SIGNED_KEYS.map { |k| "#{k}=#{p[k]}" }.join('&')
+    GoSecure.lite_hmac(canonical, SIG_SALT, 1)
+  end
+
+  def stringify(hash)
+    hash.transform_keys(&:to_s)
+  end
+end

--- a/spec/lib/ai_board_generator_spec.rb
+++ b/spec/lib/ai_board_generator_spec.rb
@@ -72,6 +72,34 @@ describe AiBoardGenerator do
       expect(logged[:response_summary]).not_to include('parent@example.com')
     end
 
+    it "marks the AI-generated output with a verifiable Article 50 marker and records it in the audit log" do
+      logged = nil
+      allow(AiApiLog).to receive(:log_ai_call) { |**kw| logged = kw }
+      complete = "WORDS: apple, banana, carrot, drink\nNAME: Snacks\nDESCRIPTION: Snack words."
+      allow(described_class).to receive(:call_anthropic).and_return(anthropic_response(complete))
+
+      result = described_class.generate_words(prompt: 'snacks', rows: 2, columns: 2)
+
+      expect(result[:ai_generated]).to be_a(Hash)
+      expect(Art50Marker.verify(result[:ai_generated])).to eq(true)
+      expect(result[:ai_generated]['provider']).to eq('claude')
+      expect(result[:ai_generated]['model']).to eq(AiBoardGenerator::DEFAULT_MODEL)
+      expect(logged[:ai_content_marked]).to eq(true)
+      expect(logged[:ai_generated_content_id]).to eq(result[:ai_generated]['content_id'])
+    end
+
+    it "does not attach a marker to a shortfall (no AI content delivered)" do
+      short = "WORDS: apple, banana\nNAME: Snacks\nDESCRIPTION: x."
+      allow(described_class).to receive(:call_anthropic).and_return(
+        anthropic_response(short), anthropic_response(short)
+      )
+
+      result = described_class.generate_words(prompt: 'snacks', rows: 2, columns: 2)
+
+      expect(result[:words]).to eq(nil)
+      expect(result[:ai_generated]).to eq(nil)
+    end
+
     context "COPPA Final Rule hard-gate" do
       it "returns a parental-consent error when coppa_blocks_ai_for? is true" do
         u = User.new(settings: { 'coppa' => { 'pending_parent_consent' => true } })

--- a/spec/lib/art50_marker_spec.rb
+++ b/spec/lib/art50_marker_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Art50Marker do
+  describe '.build' do
+    it 'returns a signed, self-verifying marker with provenance fields' do
+      m = described_class.build(provider: 'claude', model: 'claude-haiku-4-5-20251001')
+
+      expect(m['marked']).to eq(true)
+      expect(m['spec']).to eq('eu-ai-act-art50-2')
+      expect(m['provider']).to eq('claude')
+      expect(m['model']).to eq('claude-haiku-4-5-20251001')
+      expect(m['content_id']).to be_a(String)
+      expect(m['content_id']).not_to be_empty
+      expect(m['signature']).to be_a(String)
+      expect(m['signature']).not_to be_empty
+      expect(m['generated_at']).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+      expect(described_class.verify(m)).to eq(true)
+    end
+
+    it 'mints a unique content_id per generation' do
+      a = described_class.build(provider: 'claude', model: 'm')
+      b = described_class.build(provider: 'claude', model: 'm')
+      expect(a['content_id']).not_to eq(b['content_id'])
+    end
+
+    it 'honors an explicit generated_at and still verifies' do
+      t = Time.utc(2026, 8, 2, 12, 0, 0)
+      m = described_class.build(provider: 'claude', model: 'm', generated_at: t)
+      expect(m['generated_at']).to eq(t.iso8601)
+      expect(described_class.verify(m)).to eq(true)
+    end
+  end
+
+  describe '.verify' do
+    let(:marker) { described_class.build(provider: 'claude', model: 'claude-haiku-4-5-20251001') }
+
+    it 'rejects a tampered provider' do
+      expect(described_class.verify(marker.merge('provider' => 'gemini'))).to eq(false)
+    end
+
+    it 'rejects a tampered model' do
+      expect(described_class.verify(marker.merge('model' => 'evil-model'))).to eq(false)
+    end
+
+    it 'rejects a tampered generated_at' do
+      expect(described_class.verify(marker.merge('generated_at' => marker['generated_at'] + 'X'))).to eq(false)
+    end
+
+    it 'rejects a stripped or blank signature' do
+      expect(described_class.verify(marker.merge('signature' => ''))).to eq(false)
+      expect(described_class.verify(marker.except('signature'))).to eq(false)
+    end
+
+    it 'rejects a forged signature of the correct length (constant-time compare)' do
+      forged = marker.merge('signature' => 'a' * marker['signature'].length)
+      expect(described_class.verify(forged)).to eq(false)
+    end
+
+    it 'rejects a marker whose marked flag is not true' do
+      expect(described_class.verify(marker.merge('marked' => false))).to eq(false)
+    end
+
+    it 'rejects a marker with a mismatched sig_alg' do
+      expect(described_class.verify(marker.merge('sig_alg' => 'rot13'))).to eq(false)
+    end
+
+    it 'rejects non-hash input without raising' do
+      expect(described_class.verify(nil)).to eq(false)
+      expect(described_class.verify('not-a-marker')).to eq(false)
+      expect(described_class.verify(42)).to eq(false)
+    end
+
+    it 'still verifies after a JSON round-trip (as stored in board.settings)' do
+      round_tripped = JSON.parse(marker.to_json)
+      expect(described_class.verify(round_tripped)).to eq(true)
+    end
+  end
+
+  describe '.marked?' do
+    it 'is true when settings carry a valid marker under ai_generated' do
+      m = described_class.build(provider: 'claude', model: 'm')
+      expect(described_class.marked?('ai_generated' => m)).to eq(true)
+      expect(described_class.marked?(ai_generated: m)).to eq(true)
+    end
+
+    it 'is false for absent, empty, or forged markers' do
+      expect(described_class.marked?({})).to eq(false)
+      expect(described_class.marked?('ai_generated' => { 'marked' => true })).to eq(false)
+      expect(described_class.marked?(nil)).to eq(false)
+    end
+  end
+end

--- a/spec/models/ai_api_log_spec.rb
+++ b/spec/models/ai_api_log_spec.rb
@@ -558,5 +558,24 @@ describe AiApiLog, :type => :model do
         AiApiLog.log_ai_call(provider: 'evilcorp', type: 'board_generation')
       }.not_to raise_error
     end
+
+    it "also alerts (not just validation errors) on a real DB failure during save" do
+      captured = nil
+      allow(fake_sentry).to receive(:capture_message) { |msg, *| captured = msg }
+      # Simulate an operational DB hiccup -- a StatementInvalid, NOT a validation
+      # RecordInvalid -- which is the scenario the loud fix is meant to surface.
+      allow_any_instance_of(AiApiLog).to receive(:save!)
+        .and_raise(ActiveRecord::StatementInvalid.new('PG::ConnectionBad: server closed the connection'))
+
+      log = nil
+      expect {
+        log = AiApiLog.log_ai_call(provider: 'claude', type: 'board_generation')
+      }.not_to raise_error
+
+      expect(log).to be_a(AiApiLog)
+      expect(captured).to include('failed to persist audit log')
+      expect(fake_sentry).to have_received(:capture_message)
+        .with(kind_of(String), hash_including(level: 'error', tags: { audit: 'ai_api_log_persist_failed' }))
+    end
   end
 end

--- a/spec/models/ai_api_log_spec.rb
+++ b/spec/models/ai_api_log_spec.rb
@@ -518,4 +518,45 @@ describe AiApiLog, :type => :model do
       expect(log.ai_content_marked).to eq(false)
     end
   end
+
+  describe "log_ai_call audit-write failure (alert-but-continue)" do
+    # Fake Sentry so the guarded alert path runs whether or not Sentry is
+    # initialized in the test env. Mirrors AuditEvent's capture_message contract.
+    let(:fake_sentry) do
+      Module.new do
+        def self.initialized?
+          true
+        end
+      end
+    end
+
+    before(:each) do
+      stub_const('Sentry', fake_sentry)
+    end
+
+    it "alerts via Sentry and returns the unsaved log instead of raising" do
+      captured = nil
+      allow(fake_sentry).to receive(:capture_message) { |msg, *| captured = msg }
+
+      log = nil
+      expect {
+        # invalid ai_provider fails the inclusion validation -> save! raises RecordInvalid
+        log = AiApiLog.log_ai_call(provider: 'evilcorp', type: 'board_generation')
+      }.not_to raise_error
+
+      expect(log).to be_a(AiApiLog)
+      expect(log).not_to be_persisted
+      expect(captured).to include('failed to persist audit log')
+      expect(fake_sentry).to have_received(:capture_message)
+        .with(kind_of(String), hash_including(level: 'error', tags: { audit: 'ai_api_log_persist_failed' }))
+    end
+
+    it "does not let a Sentry failure escape (alerting can never break generation)" do
+      allow(fake_sentry).to receive(:capture_message).and_raise(StandardError, 'sentry down')
+
+      expect {
+        AiApiLog.log_ai_call(provider: 'evilcorp', type: 'board_generation')
+      }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## What

First (backend) slice of EU AI Act **Article 50(2)** machine-readable marking for AI-generated AAC content. Decoupled from the COPPA consent chain so the marking obligation lands independently.

- **`lib/art50_marker.rb`** (new): `Art50Marker.build/verify/marked?`. A tamper-evident, server-verifiable **provenance** marker (spec/provider/model/generated_at/content_id), signed with `GoSecure.lite_hmac` (HMAC-SHA512 keyed by the app secret). Provenance-bound, **not** content-bound, so a legitimate human edit of a generated board does not invalidate the marker. Canonical signing input is an injective JSON encoding.
- **`AiBoardGenerator.generate_words`**: marks the board-generation output on the success path, returns it as `ai_generated`, sets `ai_content_marked` + `ai_generated_content_id` on the audit row (threaded through the private `log_ai_call` wrapper, which previously dropped the fields).
- **`boards_controller#generate_labels`**: surfaces the marker in the response.
- **`AiApiLog.log_ai_call`**: alert-but-continue on a failed audit write (finding **P3**). Was a silent `Rails.logger.error`; now scrubs + logs + `Sentry.capture_message` (scrubbed message, guarded), and crucially rescues the whole `ActiveRecordError` tree so a real DB hiccup is alerted, not just validation errors. Never raises into the user's generation.

## Why now / timing

Per a fresh regulatory lookup, the Art. 50(2) machine-readable-marking deadline for an existing system is **2026-12-02** (AI Omnibus grace), not 2026-08-02. So this is built for durability rather than as a rushed response-only flag.

## Review

Claude `adversary` pass run on the first commit; the crypto was confirmed sound (server-keyed HMAC, correct constant-time compare, tamper-rejecting). Three High + two Medium + one Low findings were addressed in the second commit (broadened rescue, corrected over-claims, injective canonical, honest provenance/bearer documentation). Codex `/review-pr` intentionally skipped: compliance-adjacent code stays Claude-only per repo policy.

## Scope — explicitly NOT done in this slice (do not record Art. 50(2) as closed)

- **Durable persistence**: the marker is not yet written to `board.settings` at save, verified on save, or propagated through `relinking copy_for`. Saved/exported/shared boards are therefore **not yet marked**. (Follow-up: persistence slice.)
- **Other AI-output surfaces unmarked**: `generate_focus_words` (persists via `AiFocusWordSet`), `AiWordPredictor.predict`, eval narration, `AiPredictionGenerator`. (Follow-up: scope determination + marking.)
- **Art. 50(1) disclosure modal**: rides the COPPA consent chain, not this slice.

The Art. 50 register entry stays **OPEN** until persistence + the remaining surfaces land.

## Tests

77 examples, 0 failures (`art50_marker` + `ai_board_generator` + `ai_api_log`), plus `generate_labels` controller specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)