### PR TITLE
fix(compliance): narrow DataPolicyEnforcer's session-only retention gap

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "99e071130588610e9a34d388691f6d771a1774dbb10f2a72eac46c855654825c",
+      "contentHash": "92f126ee2288e6ddfb4e169b71419c8d2029886ac11c81c18ca278029104f4fe",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "92f126ee2288e6ddfb4e169b71419c8d2029886ac11c81c18ca278029104f4fe",
+      "contentHash": "7171d953aaa17beb8ba9323f6f47986d2f0dac11b2c37f4922ce6fd93b4ed86e",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `99e071130588` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `92f126ee2288` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `92f126ee2288` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `7171d953aaa1` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -3200,6 +3200,38 @@
         "timeframe": "90d"
       },
       "notes": "Surfaced continuing the Phase 5 rehearsal 0a follow-up (PR #521) after Scot confirmed the original personal-Gmail diagnostic email never arrived. Confidence downgraded medium->low and evidence corrected 2026-07-04 after Codex's review of this PR (running against this finding's initial commit) correctly caught that GetSendStatistics.DeliveryAttempts was being misread as delivery confirmation; verified against AWS's own SendDataPoint API docs before accepting the correction. The confirmed, undisputed fact remains: the original send to scotwahlquist@gmail.com never arrived (inbox or spam checked), while a same-account retest to a Workspace-internal address arrived immediately -- the open question is root cause, not whether a real gap exists. Low severity and no user impact today because prod/staging currently carry no real external users (project note: prod has no real users at cutover) -- all current transactional mail recipients are internal/test accounts. Note this finding's evidence base is a single send to each recipient type (n=1 each way), not a reliability claim about Workspace delivery in general; treat the Workspace-internal send as one clean data point, not a proof that SES-to-Workspace mail is broadly reliable. Revisit before onboarding real school-district/hospital/parent users on personal email providers, since password resets, registration confirmations, and consent notifications going silently missing would be a real support burden and, for consent-related mail specifically, a compliance concern (FERPA/COPPA parental notification). REPRODUCED 2026-07-04 via the actual application code path (Phase 5 step 0a follow-up, scot/docs/phase5-0a-status-v2): all prior evidence used a raw Aws::SES::Client#send_email call, not Rails ActionMailer -- this test partially closes that gap. A throwaway Cloud Run Job ran `ActionMailer::Base.mail(...).deliver_now` (delivery_method: :ses, config/environments/production.rb:116) against the currently-deployed lingolinq-web/worker image, sending to both beta@lingolinq.com and scotwahlquist@gmail.com in the same run. Both calls returned real SES MessageIds via Aws::Rails::SesMailer#deliver! (0101019f2b9c732c-... and 0101019f2b9c73e6-... respectively), confirming ActionMailer's :ses delivery-method adapter is correctly wired end-to-end in this Cloud Run environment (SES_REGION/AWS_REGION resolve, AWS_KEY/AWS_SECRET credentials work, DEFAULT_EMAIL_FROM resolves). CAVEAT (raised by Codex review of this PR, accepted): the test called the generic `ActionMailer::Base.mail(...)` directly rather than a concrete application mailer class (UserMailer/AdminMailer/SubscriptionMailer/SupervisorMailer, app/mailers/*.rb, all ActionMailer::Base subclasses) -- it verifies the SES adapter, credentials, and region wiring, not a real transactional mailer's view template or the exact code path a password-reset or notification email takes. A follow-up test through a concrete mailer class is still needed for full representativeness. Checked actual delivery via the connected Gmail account (scotwahlquist@gmail.com): the beta@lingolinq.com-addressed message arrived (INBOX, not spam) -- note this refines the earlier assumption that beta@ resolves to scot@lingolinq.com's Workspace inbox specifically; it also reaches this personal Gmail account, exact routing (group membership vs. a broader alias) not investigated further here. The message addressed directly to scotwahlquist@gmail.com was searched for across inbox/spam/trash (`in:anywhere`, `includeTrash:true`) and found nowhere -- reproducing the non-delivery exactly, now through ActionMailer rather than the raw SDK. This partially closes the 'was this just a raw-SDK artifact' question (adapter-level, not yet mailer-class-level) but does not change the underlying open root-cause question (still no per-message delivery event tracking exists to say why Gmail specifically drops it); remediation options (a)-(d) above remain the path forward."
