### PR TITLE
fix(api): round-trip Integration board_render_url/button_webhook_url, drop debug key

### DIFF
--- a/lib/json_api/integration.rb
+++ b/lib/json_api/integration.rb
@@ -25,9 +25,9 @@ module JsonApi::Integration
       end
     end
     json['render'] = !!obj.settings['board_render_url']
-    if json['render'] && permissions && permissions['edit']
-      json['board_render_url'] = obj.settings['board_render_url']
-    end
+    # not permission-gated: extra_includes already emits this same value
+    # unconditionally as render_url for any board viewer to embed (routes/board.js)
+    json['board_render_url'] = obj.settings['board_render_url'] if json['render']
 
     if args[:permissions]
       json['permissions'] = permissions

--- a/lib/json_api/integration.rb
+++ b/lib/json_api/integration.rb
@@ -12,17 +12,25 @@ module JsonApi::Integration
     json['id'] = obj.global_id
     json['name'] = obj.settings['name']
     json['custom_integration'] = !!obj.settings['custom_integration']
+    permissions = obj.permissions_for(args[:permissions]) if args[:permissions]
     json['webhook'] = !!obj.settings['button_webhook_url']
     if json['webhook']
-      json['button_webhook_url'] = obj.settings['button_webhook_url']
-      json['button_webhook_local'] = true if obj.settings['button_webhook_local']
+      if obj.settings['button_webhook_local']
+        json['button_webhook_local'] = true
+        json['button_webhook_url'] = obj.settings['button_webhook_url']
+      elsif permissions && permissions['edit']
+        # remote webhook URLs can embed a secret key (e.g. IFTTT), so only
+        # round-trip them to viewers who could have set them in the first place
+        json['button_webhook_url'] = obj.settings['button_webhook_url']
+      end
     end
     json['render'] = !!obj.settings['board_render_url']
-    json['board_render_url'] = obj.settings['board_render_url'] if json['render']
-    
+    if json['render'] && permissions && permissions['edit']
+      json['board_render_url'] = obj.settings['board_render_url']
+    end
 
     if args[:permissions]
-      json['permissions'] = obj.permissions_for(args[:permissions])
+      json['permissions'] = permissions
     end
 
     if obj.integration_key

--- a/lib/json_api/integration.rb
+++ b/lib/json_api/integration.rb
@@ -13,11 +13,12 @@ module JsonApi::Integration
     json['name'] = obj.settings['name']
     json['custom_integration'] = !!obj.settings['custom_integration']
     json['webhook'] = !!obj.settings['button_webhook_url']
-    if json['webhook'] && obj.settings['button_webhook_local']
-      json['button_webhook_local'] = true
+    if json['webhook']
       json['button_webhook_url'] = obj.settings['button_webhook_url']
+      json['button_webhook_local'] = true if obj.settings['button_webhook_local']
     end
     json['render'] = !!obj.settings['board_render_url']
+    json['board_render_url'] = obj.settings['board_render_url'] if json['render']
     
 
     if args[:permissions]
@@ -64,7 +65,6 @@ module JsonApi::Integration
       end
     end
     if obj.settings['custom_integration']
-      json['asdf'] = 'asdf'
       device_token, refresh_token = obj.device.tokens
       if obj.device && json['permissions'] && json['permissions']['edit']
         if obj.created_at > 24.hours.ago 

--- a/spec/lib/json_api/integration_spec.rb
+++ b/spec/lib/json_api/integration_spec.rb
@@ -85,6 +85,48 @@ describe JsonApi::Integration do
       expect(hash['user_settings'][1]['protected']).to eq(true)
     end
     
+    it "should round-trip board_render_url" do
+      i = UserIntegration.create
+      i.settings['board_render_url'] = 'https://example.com/render'
+      hash = JsonApi::Integration.build_json(i)
+      expect(hash['render']).to eq(true)
+      expect(hash['board_render_url']).to eq('https://example.com/render')
+    end
+
+    it "should not include board_render_url when not set" do
+      i = UserIntegration.create
+      hash = JsonApi::Integration.build_json(i)
+      expect(hash['render']).to eq(false)
+      expect(hash['board_render_url']).to eq(nil)
+    end
+
+    it "should serialize button_webhook_url for remote webhooks" do
+      i = UserIntegration.create
+      i.settings['button_webhook_url'] = 'http://example.com/hook'
+      hash = JsonApi::Integration.build_json(i)
+      expect(hash['webhook']).to eq(true)
+      expect(hash['button_webhook_url']).to eq('http://example.com/hook')
+      expect(hash['button_webhook_local']).to eq(nil)
+    end
+
+    it "should include button_webhook_local when set for local webhooks" do
+      i = UserIntegration.create
+      i.settings['button_webhook_url'] = 'http://localhost:1234/hook'
+      i.settings['button_webhook_local'] = true
+      hash = JsonApi::Integration.build_json(i)
+      expect(hash['webhook']).to eq(true)
+      expect(hash['button_webhook_url']).to eq('http://localhost:1234/hook')
+      expect(hash['button_webhook_local']).to eq(true)
+    end
+
+    it "should not include a debug asdf key" do
+      u = User.create
+      i = UserIntegration.create(user: u)
+      i.settings['custom_integration'] = true
+      hash = JsonApi::Integration.build_json(i, permissions: u)
+      expect(hash.keys).to_not be_include('asdf')
+    end
+
     it "should include user parameters for templates" do
       u = User.create
       ui = UserIntegration.create(user: u, template: true, integration_key: 'keyed')

--- a/spec/lib/json_api/integration_spec.rb
+++ b/spec/lib/json_api/integration_spec.rb
@@ -85,31 +85,29 @@ describe JsonApi::Integration do
       expect(hash['user_settings'][1]['protected']).to eq(true)
     end
     
-    it "should round-trip board_render_url for a user with edit permission" do
-      u = User.create
-      i = UserIntegration.create(user: u)
+    it "should round-trip board_render_url" do
+      i = UserIntegration.create
       i.settings['board_render_url'] = 'https://example.com/render'
-      hash = JsonApi::Integration.build_json(i, permissions: u)
+      hash = JsonApi::Integration.build_json(i)
       expect(hash['render']).to eq(true)
       expect(hash['board_render_url']).to eq('https://example.com/render')
     end
 
     it "should not include board_render_url when not set" do
-      u = User.create
-      i = UserIntegration.create(user: u)
-      hash = JsonApi::Integration.build_json(i, permissions: u)
+      i = UserIntegration.create
+      hash = JsonApi::Integration.build_json(i)
       expect(hash['render']).to eq(false)
       expect(hash['board_render_url']).to eq(nil)
     end
 
-    it "should not include board_render_url without edit permission" do
+    it "should round-trip board_render_url regardless of permission, since extra_includes already exposes the same value as render_url to any viewer" do
       u = User.create
       viewer = User.create
       i = UserIntegration.create(user: u, settings: {'global' => true})
       i.settings['board_render_url'] = 'https://example.com/render'
       hash = JsonApi::Integration.build_json(i, permissions: viewer)
       expect(hash['render']).to eq(true)
-      expect(hash['board_render_url']).to eq(nil)
+      expect(hash['board_render_url']).to eq('https://example.com/render')
     end
 
     it "should serialize button_webhook_url for remote webhooks to a user with edit permission" do

--- a/spec/lib/json_api/integration_spec.rb
+++ b/spec/lib/json_api/integration_spec.rb
@@ -85,31 +85,54 @@ describe JsonApi::Integration do
       expect(hash['user_settings'][1]['protected']).to eq(true)
     end
     
-    it "should round-trip board_render_url" do
-      i = UserIntegration.create
+    it "should round-trip board_render_url for a user with edit permission" do
+      u = User.create
+      i = UserIntegration.create(user: u)
       i.settings['board_render_url'] = 'https://example.com/render'
-      hash = JsonApi::Integration.build_json(i)
+      hash = JsonApi::Integration.build_json(i, permissions: u)
       expect(hash['render']).to eq(true)
       expect(hash['board_render_url']).to eq('https://example.com/render')
     end
 
     it "should not include board_render_url when not set" do
-      i = UserIntegration.create
-      hash = JsonApi::Integration.build_json(i)
+      u = User.create
+      i = UserIntegration.create(user: u)
+      hash = JsonApi::Integration.build_json(i, permissions: u)
       expect(hash['render']).to eq(false)
       expect(hash['board_render_url']).to eq(nil)
     end
 
-    it "should serialize button_webhook_url for remote webhooks" do
-      i = UserIntegration.create
+    it "should not include board_render_url without edit permission" do
+      u = User.create
+      viewer = User.create
+      i = UserIntegration.create(user: u, settings: {'global' => true})
+      i.settings['board_render_url'] = 'https://example.com/render'
+      hash = JsonApi::Integration.build_json(i, permissions: viewer)
+      expect(hash['render']).to eq(true)
+      expect(hash['board_render_url']).to eq(nil)
+    end
+
+    it "should serialize button_webhook_url for remote webhooks to a user with edit permission" do
+      u = User.create
+      i = UserIntegration.create(user: u)
       i.settings['button_webhook_url'] = 'http://example.com/hook'
-      hash = JsonApi::Integration.build_json(i)
+      hash = JsonApi::Integration.build_json(i, permissions: u)
       expect(hash['webhook']).to eq(true)
       expect(hash['button_webhook_url']).to eq('http://example.com/hook')
       expect(hash['button_webhook_local']).to eq(nil)
     end
 
-    it "should include button_webhook_local when set for local webhooks" do
+    it "should not leak a remote button_webhook_url (which may embed a secret key) without edit permission" do
+      u = User.create
+      viewer = User.create
+      i = UserIntegration.create(user: u, settings: {'global' => true})
+      i.settings['button_webhook_url'] = 'https://maker.ifttt.com/trigger/code/with/key/super-secret'
+      hash = JsonApi::Integration.build_json(i, permissions: viewer)
+      expect(hash['webhook']).to eq(true)
+      expect(hash['button_webhook_url']).to eq(nil)
+    end
+
+    it "should include button_webhook_local and button_webhook_url when set for local webhooks, regardless of permission" do
       i = UserIntegration.create
       i.settings['button_webhook_url'] = 'http://localhost:1234/hook'
       i.settings['button_webhook_local'] = true


### PR DESCRIPTION
## Summary
- `JsonApi::Integration#build_json` declares `board_render_url` and `button_webhook_url` as writable Ember attrs but never serialized them back under those keys (LL-27d20047db, LL-30bcbc1e27); also dropped the leftover `json['asdf'] = 'asdf'` debug key (LL-41d2d553ab).
- Verified against current code that neither read/write gap is reachable in a live flow today: `add-integration.hbs` is create-only (`createRecord`, never reload of an existing integration) and `integration-details.hbs` exposes no edit fields for these values. This matches the adversary reviewer's prior refutation recorded in `audit-reports/FINDINGS.json` -- treating this as a contract-tidiness fix per Scot's "accepted for remediation in a cleanup pass" disposition, not a live-bug fix.
- `FINDINGS.json` is intentionally left untouched; only Scot closes/attests findings per the compliance register rules.

## Changes
- `lib/json_api/integration.rb`:
  - Always emit `button_webhook_url` when `webhook` is true for **local** webhooks (unchanged prior behavior). For **remote** webhooks, only emit it when the viewer has `edit` permission -- remote URLs can embed a secret key (e.g. IFTTT's `.../with/key/<secret>` format), and `permissions.rb:20` grants `view` (not `edit`) to any user on global/template integrations, so unconditional exposure would have leaked the secret. Caught by a Codex senior-dev review pass on this branch; fixed and re-reviewed clean.
  - Always emit `board_render_url` whenever `render` is true, with no permission gate. An initial version of this fix gated it the same way as `button_webhook_url`, but the adversary review pass found that `extra_includes` (line 88) already emits the identical value unconditionally as `render_url`, consumed by any board viewer to embed the board (`app/frontend/app/routes/board.js:57-65`). Gating one key while the other leaked the same value was security theater with no real protection, so the gate was dropped.
  - Remove the stray `asdf` debug key.
- `spec/lib/json_api/integration_spec.rb`: coverage for the round-trip (local + remote webhook, with/without edit permission, board render url present/absent) and for the removed debug key.

## Review chain
1. Codex senior-dev pass #1: flagged the remote-webhook-secret-leak regression (P1). Fixed.
2. Codex senior-dev pass #2: approved the fix.
3. Adversary pass: flagged that the `board_render_url` gate was defeated by `render_url` (Medium) -- fixed by dropping the gate. Also surfaced two pre-existing, out-of-scope issues worth a follow-up look, not fixed here:
   - `lib/json_api/integration.rb:68` -- `obj.device.tokens` is called one line before the `if obj.device` guard that protects it; a userless global custom integration (no device) would 500 on serialization. Pre-existing, not touched by this PR.
   - `button_webhook_local` is a client-asserted flag with no server-side validation that the URL is actually a local/private address (`app/models/user_integration.rb:163`) -- the "local means safe to expose unconditionally" assumption isn't enforced. Pre-existing, not touched by this PR.

## Test plan
- [x] `DB_USER=scotw RAILS_ENV=test bundle exec rspec spec/lib/json_api/integration_spec.rb spec/controllers/api/integrations_controller_spec.rb spec/models/user_integration_spec.rb` -- 93 examples, 0 failures
- [x] Codex senior-dev review (`/review-pr`) -- approved after one fix round
- [x] Adversary pass (`/adversary-review`) -- ship-with-conditions, condition applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)