### PR TITLE
compliance(flusher): implement Flusher.flush_leftovers retention cleanup (LL-991d259b2a)

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "7e6edf129c73aa25180cadcead6465e67bfc299638ad34a27eaa76a5a1211509",
+      "contentHash": "f2e7580b911ef2c3051e1aaf02ef70d7abebc9ccbe3218a02ffaf42b20923de6",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `7e6edf129c73` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `f2e7580b911e` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -3005,6 +3005,33 @@
         "promotedDate": "2026-06-23"
       },
       "notes": "Promoted from claude-compliance-officer review on 2026-06-23. bin/audit_console is the documented audited-console wrapper (CLAUDE.md Security section: console access audited via AuditEvent). It still shells to the Heroku CLI (heroku auth:whoami; heroku run -a lingolinq). LingoLinq runs on Render and the legacy Heroku app is gone, so the wrapper cannot attach a console in the live environment and the per-session AuditEvent it is meant to record is not produced on Render. Net effect: the audited-console control is not operative on the current platform; privileged console access to a system holding regulated student/patient data is not captured by this path. Code/path evidence only."
+    },
+    {
+      "id": "LL-5d7197fa7d",
+      "ruleKey": "papertrail-stale-item-type-retention-undecided",
+      "title": "PaperTrail versions with unconstantizable item_type are detected but retention disposition is undecided",
+      "severity": "low",
+      "confidence": "medium",
+      "frameworks": [
+        "HIPAA",
+        "FERPA"
+      ],
+      "status": "open",
+      "evidence": {
+        "type": "code",
+        "file": "lib/flusher.rb",
+        "line": 116,
+        "snippet": "docs/legal/DATA_RETENTION.md:30, authentication/audit-trail paper_trail",
+        "sha": "84f573b34cba5c4212f4e0948abf92a20335609c"
+      },
+      "firstSeen": "2026-07-02",
+      "lastSeen": "2026-07-02",
+      "owner": "unassigned",
+      "remediation": {
+        "options": "Flusher.flush_leftovers now detects and counts PaperTrail::Version rows whose item_type no longer constantizes to a live model class, but deliberately does not delete them: DATA_RETENTION.md:30 requires 6-year retention with cold-storage archival for authentication/audit-trail paper_trail versions (User/Board/LogSession), and an unconstantizable item_type only proves the class was renamed/removed (this app is itself a rename of CoughDrop/SweetSuite), not that the audit evidence is disposable. Needs a real decision: (a) confirm which stale item_types are true dead weight vs. pre-rename aliases of a live model that should be treated as that model, (b) build actual cold-storage archival before any of these rows are ever deleted, per the existing retention schedule.",
+        "timeframe": "60d"
+      },
+      "notes": "Filed per Codex PR review of the LL-991d259b2a flush_leftovers implementation (PR branch scot/compliance/flush-leftovers-retention): the original approach would have deleted these rows outright; changed to report-only pending this decision."
     }
   ]
 }

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -9,7 +9,7 @@
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (42)
+## Open (43)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -52,6 +52,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-2695434541 |  | low | SOC2 | **accepted** | audit-run | Puma Gemfile constraint permits 7.2.0 which predates the CVE-2026-47736/47737 fix; floor unset | `Gemfile`:62 |
 | LL-b0bc6880e6 |  | low | SOC2 | **accepted** | audit-run | sync-render-secrets.yml (holds RENDER_API_KEY + 1Password token) declares no permissions: block, inheriting default write GITHUB_TOKEN | `.github/workflows/sync-render-secrets.yml`:14 |
 | LL-e76d6378b5 |  | low |  | **accepted** | audit-run | Webhook model declares notifications and content_type attrs that Rails never serializes | `app/frontend/app/models/webhook.js`:12 |
+| LL-5d7197fa7d |  | low | HIPAA, FERPA | untriaged | audit-run | PaperTrail versions with unconstantizable item_type are detected but retention disposition is undecided | `lib/flusher.rb`:116 |
 | LL-941001ca58 | Dep-eslint-8-eol | low | SOC2 | **accepted** | audit-run | eslint 8.57.1 is EOL (v8 end-of-life); dev toolchain on an unsupported linter | `app/frontend/package.json`:64 |
 | LL-a97357136e | P2-2 | low | SOC2 | **wontfix** | audit-run | params.permit! bypasses Strong Parameters | `app/controllers/api/organizations_controller.rb`:866 |
 | LL-ce00c8d3ad | P2-3 | low |  | **wontfix** | audit-run | License model lacks Processable concern | `app/models/license.rb`:1 |
@@ -113,4 +114,4 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 
 ---
 
-_82 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._
+_83 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-06-24T19:47:40Z
+**Page generated:** 2026-07-03T00:33:35Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **2** | 24 | 16 |
+| **0** | **2** | 24 | 17 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -56,6 +56,7 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-41d2d553ab |  | low |  | Integration JSON emits a debug junk key (asdf) consumed by no Ember model | `lib/json_api/integration.rb`:67 |
 | LL-553fdc242b |  | low | SOC2 | davidshimjs-qrcodejs 0.0.2 is abandoned (no release since 2014, >10 years) | `app/frontend/package.json`:36 |
 | LL-5a173ce87f |  | low |  | Utterance Rails builder emits created_at but Ember model declares timestamp instead | `app/frontend/app/models/utterance.js`:15 |
+| LL-5d7197fa7d |  | low | HIPAA, FERPA | PaperTrail versions with unconstantizable item_type are detected but retention disposition is undecided | `lib/flusher.rb`:116 |
 | LL-5f0f4f52f8 |  | low | SOC2 | Audit system files (.claude/) are not in any finder scan scope (no self-audit) | `.claude/agents/infra-auditor.md`:62 |
 | LL-6447a21503 |  | low |  | Organization model declares total_extras attribute but Rails builder never emits it | `app/frontend/app/models/organization.js`:42 |
 | LL-97f9001bb4 |  | low | SOC2 | Audit finder Bash guard is a denylist with residual fetch-and-exec bypass | `.claude/hooks/audit-readonly-guard.sh`:59 |

--- a/db/migrate/20260702120000_add_retention_cleanup_indexes.rb
+++ b/db/migrate/20260702120000_add_retention_cleanup_indexes.rb
@@ -1,0 +1,18 @@
+class AddRetentionCleanupIndexes < ActiveRecord::Migration[7.2]
+  # Concurrent index creation so the build does not take a write-blocking lock on
+  # these actively-written tables. Supports the orphan anti-joins and age scans
+  # added in Flusher.flush_leftovers (LL-991d259b2a).
+  disable_ddl_transaction!
+
+  def up
+    add_index :board_button_sounds, :button_sound_id, algorithm: :concurrently
+    add_index :progresses, :created_at, algorithm: :concurrently
+    add_index :log_session_boards, :log_session_id, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :board_button_sounds, column: :button_sound_id, algorithm: :concurrently
+    remove_index :progresses, column: :created_at, algorithm: :concurrently
+    remove_index :log_session_boards, column: :log_session_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_21_120003) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_02_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -170,6 +170,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_120003) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["board_id"], name: "index_board_button_sounds_on_board_id"
+    t.index ["button_sound_id"], name: "index_board_button_sounds_on_button_sound_id"
   end
 
   create_table "board_contents", id: :serial, force: :cascade do |t|
