### PR TITLE
compliance: Art.50(2) persist-path require_relative parity (follow-up to #507)

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1,3 +1,9 @@
+# EU AI Act Article 50(2) marker verification. Required explicitly (not left to
+# Zeitwerk) for parity with app/cloners/board_cloner.rb and lib/json_api/board.rb,
+# so the persist path below stays deterministic even where lib/ autoload is skipped
+# (RESQUE_WORKER=='true'); require_relative loads it regardless of the autoloader.
+require_relative '../../lib/art50_marker'
+
 class Board < ApplicationRecord
   DEFAULT_ICON = "/images/lingolinq-board-icon.png"
   TRANSLATION_LANGUAGE_LABELS = {
@@ -1885,11 +1891,13 @@ class Board < ApplicationRecord
     self.settings['small_header'] = params['small_header'] if params['small_header'] != nil
     # EU AI Act Article 50(2): if the client supplied an AI-generation marker, persist
     # it onto settings ONLY if it verifies as a genuine, server-signed marker. Client
-    # input is never trusted: a missing, malformed, or forged marker is silently dropped
-    # and never overwrites an existing valid marker. Marking is unconditional (no feature
-    # flag); see lib/art50_marker.rb. verify never raises, but we still guard so a marker
-    # problem can never break a board save -- including the Resque-worker path where lib/
-    # autoload is skipped and Art50Marker may be undefined (workers carry no client marker).
+    # input is never trusted: a missing, malformed, or forged marker is silently dropped,
+    # leaving any existing valid marker intact (the assignment is guarded on `marker`);
+    # only a freshly verified marker replaces the stored one. Marking is unconditional
+    # (no feature flag); see lib/art50_marker.rb. verify never raises, but we still guard
+    # so a marker problem can never break a board save. Art50Marker is require_relative'd
+    # at the top of this file, so it is defined even on the Resque-worker path where lib/
+    # autoload is skipped.
     if params['ai_generated']
       begin
         marker = Art50Marker.normalized(params['ai_generated'])


### PR DESCRIPTION
## What
Two small hardening edits to `app/models/board.rb`, following up the Claude adversary re-review of #507 (already merged to staging).

1. **`require_relative '../../lib/art50_marker'`** at the top of `board.rb`, for parity with the two sibling call sites (`app/cloners/board_cloner.rb:3`, `lib/json_api/board.rb:2`) that already require it.
2. **Corrected the persist-path comment** to match actual behavior.

## Why (the Medium finding)
The save path (`board.rb` ~line 1895) calls `Art50Marker.normalized` but was the only call site relying on Zeitwerk autoload. `lib/` autoload is skipped when `ENV['RESQUE_WORKER']=='true'` (`config/application.rb`), so on the worker path the constant could be undefined; the surrounding rescue would then convert the `NameError` into a `warn` and **silently drop a valid marker** — a fail-open on an EU AI Act Article 50(2) marking control. `require_relative` loads the file independent of the autoloader, removing the load-order dependency.

The comment previously said a dropped marker "never overwrites an existing valid marker." That conflated two cases: a forged/dropped marker leaves an existing valid marker **intact** (the assignment is guarded on `marker`), while a freshly verified marker **does** replace the stored one. Both are already locked in by `spec/models/board_art50_marking_spec.rb` (the "never lets a forged marker overwrite" and the bearer-overwrite examples).

## Not in scope (tracked follow-ups)
- **High — server-authoritative stamping.** Marking is currently client-cooperative: the server mints the marker but relies on the client to echo it back on save, so a non-cooperating client persists an AI board unmarked. This is a slice-3 architectural change; **EU AI Act Article 50(2) stays OPEN** on the findings register pending it.
- **Medium — key rotation** de-marks existing boards (no key-id/version on the marker); document that durability is bounded by the app-secret lifetime.
- **Medium — bearer/transplant** over-marking is an accepted, documented tradeoff.

## Verification
- `RAILS_ENV=production bundle exec rails zeitwerk:check` → clean ("All is good!"); no eager-load conflict from requiring in a Zeitwerk-managed model.
- `rspec spec/models/board_art50_marking_spec.rb spec/lib/art50_marker_spec.rb spec/controllers/api/boards_controller_spec.rb` → art50 model/lib/controller examples green. The single `boards_controller_spec.rb:312` failure is the known `BoardLocale.count` orphan-row test-DB pollution (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)