### PR TITLE
compliance: file follow-up findings for flush_leftovers items 1 and 3

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "51945795d17a1a1faaa352899548fdc14b738b5024ad260718ce327a5e10599a",
+      "contentHash": "d30d9f4ad3427f84ba3440fa3f3a437ea77eb06d2091f5365af90bd1bebd2d15",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `51945795d17a` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `d30d9f4ad342` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -811,9 +811,9 @@
       }
     },
     {
-      "id": "LL-abc1170c2d",
-      "ruleKey": "button-image-sound-usage-orphan-check-unimplemented",
-      "title": "Flusher.flush_leftovers has no usage-based orphan check for board_button_images/board_button_sounds (item 1)",
+      "id": "LL-57e9beb87f",
+      "ruleKey": "button-image-sound-orphaned-media-usage-check-unimplemented",
+      "title": "Flusher.flush_leftovers has no usage-based orphan check for orphaned ButtonImage/ButtonSound media records (item 1)",
       "severity": "low",
       "confidence": "medium",
       "frameworks": [
@@ -832,10 +832,10 @@
       "lastSeen": "2026-07-04",
       "owner": "unassigned",
       "remediation": {
-        "options": "The join-table-only orphan check (implemented, item 2) cannot double as a usage check: board_button_images stopped being kept in sync by Board#map_images (image usage now lives only in grid_buttons/known_button_images), and board_button_sounds can lag behind grid_buttons during an async resync window (BoyBand's deferred :map_images job), so a join-table check risks deleting rows a board is still actively using. Needs a grid_buttons-based reverse-usage check (the same signal known_button_images/known_button_sounds already use per-board) built and proven safe before either table is included in flush_leftovers on a usage basis.",
+        "options": "Item 1's deferred target is orphaned ButtonImage/ButtonSound media records themselves (images/sounds no board actually uses), NOT the BoardButtonImage/BoardButtonSound join rows -- those are already cleaned on a referential basis by item 2 (implemented). A join-table-only usage signal can't be trusted for ButtonImage/ButtonSound either: Board#map_images stopped syncing board_button_images (image usage now lives only in grid_buttons/known_button_images), and board_button_sounds can lag behind grid_buttons during an async resync window (BoyBand's deferred :map_images job), so checking \"zero join rows\" as a proxy for \"unused\" risks deleting media a board is still actively using. Needs a grid_buttons-based reverse-usage check (the same signal known_button_images/known_button_sounds already use per-board) built and proven safe before ButtonImage/ButtonSound records are deleted on a usage basis.",
         "timeframe": "90d"
       },
-      "notes": "Filed as a follow-up when LL-991d259b2a (flush_leftovers unimplemented) was attested verified-closed 2026-07-04: PR #514 deliberately left this item undone (documented inline at lib/flusher.rb:57) because implementing it unsafely risked live-data deletion, not because it was overlooked. Open here so the gap stays tracked now that the parent finding is closed."
+      "notes": "Filed as a follow-up when LL-991d259b2a (flush_leftovers unimplemented) was attested verified-closed 2026-07-04: PR #514 deliberately left this item undone (documented inline at lib/flusher.rb:57) because implementing it unsafely risked live-data deletion, not because it was overlooked. Open here so the gap stays tracked now that the parent finding is closed. Corrected 2026-07-04 per Codex review of #530: the original title/ruleKey named board_button_images/board_button_sounds (the join tables, item 2's target, already implemented) instead of the actual deferred target, ButtonImage/ButtonSound media records."
     },
     {
       "id": "LL-45bdcc73c9",

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -811,6 +811,59 @@
       }
     },
     {
+      "id": "LL-abc1170c2d",
+      "ruleKey": "button-image-sound-usage-orphan-check-unimplemented",
+      "title": "Flusher.flush_leftovers has no usage-based orphan check for board_button_images/board_button_sounds (item 1)",
+      "severity": "low",
+      "confidence": "medium",
+      "frameworks": [
+        "GDPR",
+        "FERPA"
+      ],
+      "status": "open",
+      "evidence": {
+        "type": "code",
+        "file": "lib/flusher.rb",
+        "line": 57,
+        "snippet": "1. NOT IMPLEMENTED for either button_images or button_sounds. The plan's",
+        "sha": "a877872d263fba43768a568f71c3791a4f22bf54"
+      },
+      "firstSeen": "2026-07-04",
+      "lastSeen": "2026-07-04",
+      "owner": "unassigned",
+      "remediation": {
+        "options": "The join-table-only orphan check (implemented, item 2) cannot double as a usage check: board_button_images stopped being kept in sync by Board#map_images (image usage now lives only in grid_buttons/known_button_images), and board_button_sounds can lag behind grid_buttons during an async resync window (BoyBand's deferred :map_images job), so a join-table check risks deleting rows a board is still actively using. Needs a grid_buttons-based reverse-usage check (the same signal known_button_images/known_button_sounds already use per-board) built and proven safe before either table is included in flush_leftovers on a usage basis.",
+        "timeframe": "90d"
+      },
+      "notes": "Filed as a follow-up when LL-991d259b2a (flush_leftovers unimplemented) was attested verified-closed 2026-07-04: PR #514 deliberately left this item undone (documented inline at lib/flusher.rb:57) because implementing it unsafely risked live-data deletion, not because it was overlooked. Open here so the gap stays tracked now that the parent finding is closed."
+    },
+    {
+      "id": "LL-45bdcc73c9",
+      "ruleKey": "developer-key-expiry-policy-undecided",
+      "title": "Developer key expiration policy is undecided; DeveloperKey records never age out (item 3)",
+      "severity": "low",
+      "confidence": "medium",
+      "frameworks": [
+        "SOC2"
+      ],
+      "status": "open",
+      "evidence": {
+        "type": "code",
+        "file": "lib/flusher.rb",
+        "line": 48,
+        "snippet": "NOTE on item 3 (\"expired developer keys\"): DeveloperKey has no expiration",
+        "sha": "a877872d263fba43768a568f71c3791a4f22bf54"
+      },
+      "firstSeen": "2026-07-04",
+      "lastSeen": "2026-07-04",
+      "owner": "unassigned",
+      "remediation": {
+        "options": "DeveloperKey has no expires_at column, settings-based expiry, or expired? method anywhere in the codebase today; it is a permanent OAuth client registration. Before writing any deletion/expiry logic, decide as a product/security question whether developer keys should expire at all (and on what basis - inactivity, fixed TTL, manual revocation only), since inventing an unreviewed criterion risked destroying live client credentials and was deliberately avoided in PR #514.",
+        "timeframe": "90d"
+      },
+      "notes": "Filed as a follow-up when LL-991d259b2a (flush_leftovers unimplemented) was attested verified-closed 2026-07-04: PR #514 deliberately left this item undone (documented inline at lib/flusher.rb:48) pending a policy decision, not because it was overlooked. Open here so the gap stays tracked now that the parent finding is closed."
+    },
+    {
       "id": "LL-a97357136e",
       "ruleKey": "widespread-permit-bang",
       "legacyId": "P2-2",

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -37,7 +37,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-1890f6a922 | P2-5 | medium | GDPR, FERPA | **accepted** | audit-run | DataPolicyEnforcer retention only purges session log sessions | `lib/data_policy_enforcer.rb`:14 |
 | LL-d35cbdb313 | P2-7 | medium | FERPA | **accepted** | audit-run | User creation (incl. org start codes) generates no AuditEvent | `app/controllers/api/users_controller.rb`:244 |
 | LL-310b464be4 | P2-8 | medium | FERPA | **accepted** | audit-run | protected_image accepts user_token via URL parameter | `app/controllers/api/users_controller.rb`:871 |
-| LL-abc1170c2d |  | low | GDPR, FERPA | untriaged | audit-run | Flusher.flush_leftovers has no usage-based orphan check for board_button_images/board_button_sounds (item 1) | `lib/flusher.rb`:57 |
+| LL-57e9beb87f |  | low | GDPR, FERPA | untriaged | audit-run | Flusher.flush_leftovers has no usage-based orphan check for orphaned ButtonImage/ButtonSound media records (item 1) | `lib/flusher.rb`:57 |
 | LL-45bdcc73c9 |  | low | SOC2 | untriaged | audit-run | Developer key expiration policy is undecided; DeveloperKey records never age out (item 3) | `lib/flusher.rb`:48 |
 | LL-97f9001bb4 |  | low | SOC2 | **wontfix** | audit-run | Audit finder Bash guard is a denylist with residual fetch-and-exec bypass | `.claude/hooks/audit-readonly-guard.sh`:59 |
 | LL-3483c28f3c |  | low | SOC2 | **wontfix** | audit-run | Parallel finders read live infra without synchronization (possible inconsistent snapshot) | `.claude/skills/audit-run/SKILL.md`:33 |

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -9,7 +9,7 @@
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (42)
+## Open (44)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -37,6 +37,8 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-1890f6a922 | P2-5 | medium | GDPR, FERPA | **accepted** | audit-run | DataPolicyEnforcer retention only purges session log sessions | `lib/data_policy_enforcer.rb`:14 |
 | LL-d35cbdb313 | P2-7 | medium | FERPA | **accepted** | audit-run | User creation (incl. org start codes) generates no AuditEvent | `app/controllers/api/users_controller.rb`:244 |
 | LL-310b464be4 | P2-8 | medium | FERPA | **accepted** | audit-run | protected_image accepts user_token via URL parameter | `app/controllers/api/users_controller.rb`:871 |
+| LL-abc1170c2d |  | low | GDPR, FERPA | untriaged | audit-run | Flusher.flush_leftovers has no usage-based orphan check for board_button_images/board_button_sounds (item 1) | `lib/flusher.rb`:57 |
+| LL-45bdcc73c9 |  | low | SOC2 | untriaged | audit-run | Developer key expiration policy is undecided; DeveloperKey records never age out (item 3) | `lib/flusher.rb`:48 |
 | LL-97f9001bb4 |  | low | SOC2 | **wontfix** | audit-run | Audit finder Bash guard is a denylist with residual fetch-and-exec bypass | `.claude/hooks/audit-readonly-guard.sh`:59 |
 | LL-3483c28f3c |  | low | SOC2 | **wontfix** | audit-run | Parallel finders read live infra without synchronization (possible inconsistent snapshot) | `.claude/skills/audit-run/SKILL.md`:33 |
 | LL-a2b45c2bcb |  | low | SOC2 | **accepted** | audit-run | Finder agent-memory (memory: project) may carry process state across audit runs | `.claude/agents/infra-auditor.md`:7 |
@@ -123,4 +125,4 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 
 ---
 
-_87 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._
+_89 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-07-05T00:20:25Z
+**Page generated:** 2026-07-05T05:40:07Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **4** | 23 | 18 |
+| **0** | **4** | 23 | 20 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -56,7 +56,9 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-3483c28f3c |  | low | SOC2 | Parallel finders read live infra without synchronization (possible inconsistent snapshot) | `.claude/skills/audit-run/SKILL.md`:33 |
 | LL-41d2d553ab |  | low |  | Integration JSON emits a debug junk key (asdf) consumed by no Ember model | `lib/json_api/integration.rb`:67 |
 | LL-42a24ee911 |  | low | SOC2 | A diagnostic SES send to a personal Gmail address never arrived (inbox or spam); a same-account send to a Workspace-internal address arrived immediately | (attestation) |
+| LL-45bdcc73c9 |  | low | SOC2 | Developer key expiration policy is undecided; DeveloperKey records never age out (item 3) | `lib/flusher.rb`:48 |
 | LL-553fdc242b |  | low | SOC2 | davidshimjs-qrcodejs 0.0.2 is abandoned (no release since 2014, >10 years) | `app/frontend/package.json`:36 |
+| LL-57e9beb87f |  | low | GDPR, FERPA | Flusher.flush_leftovers has no usage-based orphan check for orphaned ButtonImage/ButtonSound media records (item 1) | `lib/flusher.rb`:57 |
 | LL-5a173ce87f |  | low |  | Utterance Rails builder emits created_at but Ember model declares timestamp instead | `app/frontend/app/models/utterance.js`:15 |
 | LL-5d7197fa7d |  | low | HIPAA, FERPA | PaperTrail versions with unconstantizable item_type are detected but retention disposition is undecided | `lib/flusher.rb`:116 |
 | LL-5f0f4f52f8 |  | low | SOC2 | Audit system files (.claude/) are not in any finder scan scope (no self-audit) | `.claude/agents/infra-auditor.md`:62 |


### PR DESCRIPTION
## Summary
- LL-991d259b2a (flush_leftovers unimplemented) was attested verified-closed via #527. The adversary review of that PR flagged a Medium: two of the implementation's deliberately-deferred items (1 and 3) had no open finding tracking them once the parent finding closed - only inline code comments in `lib/flusher.rb` pointing back at LL-991d259b2a itself.
- Files two new findings, same pattern as the existing `LL-5d7197fa7d` (item 7's follow-up, filed the same way after a prior Codex PR review):
  - `LL-abc1170c2d` (low, GDPR/FERPA) - no usage-based orphan check for `board_button_images`/`board_button_sounds`. The join-table-only check (item 2, implemented) can't double as a usage check since `Board#map_images` stopped syncing `board_button_images` and `board_button_sounds` can lag during an async resync window; a real fix needs a `grid_buttons`-based reverse-usage check like `known_button_images`/`known_button_sounds` already use per-board.
  - `LL-45bdcc73c9` (low, SOC2) - developer key expiration policy is undecided. `DeveloperKey` has no expiration concept anywhere in the codebase; PR #514 deliberately avoided inventing one rather than risk destroying live OAuth client credentials.
- Both anchored to `lib/flusher.rb` at the commit that introduced the inline comments (`a877872d2`, #514's merge commit, confirmed ancestor of staging). Neither closes, downgrades, or triages anything - both land as `open`/untriaged per the register's governance rule.
- Regenerated `FINDINGS.md`, `DOCUMENT-REGISTER.json/md`, and `audit-reports/notion/compliance-audit-page.md` via the standard render scripts so counts/hashes stay in sync.

## Test plan
- [x] `ruby scripts/citation-check.rb` - both new findings PASS, 0 FAIL
- [x] `ruby scripts/citation-check.rb --render` / `document-register-render.rb` / `compliance-notion-publish.rb` re-run, diffs reviewed (headline low-count moves accordingly, no unrelated drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zjFyUU9nMc7joUt98qrdW