+    },
+    {
+      "id": "LL-caf2528468",
+      "ruleKey": "user-extra-profile-cache-not-invalidated-on-log-purge",
+      "title": "UserExtra/UserLink profile-history caches are not invalidated when the source profile LogSession is deleted",
+      "severity": "medium",
+      "confidence": "high",
+      "frameworks": [
+        "GDPR",
+        "FERPA"
+      ],
+      "status": "open",
+      "evidence": {
+        "type": "code",
+        "file": "app/models/user_extra.rb",
+        "line": 58,
+        "snippet": "self.settings['recent_profiles'][profile_id] = recents",
+        "sha": "97481d093915bc2b8da448c5640b3873c10beb00"
+      },
+      "firstSeen": "2026-07-05",
+      "lastSeen": "2026-07-05",
+      "owner": "unassigned",
+      "remediation": {
+        "options": "Before extending any retention/purge job to LogSession log_type 'profile', add cache invalidation: when a 'profile' LogSession is destroyed, either recompute UserExtra#process_profile for the affected user_id/profile_id (dropping the deleted session from the recents list) or scrub matching entries by log_id from UserExtra.settings['recent_profiles'] and UserLink.data['state']['profile_history'] directly. Add a spec asserting the cache no longer contains the deleted log's summary/log_id after purge.",
+        "timeframe": "60d"
+      },
+      "closureEvidence": {
+        "sha": "",
+        "verifierNote": "",
+        "attestation": ""
+      },
+      "notes": "Surfaced by Codex's senior-dev review (/review-pr) of PR #535 (LL-1890f6a922, DataPolicyEnforcer retention scope): extending the retention purge to LogSession log_type 'profile' would delete the source record while UserExtra#process_profile's cached identifiable summary (template_id, summary, summary_color, log_id) and the mirrored UserLink.data['state']['profile_history'] entry are never refreshed on destroy, so identifiable content would persist in those caches after the source log is gone -- worse than the pre-existing status quo of not purging 'profile' at all. PR #535 responded by dropping 'profile' from DataPolicyEnforcer::RETAINABLE_LOG_TYPES (lib/data_policy_enforcer.rb) rather than shipping a half-fixed purge; this finding tracks the cache-invalidation work needed before 'profile' can safely be added back. Checked note/assessment/eval/journal for the same pattern: none found (user_badge.rb's assessment usage re-queries live LogSession rows on demand rather than caching a summary; weekly_stats_summary.rb caches only session_ids, not identifiable content, and per DATA_RETENTION.md's Analytics events row this is documented/accepted since aggregates 'do not re-identify individuals')."
     }
   ]
 }

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -3232,6 +3232,101 @@
         "attestation": ""
       },
       "notes": "Surfaced by Codex's senior-dev review (/review-pr) of PR #535 (LL-1890f6a922, DataPolicyEnforcer retention scope): extending the retention purge to LogSession log_type 'profile' would delete the source record while UserExtra#process_profile's cached identifiable summary (template_id, summary, summary_color, log_id) and the mirrored UserLink.data['state']['profile_history'] entry are never refreshed on destroy, so identifiable content would persist in those caches after the source log is gone -- worse than the pre-existing status quo of not purging 'profile' at all. PR #535 responded by dropping 'profile' from DataPolicyEnforcer::RETAINABLE_LOG_TYPES (lib/data_policy_enforcer.rb) rather than shipping a half-fixed purge; this finding tracks the cache-invalidation work needed before 'profile' can safely be added back. Checked note/assessment/eval/journal for the same pattern: none found (user_badge.rb's assessment usage re-queries live LogSession rows on demand rather than caching a summary; weekly_stats_summary.rb caches only session_ids, not identifiable content, and per DATA_RETENTION.md's Analytics events row this is documented/accepted since aggregates 'do not re-identify individuals')."