@@ -423,6 +424,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_120003) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["board_id", "log_session_id"], name: "index_log_session_boards_on_board_id_and_log_session_id"
+    t.index ["log_session_id"], name: "index_log_session_boards_on_log_session_id"
   end
 
   create_table "log_sessions", id: :serial, force: :cascade do |t|
@@ -545,6 +547,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_120003) do
     t.datetime "finished_at", precision: nil
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["created_at"], name: "index_progresses_on_created_at"
     t.index ["nonce"], name: "index_progresses_on_nonce"
   end
 
@@ -617,7 +620,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_21_120003) do
     t.index ["communicator_user_id"], name: "index_supervisor_relationships_on_communicator_user_id"
     t.index ["consent_response_token"], name: "index_supervisor_rel_consent_token", unique: true, where: "(consent_response_token IS NOT NULL)"
     t.index ["consent_token_expires_at"], name: "index_supervisor_rel_pending_expiry", where: "((status)::text = 'pending'::text)"
-    t.index ["supervisor_user_id", "communicator_user_id"], name: "index_supervisor_rel_active_pair", unique: true, where: "((status)::text = ANY ((ARRAY['pending'::character varying, 'approved'::character varying])::text[]))"
+    t.index ["supervisor_user_id", "communicator_user_id"], name: "index_supervisor_rel_active_pair", unique: true, where: "((status)::text = ANY (ARRAY[('pending'::character varying)::text, ('approved'::character varying)::text]))"
     t.index ["supervisor_user_id"], name: "index_supervisor_relationships_on_supervisor_user_id"
   end
 

--- a/lib/flusher.rb
+++ b/lib/flusher.rb
@@ -54,30 +54,31 @@ module Flusher
   # follow-up: decide whether developer keys should expire at all before
   # writing deletion logic for them (see LL-991d259b2a).
   def self.flush_leftovers
-    # 1. removable button_sounds at least a week old with no board connections left.
-    #    "No board connections" means BOTH no board_button_sounds join row AND no
-    #    direct board_id -- a sound can be tied to a board either way, and the join
-    #    table alone is not a complete signal (see the button_images note below for
-    #    why relying on a single join table is risky). Routed through flush_record
-    #    so the has_paper_trail(:on => [:destroy]) version gets cleaned up too.
-    #
-    #    NOTE: button_images are deliberately NOT included here. The plan's
-    #    original wording ("no board connections") assumed board_button_images
-    #    reflects live usage, the same way board_button_sounds does for sounds.
-    #    It doesn't: Board#map_images stopped calling BoardButtonImage.connect/
-    #    disconnect (see the commented-out calls around board.rb's map_images),
-    #    while BoardButtonSound.connect/disconnect are still active. Board image
-    #    usage is now derived purely from grid_buttons ('image_id' on each button,
-    #    see Board#known_button_images), not from the join table. Using
-    #    board_button_images as the orphan signal would treat every actively-used
-    #    image as orphaned and destroy it -- including its S3 file -- on the first
-    #    run. Left undone until image usage can be checked against grid_buttons (or
-    #    the join table is restored), rather than shipping a check known to delete
-    #    live data. See LL-991d259b2a.
-    button_sound_scope = ButtonSound.where(removable: true)
-      .where('button_sounds.created_at < ?', 1.week.ago)
-      .where(board_id: nil)
-      .left_joins(:board_button_sounds).where(board_button_sounds: { id: nil })
+    # 1. NOT IMPLEMENTED for either button_images or button_sounds. The plan's
+    #    wording ("no board connections") assumed the board_button_images/
+    #    board_button_sounds join tables reflect live usage. Neither can be trusted
+    #    for that on its own:
+    #    - board_button_images: Board#map_images stopped calling
+    #      BoardButtonImage.connect/disconnect entirely (see the commented-out
+    #      calls around board.rb's map_images). Board image usage is now derived
+    #      purely from grid_buttons ('image_id' on each button, see
+    #      Board#known_button_images), never from the join table. Using it as the
+    #      orphan signal would treat every actively-used image as orphaned.
+    #    - board_button_sounds: BoardButtonSound.connect/disconnect are still
+    #      called, but map_images can defer that resync to an async background
+    #      job (the @map_later flag, set by Board#swap_images and the batch
+    #      public/privacy toggle), via `self.schedule(:map_images, true)`
+    #      (BoyBand::AsyncInstanceMethods, i.e. a real Resque job, not
+    #      synchronous). During that window a sound already referenced by a
+    #      board's grid_buttons can have zero board_button_sounds rows, so a
+    #      join-table-only orphan check has a live-data-deletion race. Board#
+    #      known_button_sounds itself documents not relying on this join table
+    #      being in sync, for the same reason.
+    #    Both would need a grid_buttons-based reverse-usage check (the same
+    #    signal known_button_images/known_button_sounds use per-board) to be
+    #    implemented safely; that is real additional work, not a query tweak, so
+    #    it is left undone here rather than shipping either join-table check.
+    #    See LL-991d259b2a.
 
     # 2. board_button_images/board_button_sounds with no linked board, button_image,
     #    or button_sound. Neither join model is paper-trailed, so a batched
@@ -132,7 +133,6 @@ module Flusher
     # with no record of them. counts reflect what is ABOUT to be removed, not a
     # post-hoc tally, by design.
     counts = {
-      'button_sounds' => button_sound_scope.count,
       'board_button_images' => board_button_image_scope.count,
       'board_button_sounds' => board_button_sound_scope.count,
       'log_session_boards' => log_session_board_scope.count,
@@ -149,7 +149,6 @@ module Flusher
       data: counts
     )
 
-    button_sound_scope.find_each { |bs| flush_record(bs) }
     board_button_image_scope.in_batches.delete_all
     board_button_sound_scope.in_batches.delete_all
     log_session_board_scope.in_batches.delete_all

--- a/lib/flusher.rb
+++ b/lib/flusher.rb
@@ -209,18 +209,25 @@ module Flusher
     ids.each_slice(slice_size).sum { |slice| klass.where(id: slice).delete_all }
   end
 
