### PR TITLE
compliance: EU AI Act Art.50(2) durable marker persistence (slice 2)

### DIFF
--- a/app/cloners/board_cloner.rb
+++ b/app/cloners/board_cloner.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../lib/art50_marker'
+
 class BoardCloner < Clowne::Cloner
   adapter :active_record
 
@@ -116,7 +118,13 @@ class BoardCloner < Clowne::Cloner
     # generation, not the exact bytes) and server-signed, so it stays valid on a copy.
     # The cloner only copies allowlisted settings keys, so an unlisted key is silently
     # dropped on copy; without this line copied/shared boards would lose their marking.
-    record.settings['ai_generated'] = source.settings['ai_generated'] if source.settings['ai_generated']
+    # Re-normalize on copy: this drops any unsigned keys and, crucially, refuses to
+    # propagate a marker that no longer verifies (e.g. a stale marker after key rotation),
+    # so only genuine, canonical markers ride onto the copy.
+    if source.settings['ai_generated']
+      marker = Art50Marker.normalized(source.settings['ai_generated'])
+      record.settings['ai_generated'] = marker if marker
+    end
     record.settings['intro']['unapproved'] = true if record.settings['intro'].is_a?(Hash)
     record.settings['never_edited'] = true
 

--- a/app/cloners/board_cloner.rb
+++ b/app/cloners/board_cloner.rb
@@ -111,6 +111,12 @@ class BoardCloner < Clowne::Cloner
     record.settings['word_suggestions'] = source.settings['word_suggestions']
     record.settings['categories'] = source.settings['categories']
     record.settings['license'] = source.settings['license']
+    # EU AI Act Article 50(2): carry the AI-generation provenance marker onto copies.
+    # The marker is provenance-bound (it attests the content originated from AI
+    # generation, not the exact bytes) and server-signed, so it stays valid on a copy.
+    # The cloner only copies allowlisted settings keys, so an unlisted key is silently
+    # dropped on copy; without this line copied/shared boards would lose their marking.
+    record.settings['ai_generated'] = source.settings['ai_generated'] if source.settings['ai_generated']
     record.settings['intro']['unapproved'] = true if record.settings['intro'].is_a?(Hash)
     record.settings['never_edited'] = true
 

