### PR TITLE
fix(uploads): set UPLOADS_S3_NO_ACL=1 for the private uploads bucket

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -115,7 +115,12 @@ jobs:
       # Block Public Access, per the private-bucket model (Scot, 2026-07-05). A presigned POST
       # carrying acl=public-read is rejected by such a bucket, so lib/uploader.rb must omit the
       # ACL field. Client-facing reads go through presigned GETs / CDN, not public object URLs.
-      APP_ENV_VARS_STATIC: AWS_REGION=us-west-2,SES_REGION=us-west-2,UPLOADS_S3_BUCKET=lingolinq-prod-uploads,STATIC_S3_BUCKET=lingolinq-prod-static,UPLOADS_S3_NO_ACL=1,SENTRY_ENVIRONMENT=production,RAILS_LOG_TO_STDOUT=true,RAILS_SERVE_STATIC_FILES=true,RUBY_YJIT_ENABLE=1,WEB_CONCURRENCY=2
+      # UPLOADS_S3_CDN: CloudFront distribution E2X2HAS6Y1L2MI fronts the private bucket via
+      # Origin Access Control (bucket policy + KMS key policy grant scoped to the distribution
+      # ARN). Uploader.fronted_url rewrites stored bucket URLs to this domain at serialization
+      # time; stable (non-presigned) URLs are required by the Ember offline cache, which is
+      # URL-keyed and does not strip X-Amz-* params.
+      APP_ENV_VARS_STATIC: AWS_REGION=us-west-2,SES_REGION=us-west-2,UPLOADS_S3_BUCKET=lingolinq-prod-uploads,STATIC_S3_BUCKET=lingolinq-prod-static,UPLOADS_S3_NO_ACL=1,UPLOADS_S3_CDN=https://d34sa6lc5jfe66.cloudfront.net,SENTRY_ENVIRONMENT=production,RAILS_LOG_TO_STDOUT=true,RAILS_SERVE_STATIC_FILES=true,RUBY_YJIT_ENABLE=1,WEB_CONCURRENCY=2
       # REDIS_TLS_VERIFY_HOSTNAME=false is set on every deploy below: Memorystore is reached by
       # private IP and its server cert is issued for the instance, not the IP, so hostname
       # matching cannot pass. CA-chain verification (VERIFY_PEER against REDIS_CA_CERT) stays on.

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -111,7 +111,11 @@ jobs:
       # committed. LD_PRELOAD/MALLOC_CONF are DELIBERATELY EXCLUDED until jemalloc is verified present
       # in the image -- pointing LD_PRELOAD at a missing .so breaks boot (plan Group C). RAILS_ENV is
       # set inline on every deploy; DEPLOY_TRIGGER/SEED_READY/LEADER_POSTGRES_URL are Render-only.
-      APP_ENV_VARS_STATIC: AWS_REGION=us-west-2,SES_REGION=us-west-2,UPLOADS_S3_BUCKET=lingolinq-prod-uploads,STATIC_S3_BUCKET=lingolinq-prod-static,SENTRY_ENVIRONMENT=production,RAILS_LOG_TO_STDOUT=true,RAILS_SERVE_STATIC_FILES=true,RUBY_YJIT_ENABLE=1,WEB_CONCURRENCY=2
+      # UPLOADS_S3_NO_ACL=1: lingolinq-prod-uploads is BucketOwnerEnforced (ACLs disabled) +
+      # Block Public Access, per the private-bucket model (Scot, 2026-07-05). A presigned POST
+      # carrying acl=public-read is rejected by such a bucket, so lib/uploader.rb must omit the
+      # ACL field. Client-facing reads go through presigned GETs / CDN, not public object URLs.
+      APP_ENV_VARS_STATIC: AWS_REGION=us-west-2,SES_REGION=us-west-2,UPLOADS_S3_BUCKET=lingolinq-prod-uploads,STATIC_S3_BUCKET=lingolinq-prod-static,UPLOADS_S3_NO_ACL=1,SENTRY_ENVIRONMENT=production,RAILS_LOG_TO_STDOUT=true,RAILS_SERVE_STATIC_FILES=true,RUBY_YJIT_ENABLE=1,WEB_CONCURRENCY=2
       # REDIS_TLS_VERIFY_HOSTNAME=false is set on every deploy below: Memorystore is reached by
       # private IP and its server cert is issued for the instance, not the IP, so hostname
       # matching cannot pass. CA-chain verification (VERIFY_PEER against REDIS_CA_CERT) stays on.