-  # Deletes one flush_leftovers category and immediately records its own
-  # AuditEvent, so a category's deletion and its audit record land together --
-  # a later category raising can never leave an EARLIER category's real
-  # deletions with no audit trail at all.
+  # Deletes one flush_leftovers category and records its own AuditEvent, both
+  # inside a single transaction. delete_by_id_in_slices still issues one
+  # DELETE per 1000-id slice (so this never locks more than one category's
+  # worth of rows at a time, unlike wrapping the whole job in one transaction),
+  # but all of THIS category's slices plus its audit insert either all commit
+  # together or all roll back -- a slice or the audit write raising can never
+  # leave partially-deleted rows with no audit record, and can never leave an
+  # audit record claiming a deletion that got rolled back.
   def self.delete_and_record_category(category, klass, ids)
-    deleted = delete_by_id_in_slices(klass, ids)
-    AuditEvent.create!(
-      user_key: 'system',
-      event_type: 'retention_flush',
-      summary: "retention_flush category completed #{category}=#{deleted}",
-      data: { 'status' => 'category_completed', 'category' => category, 'count' => deleted }
-    )
+    deleted = nil
+    ActiveRecord::Base.transaction do
+      deleted = delete_by_id_in_slices(klass, ids)
+      AuditEvent.create!(
+        user_key: 'system',
+        event_type: 'retention_flush',
+        summary: "retention_flush category completed #{category}=#{deleted}",
+        data: { 'status' => 'category_completed', 'category' => category, 'count' => deleted }
+      )
+    end
     deleted
   end
   

--- a/lib/flusher.rb
+++ b/lib/flusher.rb
@@ -127,17 +127,28 @@ module Flusher
     stale_types = known_types.reject { |t| t.safe_constantize }
     stale_version_scope = stale_types.any? ? PaperTrail::Version.where(item_type: stale_types) : PaperTrail::Version.none
 
-    # Counts are computed BEFORE any deletion runs, and the AuditEvent is written
-    # before any deletion runs, so a failed audit write aborts the whole job (it
-    # raises out of flush_leftovers) instead of leaving deletions that happened
-    # with no record of them. counts reflect what is ABOUT to be removed, not a
-    # post-hoc tally, by design.
+    # Candidate ids are snapshotted BEFORE the AuditEvent is written, and deletion
+    # below targets exactly these snapshotted ids (not a re-evaluated scope), so
+    # the audit counts and what actually gets deleted can never drift apart: a row
+    # that becomes newly orphaned after the snapshot is simply left for the next
+    # run, rather than being deleted without ever appearing in an audit count (and
+    # a row that stops being orphaned in between still existed as orphaned at
+    # snapshot time, so counting and removing it is correct, not an overcount).
+    # The AuditEvent write itself still happens before any deletion runs, so a
+    # failed audit write aborts the whole job instead of leaving deletions that
+    # happened with no record of them.
+    board_button_image_ids = board_button_image_scope.pluck(:id)
+    board_button_sound_ids = board_button_sound_scope.pluck(:id)
+    log_session_board_ids = log_session_board_scope.pluck(:id)
+    progress_ids = progress_scope.pluck(:id)
+    user_board_connection_ids = user_board_connection_scope.pluck(:id)
+
     counts = {
-      'board_button_images' => board_button_image_scope.count,
-      'board_button_sounds' => board_button_sound_scope.count,
-      'log_session_boards' => log_session_board_scope.count,
-      'progresses' => progress_scope.count,
-      'user_board_connections' => user_board_connection_scope.count,
+      'board_button_images' => board_button_image_ids.length,
+      'board_button_sounds' => board_button_sound_ids.length,
+      'log_session_boards' => log_session_board_ids.length,
+      'progresses' => progress_ids.length,
+      'user_board_connections' => user_board_connection_ids.length,
       'versions_stale_type_detected_not_deleted' => stale_version_scope.count
     }
 
@@ -149,11 +160,11 @@ module Flusher
       data: counts
     )
 
-    board_button_image_scope.in_batches.delete_all
-    board_button_sound_scope.in_batches.delete_all
-    log_session_board_scope.in_batches.delete_all
-    progress_scope.in_batches.delete_all
-    user_board_connection_scope.in_batches.delete_all
+    BoardButtonImage.where(id: board_button_image_ids).in_batches.delete_all
+    BoardButtonSound.where(id: board_button_sound_ids).in_batches.delete_all
+    LogSessionBoard.where(id: log_session_board_ids).in_batches.delete_all
+    Progress.where(id: progress_ids).in_batches.delete_all
+    UserBoardConnection.where(id: user_board_connection_ids).in_batches.delete_all
     # versions_stale_type_detected_not_deleted: intentionally not deleted, see note above.
 
     counts

--- a/lib/flusher.rb
+++ b/lib/flusher.rb
@@ -124,50 +124,73 @@ module Flusher
     #    not a mechanical delete. Tracked as a follow-up finding (see
     #    audit-reports/FINDINGS.json) rather than implemented here.
     known_types = PaperTrail::Version.distinct.pluck(:item_type).compact
-    stale_types = known_types.reject { |t| t.safe_constantize }
-    stale_version_scope = stale_types.any? ? PaperTrail::Version.where(item_type: stale_types) : PaperTrail::Version.none
+    stale_types = known_types.reject do |t|
+      klass = t.safe_constantize
+      # safe_constantize succeeds for ANY resolvable Ruby constant (e.g. a stale
+      # item_type of 'File' would resolve to the built-in File class), not just
+      # live model classes, so a truthy check alone would wrongly treat those as
+      # "still a real model" and skip them.
+      klass.is_a?(Class) && klass < ActiveRecord::Base
+    end
+    stale_version_count = stale_types.any? ? PaperTrail::Version.where(item_type: stale_types).count : 0
 
-    # Candidate ids are snapshotted BEFORE the AuditEvent is written, and deletion
-    # below targets exactly these snapshotted ids (not a re-evaluated scope), so
-    # the audit counts and what actually gets deleted can never drift apart: a row
-    # that becomes newly orphaned after the snapshot is simply left for the next
-    # run, rather than being deleted without ever appearing in an audit count (and
-    # a row that stops being orphaned in between still existed as orphaned at
-    # snapshot time, so counting and removing it is correct, not an overcount).
-    # The AuditEvent write itself still happens before any deletion runs, so a
-    # failed audit write aborts the whole job instead of leaving deletions that
-    # happened with no record of them.
+    # Candidate ids are snapshotted before the "planned" AuditEvent is written, so
+    # a failed audit write aborts the whole job instead of leaving deletions with
+    # no record of them at all. A second "completed" AuditEvent below records the
+    # ACTUAL per-category delete_all counts once deletion finishes, so a partial
+    # failure part-way through (one category succeeds, a later one raises) is
+    # reflected accurately rather than the permanent audit trail claiming the
+    # full planned set was removed.
     board_button_image_ids = board_button_image_scope.pluck(:id)
     board_button_sound_ids = board_button_sound_scope.pluck(:id)
     log_session_board_ids = log_session_board_scope.pluck(:id)
     progress_ids = progress_scope.pluck(:id)
     user_board_connection_ids = user_board_connection_scope.pluck(:id)
 