+    },
+    {
+      "id": "LL-14edf1a801",
+      "ruleKey": "data-policy-enforcer-child-org-inheritance-skipped",
+      "title": "DataPolicyEnforcer retention job skips child orgs that inherit (rather than set) a retention_months policy",
+      "severity": "medium",
+      "confidence": "high",
+      "frameworks": [
+        "GDPR",
+        "FERPA"
+      ],
+      "status": "open",
+      "evidence": {
+        "type": "code",
+        "file": "lib/data_policy_enforcer.rb",
+        "line": 22,
+        "snippet": "Organization.where(\"data_policy_version > 0\").find_each do |org|",
+        "sha": "66ac5bd2eea2508df0c81250d195b97ae7ed5592"
+      },
+      "firstSeen": "2026-07-05",
+      "lastSeen": "2026-07-05",
+      "owner": "unassigned",
+      "remediation": {
+        "options": "Organization#effective_data_policy (app/models/organization.rb:81-101) is explicitly designed to inherit retention_months from a parent org, but enforce_retention!'s candidate-org WHERE clause only matches orgs whose OWN data_policy_version is > 0, and then only sweeps that org's own sponsored_users. A child org that never set its own policy (data_policy_version stays 0) is skipped by the WHERE clause entirely, even though its users are governed by an inherited window via a parent's policy -- so their communication logs never expire. Widen the candidate set to include any org whose effective (not just own) retention_months resolves to a positive value -- e.g. iterate every org with a policy-bearing ancestor, or drive the sweep off each org's own effective_data_policy rather than gating the WHERE clause on data_policy_version. Add a parent(policy)+child(data_policy_version 0) spec asserting the child's stale logs are purged.",
+        "timeframe": "60d"
+      },
+      "closureEvidence": {
+        "sha": "",
+        "verifierNote": "",
+        "attestation": ""
+      },
+      "notes": "Surfaced by adversary review of PR #535 (LL-1890f6a922, DataPolicyEnforcer log_type scope). Pre-existing since before that PR -- it changed only the log_type filter inside the loop, not the org-selection WHERE clause or the sponsored_users scoping -- but it directly undermines LL-1890f6a922's storage-limitation objective: an org hierarchy where only the parent sets retention_months leaves every child org's logs permanently unenforced. Confirmed against Organization#effective_data_policy's inheritance logic (organization.rb:84-96), which resolves retention_months from a parent for exactly this configuration, and against Organization#sponsored_users (organization.rb:677-685), which is scoped to one org's own attached users, not any descendant org's users."
+    },
+    {
+      "id": "LL-3bb2e2eaad",
+      "ruleKey": "data-policy-enforcer-purge-no-audit-event-deletes-papertrail",
+      "title": "Retention purge deletes the LogSession's PaperTrail destroy-version and writes no disposal AuditEvent",
+      "severity": "medium",
+      "confidence": "high",
+      "frameworks": [
+        "GDPR",
+        "HIPAA"
+      ],
+      "status": "open",
+      "evidence": {
+        "type": "code",
+        "file": "lib/flusher.rb",
+        "line": 45,
+        "snippet": "PaperTrail::Version.where(:item_type => record_class, :item_id => record_db_id).delete_all",
+        "sha": "66ac5bd2eea2508df0c81250d195b97ae7ed5592"
+      },
+      "firstSeen": "2026-07-05",
+      "lastSeen": "2026-07-05",
+      "owner": "unassigned",
+      "remediation": {
+        "options": "Flusher.flush_record (lib/flusher.rb) destroys the record (creating a has_paper_trail :on => [:destroy] version, log_session.rb:24) and then immediately delete_alls that same version via flush_versions, and DataPolicyEnforcer.enforce_retention! writes no AuditEvent for its purges at all -- unlike Flusher.flush_leftovers, which records a per-category AuditEvent for its deletions (lib/flusher.rb ~line 224). This contradicts docs/legal/DATA_RETENTION.md row 30 (Authentication and audit trails / PaperTrail versions on User, Board, LogSession retained 6 years, HIPAA 45 CFR Sec 164.316(b)(2)(i)) and leaves no record proving what data was destroyed, when, or by which policy. Either stop deleting the destroy-version for LogSession specifically in this retention path (retain per row 30), or have enforce_retention! emit a per-run AuditEvent (actor 'system', org id, purged log ids/counts) the way flush_leftovers already does, so a HIPAA access-log review can reconstruct the disposal.",
+        "timeframe": "60d"
+      },
+      "closureEvidence": {
+        "sha": "",
+        "verifierNote": "",
+        "attestation": ""
+      },
+      "notes": "Surfaced by adversary review of PR #535 (LL-1890f6a922, DataPolicyEnforcer log_type scope). Pre-existing since before that PR -- Flusher.flush_record's destroy-then-delete-versions behavior and enforce_retention!'s lack of an AuditEvent call are both unchanged by it -- but PR #535 widens the set of log_types this same behavior applies to from 1 (session) to 4 (session/note/assessment/eval/journal), modestly increasing real-world exposure. No user impact today (prod/staging carry no real users, per project note), but this needs resolving before onboarding real school-district/hospital users, since the retention job is precisely the mechanism DATA_RETENTION.md documents as satisfying GDPR 5(1)(e) storage limitation, and doing so by destroying the very audit trail row 30 requires keeping for 6 years is an internal contradiction in the documented schedule, not just a code gap."
+    },
+    {
+      "id": "LL-de9c94bf36",
+      "ruleKey": "data-policy-enforcer-user-wide-scope-cross-org-logs",
+      "title": "Org retention policy purges a sponsored user's entire log history, including logs outside that org's context",
+      "severity": "low",
+      "confidence": "medium",
+      "frameworks": [
+        "GDPR"
+      ],
+      "status": "open",
+      "evidence": {
+        "type": "code",
+        "file": "lib/data_policy_enforcer.rb",
+        "line": 31,
+        "snippet": "stale = LogSession.where(user_id: user_ids)",
+        "sha": "66ac5bd2eea2508df0c81250d195b97ae7ed5592"
+      },
+      "firstSeen": "2026-07-05",
+      "lastSeen": "2026-07-05",
+      "owner": "unassigned",
+      "remediation": {
+        "options": "Confirm with Scot whether an org's retention_months is meant to reach a sponsored user's entire log history (including logs predating enrollment, or generated under a personal/other-org context), or only logs created within that org's context. Today the query is user_id-scoped only, with no org/context filter, so any sponsoring org that sets retention_months deletes all of that user's aged logs regardless of origin -- for a user sponsored by more than one org, the most-aggressive policy effectively wins for their whole history. If the current behavior is intentional, document it explicitly in DATA_RETENTION.md's LogSession row rather than leaving it implicit; if not, scope the purge query by log ownership/context (e.g. author's org at the time, or a recorded originating-org field).",
+        "timeframe": "90d"
+      },
+      "closureEvidence": {
+        "sha": "",
+        "verifierNote": "",
+        "attestation": ""
+      },
+      "notes": "Surfaced by adversary review of PR #535 (LL-1890f6a922, DataPolicyEnforcer log_type scope). Pre-existing since before that PR -- the user_id-only scoping is unchanged, and PR #535 only widened the log_type filter -- but broadening the purge to 4 additional log_types (note/assessment/eval/journal) means more of a cross-context user's history is now reachable by this same scoping gap than before. This is data over-deletion risk, not a data leak, and is plausibly by design (retention as a property of the user's relationship to a sponsoring org); flagged as a design question for Scot rather than asserted as a defect."
     }
   ]
 }

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -9,7 +9,7 @@
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (42)
+## Open (45)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -33,6 +33,8 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-b06f063f85 |  | medium | WCAG | **accepted** | audit-run | Shared modal-dialog wrapper sets role=dialog/aria-modal but no accessible name | `app/frontend/app/templates/components/modal-dialog.hbs`:6 |
 | LL-8fab55372e |  | medium | WCAG | **accepted** | audit-run | Speak-bar remote-modeling (#reply_icon) button has no accessible name | `app/frontend/app/templates/application.hbs`:148 |
 | LL-caf2528468 |  | medium | GDPR, FERPA | untriaged | audit-run | UserExtra/UserLink profile-history caches are not invalidated when the source profile LogSession is deleted | `app/models/user_extra.rb`:58 |
+| LL-14edf1a801 |  | medium | GDPR, FERPA | untriaged | audit-run | DataPolicyEnforcer retention job skips child orgs that inherit (rather than set) a retention_months policy | `lib/data_policy_enforcer.rb`:22 |
+| LL-3bb2e2eaad |  | medium | GDPR, HIPAA | untriaged | audit-run | Retention purge deletes the LogSession's PaperTrail destroy-version and writes no disposal AuditEvent | `lib/flusher.rb`:45 |
 | LL-1890f6a922 | P2-5 | medium | GDPR, FERPA | **accepted** | audit-run | DataPolicyEnforcer retention only purges session log sessions | `lib/data_policy_enforcer.rb`:14 |
 | LL-d35cbdb313 | P2-7 | medium | FERPA | **accepted** | audit-run | User creation (incl. org start codes) generates no AuditEvent | `app/controllers/api/users_controller.rb`:244 |
 | LL-310b464be4 | P2-8 | medium | FERPA | **accepted** | audit-run | protected_image accepts user_token via URL parameter | `app/controllers/api/users_controller.rb`:871 |
@@ -52,6 +54,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-e76d6378b5 |  | low |  | **accepted** | audit-run | Webhook model declares notifications and content_type attrs that Rails never serializes | `app/frontend/app/models/webhook.js`:12 |
 | LL-5d7197fa7d |  | low | HIPAA, FERPA | untriaged | audit-run | PaperTrail versions with unconstantizable item_type are detected but retention disposition is undecided | `lib/flusher.rb`:116 |
 | LL-42a24ee911 |  | low | SOC2 | untriaged | audit-run | A diagnostic SES send to a personal Gmail address never arrived (inbox or spam); a same-account send to a Workspace-internal address arrived immediately | (attestation) |
+| LL-de9c94bf36 |  | low | GDPR | untriaged | audit-run | Org retention policy purges a sponsored user's entire log history, including logs outside that org's context | `lib/data_policy_enforcer.rb`:31 |
 | LL-941001ca58 | Dep-eslint-8-eol | low | SOC2 | **accepted** | audit-run | eslint 8.57.1 is EOL (v8 end-of-life); dev toolchain on an unsupported linter | `app/frontend/package.json`:64 |
 | LL-a97357136e | P2-2 | low | SOC2 | **wontfix** | audit-run | params.permit! bypasses Strong Parameters | `app/controllers/api/organizations_controller.rb`:866 |
 | LL-ce00c8d3ad | P2-3 | low |  | **wontfix** | audit-run | License model lacks Processable concern | `app/models/license.rb`:1 |
@@ -126,4 +129,4 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 
 ---
 
-_90 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._
+_93 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -9,7 +9,7 @@
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (41)
+## Open (42)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -32,6 +32,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-e08bd45a9f |  | medium | WCAG | **accepted** | audit-run | Sentence box / utterance bar vocalize control is an anchor with no button role or accessible name | `app/frontend/app/templates/application.hbs`:86 |
 | LL-b06f063f85 |  | medium | WCAG | **accepted** | audit-run | Shared modal-dialog wrapper sets role=dialog/aria-modal but no accessible name | `app/frontend/app/templates/components/modal-dialog.hbs`:6 |
 | LL-8fab55372e |  | medium | WCAG | **accepted** | audit-run | Speak-bar remote-modeling (#reply_icon) button has no accessible name | `app/frontend/app/templates/application.hbs`:148 |
+| LL-caf2528468 |  | medium | GDPR, FERPA | untriaged | audit-run | UserExtra/UserLink profile-history caches are not invalidated when the source profile LogSession is deleted | `app/models/user_extra.rb`:58 |
 | LL-1890f6a922 | P2-5 | medium | GDPR, FERPA | **accepted** | audit-run | DataPolicyEnforcer retention only purges session log sessions | `lib/data_policy_enforcer.rb`:14 |
 | LL-d35cbdb313 | P2-7 | medium | FERPA | **accepted** | audit-run | User creation (incl. org start codes) generates no AuditEvent | `app/controllers/api/users_controller.rb`:244 |
 | LL-310b464be4 | P2-8 | medium | FERPA | **accepted** | audit-run | protected_image accepts user_token via URL parameter | `app/controllers/api/users_controller.rb`:871 |
@@ -125,4 +126,4 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 
 ---
 
-_89 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._
+_90 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-07-05T22:14:08Z
+**Page generated:** 2026-07-05T23:56:18Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **4** | 21 | 19 |
+| **0** | **4** | 22 | 19 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -45,6 +45,7 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-ab88513735 |  | medium |  | User model declares is_admin attribute but Rails JSON builder never emits it | `app/frontend/app/models/user.js`:40 |
 | LL-b06f063f85 |  | medium | WCAG | Shared modal-dialog wrapper sets role=dialog/aria-modal but no accessible name | `app/frontend/app/templates/components/modal-dialog.hbs`:6 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
+| LL-caf2528468 |  | medium | GDPR, FERPA | UserExtra/UserLink profile-history caches are not invalidated when the source profile LogSession is deleted | `app/models/user_extra.rb`:58 |
 | LL-e08bd45a9f |  | medium | WCAG | Sentence box / utterance bar vocalize control is an anchor with no button role or accessible name | `app/frontend/app/templates/application.hbs`:86 |
 | LL-ed914bded3 |  | medium | WCAG | Raw low-contrast brand token used as text foreground (board-tile language pill) | `app/frontend/app/styles/app.scss`:193 |
 | LL-1890f6a922 | P2-5 | medium | GDPR, FERPA | DataPolicyEnforcer retention only purges session log sessions | `lib/data_policy_enforcer.rb`:14 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-07-05T23:56:18Z
+**Page generated:** 2026-07-06T00:10:24Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **4** | 22 | 19 |
+| **0** | **4** | 24 | 20 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -31,7 +31,9 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-0c6e931f47 |  | medium | WCAG | Sentence box (utterance bar) symbol chip images have no alt attribute | `app/frontend/app/templates/components/button-list.hbs`:21 |
 | LL-13ad11eaee |  | medium | WCAG | Loading status text has no aria-live or role=status | `app/frontend/app/templates/bento.hbs`:14 |
+| LL-14edf1a801 |  | medium | GDPR, FERPA | DataPolicyEnforcer retention job skips child orgs that inherit (rather than set) a retention_months policy | `lib/data_policy_enforcer.rb`:22 |
 | LL-35e6b7a3d6 |  | medium | WCAG | Dashboard search overlay text input has no programmatic label (placeholder only) | `app/frontend/app/templates/components/dashboard/authenticated-view.hbs`:588 |
+| LL-3bb2e2eaad |  | medium | GDPR, HIPAA | Retention purge deletes the LogSession's PaperTrail destroy-version and writes no disposal AuditEvent | `lib/flusher.rb`:45 |
 | LL-40dd412ed6 |  | medium | WCAG | Rails application layout html element has no lang attribute | `app/views/layouts/application.html.erb`:2 |
 | LL-52ff2a9a79 |  | medium | SOC2 | CI security-scan job (Brakeman SAST, bundle-audit, npm audit, gitleaks) is entirely non-blocking | `.github/workflows/ci.yml`:107 |
 | LL-5954bcbbe6 |  | medium | SOC2 | Pre-existing Resque background-job failures: ImageMagick identify missing in Cloud Run image, stale job_stash lookups, and a call to a removed Board method | (attestation) |
@@ -65,6 +67,7 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-a2b45c2bcb |  | low | SOC2 | Finder agent-memory (memory: project) may carry process state across audit runs | `.claude/agents/infra-auditor.md`:7 |
 | LL-b0bc6880e6 |  | low | SOC2 | sync-render-secrets.yml (holds RENDER_API_KEY + 1Password token) declares no permissions: block, inheriting default write GITHUB_TOKEN | `.github/workflows/sync-render-secrets.yml`:14 |
 | LL-ba0585ab93 |  | low | SOC2, HIPAA, FERPA | Production Postgres uses sslmode=require (encrypt only), not verify-ca/verify-full | `config/database.yml`:26 |
+| LL-de9c94bf36 |  | low | GDPR | Org retention policy purges a sponsored user's entire log history, including logs outside that org's context | `lib/data_policy_enforcer.rb`:31 |
 | LL-e066ea6fa3 |  | low | SOC2 | http-proxy 1.18.1 (EOL, last release 2021) has CVE-2024-21943 (ReDoS via Host header); dev-only | `app/frontend/package.json`:64 |
 | LL-e76d6378b5 |  | low |  | Webhook model declares notifications and content_type attrs that Rails never serializes | `app/frontend/app/models/webhook.js`:12 |
 | LL-941001ca58 | Dep-eslint-8-eol | low | SOC2 | eslint 8.57.1 is EOL (v8 end-of-life); dev toolchain on an unsupported linter | `app/frontend/package.json`:64 |

--- a/lib/data_policy_enforcer.rb
+++ b/lib/data_policy_enforcer.rb
@@ -1,4 +1,14 @@
 module DataPolicyEnforcer
+  # Discrete, timestamped communication logs the retention window in
+  # DATA_RETENTION.md ("Communication logs (LogSession)") applies to -- the
+  # same set api/logs_controller.rb exposes as browsable per-event logs.
+  # Deliberately excludes 'daily_use' and 'modeling_activities': those are
+  # per-user singleton trackers (LogSession.find_or_create_by(log_type:,
+  # user_id:)) whose started_at freezes at first creation and never advances
+  # on later updates, so an age-based purge would delete a still-in-use
+  # record for any long-tenured active user instead of a stale one.
+  RETAINABLE_LOG_TYPES = %w[session note assessment eval profile journal].freeze
+
   def self.enforce_retention!
     count = 0
     Organization.where("data_policy_version > 0").find_each do |org|
@@ -11,7 +21,7 @@ module DataPolicyEnforcer
       next if user_ids.empty?
 
       stale = LogSession.where(user_id: user_ids)
-                        .where(log_type: 'session')
+                        .where(log_type: RETAINABLE_LOG_TYPES)
                         .where('started_at < ?', cutoff)
 
       stale.find_each do |session|

--- a/lib/data_policy_enforcer.rb
+++ b/lib/data_policy_enforcer.rb
@@ -7,7 +7,15 @@ module DataPolicyEnforcer
   # user_id:)) whose started_at freezes at first creation and never advances
   # on later updates, so an age-based purge would delete a still-in-use
   # record for any long-tenured active user instead of a stale one.
-  RETAINABLE_LOG_TYPES = %w[session note assessment eval profile journal].freeze
+  # Deliberately excludes 'profile': UserExtra#process_profile caches each
+  # profile session's identifiable summary + global_id into
+  # UserExtra.settings['recent_profiles'] and matching
+  # UserLink.data['state']['profile_history'] (app/models/user_extra.rb:40-97),
+  # and nothing refreshes those caches when the source LogSession is later
+  # destroyed. Purging 'profile' logs here today would delete the source
+  # record while leaving its identifiable summary behind in those caches --
+  # tracked as a follow-up (LL-caf2528468) rather than shipped half-fixed.
+  RETAINABLE_LOG_TYPES = %w[session note assessment eval journal].freeze
 
   def self.enforce_retention!
     count = 0

--- a/spec/lib/data_policy_enforcer_spec.rb
+++ b/spec/lib/data_policy_enforcer_spec.rb
@@ -46,22 +46,24 @@ describe DataPolicyEnforcer do
       expect(LogSession.where(id: fresh.id).count).to eq(1)
     end
 
-    it "purges stale note, assessment, eval, profile, and journal logs" do
+    it "purges stale note, assessment, eval, and journal logs" do
       o, u = sponsored_org(3)
-      stale_logs = %w[note assessment eval profile journal].map { |type| log(u, type, 4.months.ago) }
-      expect(DataPolicyEnforcer.enforce_retention!).to eq(5)
+      stale_logs = %w[note assessment eval journal].map { |type| log(u, type, 4.months.ago) }
+      expect(DataPolicyEnforcer.enforce_retention!).to eq(4)
       stale_logs.each do |s|
         expect(LogSession.where(id: s.id).count).to eq(0)
       end
     end
 
-    it "never purges daily_use or modeling_activities logs regardless of age" do
+    it "never purges daily_use, modeling_activities, or profile logs regardless of age" do
       o, u = sponsored_org(3)
       daily = log(u, 'daily_use', 5.years.ago)
       modeling = log(u, 'modeling_activities', 5.years.ago)
+      profile = log(u, 'profile', 5.years.ago)
       expect(DataPolicyEnforcer.enforce_retention!).to eq(0)
       expect(LogSession.where(id: daily.id).count).to eq(1)
       expect(LogSession.where(id: modeling.id).count).to eq(1)
+      expect(LogSession.where(id: profile.id).count).to eq(1)
     end
 
     it "leaves logs for users outside the org's sponsorship untouched" do

--- a/spec/lib/data_policy_enforcer_spec.rb
+++ b/spec/lib/data_policy_enforcer_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe DataPolicyEnforcer do
+  def log(user, log_type, started_at)
+    s = LogSession.create(user: user, author: user, device: Device.create(user: user))
+    s.update_column(:log_type, log_type)
+    s.update_column(:started_at, started_at)
+    s
+  end
+
+  def sponsored_org(retention_months)
+    o = Organization.create(settings: {total_licenses: 1})
+    manager = User.create
+    o.add_manager(manager.user_name, true)
+    u = User.create
+    o.add_user(u.user_name, false, true)
+    o.reload
+    o.update_data_policy({'retention_months' => retention_months}, manager)
+    o.save!
+    [o, u.reload]
+  end
+
+  describe "enforce_retention!" do
+    it "does nothing for orgs with no data policy set" do
+      o = Organization.create(settings: {total_licenses: 1})
+      u = User.create
+      o.add_user(u.user_name, false, true)
+      log(u, 'session', 10.years.ago)
+      expect(DataPolicyEnforcer.enforce_retention!).to eq(0)
+      expect(LogSession.where(user_id: u.id).count).to eq(1)
+    end
+
+    it "does nothing when retention_months is not set or zero" do
+      o, u = sponsored_org(nil)
+      log(u, 'session', 10.years.ago)
+      expect(DataPolicyEnforcer.enforce_retention!).to eq(0)
+      expect(LogSession.where(user_id: u.id).count).to eq(1)
+    end
+
+    it "purges stale session logs older than the retention window" do
+      o, u = sponsored_org(3)
+      stale = log(u, 'session', 4.months.ago)
+      fresh = log(u, 'session', 1.month.ago)
+      expect(DataPolicyEnforcer.enforce_retention!).to eq(1)
+      expect(LogSession.where(id: stale.id).count).to eq(0)
+      expect(LogSession.where(id: fresh.id).count).to eq(1)
+    end
+
+    it "purges stale note, assessment, eval, profile, and journal logs" do
+      o, u = sponsored_org(3)
+      stale_logs = %w[note assessment eval profile journal].map { |type| log(u, type, 4.months.ago) }
+      expect(DataPolicyEnforcer.enforce_retention!).to eq(5)
+      stale_logs.each do |s|
+        expect(LogSession.where(id: s.id).count).to eq(0)
+      end
+    end
+
+    it "never purges daily_use or modeling_activities logs regardless of age" do
+      o, u = sponsored_org(3)
+      daily = log(u, 'daily_use', 5.years.ago)
+      modeling = log(u, 'modeling_activities', 5.years.ago)
+      expect(DataPolicyEnforcer.enforce_retention!).to eq(0)
+      expect(LogSession.where(id: daily.id).count).to eq(1)
+      expect(LogSession.where(id: modeling.id).count).to eq(1)
+    end
+
+    it "leaves logs for users outside the org's sponsorship untouched" do
+      o, u = sponsored_org(3)
+      unrelated = User.create
+      other_stale = log(unrelated, 'session', 4.months.ago)
+      expect(DataPolicyEnforcer.enforce_retention!).to eq(0)
+      expect(LogSession.where(id: other_stale.id).count).to eq(1)
+    end
+  end
+end

--- a/spec/lib/data_policy_enforcer_spec.rb
+++ b/spec/lib/data_policy_enforcer_spec.rb
@@ -73,5 +73,23 @@ describe DataPolicyEnforcer do
       expect(DataPolicyEnforcer.enforce_retention!).to eq(0)
       expect(LogSession.where(id: other_stale.id).count).to eq(1)
     end
+
+    it "does not purge a log just inside the retention window" do
+      # A precise tie against `months.months.ago` would race the two separate
+      # "now" calls (the fixture's and enforce_retention!'s); this codebase has
+      # no Timecop/travel_to helper to freeze time for that, so assert the
+      # boundary direction with a safe day-wide margin instead.
+      o, u = sponsored_org(3)
+      just_inside = log(u, 'session', 3.months.ago + 1.day)
+      expect(DataPolicyEnforcer.enforce_retention!).to eq(0)
+      expect(LogSession.where(id: just_inside.id).count).to eq(1)
+    end
+
+    it "never purges an eval log with no started_at, since NULL < cutoff never matches in SQL" do
+      o, u = sponsored_org(3)
+      undated_eval = log(u, 'eval', nil)
+      expect(DataPolicyEnforcer.enforce_retention!).to eq(0)
+      expect(LogSession.where(id: undated_eval.id).count).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- `DataPolicyEnforcer.enforce_retention!` filtered `LogSession` to `log_type: 'session'` only, so notes, quick assessments, evals, and journal entries never expired under an org's `retention_months` policy, even though `docs/legal/DATA_RETENTION.md` documents the whole "Communication logs (LogSession)" category as governed by this nightly job (GDPR 5(1)(e); FERPA).
- Extends the retention filter to `session`, `note`, `assessment`, `eval`, `journal` -- the same discrete, timestamped log types `api/logs_controller.rb` already exposes as browsable communication logs, minus `profile` (see below).
- Deliberately excludes `daily_use` and `modeling_activities`: verified via `LogSession.process_daily_use`/`process_modeling_event` that these are per-user singleton trackers (`find_or_create_by` on `log_type`+`user_id`) whose `started_at` freezes at first creation and never advances, so an age-based purge would delete a still-in-use record for any long-tenured active user rather than a stale one.
- Deliberately excludes `profile`: Codex's review of this PR found `UserExtra#process_profile` caches each profile session's identifiable summary + `global_id` into `UserExtra.settings['recent_profiles']` and `UserLink.data['state']['profile_history']`, and nothing refreshes those caches when the source log is destroyed -- purging `profile` today would delete the source record while leaving identifiable content behind elsewhere. Filed **LL-caf2528468** to track the cache-invalidation work needed before `profile` can be added back.
- Boards, button images/sounds, and `AiApiLog` are out of scope: each has its own documented, separate retention mechanism in `DATA_RETENTION.md` unrelated to org `retention_months`.

**This narrows, but does not close, LL-1890f6a922.** Adversary review found three more pre-existing gaps on axes this PR doesn't touch, each real enough that framing this as a full fix would overclaim:
- **LL-14edf1a801** (medium): `enforce_retention!`'s candidate-org query only matches orgs whose *own* `data_policy_version` is set, so a child org that merely *inherits* `retention_months` from a parent (`Organization#effective_data_policy`) is skipped entirely -- its users' logs never expire.
- **LL-3bb2e2eaad** (medium): `Flusher.flush_record` destroys the `LogSession` and immediately deletes its own PaperTrail version, and this job writes no `AuditEvent` -- contradicts `DATA_RETENTION.md`'s row committing PaperTrail versions to 6 years (HIPAA), and leaves no record of what was purged or when.
- **LL-de9c94bf36** (low): the purge is scoped to `user_id` only, so one sponsoring org's policy reaches a user's entire log history, including logs outside that org's context -- flagged as a design question for Scot, not asserted as a defect.

All three are pre-existing (this PR only changed the `log_type` filter) and are left open/untriaged in the register rather than fixed here -- same reasoning as the `profile` deferral: scope-creeping this PR into the org-iteration and audit-trail logic would be a materially larger, riskier change deserving its own dedicated review.

## Test plan
- [x] `spec/lib/data_policy_enforcer_spec.rb`: no-op with no data policy / zero retention_months, purge of stale `session`/`note`/`assessment`/`eval`/`journal` logs, `daily_use`/`modeling_activities`/`profile` never purged regardless of age, logs outside the org's sponsorship untouched, near-boundary retention window, `eval` with nil `started_at` never purged.
- [x] `bundle exec rspec spec/lib/data_policy_enforcer_spec.rb` -- 8 examples, 0 failures.
- [x] `bundle exec rspec spec/models/organization_spec.rb spec/models/log_session_spec.rb` green (no regressions); `spec/lib/flusher_spec.rb` has 3 pre-existing failures unrelated to this change (stale `ButtonImage` row count in the shared test DB, a known issue).
- [x] Codex senior-dev review (`/review-pr`) and adversary review both run; findings addressed or filed as follow-ups above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)