--- a/app/frontend/app/components/create-board-new.js
+++ b/app/frontend/app/components/create-board-new.js
@@ -1819,6 +1819,11 @@ export default Component.extend({
         if(res && res.name && !(_this.get('model.name') || '').trim().length) {
           _this.set('model.name', res.name);
         }
+        // EU AI Act Article 50(2): carry the signed AI-generation marker onto the board
+        // so it rides the save payload and the server can verify + persist it.
+        if(res && res.ai_generated) {
+          _this.set('model.ai_generated', res.ai_generated);
+        }
         _this.set('ai_generating', false);
         _this.set('ai_labels_generated', true);
       }, function(err) {

--- a/app/frontend/app/components/generate-board.js
+++ b/app/frontend/app/components/generate-board.js
@@ -200,6 +200,9 @@ export default Component.extend({
         _this.set('labels', labels);
         if (res && res.name) { _this.set('name', res.name); }
         if (res && res.description) { _this.set('description', res.description); }
+        // EU AI Act Article 50(2): hold the signed AI-generation marker so createBoard
+        // can include it in the board payload for the server to verify + persist.
+        if (res && res.ai_generated) { _this.set('ai_generated', res.ai_generated); }
       }, function(err) {
         var msg = i18n.t('generate_failed', 'Generation failed');
         var resp = (err && err.fakeXHR && err.fakeXHR.responseJSON) || (err && err.responseJSON) || (err && err.responseText ? (function() {
@@ -244,6 +247,11 @@ export default Component.extend({
       };
       if (this.get('image_url')) {
         boardPayload.image_url = this.get('image_url');
+      }
+      // EU AI Act Article 50(2): pass the signed AI-generation marker through so the
+      // server verifies and persists it onto the new board's settings.
+      if (this.get('ai_generated')) {
+        boardPayload.ai_generated = this.get('ai_generated');
       }
 
       if (!persistenceService || !persistenceService.ajax) {

--- a/app/frontend/app/models/board.js
+++ b/app/frontend/app/models/board.js
@@ -162,6 +162,9 @@ LingoLinq.Board = BaseModel.extend({
   categories: attr('raw'),
   home_board: attr('boolean'),
   has_fallbacks: attr('boolean'),
+  // EU AI Act Article 50(2) signed provenance marker, set from the AI label-generation
+  // response and round-tripped on save so the server can verify and persist it.
+  ai_generated: attr('raw'),
   /** When loaded by key, the API returns global_id as id; we normalize to key and store backend id here. */
   _actual_id: attr('string'),
   /** Backend global_id for comparisons (e.g. preferences.home_board.id). Use this when comparing with server ids. */

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1883,6 +1883,20 @@ class Board < ApplicationRecord
     self.settings['text_only'] = params['text_only'] if params['text_only'] != nil
     self.settings['dim_header'] = params['dim_header'] if params['dim_header'] != nil
     self.settings['small_header'] = params['small_header'] if params['small_header'] != nil
+    # EU AI Act Article 50(2): if the client supplied an AI-generation marker, persist
+    # it onto settings ONLY if it verifies as a genuine, server-signed marker. Client
+    # input is never trusted: a missing, malformed, or forged marker is silently dropped
+    # and never overwrites an existing valid marker. Marking is unconditional (no feature
+    # flag); see lib/art50_marker.rb. verify never raises, but we still guard so a marker
+    # problem can never break a board save -- including the Resque-worker path where lib/
+    # autoload is skipped and Art50Marker may be undefined (workers carry no client marker).
+    if params['ai_generated']
+      begin
+        self.settings['ai_generated'] = params['ai_generated'] if Art50Marker.verify(params['ai_generated'])
+      rescue StandardError => e
+        Rails.logger.warn("Art50 marker verification skipped on save: #{e.class}")
+      end
+    end
     self.settings['never_edited'] = false if self.id
     button_params = params['buttons']
     button_params.instance_variable_set('@add_voc_error', non_user_params['add_voc_error']) if button_params

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1892,7 +1892,8 @@ class Board < ApplicationRecord
     # autoload is skipped and Art50Marker may be undefined (workers carry no client marker).
     if params['ai_generated']
       begin
-        self.settings['ai_generated'] = params['ai_generated'] if Art50Marker.verify(params['ai_generated'])
+        marker = Art50Marker.normalized(params['ai_generated'])
+        self.settings['ai_generated'] = marker if marker
       rescue StandardError => e
         Rails.logger.warn("Art50 marker verification skipped on save: #{e.class}")
       end

--- a/lib/art50_marker.rb
+++ b/lib/art50_marker.rb
@@ -78,7 +78,15 @@ module Art50Marker
     return false unless SIGNED_KEYS.all? { |k| m[k].is_a?(String) && !m[k].empty? }
 
     ActiveSupport::SecurityUtils.secure_compare(sig, sign(m))
-  rescue StandardError
+  rescue StandardError => e
+    # A forged or malformed marker returns false WITHOUT raising (the checks above and
+    # secure_compare do not raise). Reaching this rescue means an unexpected crypto/config
+    # fault -- most likely a missing or rotated signing secret -- which would otherwise
+    # silently drop every marker with no signal. Log the exception class only (never the
+    # marker contents, which could carry provenance identifiers) so the failure is
+    # observable without leaking a secret, and still return false so a marker problem can
+    # never raise into a board save or render.
+    Rails.logger.error("Art50Marker.verify errored: #{e.class}") if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
     false
   end
 
@@ -86,6 +94,22 @@ module Art50Marker
   def marked?(settings)
     return false unless settings.is_a?(Hash)
     verify(settings['ai_generated'] || settings[:ai_generated])
+  end
+
+  # The canonical key set an at-rest marker may carry: exactly the fields #build emits
+  # (the signed payload plus the marked/sig_alg/signature control fields). Anything else a
+  # client tacks on is unsigned and must not ride along inside a "verified" marker.
+  PERSIST_KEYS = (SIGNED_KEYS + %w[marked sig_alg signature]).freeze
+
+  # Reduces a marker to its canonical, server-signed shape -- but ONLY if it verifies;
+  # otherwise nil. Because #sign ignores unsigned keys, #verify alone would accept a valid
+  # marker padded with arbitrary extra keys and #persist/#clone would store them verbatim.
+  # Normalizing at every persistence/propagation boundary guarantees a stored marker is
+  # exactly what the server signed. Dropping the extra keys never breaks verification (they
+  # were never part of the signature), so the normalized marker still verifies.
+  def normalized(marker)
+    return nil unless verify(marker)
+    stringify(marker).slice(*PERSIST_KEYS)
   end
 
   # Non-secret provenance fields safe to expose to API consumers / downstream deployers

--- a/lib/art50_marker.rb
+++ b/lib/art50_marker.rb
@@ -88,6 +88,26 @@ module Art50Marker
     verify(settings['ai_generated'] || settings[:ai_generated])
   end
 
+  # Non-secret provenance fields safe to expose to API consumers / downstream deployers
+  # for Article 50(2) detection. Deliberately EXCLUDES signature and content_id.
+  PUBLIC_KEYS = %w[spec provider model generated_at].freeze
+
+  # Public, non-secret view of a stored marker for API exposure. Returns the provenance
+  # fields a downstream consumer needs to detect AI-generated content (spec/provider/
+  # model/generated_at + marked:true) and WITHHOLDS the signature and content_id: the
+  # HMAC is keyed by the server secret so a client cannot verify it anyway, and content_id
+  # links to an internal AiApiLog row -- exposing them only enables a bearer-token
+  # transplant that mislinks per-board provenance. Returns nil unless the stored marker
+  # actually verifies, so a forged or key-rotation-invalidated marker reads as unmarked
+  # (consistent with #marked?).
+  def public_view(marker)
+    return nil unless verify(marker)
+    m = stringify(marker)
+    view = { 'marked' => true }
+    PUBLIC_KEYS.each { |k| view[k] = m[k] }
+    view
+  end
+
   # Computes the signature over the canonical serialization of the signed fields.
   # Extra (unsigned) keys on the input are ignored, so #verify can pass the full
   # marker hash here without stripping marked/sig_alg/signature first.

--- a/lib/json_api/board.rb
+++ b/lib/json_api/board.rb
@@ -1,4 +1,5 @@
 require_relative '../method_tracer'
+require_relative '../art50_marker'
 
 module JsonApi::Board
   extend MethodTracer
@@ -21,6 +22,12 @@ module JsonApi::Board
     ['name', 'prefix', 'description', 'image_url', 'stars', 'forks', 'word_suggestions', 'locale', 'home_board', 'categories', 'dim_header', 'small_header'].each do |key|
       json[key] = board.settings[key]
     end
+    # EU AI Act Article 50(2): expose the marking as a non-secret provenance view
+    # (spec/provider/model/generated_at + marked), verified server-side. The signature and
+    # content_id are withheld -- clients cannot verify the server-secret HMAC and content_id
+    # links to an internal AiApiLog row, so exposing them would only enable a bearer-token
+    # transplant. Returns nil (unmarked) for a board with no valid marker. See Art50Marker.
+    json['ai_generated'] = Art50Marker.public_view(board.settings['ai_generated'])
     json['sort_score'] = ((board.popularity || -1) + 1) * (board.any_upstream ? 1 : 2)
 
     list = [board.settings['locale'] || 'en']

--- a/spec/controllers/api/boards_controller_spec.rb
+++ b/spec/controllers/api/boards_controller_spec.rb
@@ -1353,6 +1353,50 @@ describe Api::BoardsController, :type => :controller do
     end
   end
 
+  describe "create (Art.50(2) marker persistence)" do
+    it "verifies and persists a valid AI-generated marker onto the saved board" do
+      token_user
+      marker = Art50Marker.build(provider: 'claude', model: 'claude-haiku-4-5-20251001')
+      request.headers['Content-Type'] = 'application/json'
+      post :create, params: {}, body: {board: {name: 'AI board', ai_generated: marker}}.to_json
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+      board = Board.find_by_path(json['board']['id'])
+      # full signed marker is persisted server-side (verifiable on re-save)
+      expect(board.settings['ai_generated']).to eq(marker)
+      expect(Art50Marker.verify(board.settings['ai_generated'])).to eq(true)
+      # but the create response exposes only the non-secret provenance view
+      expect(json['board']['ai_generated']['marked']).to eq(true)
+      expect(json['board']['ai_generated']['provider']).to eq(marker['provider'])
+      expect(json['board']['ai_generated']).not_to have_key('signature')
+    end
+
+    it "verifies and persists a valid marker via the form-encoded param path (string 'true' + string values)" do
+      # The JSON-body path sends marked:true (boolean); the Rails form-param path arrives
+      # with every value stringified, so marked becomes "true". Art50Marker.verify accepts
+      # both. This exercises that path + indifferent-access key handling end to end.
+      token_user
+      marker = Art50Marker.build(provider: 'claude', model: 'claude-haiku-4-5-20251001')
+      post :create, params: {board: {name: 'AI board', ai_generated: marker}}
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+      board = Board.find_by_path(json['board']['id'])
+      expect(Art50Marker.verify(board.settings['ai_generated'])).to eq(true)
+    end
+
+    it "silently drops a forged marker but still saves the board" do
+      token_user
+      marker = Art50Marker.build(provider: 'claude', model: 'm')
+      forged = marker.merge('provider' => 'evil-corp')
+      request.headers['Content-Type'] = 'application/json'
+      post :create, params: {}, body: {board: {name: 'b', ai_generated: forged}}.to_json
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+      board = Board.find_by_path(json['board']['id'])
+      expect(board.settings['ai_generated']).to be_nil
+    end
+  end
+
   describe "generate_labels" do
     it "should reject non-object JSON body" do
       token_user

--- a/spec/lib/art50_marker_spec.rb
+++ b/spec/lib/art50_marker_spec.rb
@@ -114,4 +114,39 @@ describe Art50Marker do
       expect(described_class.public_view({ 'marked' => true })).to be_nil
     end
   end
+
+  describe '.normalized' do
+    let(:marker) { described_class.build(provider: 'claude', model: 'claude-haiku-4-5-20251001') }
+
+    it 'returns a verified marker unchanged when it carries only canonical keys' do
+      normalized = described_class.normalized(marker)
+      expect(normalized).to eq(marker)
+      expect(described_class.verify(normalized)).to eq(true)
+    end
+
+    it 'strips unsigned keys a client padded onto an otherwise-valid marker' do
+      padded = marker.merge('evil' => '<script>', 'extra' => { 'nested' => true })
+      # the padded marker still verifies (sign ignores unsigned keys) ...
+      expect(described_class.verify(padded)).to eq(true)
+      # ... but normalizing drops everything the server did not sign
+      normalized = described_class.normalized(padded)
+      expect(normalized).to eq(marker)
+      expect(normalized).not_to have_key('evil')
+      expect(normalized).not_to have_key('extra')
+      expect(described_class.verify(normalized)).to eq(true)
+    end
+
+    it 'keeps every field the signature covers (dropping content_id would break verify)' do
+      normalized = described_class.normalized(marker)
+      described_class::PERSIST_KEYS.each { |k| expect(normalized).to have_key(k) }
+      expect(normalized['content_id']).to eq(marker['content_id'])
+      expect(normalized['signature']).to eq(marker['signature'])
+    end
+
+    it 'returns nil for a forged, missing, or malformed marker' do
+      expect(described_class.normalized(marker.merge('model' => 'tampered'))).to be_nil
+      expect(described_class.normalized(nil)).to be_nil
+      expect(described_class.normalized({ 'marked' => true })).to be_nil
+    end
+  end
 end

--- a/spec/lib/art50_marker_spec.rb
+++ b/spec/lib/art50_marker_spec.rb
@@ -91,4 +91,27 @@ describe Art50Marker do
       expect(described_class.marked?(nil)).to eq(false)
     end
   end
+
+  describe '.public_view' do
+    let(:marker) { described_class.build(provider: 'claude', model: 'claude-haiku-4-5-20251001') }
+
+    it 'returns the non-secret provenance fields and withholds signature + content_id' do
+      view = described_class.public_view(marker)
+      expect(view).to eq({
+        'marked' => true,
+        'spec' => 'eu-ai-act-art50-2',
+        'provider' => 'claude',
+        'model' => 'claude-haiku-4-5-20251001',
+        'generated_at' => marker['generated_at']
+      })
+      expect(view).not_to have_key('signature')
+      expect(view).not_to have_key('content_id')
+    end
+
+    it 'returns nil for a forged, missing, or malformed marker' do
+      expect(described_class.public_view(marker.merge('provider' => 'evil'))).to be_nil
+      expect(described_class.public_view(nil)).to be_nil
+      expect(described_class.public_view({ 'marked' => true })).to be_nil
+    end
+  end
 end

--- a/spec/models/board_art50_marking_spec.rb
+++ b/spec/models/board_art50_marking_spec.rb
@@ -79,6 +79,20 @@ describe 'Board Art.50(2) marker persistence' do
       b.process({'name' => 'renamed'}, {user: u, author: u})
       expect(b.reload.settings).not_to have_key('ai_generated')
     end
+
+    it 'strips unsigned client-supplied keys, persisting only the canonical signed marker' do
+      # A client can pad an otherwise-valid marker with extra keys: the signature ignores
+      # unsigned fields so it still verifies. process_params must normalize before persist so
+      # those keys never ride along inside the stored (and later cloned/exported) marker.
+      u = User.create
+      padded = valid_marker.merge('evil' => '<script>alert(1)</script>', 'admin' => true)
+      b = Board.process_new({'name' => 'b', 'ai_generated' => padded}, {user: u, author: u})
+      stored = b.reload.settings['ai_generated']
+      expect(stored).to eq(valid_marker)
+      expect(stored).not_to have_key('evil')
+      expect(stored).not_to have_key('admin')
+      expect(Art50Marker.verify(stored)).to eq(true)
+    end
   end
 
   describe 'propagation through copy_for / BoardCloner' do
@@ -95,6 +109,27 @@ describe 'Board Art.50(2) marker persistence' do
     it 'leaves a copy unmarked when the source has no marker' do
       u = User.create
       src = Board.create(user: u, public: true)
+      copy = src.copy_for(u)
+      expect(copy.settings['ai_generated']).to be_nil
+    end
+
+    it 'normalizes on copy: unsigned keys on an at-rest marker do not propagate' do
+      u = User.create
+      src = Board.create(user: u, public: true)
+      src.settings['ai_generated'] = valid_marker.merge('evil' => 'x')
+      src.save
+      copy = src.copy_for(u)
+      expect(copy.settings['ai_generated']).to eq(valid_marker)
+      expect(copy.settings['ai_generated']).not_to have_key('evil')
+    end
+
+    it 'does not propagate an at-rest marker that no longer verifies' do
+      u = User.create
+      src = Board.create(user: u, public: true)
+      # a tampered/forged marker sitting in settings (e.g. written by a legacy path) must
+      # not be carried onto the copy -- the cloner re-verifies via Art50Marker.normalized
+      src.settings['ai_generated'] = valid_marker.merge('model' => 'tampered')
+      src.save
       copy = src.copy_for(u)
       expect(copy.settings['ai_generated']).to be_nil
     end

--- a/spec/models/board_art50_marking_spec.rb
+++ b/spec/models/board_art50_marking_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# EU AI Act Article 50(2) durable persistence (slice 2). The signed provenance
+# marker minted in slice 1 (lib/art50_marker.rb) must survive a board save, be
+# verified server-side (never trust client input), propagate through copies, stay
+# inline through content offload, and be machine-readable in the JSON API output.
+describe 'Board Art.50(2) marker persistence' do
+  let(:valid_marker) { Art50Marker.build(provider: 'claude', model: 'claude-haiku-4-5-20251001') }
+
+  # BoardDownstreamButtonSet rows can be committed outside the per-example fixture
+  # transaction by other specs and survive across runs (see docs/task-management notes on
+  # test-DB orphan rows). Stale rows encrypted under a different key raise
+  # OpenSSL::Cipher::CipherError ("bad decrypt") when copy_for regenerates button sets here.
+  # Clear them per example so this file is deterministic regardless of leftover pollution.
+  before(:each) { BoardDownstreamButtonSet.delete_all }
+
+  describe 'verify-on-save (Board#process_params)' do
+    it 'persists a valid, server-signed marker onto settings on update' do
+      u = User.create
+      b = Board.create(user: u)
+      b.process({'ai_generated' => valid_marker}, {user: u, author: u})
+      expect(b.reload.settings['ai_generated']).to eq(valid_marker)
+      expect(Art50Marker.marked?(b.settings)).to eq(true)
+    end
+
+    it 'persists a valid marker on create (process_new)' do
+      u = User.create
+      b = Board.process_new({'name' => 'AI board', 'ai_generated' => valid_marker}, {user: u, author: u})
+      expect(b.persisted?).to eq(true)
+      expect(b.settings['ai_generated']).to eq(valid_marker)
+      expect(Art50Marker.verify(b.settings['ai_generated'])).to eq(true)
+    end
+
+    it 'silently drops a forged marker (bad signature) without breaking the save' do
+      u = User.create
+      forged = valid_marker.merge('provider' => 'evil-corp')
+      b = Board.process_new({'name' => 'b', 'ai_generated' => forged}, {user: u, author: u})
+      expect(b.persisted?).to eq(true)
+      expect(b.settings['ai_generated']).to be_nil
+    end
+
+    it 'silently drops a structurally invalid marker (not a signed hash)' do
+      u = User.create
+      b = Board.process_new({'name' => 'b', 'ai_generated' => {'marked' => true}}, {user: u, author: u})
+      expect(b.persisted?).to eq(true)
+      expect(b.settings['ai_generated']).to be_nil
+    end
+
+    it 'never lets a forged marker overwrite an existing valid one' do
+      u = User.create
+      b = Board.create(user: u)
+      b.settings['ai_generated'] = valid_marker
+      b.save
+      forged = valid_marker.merge('model' => 'tampered')
+      b.process({'ai_generated' => forged}, {user: u, author: u})
+      expect(b.reload.settings['ai_generated']).to eq(valid_marker)
+    end
+
+    it 'lets a valid harvested marker overwrite an existing valid one (accepted bearer behavior)' do
+      # The marker is a provenance BEARER token by design (see lib/art50_marker.rb): a
+      # genuine server-signed marker verifies regardless of which board carries it, so a
+      # second valid marker replaces a first. This test locks that in as a deliberate,
+      # documented tradeoff (per-board provenance sub-fields are not board-authenticated).
+      u = User.create
+      b = Board.create(user: u)
+      first = Art50Marker.build(provider: 'claude', model: 'first')
+      second = Art50Marker.build(provider: 'claude', model: 'second')
+      b.settings['ai_generated'] = first
+      b.save
+      b.process({'ai_generated' => second}, {user: u, author: u})
+      expect(b.reload.settings['ai_generated']).to eq(second)
+    end
+
+    it 'leaves settings untouched when no marker is supplied' do
+      u = User.create
+      b = Board.create(user: u)
+      b.process({'name' => 'renamed'}, {user: u, author: u})
+      expect(b.reload.settings).not_to have_key('ai_generated')
+    end
+  end
+
+  describe 'propagation through copy_for / BoardCloner' do
+    it 'carries a valid marker onto a copy' do
+      u = User.create
+      src = Board.create(user: u, public: true)
+      src.settings['ai_generated'] = valid_marker
+      src.save
+      copy = src.copy_for(u)
+      expect(copy.settings['ai_generated']).to eq(valid_marker)
+      expect(Art50Marker.verify(copy.settings['ai_generated'])).to eq(true)
+    end
+
+    it 'leaves a copy unmarked when the source has no marker' do
+      u = User.create
+      src = Board.create(user: u, public: true)
+      copy = src.copy_for(u)
+      expect(copy.settings['ai_generated']).to be_nil
+    end
+  end
+
+  describe 'content offload round-trip (BoardContent)' do
+    it 'keeps the marker inline and valid after offloading buttons/grid/etc.' do
+      u = User.create
+      b = Board.create(user: u)
+      b.settings['ai_generated'] = valid_marker
+      b.settings['buttons'] = [{'id' => 1, 'label' => 'hi'}]
+      b.settings['grid'] = {'rows' => 1, 'columns' => 1, 'order' => [[1]]}
+      b.save
+      BoardContent.generate_from(b)
+      b.reload
+      # offload actually happened (content lives on a BoardContent record now), but the
+      # marker is not an offloadable attribute, so it stays inline on board.settings
+      expect(b.board_content_id).to be_present
+      expect(b.board_content_id).to be > 0
+      expect(b.settings['ai_generated']).to eq(valid_marker)
+      expect(Art50Marker.verify(b.settings['ai_generated'])).to eq(true)
+      # and the offloaded content is still loadable alongside the inline marker
+      expect(BoardContent.load_content(b, 'buttons')).to eq([{'id' => 1, 'label' => 'hi'}])
+    end
+  end
+
+  describe 'machine-readability in JSON API output' do
+    it 'exposes a non-secret provenance view (no signature, no content_id)' do
+      u = User.create
+      b = Board.create(user: u)
+      b.settings['ai_generated'] = valid_marker
+      b.save
+      json = JsonApi::Board.build_json(b.reload)
+      expect(json['ai_generated']).to eq({
+        'marked' => true,
+        'spec' => 'eu-ai-act-art50-2',
+        'provider' => valid_marker['provider'],
+        'model' => valid_marker['model'],
+        'generated_at' => valid_marker['generated_at']
+      })
+      # the server-secret signature and the AiApiLog-linking content_id are NOT exposed
+      expect(json['ai_generated']).not_to have_key('signature')
+      expect(json['ai_generated']).not_to have_key('content_id')
+    end
+
+    it 'reports nil for a board with no marker' do
+      u = User.create
+      b = Board.create(user: u)
+      json = JsonApi::Board.build_json(b.reload)
+      expect(json['ai_generated']).to be_nil
+    end
+
+    it 'reports nil (unmarked) for a forged marker that somehow reached settings' do
+      u = User.create
+      b = Board.create(user: u)
+      b.settings['ai_generated'] = valid_marker.merge('model' => 'tampered')
+      b.save
+      json = JsonApi::Board.build_json(b.reload)
+      expect(json['ai_generated']).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## What

Slice 2 of EU AI Act Article 50(2) machine-readable marking. Slice 1 (#505) minted a signed AI-generation marker but only returned it on the transient `generate_labels` response, so **saved / copied / API-read boards were unmarked**. This makes the marking durable.

## Changes

**Backend**
- **`Board#process_params`** — verify a client-supplied `ai_generated` marker with `Art50Marker.verify` and persist onto `settings` **only if valid**. Missing / malformed / forged markers are silently dropped and never overwrite an existing valid marker (client input is never trusted). Guarded so a marker problem can never break a board save, including the Resque-worker path where `lib/` autoload is skipped (workers carry no client marker anyway).
- **`BoardCloner`** — propagate the marker onto copies. This is the *real* clone allowlist (`copy_for` delegates to `BoardCloner.call`). `ai_generated` is not in `BoardContent::OFFLOADABLE_ATTRIBUTES`, so it stays inline through content offload.
- **`JsonApi::Board`** — expose a **non-secret provenance view** via new `Art50Marker.public_view` (`marked/spec/provider/model/generated_at`), verified server-side. `signature` and `content_id` are **withheld**: clients cannot verify the server-secret HMAC, and `content_id` links to an internal `AiApiLog` row, so exposing them would only enable a bearer-token transplant that mislinks per-board provenance. The full signed marker still lives in `board.settings`.

**Frontend (Ember 3.28 / Node 20)**
- `board.js`: `ai_generated: attr('raw')` (serializes on save, round-trips on read).
- `create-board-new.js` and `generate-board.js`: capture `res.ai_generated` from the generation response into the board-save payload.

Marking stays **UNCONDITIONAL** (no feature flag).

## Tests

47 examples, 0 failures: verify-on-save (create+update persist, forged/invalid dropped, never-overwrites-valid, no-marker untouched), form-encoded param path, `copy_for` propagation, offload round-trip, `public_view` unit tests, and the narrowed API view (signature/content_id absent, forged reads as unmarked). A file-scoped `BoardDownstreamButtonSet.delete_all` guards against orphan-row bad-decrypt pollution (PR #367 pattern). `json_api/board_spec` regression-clean.

## Review

Claude `adversary` pass: **ship with conditions, no Critical/High**. All four locked security properties hold (unforgeable HMAC, dropped-on-invalid, never-breaks-save incl. worker path, forged-never-overwrites-valid). The one **Medium** (bearer-transplant → `AiApiLog` mislinkage) is **resolved** by the non-secret-subset API view above. Codex `/review-pr` intentionally skipped (compliance-adjacent = Claude-only per repo policy).

## Not in scope / follow-ups

- **Art.50(2) register stays OPEN.** This PR does not close it.
- Unmarked AI-output paths remain: `generate_focus_words` (AiFocusWordSet cache), `AiWordPredictor.predict`, eval narration.
- Art.50(1) disclosure modal rides the separate COPPA VPC chain.
- **Two deferred adversary Lows to record in the Art.50(2) compliance document:**
  1. OBF/OBZ export/import does not carry the marker → export→reimport launders AI provenance (under-marking).
  2. `SECURE_ENCRYPTION_KEY` rotation invalidates all persisted markers (also breaks `secure_serialize` app-wide, so effectively never rotated).
- Frontend verified by code-reading, not runtime (`ember test` only lints; QUnit unit specs do not execute — AMD loader defect). CI lints the JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqq9wdV6eAyK99QQJcJUoG