### PR TITLE
security: remove external_reference from license serializer (LL-55baae6d40)

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "f2e7580b911ef2c3051e1aaf02ef70d7abebc9ccbe3218a02ffaf42b20923de6",
+      "contentHash": "2f64fde503c1d3c6575df20dc7810ff5b26b1e95a996609534672fa66574d0be",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "2f64fde503c1d3c6575df20dc7810ff5b26b1e95a996609534672fa66574d0be",
+      "contentHash": "49ad3ec7877bbb40889a3450c86ad6c4262ebceed81993c168dcee0dac312b14",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `f2e7580b911e` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `2f64fde503c1` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `2f64fde503c1` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `49ad3ec7877b` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -910,8 +910,8 @@
         "timeframe": "60d"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
+        "sha": "27d331e2707787a6147cdbe60203d877a190301d",
+        "verifierNote": "Fix landed on scot/security/license-external-reference-leak (commit 27d331e27, not yet merged to staging): lib/json_api/license.rb no longer serializes external_reference at all (removed rather than gated, since a grep confirmed zero frontend consumers of the field and JsonApi::License has no permissions-hash pattern to gate against). Covered by new spec/lib/json_api/license_spec.rb (unclaimed and claimed license cases) plus two updated examples in spec/models/license_spec.rb that previously asserted the leaky behavior. 13 examples, 0 failures. Codex senior-dev review (review-pr) additionally checked for a stale cached_json_response path on License (none exists) and found no other consumers; no findings raised.",
         "attestation": ""
       },
       "notes": "Verified still open 2026-06-12: external_reference (PO number / Stripe id) always serialized (json_api/license.rb:16).",

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -914,7 +914,7 @@
         "verifierNote": "Fix landed on scot/security/license-external-reference-leak (commit 27d331e27, not yet merged to staging): lib/json_api/license.rb no longer serializes external_reference at all (removed rather than gated, since a grep confirmed zero frontend consumers of the field and JsonApi::License has no permissions-hash pattern to gate against). Covered by new spec/lib/json_api/license_spec.rb (unclaimed and claimed license cases) plus two updated examples in spec/models/license_spec.rb that previously asserted the leaky behavior. 13 examples, 0 failures. Codex senior-dev review (review-pr) additionally checked for a stale cached_json_response path on License (none exists) and found no other consumers; no findings raised.",
         "attestation": ""
       },
-      "notes": "Verified still open 2026-06-12: external_reference (PO number / Stripe id) always serialized (json_api/license.rb:16).",
+      "notes": "Verified still open 2026-06-12: external_reference (PO number / Stripe id) always serialized (json_api/license.rb:16). Superseded 2026-07-03: fix landed, see closureEvidence; status/disposition remain open/accepted pending Scot's verified-close attestation.",
       "disposition": {
         "state": "accepted",
         "decidedBy": "Scot Wahlquist",

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,7 +11,7 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-07-03T16:44:58Z
+**Page generated:** 2026-07-03T18:12:38Z
 
 ## Headline - open findings
 

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,7 +11,7 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-07-03T00:33:35Z
+**Page generated:** 2026-07-03T16:44:58Z
 
 ## Headline - open findings
 

--- a/lib/json_api/license.rb
+++ b/lib/json_api/license.rb
@@ -13,7 +13,6 @@ module JsonApi::License
     json['status'] = license.status
     json['granted_at'] = license.granted_at&.iso8601
     json['expires_at'] = license.expires_at&.iso8601
-    json['external_reference'] = license.external_reference
     if license.user_id
       json['user_id'] = license.related_global_id(license.user_id)
       json['user_name'] = license.user&.user_name

--- a/spec/lib/json_api/license_spec.rb
+++ b/spec/lib/json_api/license_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe JsonApi::License do
+  let(:org) { Organization.create(:settings => {'name' => 'Test District'}) }
+
+  describe "external_reference exposure (LL-55baae6d40)" do
+    it "never includes external_reference for a district manager viewing the org's license list" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active',
+                          external_reference: 'cus_stripe12345')
+      json = JsonApi::License.build_json(l.reload)
+      expect(json).to_not have_key('external_reference')
+    end
+
+    it "never includes external_reference when a license is claimed for a user" do
+      u = User.create
+      l = License.create!(organization: org, seat_type: 'student', status: 'active',
+                          user_id: u.id, external_reference: 'PO-99999')
+      json = JsonApi::License.build_json(l.reload)
+      expect(json).to_not have_key('external_reference')
+    end
+
+    it "leaves the rest of the license payload intact" do
+      l = License.create!(organization: org, seat_type: 'student', status: 'active',
+                          external_reference: 'cus_stripe12345')
+      json = JsonApi::License.build_json(l.reload)
+      expect(json['id']).to eq(l.global_id)
+      expect(json['organization_id']).to eq(org.global_id)
+      expect(json['seat_type']).to eq('student')
+      expect(json['status']).to eq('active')
+    end
+  end
+end

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -53,7 +53,7 @@ describe License, :type => :model do
       l = License.create!(organization: org, seat_type: 'student', status: 'active')
       expect(License.find(l.id).external_reference).to eq(nil)
       json = JsonApi::License.build_json(l.reload)
-      expect(json['external_reference']).to eq(nil)
+      expect(json).to_not have_key('external_reference')
     end
 
     it "still reads LEGACY plaintext external_reference (reads do not break)" do
@@ -62,11 +62,11 @@ describe License, :type => :model do
       expect(License.find(l.id).external_reference).to eq('cus_legacyPlain')
     end
 
-    it "is serialized correctly through JsonApi::License" do
+    it "is never included in JsonApi::License output (LL-55baae6d40)" do
       l = License.create!(organization: org, seat_type: 'student', status: 'active',
                           external_reference: 'PO-777')
       json = JsonApi::License.build_json(l.reload)
-      expect(json['external_reference']).to eq('PO-777')
+      expect(json).to_not have_key('external_reference')
     end
   end
 


### PR DESCRIPTION
## Summary
- `lib/json_api/license.rb` unconditionally serialized `license.external_reference` (a PO Number / Stripe billing id, already flagged sensitive enough to be manually encrypted at rest as a follow-up to LL-740bcb10fa). Removed the one line; a grep of `app/frontend` confirmed zero consumers, so removal (not gating) was the correct fix per the task's own decision tree.
- Affected surface: `#licenses` and `#claim_user` in `app/controllers/api/organizations_controller.rb`, both gated by org `edit`/`manage` permission — which ordinary district managers/assistants hold, not just LingoLinq's internal billing role (`update_licenses`/`manage_subscription`). So the field was reaching more people than necessary even though the endpoints were never public.
- Recorded `closureEvidence` (sha + verifier note) on the pre-existing register entry `LL-55baae6d40` in `audit-reports/FINDINGS.json` (status stays `open`, disposition stays `accepted` from 2026-06-23 — only Scot's attestation moves it to `verified-closed`). Regenerated `FINDINGS.md` and the Notion-mirror page via the standard scripts; citation-check is green (77 PASS / 0 FAIL).

## Compliance notes
- **HIPAA** minimum-necessary / **FERPA** re-disclosure: district staff assigning student seats no longer receive an internal billing/contract identifier they don't need for that task.
- Billing/contract identifiers exposed to end users also created a correlation risk (linking a district account to external payment systems). Severity: **Low**.

## Test plan
- [x] New `spec/lib/json_api/license_spec.rb` (3 examples): field absent from both the org-list path and the claim-user path; rest of the payload (`id`, `organization_id`, `seat_type`, `status`) confirmed intact.
- [x] Updated 2 pre-existing examples in `spec/models/license_spec.rb` that had encoded the old (leaky) behavior, now assert its absence.
- [x] `13 examples, 0 failures` (`DB_USER=scotw RAILS_ENV=test bundle exec rspec spec/lib/json_api/license_spec.rb spec/models/license_spec.rb`).
- [x] Codex senior-dev review (`/review-pr`): clean, no findings. It additionally verified `License` has no `cached_json_response` method (ruling out a stale-cache path serving the old JSON) and confirmed no other consumers.
- [ ] No frontend browser smoke test run in this pass — the `app/frontend` grep showing zero consumers is the evidence backing that decision; flagging in case a manual `ember serve` check of the org licenses screen is wanted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)