-    counts = {
+    planned_counts = {
       'board_button_images' => board_button_image_ids.length,
       'board_button_sounds' => board_button_sound_ids.length,
       'log_session_boards' => log_session_board_ids.length,
       'progresses' => progress_ids.length,
       'user_board_connections' => user_board_connection_ids.length,
-      'versions_stale_type_detected_not_deleted' => stale_version_scope.count
+      'versions_stale_type_detected_not_deleted' => stale_version_count
     }
 
-    Rails.logger.info("[Flusher.flush_leftovers] #{counts.to_a.map { |k, v| "#{k}=#{v}" }.join(' ')}")
+    Rails.logger.info("[Flusher.flush_leftovers] planned #{planned_counts.to_a.map { |k, v| "#{k}=#{v}" }.join(' ')}")
     AuditEvent.create!(
       user_key: 'system',
       event_type: 'retention_flush',
-      summary: "retention_flush " + counts.to_a.map { |k, v| "#{k}=#{v}" }.join(' '),
-      data: counts
+      summary: "retention_flush planned " + planned_counts.to_a.map { |k, v| "#{k}=#{v}" }.join(' '),
+      data: planned_counts.merge('status' => 'planned')
     )
 
-    BoardButtonImage.where(id: board_button_image_ids).in_batches.delete_all
-    BoardButtonSound.where(id: board_button_sound_ids).in_batches.delete_all
-    LogSessionBoard.where(id: log_session_board_ids).in_batches.delete_all
-    Progress.where(id: progress_ids).in_batches.delete_all
-    UserBoardConnection.where(id: user_board_connection_ids).in_batches.delete_all
-    # versions_stale_type_detected_not_deleted: intentionally not deleted, see note above.
+    actual_counts = {
+      'board_button_images' => delete_by_id_in_slices(BoardButtonImage, board_button_image_ids),
+      'board_button_sounds' => delete_by_id_in_slices(BoardButtonSound, board_button_sound_ids),
+      'log_session_boards' => delete_by_id_in_slices(LogSessionBoard, log_session_board_ids),
+      'progresses' => delete_by_id_in_slices(Progress, progress_ids),
+      'user_board_connections' => delete_by_id_in_slices(UserBoardConnection, user_board_connection_ids),
+      # not deleted, see note above -- carried through for visibility only.
+      'versions_stale_type_detected_not_deleted' => stale_version_count
+    }
 
-    counts
+    Rails.logger.info("[Flusher.flush_leftovers] completed #{actual_counts.to_a.map { |k, v| "#{k}=#{v}" }.join(' ')}")
+    AuditEvent.create!(
+      user_key: 'system',
+      event_type: 'retention_flush',
+      summary: "retention_flush completed " + actual_counts.to_a.map { |k, v| "#{k}=#{v}" }.join(' '),
+      data: actual_counts.merge('status' => 'completed')
+    )
+
+    actual_counts
+  end
+
+  # Deletes exactly the given ids, in bounded slices so a large candidate set
+  # (this table has never been cleaned up before, so one could exist) never
+  # builds a single WHERE id IN (...) predicate past Postgres's ~65535
+  # bind-parameter limit. Returns the actual number of rows deleted.
+  def self.delete_by_id_in_slices(klass, ids, slice_size: 1000)
+    ids.each_slice(slice_size).sum { |slice| klass.where(id: slice).delete_all }
   end
   
   def self.flush_board(board_id, key, aggressive_flush=false)

--- a/lib/flusher.rb
+++ b/lib/flusher.rb
@@ -45,21 +45,119 @@ module Flusher
     PaperTrail::Version.where(:item_type => record_class, :item_id => record_db_id).delete_all
   end
   
+  # NOTE on item 3 ("expired developer keys"): DeveloperKey has no expiration
+  # concept anywhere in this codebase (no expires_at column, no settings blob,
+  # no expired? method). Session/device tokens expire (Device#settings['keys']),
+  # but a DeveloperKey is a permanent OAuth client registration. Implementing
+  # this item would mean inventing an unreviewed criterion for destroying live
+  # client credentials, so it is deliberately left undone here. Tracked as a
+  # follow-up: decide whether developer keys should expire at all before
+  # writing deletion logic for them (see LL-991d259b2a).
   def self.flush_leftovers
-    # 1. look for removable button_images and button_sounds and .destroy them if
-    #    they are at least a week old and there are no board connections for them
-    # 2. look for any board_button_images and board_button_sounds with no linked
-    #    board, button or sound and .destroy them (also note it somewhere, in case
-    #    there is a consistent leakage problem)
-    # 3. look for any expired developer keys and .destroy them
-    # 4. look for any log_session_boards that don't have a session or board
-    #    and .destroy them (also note in case consistent leakage)
-    # 5. look for any progress records more than a month old and destroy them
-    # 6. look for any user_board_connections with no linked board or user
-    #    and .destroy them (also note in case consistent leakage)
-    # 7. look for any paper trail versions that point to records that
-    #    don't exist anymore and .destroy them (also note in case consistent leakage)
-    # TODO: also prune old versions? The list will get huge soon...
+    # 1. removable button_sounds at least a week old with no board connections left.
+    #    "No board connections" means BOTH no board_button_sounds join row AND no
+    #    direct board_id -- a sound can be tied to a board either way, and the join
+    #    table alone is not a complete signal (see the button_images note below for
+    #    why relying on a single join table is risky). Routed through flush_record
+    #    so the has_paper_trail(:on => [:destroy]) version gets cleaned up too.
+    #
+    #    NOTE: button_images are deliberately NOT included here. The plan's
+    #    original wording ("no board connections") assumed board_button_images
+    #    reflects live usage, the same way board_button_sounds does for sounds.
+    #    It doesn't: Board#map_images stopped calling BoardButtonImage.connect/
+    #    disconnect (see the commented-out calls around board.rb's map_images),
+    #    while BoardButtonSound.connect/disconnect are still active. Board image
+    #    usage is now derived purely from grid_buttons ('image_id' on each button,
+    #    see Board#known_button_images), not from the join table. Using
+    #    board_button_images as the orphan signal would treat every actively-used
+    #    image as orphaned and destroy it -- including its S3 file -- on the first
+    #    run. Left undone until image usage can be checked against grid_buttons (or
+    #    the join table is restored), rather than shipping a check known to delete
+    #    live data. See LL-991d259b2a.
+    button_sound_scope = ButtonSound.where(removable: true)
+      .where('button_sounds.created_at < ?', 1.week.ago)
+      .where(board_id: nil)
+      .left_joins(:board_button_sounds).where(board_button_sounds: { id: nil })
+
+    # 2. board_button_images/board_button_sounds with no linked board, button_image,
+    #    or button_sound. Neither join model is paper-trailed, so a batched
+    #    delete_all (no flush_record needed) matches how flush_board_by_db_id
+    #    already cleans these same tables.
+    board_button_image_scope = BoardButtonImage.left_joins(:board, :button_image)
+      .where(boards: { id: nil }).or(
+        BoardButtonImage.left_joins(:board, :button_image).where(button_images: { id: nil })
+      )
+    board_button_sound_scope = BoardButtonSound.left_joins(:board, :button_sound)
+      .where(boards: { id: nil }).or(
+        BoardButtonSound.left_joins(:board, :button_sound).where(button_sounds: { id: nil })
+      )
+
+    # 4. log_session_boards with no linked log_session or board. Not paper-trailed.
+    log_session_board_scope = LogSessionBoard.left_joins(:log_session, :board)
+      .where(log_sessions: { id: nil }).or(
+        LogSessionBoard.left_joins(:log_session, :board).where(boards: { id: nil })
+      )
+
+    # 5. progress records more than a month old. Progress.clear_old_progresses
+    #    already prunes finished progresses after 7 days, but only opportunistically
+    #    (called from Progress.schedule) and only when finished_at is set, so a
+    #    crashed/never-finished progress record sits forever. This closes that gap
+    #    with an unconditional age check on created_at. Not paper-trailed.
+    progress_scope = Progress.where('progresses.created_at < ?', 1.month.ago)
+
+    # 6. user_board_connections with no linked board or user. Not paper-trailed.
+    user_board_connection_scope = UserBoardConnection.left_joins(:board, :user)
+      .where(boards: { id: nil }).or(
+        UserBoardConnection.left_joins(:board, :user).where(users: { id: nil })
+      )
+
+    # 7. paper trail versions whose item_type no longer maps to any model class
+    #    (e.g. a renamed/removed legacy model). REPORT-ONLY, not deleted: per
+    #    docs/legal/DATA_RETENTION.md:30, authentication/audit-trail paper_trail
+    #    versions (User/Board/LogSession) require 6-year retention with cold-storage
+    #    archival, not deletion. safe_constantize returning nil proves the CODE was
+    #    renamed/removed, not that the audit evidence those rows carry is disposable
+    #    -- a stale item_type could just as easily be a pre-rename class name (this
+    #    app is a rename of CoughDrop/SweetSuite) whose versions still matter. Log
+    #    and count for visibility; actual disposition needs a real archival decision,
+    #    not a mechanical delete. Tracked as a follow-up finding (see
+    #    audit-reports/FINDINGS.json) rather than implemented here.
+    known_types = PaperTrail::Version.distinct.pluck(:item_type).compact
+    stale_types = known_types.reject { |t| t.safe_constantize }
+    stale_version_scope = stale_types.any? ? PaperTrail::Version.where(item_type: stale_types) : PaperTrail::Version.none
+
+    # Counts are computed BEFORE any deletion runs, and the AuditEvent is written
+    # before any deletion runs, so a failed audit write aborts the whole job (it
+    # raises out of flush_leftovers) instead of leaving deletions that happened
+    # with no record of them. counts reflect what is ABOUT to be removed, not a
+    # post-hoc tally, by design.
+    counts = {
+      'button_sounds' => button_sound_scope.count,
+      'board_button_images' => board_button_image_scope.count,
+      'board_button_sounds' => board_button_sound_scope.count,
+      'log_session_boards' => log_session_board_scope.count,
+      'progresses' => progress_scope.count,
+      'user_board_connections' => user_board_connection_scope.count,
+      'versions_stale_type_detected_not_deleted' => stale_version_scope.count
+    }
+
+    Rails.logger.info("[Flusher.flush_leftovers] #{counts.to_a.map { |k, v| "#{k}=#{v}" }.join(' ')}")
+    AuditEvent.create!(
+      user_key: 'system',
+      event_type: 'retention_flush',
+      summary: "retention_flush " + counts.to_a.map { |k, v| "#{k}=#{v}" }.join(' '),
+      data: counts
+    )
+
+    button_sound_scope.find_each { |bs| flush_record(bs) }
+    board_button_image_scope.in_batches.delete_all
+    board_button_sound_scope.in_batches.delete_all
+    log_session_board_scope.in_batches.delete_all
+    progress_scope.in_batches.delete_all
+    user_board_connection_scope.in_batches.delete_all
+    # versions_stale_type_detected_not_deleted: intentionally not deleted, see note above.
+
+    counts
   end
   
   def self.flush_board(board_id, key, aggressive_flush=false)

--- a/lib/flusher.rb
+++ b/lib/flusher.rb
@@ -141,6 +141,15 @@ module Flusher
     # failure part-way through (one category succeeds, a later one raises) is
     # reflected accurately rather than the permanent audit trail claiming the
     # full planned set was removed.
+    #
+    # NOTE: pluck(:id) materializes each category's full candidate set in memory
+    # before any deletion starts (only the DELETE itself is chunked, by
+    # delete_by_id_in_slices). Accepted tradeoff, not fixed here: this app's real
+    # scale (a single AAC vendor's data, not a hyperscale table) makes an orphan
+    # backlog large enough to threaten worker memory (tens of millions of rows in
+    # one category) implausible even after this job has never run before. A
+    # cursor/find_in_batches rewrite would remove the assumption entirely if that
+    # ever stops being true.
     board_button_image_ids = board_button_image_scope.pluck(:id)
     board_button_sound_ids = board_button_sound_scope.pluck(:id)
     log_session_board_ids = log_session_board_scope.pluck(:id)
@@ -164,12 +173,19 @@ module Flusher
       data: planned_counts.merge('status' => 'planned')
     )
 
+    # Each category is deleted AND recorded immediately, one at a time, rather
+    # than accumulated into a single hash and written in one final AuditEvent.
+    # That way, if a later category (or the very next one) raises, every
+    # category that already finished still has its own durable audit record of
+    # what actually got deleted -- a partial failure can never leave deletions
+    # with zero audit trail, only the not-yet-reached categories are unrecorded
+    # (and undeleted, since they never ran).
     actual_counts = {
-      'board_button_images' => delete_by_id_in_slices(BoardButtonImage, board_button_image_ids),
-      'board_button_sounds' => delete_by_id_in_slices(BoardButtonSound, board_button_sound_ids),
-      'log_session_boards' => delete_by_id_in_slices(LogSessionBoard, log_session_board_ids),
-      'progresses' => delete_by_id_in_slices(Progress, progress_ids),
-      'user_board_connections' => delete_by_id_in_slices(UserBoardConnection, user_board_connection_ids),
+      'board_button_images' => delete_and_record_category('board_button_images', BoardButtonImage, board_button_image_ids),
+      'board_button_sounds' => delete_and_record_category('board_button_sounds', BoardButtonSound, board_button_sound_ids),
+      'log_session_boards' => delete_and_record_category('log_session_boards', LogSessionBoard, log_session_board_ids),
+      'progresses' => delete_and_record_category('progresses', Progress, progress_ids),
+      'user_board_connections' => delete_and_record_category('user_board_connections', UserBoardConnection, user_board_connection_ids),
       # not deleted, see note above -- carried through for visibility only.
       'versions_stale_type_detected_not_deleted' => stale_version_count
     }
@@ -191,6 +207,21 @@ module Flusher
   # bind-parameter limit. Returns the actual number of rows deleted.
   def self.delete_by_id_in_slices(klass, ids, slice_size: 1000)
     ids.each_slice(slice_size).sum { |slice| klass.where(id: slice).delete_all }
+  end
+
+  # Deletes one flush_leftovers category and immediately records its own
+  # AuditEvent, so a category's deletion and its audit record land together --
+  # a later category raising can never leave an EARLIER category's real
+  # deletions with no audit trail at all.
+  def self.delete_and_record_category(category, klass, ids)
+    deleted = delete_by_id_in_slices(klass, ids)
+    AuditEvent.create!(
+      user_key: 'system',
+      event_type: 'retention_flush',
+      summary: "retention_flush category completed #{category}=#{deleted}",
+      data: { 'status' => 'category_completed', 'category' => category, 'count' => deleted }
+    )
+    deleted
   end
   
   def self.flush_board(board_id, key, aggressive_flush=false)

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -38,6 +38,7 @@ end
 task :clean_old_deleted_boards => :environment do
   User.schedule_for(:slow, :flush_old_versions)
   Worker.schedule(Flusher, :flush_resque_errors)
+  Worker.schedule_for(:slow, Flusher, :flush_leftovers)
   puts "Cleaning old deleted boards..."
   count = DeletedBoard.flush_old_records
   JobStash.flush_old_records
@@ -126,6 +127,7 @@ task "scheduler:dispatch" => :environment do
     run_task.call("clean_old_deleted_boards") do
       User.schedule_for(:slow, :flush_old_versions)
       Worker.schedule(Flusher, :flush_resque_errors)
+      Worker.schedule_for(:slow, Flusher, :flush_leftovers)
       count = DeletedBoard.flush_old_records
       JobStash.flush_old_records
       "#{count} deleted"

--- a/spec/lib/flusher_spec.rb
+++ b/spec/lib/flusher_spec.rb
@@ -431,4 +431,208 @@ describe Flusher do
       expect(Worker.scheduled?(Flusher, :flush_user_completely, u3.global_id, u3.user_name)).to eq(false)
     end
   end
+
+  describe "flush_leftovers" do
+    it "should not error when there is nothing to flush" do
+      expect { Flusher.flush_leftovers }.to_not raise_error
+    end
+
+    it "should never destroy button_images -- board_button_images no longer reflects live usage" do
+      # Regression guard: Board#map_images stopped calling BoardButtonImage.connect
+      # for images (board.rb), so an actively-used image now has zero
+      # board_button_images rows -- the same state a genuinely orphaned image would
+      # be in. flush_leftovers must not use that join table as an orphan signal for
+      # images (it still can for sounds, whose connect/disconnect stayed active).
+      # This reproduces real usage via process_buttons + grid_buttons, not a manual
+      # BoardButtonImage.connect call, so it actually exercises the live code path.
+      u = User.create
+      old_in_use = ButtonImage.create(user: u, removable: true)
+      old_in_use.update_column(:created_at, 8.days.ago)
+      b = Board.create!(user: u)
+      b.process_buttons([{ 'id' => '1', 'label' => 'hat', 'image_id' => old_in_use.global_id }], u)
+      b.save
+      expect(BoardButtonImage.where(button_image_id: old_in_use.id).count).to eq(0)
+      Flusher.flush_leftovers
+      expect(ButtonImage.where(id: old_in_use.id).count).to eq(1)
+
+      old_orphan = ButtonImage.create(user: u, removable: true)
+      old_orphan.update_column(:created_at, 8.days.ago)
+      recent = ButtonImage.create(user: u, removable: true)
+      Flusher.flush_leftovers
+      expect(ButtonImage.where(id: old_orphan.id).count).to eq(1)
+      expect(ButtonImage.where(id: recent.id).count).to eq(1)
+    end
+
+    it "should destroy an orphaned removable button_sound older than a week", :versioning => true do
+      u = User.create
+      old_orphan = ButtonSound.create(user: u, removable: true)
+      old_orphan.update_column(:created_at, 8.days.ago)
+      Flusher.flush_leftovers
+      expect(ButtonSound.where(id: old_orphan.id).count).to eq(0)
+      expect(PaperTrail::Version.where(item_type: 'ButtonSound', item_id: old_orphan.id).count).to eq(0)
+    end
+
+    it "should not destroy an old removable button_sound with a direct board_id even without a board_button_sounds row" do
+      u = User.create
+      b = Board.create(user: u)
+      connected = ButtonSound.create(user: u, removable: true, board_id: b.id)
+      connected.update_column(:created_at, 8.days.ago)
+      expect(BoardButtonSound.where(button_sound_id: connected.id).count).to eq(0)
+      Flusher.flush_leftovers
+      expect(ButtonSound.where(id: connected.id).count).to eq(1)
+    end
+
+    it "should not destroy an old removable button_sound that still has a board connection" do
+      u = User.create
+      b = Board.create(user: u)
+      connected = ButtonSound.create(user: u, removable: true)
+      connected.update_column(:created_at, 8.days.ago)
+      BoardButtonSound.create!(board_id: b.id, button_sound_id: connected.id)
+      Flusher.flush_leftovers
+      expect(ButtonSound.where(id: connected.id).count).to eq(1)
+    end
+
+    it "should remove a board_button_image left dangling by a hard-deleted button_image" do
+      u = User.create
+      b = Board.create(user: u)
+      i = ButtonImage.create(user: u)
+      bbi = BoardButtonImage.create!(board_id: b.id, button_image_id: i.id)
+      i.delete
+      Flusher.flush_leftovers
+      expect(BoardButtonImage.where(id: bbi.id).count).to eq(0)
+    end
+
+    it "should remove a board_button_image left dangling by a hard-deleted board" do
+      u = User.create
+      b = Board.create(user: u)
+      i = ButtonImage.create(user: u)
+      bbi = BoardButtonImage.create!(board_id: b.id, button_image_id: i.id)
+      b.delete
+      Flusher.flush_leftovers
+      expect(BoardButtonImage.where(id: bbi.id).count).to eq(0)
+    end
+
+    it "should not remove a board_button_image with a live board and button_image" do
+      u = User.create
+      b = Board.create(user: u)
+      i = ButtonImage.create(user: u)
+      bbi = BoardButtonImage.create!(board_id: b.id, button_image_id: i.id)
+      Flusher.flush_leftovers
+      expect(BoardButtonImage.where(id: bbi.id).count).to eq(1)
+    end
+
+    it "should remove a board_button_sound left dangling by a hard-deleted button_sound" do
+      u = User.create
+      b = Board.create(user: u)
+      s = ButtonSound.create(user: u)
+      bbs = BoardButtonSound.create!(board_id: b.id, button_sound_id: s.id)
+      s.delete
+      Flusher.flush_leftovers
+      expect(BoardButtonSound.where(id: bbs.id).count).to eq(0)
+    end
+
+    it "should not remove a board_button_sound with a live board and button_sound" do
+      u = User.create
+      b = Board.create(user: u)
+      s = ButtonSound.create(user: u)
+      bbs = BoardButtonSound.create!(board_id: b.id, button_sound_id: s.id)
+      Flusher.flush_leftovers
+      expect(BoardButtonSound.where(id: bbs.id).count).to eq(1)
+    end
+
+    it "should remove a log_session_board left dangling by a hard-deleted log_session" do
+      u = User.create
+      d = Device.create(:user => u)
+      b = Board.create(user: u)
+      s = LogSession.create!(user: u, author: u, device: d)
+      lsb = LogSessionBoard.create!(log_session_id: s.id, board_id: b.id)
+      s.delete
+      Flusher.flush_leftovers
+      expect(LogSessionBoard.where(id: lsb.id).count).to eq(0)
+    end
+
+    it "should not remove a log_session_board with a live session and board" do
+      u = User.create
+      d = Device.create(:user => u)
+      b = Board.create(user: u)
+      s = LogSession.create!(user: u, author: u, device: d)
+      lsb = LogSessionBoard.create!(log_session_id: s.id, board_id: b.id)
+      Flusher.flush_leftovers
+      expect(LogSessionBoard.where(id: lsb.id).count).to eq(1)
+    end
+
+    it "should not touch developer keys -- there is no expiration concept for them (LL-991d259b2a)" do
+      key = DeveloperKey.create!
+      Flusher.flush_leftovers
+      expect(DeveloperKey.where(id: key.id).count).to eq(1)
+    end
+
+    it "should destroy progress records more than a month old" do
+      old = Progress.create!
+      old.update_column(:created_at, 40.days.ago)
+      recent = Progress.create!
+      Flusher.flush_leftovers
+      expect(Progress.where(id: old.id).count).to eq(0)
+      expect(Progress.where(id: recent.id).count).to eq(1)
+    end
+
+    it "should remove a user_board_connection left dangling by a hard-deleted user" do
+      u = User.create
+      b = Board.create(user: u)
+      ubc = UserBoardConnection.create!(user_id: u.id, board_id: b.id)
+      u.delete
+      Flusher.flush_leftovers
+      expect(UserBoardConnection.where(id: ubc.id).count).to eq(0)
+    end
+
+    it "should not remove a user_board_connection with a live user and board" do
+      u = User.create
+      b = Board.create(user: u)
+      ubc = UserBoardConnection.create!(user_id: u.id, board_id: b.id)
+      Flusher.flush_leftovers
+      expect(UserBoardConnection.where(id: ubc.id).count).to eq(1)
+    end
+
+    it "should report but not delete paper trail versions whose item_type no longer maps to any class" do
+      # PaperTrail::Version has a real polymorphic belongs_to :item, so .create!
+      # would itself raise NameError trying to resolve a bogus item_type (the gem's
+      # version_limit callback loads .item). Insert directly to simulate a version
+      # row left behind from a since-renamed/removed model, bypassing that check --
+      # the same way it would have been possible historically, before the rename.
+      #
+      # Per DATA_RETENTION.md:30, these rows require 6-year retention + cold-storage
+      # archival, not deletion -- an unconstantizable item_type only proves the code
+      # was renamed, not that the audit evidence is disposable. flush_leftovers must
+      # only report/count these, never delete them (see LL-991d259b2a follow-up).
+      PaperTrail::Version.insert!({ item_type: 'LegacyWidgetThatNoLongerExists', item_id: 12345, event: 'destroy', created_at: Time.now })
+      Flusher.flush_leftovers
+      expect(PaperTrail::Version.where(item_type: 'LegacyWidgetThatNoLongerExists').count).to eq(1)
+      ev = AuditEvent.where(event_type: 'retention_flush').order('id DESC').first
+      expect(ev.data['versions_stale_type_detected_not_deleted']).to eq(1)
+    end
+
+    it "should not remove paper trail versions for a real model class, even for a destroyed record (audit trail preservation)", :versioning => true do
+      PaperTrail.request.whodunnit = 'user:jane'
+      u = User.create
+      u.user_name = 'renamed'
+      u.save
+      u.reload
+      version_ids = u.versions.pluck(:id)
+      expect(version_ids).to_not be_empty
+      u.destroy
+      Flusher.flush_leftovers
+      expect(PaperTrail::Version.where(id: version_ids).count).to eq(version_ids.length)
+    end
+
+    it "should log a retention_flush AuditEvent with per-category counts" do
+      u = User.create
+      old_orphan = ButtonSound.create(user: u, removable: true)
+      old_orphan.update_column(:created_at, 8.days.ago)
+      Flusher.flush_leftovers
+      ev = AuditEvent.where(event_type: 'retention_flush').order('id DESC').first
+      expect(ev).to_not eq(nil)
+      expect(ev.user_key).to eq('system')
+      expect(ev.data['button_sounds']).to eq(1)
+    end
+  end
 end

--- a/spec/lib/flusher_spec.rb
+++ b/spec/lib/flusher_spec.rb
@@ -463,33 +463,35 @@ describe Flusher do
       expect(ButtonImage.where(id: recent.id).count).to eq(1)
     end
 
-    it "should destroy an orphaned removable button_sound older than a week", :versioning => true do
+    it "should never destroy button_sounds -- board_button_sounds sync can be deferred to an async job" do
+      # Regression guard: BoardButtonSound.connect/disconnect are still called (unlike
+      # images), but Board#map_images can defer that resync via @map_later to a real
+      # Resque job (Board#swap_images, the batch public/privacy toggle). During that
+      # window a sound already referenced by a board's grid_buttons can have zero
+      # board_button_sounds rows, so a join-table-only orphan check has a live-data-
+      # deletion race (the same underlying flaw as the button_images case above).
+      # flush_leftovers must not delete button_sounds via that signal at all.
       u = User.create
+      old_in_use = ButtonSound.create(user: u, removable: true)
+      old_in_use.update_column(:created_at, 8.days.ago)
+      b = Board.create!(user: u)
+      b.process_buttons([{ 'id' => '1', 'label' => 'moo', 'sound_id' => old_in_use.global_id }], u)
+      # Reproduce the real @map_later deferral (Board#swap_images / the batch
+      # public-privacy toggle set this instance variable before saving) so
+      # map_images defers to an async job instead of syncing board_button_sounds
+      # synchronously -- the exact window the join-table check would be blind to.
+      b.instance_variable_set('@map_later', true)
+      b.save
+      expect(BoardButtonSound.where(button_sound_id: old_in_use.id).count).to eq(0)
+      Flusher.flush_leftovers
+      expect(ButtonSound.where(id: old_in_use.id).count).to eq(1)
+
       old_orphan = ButtonSound.create(user: u, removable: true)
       old_orphan.update_column(:created_at, 8.days.ago)
+      recent = ButtonSound.create(user: u, removable: true)
       Flusher.flush_leftovers
-      expect(ButtonSound.where(id: old_orphan.id).count).to eq(0)
-      expect(PaperTrail::Version.where(item_type: 'ButtonSound', item_id: old_orphan.id).count).to eq(0)
-    end
-
-    it "should not destroy an old removable button_sound with a direct board_id even without a board_button_sounds row" do
-      u = User.create
-      b = Board.create(user: u)
-      connected = ButtonSound.create(user: u, removable: true, board_id: b.id)
-      connected.update_column(:created_at, 8.days.ago)
-      expect(BoardButtonSound.where(button_sound_id: connected.id).count).to eq(0)
-      Flusher.flush_leftovers
-      expect(ButtonSound.where(id: connected.id).count).to eq(1)
-    end
-
-    it "should not destroy an old removable button_sound that still has a board connection" do
-      u = User.create
-      b = Board.create(user: u)
-      connected = ButtonSound.create(user: u, removable: true)
-      connected.update_column(:created_at, 8.days.ago)
-      BoardButtonSound.create!(board_id: b.id, button_sound_id: connected.id)
-      Flusher.flush_leftovers
-      expect(ButtonSound.where(id: connected.id).count).to eq(1)
+      expect(ButtonSound.where(id: old_orphan.id).count).to eq(1)
+      expect(ButtonSound.where(id: recent.id).count).to eq(1)
     end
 
     it "should remove a board_button_image left dangling by a hard-deleted button_image" do
@@ -625,14 +627,13 @@ describe Flusher do
     end
 
     it "should log a retention_flush AuditEvent with per-category counts" do
-      u = User.create
-      old_orphan = ButtonSound.create(user: u, removable: true)
-      old_orphan.update_column(:created_at, 8.days.ago)
+      old = Progress.create!
+      old.update_column(:created_at, 40.days.ago)
       Flusher.flush_leftovers
       ev = AuditEvent.where(event_type: 'retention_flush').order('id DESC').first
       expect(ev).to_not eq(nil)
       expect(ev.user_key).to eq('system')
-      expect(ev.data['button_sounds']).to eq(1)
+      expect(ev.data['progresses']).to eq(1)
     end
   end
 end

--- a/spec/lib/flusher_spec.rb
+++ b/spec/lib/flusher_spec.rb
@@ -613,6 +613,17 @@ describe Flusher do
       expect(ev.data['versions_stale_type_detected_not_deleted']).to eq(1)
     end
 
+    it "should treat an item_type that resolves to a non-model Ruby constant as stale, not as a live model" do
+      # safe_constantize succeeds for ANY resolvable constant, not just ActiveRecord
+      # models -- 'File' resolves to the built-in File class. A truthy-only check
+      # would wrongly treat that as "still a real model" and skip counting it.
+      PaperTrail::Version.insert!({ item_type: 'File', item_id: 12345, event: 'destroy', created_at: Time.now })
+      Flusher.flush_leftovers
+      expect(PaperTrail::Version.where(item_type: 'File').count).to eq(1)
+      ev = AuditEvent.where(event_type: 'retention_flush').order('id DESC').first
+      expect(ev.data['versions_stale_type_detected_not_deleted']).to eq(1)
+    end
+
     it "should not remove paper trail versions for a real model class, even for a destroyed record (audit trail preservation)", :versioning => true do
       PaperTrail.request.whodunnit = 'user:jane'
       u = User.create

--- a/spec/lib/tasks/scheduler_spec.rb
+++ b/spec/lib/tasks/scheduler_spec.rb
@@ -28,6 +28,7 @@ describe 'scheduler:dispatch rake task' do
     allow(Flusher).to receive(:flush_deleted_users).and_return(0)
     allow(Utterance).to receive(:clear_old_nonces)
     allow(Worker).to receive(:schedule)
+    allow(Worker).to receive(:schedule_for)
     allow(DeletedBoard).to receive(:flush_old_records).and_return(0)
     allow(JobStash).to receive(:flush_old_records)
     allow(DataPolicyEnforcer).to receive(:enforce_retention!).and_return(0)


### PR DESCRIPTION
## Summary
- Implements `Flusher.flush_leftovers`, previously an empty stub with a 7-item TODO describing retention cleanup that was never built (compliance finding LL-991d259b2a).
- Cleans up orphaned `board_button_images`/`board_button_sounds` join rows, orphaned `log_session_boards`/`user_board_connections` join rows, and stale `Progress` records (>1 month), all via ID-batched scoped deletes (never unbounded `.destroy_all`).
- Reports (does not delete) stale-`item_type` `PaperTrail::Version` rows: `DATA_RETENTION.md` requires 6-year retention + cold-storage archival, and a renamed/removed model class isn't grounds to treat that audit trail as disposable. Filed as follow-up finding `LL-5d7197fa7d`.
- Does **not** delete `board_images`/`board_sounds` themselves via join-table orphan checks — dropped after review found the join tables can be transiently (`board_button_sounds`, async `map_images` deferral) or permanently (`board_button_images`, no longer populated) stale, which would risk deleting live media on a false-positive orphan read.
- Does not implement developer-key expiry: `DeveloperKey` has no expiration concept in this codebase; documented inline rather than invented.
- Each deletion category writes its own `AuditEvent` (`event_type: 'retention_flush'`) atomically with its delete (one transaction per category), preceded by a "planned" event and followed by a final aggregate "completed" event.
- Scheduler now dispatches this job via `Worker.schedule_for(:slow, ...)` instead of the default queue.
- New migration adds indexes (`board_button_sounds.button_sound_id`, `progresses.created_at`, `log_session_boards.log_session_id`) backing the new anti-join/age scans, added `algorithm: :concurrently`.

## Test plan
- [x] `bundle exec rspec spec/lib/flusher_spec.rb spec/lib/tasks/scheduler_spec.rb` — 53 examples, all green except 3 pre-existing unrelated failures from shared test-DB row pollution (tracked separately, PR #367)
- [x] Regression specs for the button_image/button_sound "never touched" race (via real `process_buttons`/`@map_later`, not synthetic joins)
- [x] Orphan removal + non-removal specs for each join-table category
- [x] Stale `PaperTrail::Version` item_type report-only detection (real class survives, renamed/removed class is reported not deleted, non-model constant like `File` handled)
- [x] Per-category `AuditEvent` count verification
- [x] Migration applied locally, `schema.rb` updated
- [x] Reviewed across 5 rounds of Codex `/review-pr` passes (button_sound race, count-drift, batch bind-param limits, per-category audit atomicity) — all fixed and re-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCpaUZSWtiWMWH6fsmKfF7