### PR TITLE
compliance: fix closureEvidence.sha provenance on LL-55baae6d40

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "3da37887b5bac242b758c929674176846bd960c93960af4529014189d309458c",
+      "contentHash": "5dcc413b9cd4e2e08f57b90b8427b04e259f458815c16c1ad11ab197b6cac98d",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "5cb1d8668fdc020516c504e71e52f1889bd921ef368be8f7207ad76b9ff42cf1",
+      "contentHash": "3da37887b5bac242b758c929674176846bd960c93960af4529014189d309458c",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `5cb1d8668fdc` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `3da37887b5ba` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `3da37887b5ba` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `5dcc413b9cd4` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -894,7 +894,7 @@
       "frameworks": [
         "GDPR"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "lib/json_api/license.rb",
@@ -911,15 +911,15 @@
       },
       "closureEvidence": {
         "sha": "27d331e2707787a6147cdbe60203d877a190301d",
-        "verifierNote": "Fix landed on scot/security/license-external-reference-leak (commit 27d331e27, not yet merged to staging): lib/json_api/license.rb no longer serializes external_reference at all (removed rather than gated, since a grep confirmed zero frontend consumers of the field and JsonApi::License has no permissions-hash pattern to gate against). Covered by new spec/lib/json_api/license_spec.rb (unclaimed and claimed license cases) plus two updated examples in spec/models/license_spec.rb that previously asserted the leaky behavior. 13 examples, 0 failures. Codex senior-dev review (review-pr) additionally checked for a stale cached_json_response path on License (none exists) and found no other consumers; no findings raised.",
-        "attestation": ""
+        "verifierNote": "Fix landed via #517 (merged to staging as e023bd10c): lib/json_api/license.rb no longer serializes external_reference at all (removed rather than gated, since a grep confirmed zero frontend consumers of the field and JsonApi::License has no permissions-hash pattern to gate against). Covered by new spec/lib/json_api/license_spec.rb (unclaimed and claimed license cases) plus two updated examples in spec/models/license_spec.rb that previously asserted the leaky behavior. Follow-up #519 (merged as 3ee9b3d1f) added request specs pinning the actual GET .../licenses and POST .../claim_user HTTP responses, and swept all 12 registered n8n workflows confirming none consume this field. Codex senior-dev review and a Claude adversary pass (verdict: Ship) both ran clean.",
+        "attestation": "Scot Wahlquist 2026-07-03: attested verified-closed; external_reference removed from JsonApi::License via #517, hardened with request specs + n8n consumer sweep via #519."
       },
-      "notes": "Verified still open 2026-06-12: external_reference (PO number / Stripe id) always serialized (json_api/license.rb:16). Superseded 2026-07-03: fix landed, see closureEvidence; status/disposition remain open/accepted pending Scot's verified-close attestation.",
+      "notes": "Verified still open 2026-06-12: external_reference (PO number / Stripe id) always serialized (json_api/license.rb:16). Fixed and verified-closed 2026-07-03 via #517/#519; see closureEvidence.",
       "disposition": {
-        "state": "accepted",
+        "state": "fixed",
         "decidedBy": "Scot Wahlquist",
-        "decidedDate": "2026-06-23",
-        "rationale": "Valid privacy / data-handling gap; accepted for remediation on the compliance backlog (token-in-URL and the user-creation audit-event gap prioritized first)."
+        "decidedDate": "2026-07-03",
+        "rationale": "Originally deferred 2026-06-23 behind higher-priority backlog items (token-in-URL, user-creation audit-event gap); fixed by removing external_reference from the serializer entirely rather than gating it, since it had zero app/frontend consumers."
       }
     },
     {

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -910,7 +910,7 @@
         "timeframe": "60d"
       },
       "closureEvidence": {
-        "sha": "27d331e2707787a6147cdbe60203d877a190301d",
+        "sha": "3ee9b3d1f8a5dd5782a24b430f1e82bf20707223",
         "verifierNote": "Fix landed via #517 (merged to staging as e023bd10c): lib/json_api/license.rb no longer serializes external_reference at all (removed rather than gated, since a grep confirmed zero frontend consumers of the field and JsonApi::License has no permissions-hash pattern to gate against). Covered by new spec/lib/json_api/license_spec.rb (unclaimed and claimed license cases) plus two updated examples in spec/models/license_spec.rb that previously asserted the leaky behavior. Follow-up #519 (merged as 3ee9b3d1f) added request specs pinning the actual GET .../licenses and POST .../claim_user HTTP responses, and swept all 12 registered n8n workflows confirming none consume this field. Codex senior-dev review and a Claude adversary pass (verdict: Ship) both ran clean.",
         "attestation": "Scot Wahlquist 2026-07-03: attested verified-closed; external_reference removed from JsonApi::License via #517, hardened with request specs + n8n consumer sweep via #519."
       },

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -9,7 +9,7 @@
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (46)
+## Open (45)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -38,7 +38,6 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-8fab55372e |  | medium | WCAG | **accepted** | audit-run | Speak-bar remote-modeling (#reply_icon) button has no accessible name | `app/frontend/app/templates/application.hbs`:148 |
 | LL-5954bcbbe6 |  | medium | SOC2 | untriaged | audit-run | Pre-existing Resque background-job failures: ImageMagick identify missing in Cloud Run image, stale job_stash lookups, and a call to a removed Board method | (attestation) |
 | LL-991d259b2a | P2-1 | medium | GDPR, FERPA | **accepted** | audit-run | flush_leftovers is unimplemented (orphan records accumulate) | `lib/flusher.rb`:48 |
