### PR TITLE
fix: stop valet_login string 'false' from breaking self-service password change

### DIFF
--- a/app/frontend/app/controllers/user/index.js
+++ b/app/frontend/app/controllers/user/index.js
@@ -1549,7 +1549,7 @@ export default Controller.extend({
         var keys = "23456789abcdef";
         var pw = "";
         for(var idx = 0; idx < 8; idx++) {
-          var hit = Math.round(Math.random() * keys.length);
+          var hit = Math.floor(Math.random() * keys.length);
           var key = keys.substring(hit, hit + 1);
           pw = pw + key;
         }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1370,12 +1370,22 @@ class User < ApplicationRecord
       end
       params.delete('valet_login')
     end
-    if params['valet_login']
-      self.set_valet_password(params['valet_password'])
-      self.settings['valet_long_term'] = process_boolean(params['valet_long_term']) if params['valet_long_term'] != nil
-      self.settings['valet_prevent_disable'] = process_boolean(params['valet_prevent_disable']) if params['valet_prevent_disable'] != nil
-    elsif params['valet_login'] == false
-      self.set_valet_password(false)
+    # Coerce valet_login through process_boolean. The client serializes this
+    # boolean attribute as a STRING ('true'/'false'), and a bare `if
+    # params['valet_login']` treats the non-empty string 'false' as truthy --
+    # which wrongly ENABLED valet mode (assert_valet_mode! + a random valet
+    # password) on every profile save. With valet mode on, the subsequent
+    # valid_password? check compares the user's real password against the valet
+    # secret, so self-service password changes always failed with "incorrect
+    # current password". Only an explicitly-absent (nil) value is a no-op.
+    unless params['valet_login'].nil?
+      if process_boolean(params['valet_login'])
+        self.set_valet_password(params['valet_password'])
+        self.settings['valet_long_term'] = process_boolean(params['valet_long_term']) if params['valet_long_term'] != nil
+        self.settings['valet_prevent_disable'] = process_boolean(params['valet_prevent_disable']) if params['valet_prevent_disable'] != nil
+      else
+        self.set_valet_password(false)
+      end
     end
     if params['preferences']
       CONFIRMATION_PREFERENCE_PARAMS.each do |key|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -742,6 +742,42 @@ describe User, :type => :model do
       expect(u.valid_password?('braised-beef')).to eq(true)
     end
 
+    it "should allow a self-service password change even when valet_login is the string 'false' (regression)" do
+      # The Ember client serializes the boolean valet_login attribute as a
+      # STRING, so a normal profile save sends valet_login => 'false'. A bare
+      # truthiness check treated the non-empty string 'false' as true, enabled
+      # valet mode (assert_valet_mode! + a random valet password), and the
+      # following valid_password? check then compared the real password against
+      # the valet secret -> every self-service password change failed with
+      # "incorrect current password". The valet block only runs when the
+      # updater is the user themselves, so pass updater => u.
+      u = User.create
+      u.generate_password('horseradish')
+      u.save!
+      expect(u.valet_mode?).to eq(false)
+      res = u.process_params({
+        'password' => 'chicken',
+        'old_password' => 'horseradish',
+        'valet_login' => 'false'
+      }, {'updater' => u})
+      expect(u.processing_errors).to eq([])
+      expect(res).to_not eq(false)
+      expect(u.valid_password?('chicken')).to eq(true)
+      # valet mode must NOT have been silently enabled by the falsey string
+      expect(u.valet_mode?).to eq(false)
+      expect(u.settings['valet_password']).to eq(nil)
+    end
+
+    it "should still disable valet when valet_login is boolean false" do
+      u = User.create
+      u.generate_password('horseradish')
+      u.process_params({'valet_login' => true, 'valet_password' => 'gemini'}, {'updater' => u})
+      u.save!
+      expect(u.settings['valet_password']).to_not eq(nil)
+      u.process_params({'valet_login' => false}, {'updater' => u})
+      expect(u.settings['valet_password']).to eq(nil)
+    end
+
     describe "password-change audit trail (LL-747bb0e02d)" do
       # AuditEvent.log_command commits outside the per-example transaction, so
       # rows leak across examples and inflate counts. Scope the reset to this


### PR DESCRIPTION
## Problem

Self-service password changes (and the org-admin "reset code" flow) always failed with a **400 `incorrect current password`**, even when the current password was correct. Reproduced live on prod via Playwright: a minimal profile save succeeded, but adding `valet_login` to the payload produced the 400.

## Root cause

The Ember client serializes the boolean `valet_login` attribute as a **string** (`'true'` / `'false'`). In `User#process_params`, the guard was a bare truthiness check:

```ruby
if params['valet_login']   # the STRING 'false' is truthy in Ruby
```

So a normal profile save (which sends `valet_login => 'false'`) wrongly **enabled valet mode** and set a random valet password. The password-change block runs afterward and calls `valid_password?`, which in valet mode compares the entered current password against the *valet* secret, never the real one. Result: every self-service password change failed, and normal saves were silently turning on classroom/valet login.

## Fix

- **`app/models/user.rb`** — coerce `valet_login` through `process_boolean`, and only act when the value is explicitly present (nil is a no-op). Boolean `false` still correctly disables valet.
- **`app/frontend/app/controllers/user/index.js`** — `Math.round` -> `Math.floor` in the admin temp-password generator, so the generated code is always the full 8 characters (round could index past the key string and yield an empty char).
- **`spec/models/user_spec.rb`** — two regression specs: string-`'false'` password change now succeeds and leaves valet off; boolean-`false` still disables valet.

## Testing

```
DB_USER=scotw RAILS_ENV=test bundle exec rspec spec/models/user_spec.rb \
  -e "should reset password only if allowed" \
  -e "self-service password change even when valet_login" \
  -e "still disable valet when valet_login is boolean false"
# 3 examples, 0 failures
```

## Notes

- No user-facing strings changed; no new feature (bug fix to existing behavior), so no feature flag needed.
- The live Cloud Run / Render images still run the old code; this bug persists in the running app until this ships in the next image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
