### PR TITLE
compliance(users): emit AuditEvent for every account creation (LL-d35cbdb313)

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -252,6 +252,7 @@ class Api::UsersController < ApplicationController
     end
     user = User.process_new(user_data, {:pending => true, :author => @api_user})
     start_progress = nil
+    start_code_org = nil
     if !user || user.errored?
       return api_error(400, {error: "user creation failed", errors: user && user.processing_errors})
     end
@@ -259,6 +260,7 @@ class Api::UsersController < ApplicationController
       # Process start code actions once the user is fully created (can't add supervisors beforehand)
       res = Organization.parse_activation_code(user_data['start_code'], user)
       start_progress = res[:progress]
+      start_code_org = res[:target] if res.is_a?(Hash) && res[:target].is_a?(Organization)
     end
     UserBoardProvisioner.provision_for(user)
     # Org-authored (school-official) creation: emit the immutable authorization audit
@@ -293,6 +295,35 @@ class Api::UsersController < ApplicationController
         end
         Rails.logger.error("school_authorization audit failed to persist for #{user.global_id}: #{e.class} #{detail}")
       end
+    end
+    # General account-creation audit trail (LL-d35cbdb313): fires for EVERY new account,
+    # regardless of how it was created (self-registration, admin-created, or via an org
+    # start code). This is additive to, not a replacement for, the school_authorization
+    # event above -- that one separately records the specific COPPA authorization basis
+    # for org-authored under-13 accounts. Together: "was any account created" (this event,
+    # always) vs. "was it specifically authorized under the school exception" (that event,
+    # only when applicable).
+    begin
+      AuditEvent.create!(
+        user_key: user.global_id,
+        data: {
+          'type' => 'user_creation',
+          'author' => @api_user && @api_user.global_id,
+          'via_start_code' => !!(user_data && user_data['start_code'].present?),
+          'organization_id' => start_code_org && start_code_org.global_id
+        },
+        event_type: 'user_creation',
+        record_id: start_code_org && start_code_org.global_id
+      )
+    rescue => e
+      # Fail-open, same rationale as school_authorization above: the account is already
+      # persisted, so a failed audit insert must not 500 the request or orphan the account.
+      detail = begin
+        PiiScrubber.scrub_log_line(e.message.to_s).truncate(300)
+      rescue ScriptError, StandardError => scrub_err
+        "[unscrubbable:#{scrub_err.class}]"
+      end
+      Rails.logger.error("user_creation audit failed to persist for #{user.global_id}: #{e.class} #{detail}")
     end
     coppa_pending = user.coppa_parental_consent_pending?
     unless coppa_pending

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -661,6 +661,61 @@ describe Api::UsersController, :type => :controller do
       expect(response).to be_successful
     end
 
+    describe "user_creation audit trail" do
+      it "records a user_creation AuditEvent for plain self-registration" do
+        post :create, params: {:user => {'name' => 'fred'}}
+        json = assert_success_json
+        u = User.find_by_path(json['user']['id'])
+        ev = AuditEvent.where(:event_type => 'user_creation').where("user_key = ?", u.global_id).first
+        expect(ev).to be_present
+        expect(ev.data['author']).to eq(nil)
+        expect(ev.data['via_start_code']).to eq(false)
+        expect(ev.data['organization_id']).to eq(nil)
+      end
+
+      it "records the authoring organization when created via a valid start code" do
+        o = Organization.create
+        code = Organization.activation_code(o, {'user_type' => 'communicator'})
+        post :create, params: {:user => {'name' => 'fred', 'start_code' => code}}
+        json = assert_success_json
+        u = User.find_by_path(json['user']['id'])
+        ev = AuditEvent.where(:event_type => 'user_creation', :record_id => o.global_id).first
+        expect(ev).to be_present
+        expect(ev.user_key).to eq(u.global_id)
+        expect(ev.data['via_start_code']).to eq(true)
+        expect(ev.data['organization_id']).to eq(o.global_id)
+      end
+
+      it "records both school_authorization and user_creation for an org-authored minor" do
+        allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+        token_user
+        o = Organization.create(:settings => {'total_licenses' => 1})
+        o.add_manager(@user.user_name, true)
+        post :create, params: {:user => {
+          'name' => 'school_kid_both_events',
+          'email' => 'school_kid_both_events@example.com',
+          'password' => 'abcdef',
+          'terms_agree' => true,
+          'authored_organization_id' => o.global_id,
+          'coppa_under_13' => true
+        }}
+        json = assert_success_json
+        u = User.find_by_path(json['user']['id'])
+        expect(AuditEvent.where(:event_type => 'school_authorization').where("user_key = ?", u.global_id).count).to eq(1)
+        expect(AuditEvent.where(:event_type => 'user_creation').where("user_key = ?", u.global_id).count).to eq(1)
+      end
+
+      it "does not orphan or 500 the account when the user_creation audit fails (fail-open)" do
+        allow(AuditEvent).to receive(:create!).and_call_original
+        expect(AuditEvent).to receive(:create!).with(hash_including(:event_type => 'user_creation')).and_raise(StandardError.new('boom'))
+        post :create, params: {:user => {'name' => 'audit_fail_plain'}}
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        u = User.find_by_path(json['user']['id'])
+        expect(u).to be_present
+      end
+    end
+
     describe "COPPA parental consent" do
       before do
         allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)


### PR DESCRIPTION
## Summary
- Compliance finding LL-d35cbdb313 (FERPA, accepted 2026-06-23): `api/users#create` persisted new accounts with no audit trail, except the narrow `school_authorization` event (#444) that only fires for org-authored under-13 accounts. Plain self-registration and ordinary org start-code signups left no creation record.
- Adds a second, general-purpose `user_creation` AuditEvent that fires for **every** created account, recording the authenticated author (nil for self-registration), whether a start code was used, and the authoring organization's global_id when the code resolves to one.
- Additive, not a replacement: the existing `school_authorization` event is untouched and still separately records the COPPA authorization basis for org-authored minors. Same fail-open pattern as that event (audit-insert failure logs loudly, PII-scrubbed, never 500s or orphans the already-persisted account).

## Test plan
- [x] 4 new controller specs: plain signup, start-code signup records the org, org-authored minor records both events, fail-open on audit-insert error
- [x] Full `create` block: 43 examples, 0 failures, 1 pre-existing unrelated pending
- [x] `ruby -c` + rubocop on both changed files — no new offenses introduced

## Follow-up
Register attestation (marking LL-d35cbdb313 `verified-closed`) is a separate PR after this merges, matching the pattern used for LL-991d259b2a (#514 shipped the fix, #527 attested it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)