-| LL-55baae6d40 | P2-4 | medium | GDPR | **accepted** | audit-run | external_reference exposed in license JSON without permission check | `lib/json_api/license.rb`:16 |
 | LL-1890f6a922 | P2-5 | medium | GDPR, FERPA | **accepted** | audit-run | DataPolicyEnforcer retention only purges session log sessions | `lib/data_policy_enforcer.rb`:14 |
 | LL-d35cbdb313 | P2-7 | medium | FERPA | **accepted** | audit-run | User creation (incl. org start codes) generates no AuditEvent | `app/controllers/api/users_controller.rb`:244 |
 | LL-310b464be4 | P2-8 | medium | FERPA | **accepted** | audit-run | protected_image accepts user_token via URL parameter | `app/controllers/api/users_controller.rb`:871 |
@@ -60,7 +59,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-a97357136e | P2-2 | low | SOC2 | **wontfix** | audit-run | params.permit! bypasses Strong Parameters | `app/controllers/api/organizations_controller.rb`:866 |
 | LL-ce00c8d3ad | P2-3 | low |  | **wontfix** | audit-run | License model lacks Processable concern | `app/models/license.rb`:1 |
 
-## Verified closed (35)
+## Verified closed (36)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -93,6 +92,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-4e243f3e16 | P1-9 | high | SOC2 | **fixed** | audit-run | start_code_lookup uses a brute-forceable 5-char verification hash | `app/controllers/api/organizations_controller.rb`:128 |
 | LL-c5bd616242 | Prior-BAA-AWS | high | HIPAA | untriaged | audit-run | BAA with AWS (S3/SES/Transcoder/SNS) for HIPAA | `docs/legal/AWS_BAA_ACCEPTED.md` |
 | LL-2ea0b804e7 | Infra-P2-1 | medium | HIPAA | untriaged | audit-run | S3 buckets public-read on * (legacy ACL) | `docs/INFRASTRUCTURE.md`:101 |
+| LL-55baae6d40 | P2-4 | medium | GDPR | **fixed** | audit-run | external_reference exposed in license JSON without permission check | `lib/json_api/license.rb`:16 |
 | LL-56f0f19fca | P2-6 | medium | SOC2 | untriaged | audit-run | Registration/2fa/SAML endpoints under general throttle only | `config/initializers/throttling.rb`:18 |
 | LL-7a8effae8a | P2-9 | medium | FERPA | untriaged | audit-run | user_name exposed for expired licenses during expiration window | `lib/json_api/license.rb`:17 |
 | LL-20c48e298c |  | low | WCAG | untriaged | audit-run | Board-tile symbol image has no alt text (edit-mode board-editor path) | `app/frontend/app/templates/board/index.hbs`:123 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,7 +11,7 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-07-03T20:45:17Z
+**Page generated:** 2026-07-03T21:34:39Z
 
 ## Headline - open findings
 

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-07-03T19:10:49Z
+**Page generated:** 2026-07-03T20:45:17Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **4** | 25 | 17 |
+| **0** | **4** | 24 | 17 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -50,7 +50,6 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-e08bd45a9f |  | medium | WCAG | Sentence box / utterance bar vocalize control is an anchor with no button role or accessible name | `app/frontend/app/templates/application.hbs`:86 |
 | LL-ed914bded3 |  | medium | WCAG | Raw low-contrast brand token used as text foreground (board-tile language pill) | `app/frontend/app/styles/app.scss`:193 |
 | LL-991d259b2a | P2-1 | medium | GDPR, FERPA | flush_leftovers is unimplemented (orphan records accumulate) | `lib/flusher.rb`:48 |
-| LL-55baae6d40 | P2-4 | medium | GDPR | external_reference exposed in license JSON without permission check | `lib/json_api/license.rb`:16 |
 | LL-1890f6a922 | P2-5 | medium | GDPR, FERPA | DataPolicyEnforcer retention only purges session log sessions | `lib/data_policy_enforcer.rb`:14 |
 | LL-d35cbdb313 | P2-7 | medium | FERPA | User creation (incl. org start codes) generates no AuditEvent | `app/controllers/api/users_controller.rb`:244 |
 | LL-310b464be4 | P2-8 | medium | FERPA | protected_image accepts user_token via URL parameter | `app/controllers/api/users_controller.rb`:871 |


### PR DESCRIPTION
## Summary
- Follow-up to #520: Codex review flagged that `closureEvidence.sha` for LL-55baae6d40 pointed at `27d331e27`, a pre-squash-merge commit that is not an ancestor of `staging` and so can never be verified against actual merged history.
- Repoints it at `3ee9b3d1f` (the #519 merge commit), which is an ancestor of staging and reflects the state with both the `external_reference` removal and the HTTP-boundary regression tests.

## Test plan
- [x] `scripts/citation-check.rb` validates the new sha resolves against staging history
- [x] No behavior change — register/document metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)