--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -130,6 +130,21 @@ is not schedulable to a firm date until this passes.
   measured number, tracker 4.2). Also confirm DirtyExit jobs (TERM outside job execution / SIGKILL)
   are visible in the Resque failed queue.
 
+**Private-bucket read/write path checks (added 2026-07-05, findings LL-705b10bcd7 / LL-9a09771121):**
+
+- **S3 write path.** Create a real ButtonImage from an external PNG URL and let the worker pool
+  process it: the record's `url` must become a `lingolinq-prod-uploads` bucket URL (no
+  `data_uri` fallback, no `errored_pending_url`), and `head-object` must show the object with
+  `ServerSideEncryption: aws:kms` under the expected CMK. Verified green on the rehearsal stack
+  2026-07-05 (synthetic ButtonImage id 840). Prerequisites: IAM policy `lingolinq-cloudrun-s3-ses`
+  v2 (KMS statement) attached to `lingolinq-cloudrun-prod`; `UPLOADS_S3_NO_ACL=1` in the deploy env.
+- **S3 read path via CDN.** The bucket blocks all public access; client reads go through CloudFront
+  distribution `E2X2HAS6Y1L2MI` (`https://d34sa6lc5jfe66.cloudfront.net`, OAC + KMS grant). Confirm
+  `UPLOADS_S3_CDN` is set on web + worker, an uploaded image renders in a browser via its CDN URL
+  (and the raw `s3.amazonaws.com` URL still 403s), and the response carries
+  `access-control-allow-origin` (the Ember offline-sync XHR needs CORS). Then sync a board offline
+  in the app and confirm images cache.
+
 ### 0b. Worker health verification  (was Copilot "6b warmup", reframed)
 
 The worker is a Cloud Run **worker-pool** (`gcloud beta run worker-pools`, see


### PR DESCRIPTION
## What

Adds `UPLOADS_S3_NO_ACL=1` to `APP_ENV_VARS_STATIC` in the Cloud Run deploy workflow (covers web + worker).

## Why

Continuation of finding **LL-705b10bcd7** (S3 SigV4/KMS-SSE upload failure on the GCP rehearsal stack). The SigV4 rewrite (77233fb19, afe03d2de) is deployed and correct; the remaining failures are AWS-side, and there are two stacked blockers:

1. **KMS (admin action, not this PR):** `lingolinq-prod-uploads` has SSE-KMS default encryption (CMK `d5a1a377-...`) and the runtime principal is denied `kms:GenerateDataKey`, so every write fails. The needed statement already exists in `scripts/gcp/iam/lingolinq-cloudrun-s3-ses-policy.json`; it has to be attached with admin credentials.
2. **ACL (this PR):** the bucket is `BucketOwnerEnforced` + full Block Public Access, so once KMS is fixed the presigned POST would still be rejected for carrying `acl=public-read`. `lib/uploader.rb` already supports `UPLOADS_S3_NO_ACL` but nothing set it.

Access model decision (Scot, 2026-07-05): keep the bucket private (HIPAA/FERPA posture) rather than restoring legacy public-read parity. Client-facing reads will need presigned GETs / CDN with OAC; that read-path audit is a follow-up, not this PR.

## Verification

- Both blockers confirmed with read-only checks plus a synthetic `put-object` (denied at KMS; nothing written; test key deleted).
- The same env var was applied live to the rehearsal stack alongside this PR so the next synthetic ButtonImage test can exercise it once KMS perms land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011i7vwUmphP4z5sa8BubCsy