### PR TITLE
compliance(register): S3 private-bucket findings update (LL-705b10bcd7 evidence + new Render-prod SigV2 finding)

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "7171d953aaa17beb8ba9323f6f47986d2f0dac11b2c37f4922ce6fd93b4ed86e",
+      "contentHash": "bae2350fdc23ae1e08b319ba978a2c717d46d7cd9bf02e42450b083c28718018",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `7171d953aaa1` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `bae2350fdc23` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -3133,7 +3133,7 @@
         "sha": ""
       },
       "firstSeen": "2026-07-03",
-      "lastSeen": "2026-07-03",
+      "lastSeen": "2026-07-05",
       "owner": "unassigned",
       "remediation": {
         "options": "Codex review of PR #516 correctly caught two rounds of an inaccurate fix here: first, that the original remediation (bump signature_version on an Aws::S3::Client) targets a client this code path never uses; second, that the corrected suggestion (Aws::S3::Presigner#presigned_post) names a method that doesn't exist on the installed aws-sdk-s3 1.219.0 - Presigner only exposes presigned_url/presigned_request. POST-policy signing lives on the separate Aws::S3::PresignedPost class (lib/aws-sdk-s3/presigned_post.rb), normally reached via the Aws::S3::Bucket resource's presigned_post(options) method (lib/aws-sdk-s3/customizations/bucket.rb:126-133), which builds one from the client's credentials/region/bucket name. Replace the handcrafted SigV2 POST policy in Uploader.remote_upload_params (lib/uploader.rb:293-336) with a PresignedPost built this way (either via Aws::S3::Resource.new(...).bucket(name).presigned_post(...) or Aws::S3::PresignedPost.new(credentials, region, bucket_name, options) directly) - it produces the same browser-postable form-field shape (key/policy/x-amz-* fields) but signed AWS4-HMAC-SHA256, satisfying the KMS-SSE bucket's SigV4 requirement. Verify against the bucket's policy that SSE-KMS enforcement is intended, then re-run the affected board's button-set update and confirm Resque::Failure stops accumulating this error.",
@@ -3141,7 +3141,7 @@
       },
       "closureEvidence": {
         "sha": "afe03d2ded769fe14f9a55692c5c92cf4e436b59",
-        "verifierNote": "Code-remediated on scot/fix/worker-pool-oom-sigv4: Uploader.remote_upload_params (lib/uploader.rb:293-336, formerly hand-signed SigV2) rewritten to build an Aws::S3::PresignedPost(credentials, region, bucket_name, key:, content_type:, content_length_range:, success_action_status:, acl:) directly, producing an AWS4-HMAC-SHA256-signed POST policy (x-amz-credential/x-amz-algorithm/x-amz-date/x-amz-signature fields) that satisfies SSE-KMS buckets' SigV4 requirement, exactly matching the remediation option's guidance (Aws::S3::PresignedPost, not the nonexistent Presigner#presigned_post). Codex review of this PR (#521) caught a follow-on regression in the first pass (commit 77233fb19): returning the PresignedPost's own regional endpoint as upload_url broke every consumer that pattern-matches a stored self.url against the static global s3.amazonaws.com form (valid_import_bundle_url?, removable_remote_url?, fronted_url, remote_remove, and every *_controller.rb upload_success action). Fixed in afe03d2de: remote_upload_params now returns both upload_url (unchanged canonical global form, for URL construction/matching) and a new post_url (the regional SigV4 POST target); the three Typhoeus.post call sites and two frontend POST targets (content-grabbers.js, beta-feedback-form.js, with a post_url || upload_url fallback) now use post_url. spec/lib/uploader_spec.rb and spec/models/concerns/uploadable_spec.rb updated to assert the split shape; full uploader/uploadable/button_sound/beta_feedback_recording/extra_data/logs/sounds spec suites green except two pre-existing unrelated test-DB-pollution failures (ButtonImage.count inflated by orphaned committed rows; an unrelated GoSecure OpenSSL 'bad decrypt' on cached_copy; a boards_controller_spec BoardLocale.count leak - all three reproduce in isolation on main, unrelated to this change). Not yet live-verified: requires redeploying the rehearsal image and confirming Resque::Failure stops accumulating the KMS-SSE SigV4 error on the next BoardDownstreamButtonSet run, plus a bucket-policy check that SSE-KMS enforcement on this bucket is actually intended.",
+        "verifierNote": "Code-remediated on scot/fix/worker-pool-oom-sigv4: Uploader.remote_upload_params (lib/uploader.rb:293-336, formerly hand-signed SigV2) rewritten to build an Aws::S3::PresignedPost(credentials, region, bucket_name, key:, content_type:, content_length_range:, success_action_status:, acl:) directly, producing an AWS4-HMAC-SHA256-signed POST policy (x-amz-credential/x-amz-algorithm/x-amz-date/x-amz-signature fields) that satisfies SSE-KMS buckets' SigV4 requirement, exactly matching the remediation option's guidance (Aws::S3::PresignedPost, not the nonexistent Presigner#presigned_post). Codex review of this PR (#521) caught a follow-on regression in the first pass (commit 77233fb19): returning the PresignedPost's own regional endpoint as upload_url broke every consumer that pattern-matches a stored self.url against the static global s3.amazonaws.com form (valid_import_bundle_url?, removable_remote_url?, fronted_url, remote_remove, and every *_controller.rb upload_success action). Fixed in afe03d2de: remote_upload_params now returns both upload_url (unchanged canonical global form, for URL construction/matching) and a new post_url (the regional SigV4 POST target); the three Typhoeus.post call sites and two frontend POST targets (content-grabbers.js, beta-feedback-form.js, with a post_url || upload_url fallback) now use post_url. spec/lib/uploader_spec.rb and spec/models/concerns/uploadable_spec.rb updated to assert the split shape; full uploader/uploadable/button_sound/beta_feedback_recording/extra_data/logs/sounds spec suites green except two pre-existing unrelated test-DB-pollution failures (ButtonImage.count inflated by orphaned committed rows; an unrelated GoSecure OpenSSL 'bad decrypt' on cached_copy; a boards_controller_spec BoardLocale.count leak - all three reproduce in isolation on main, unrelated to this change). Not yet live-verified: requires redeploying the rehearsal image and confirming Resque::Failure stops accumulating the KMS-SSE SigV4 error on the next BoardDownstreamButtonSet run, plus a bucket-policy check that SSE-KMS enforcement on this bucket is actually intended. LIVE-VERIFIED 2026-07-05 on the GCP rehearsal stack: root cause was three stacked AWS-side blockers on lingolinq-prod-uploads (SSE-KMS default encryption with CMK d5a1a377-8f55-469d-a0ab-4a86481dba67 + BucketOwnerEnforced + Block Public Access), not residual code error. Fixes applied with Scot's approval: IAM policy lingolinq-cloudrun-s3-ses v2 (adds kms:GenerateDataKey/kms:Decrypt on the CMK, matching scripts/gcp/iam/lingolinq-cloudrun-s3-ses-policy.json) set as default for user lingolinq-cloudrun-prod; UPLOADS_S3_NO_ACL=1 applied live to lingolinq-web (rev 00003-5t9) and the lingolinq-worker pool and added to deploy-cloudrun.yml via PR #531. End-to-end synthetic verification: a real ButtonImage (id 840) processed by the live worker pool landed in the bucket (224566 bytes, image/png, ServerSideEncryption aws:kms under the expected CMK); record destroy also removed the S3 object. Read path: CloudFront distribution E2X2HAS6Y1L2MI (OAC, bucket-policy + KMS key-policy grants scoped to the distribution ARN) fronts the bucket; UPLOADS_S3_CDN set on both stacks 2026-07-05. Awaiting Scot's verified-closed call.",
         "attestation": ""
       },
       "notes": "Surfaced while verifying PR #516's 0a rehearsal status update. A production data path (board downstream button-set caching, the 'find a button' feature's backing data) is silently failing to persist to S3 on this rehearsal stack."
@@ -3327,6 +3327,44 @@
         "attestation": ""
       },
       "notes": "Surfaced by adversary review of PR #535 (LL-1890f6a922, DataPolicyEnforcer log_type scope). Pre-existing since before that PR -- the user_id-only scoping is unchanged, and PR #535 only widened the log_type filter -- but broadening the purge to 4 additional log_types (note/assessment/eval/journal) means more of a cross-context user's history is now reachable by this same scoping gap than before. This is data over-deletion risk, not a data leak, and is plausibly by design (retention as a property of the user's relationship to a sponsoring org); flagged as a design question for Scot rather than asserted as a defect."
+    },
+    {
+      "id": "LL-9a09771121",
+      "ruleKey": "s3-sigv2-post-policy-main-prod-uploads",
+      "title": "Render production (branch main) still hand-signs S3 POST policies with SigV2; every upload to the SSE-KMS uploads bucket fails and silently degrades to DB-stored data URIs",
+      "severity": "high",
+      "confidence": "high",
+      "frameworks": [
+        "SOC2"
+      ],
+      "status": "open",
+      "disposition": {
+        "state": "untriaged",
+        "decidedBy": "",
+        "decidedDate": "",
+        "rationale": ""
+      },
+      "evidence": {
+        "type": "code",
+        "source": "2026-07-05 private-bucket read-path audit: Render prod web+worker run branch main (last merge PR #365, deployed commit e4fd315ad) as IAM user lingolinq-app and share UPLOADS_S3_BUCKET=lingolinq-prod-uploads with the GCP stack. main's Uploader.remote_upload_params still hand-builds the SigV2 (HMAC-SHA1) POST policy that S3 rejects for SSE-KMS buckets (the exact LL-705b10bcd7 defect, fixed on staging in 77233fb19+afe03d2de but never merged to main). Prod DB shows the blast radius: 49 of 94 button_images and 2 button_sounds are data-URI fallback rows, zero records reference the bucket. Re-drive test on a live Render one-off job (2026-07-05) confirmed the upload still fails and re-stores the data URI.",
+        "file": "lib/uploader.rb",
+        "line": 291,
+        "sha": "e4fd315ad1ad9af56730c41600ebf341545e89cc",
+        "snippet": "OpenSSL::Digest.new('sha1'), config[:secret], policy_encoded"
+      },
+      "firstSeen": "2026-07-05",
+      "lastSeen": "2026-07-05",
+      "owner": "unassigned",
+      "remediation": {
+        "options": "Cherry-pick the two proven SigV4 commits (77233fb19 PresignedPost rewrite + afe03d2de upload_url/post_url split) from staging onto a main-based branch, or merge staging to main. Environment prerequisites are ALREADY in place (applied 2026-07-05): KMS key policy statement AllowRenderProdS3Encryption grants lingolinq-app kms:GenerateDataKey/kms:Decrypt on the CMK; UPLOADS_S3_NO_ACL=1 set on Render prod web+worker; UPLOADS_S3_CDN=https://d34sa6lc5jfe66.cloudfront.net set on both for the read path. After the code lands, re-drive the ~51 stored data-URI records via upload_to_remote (data-URI argument form on main; UPLOAD_FROM_STORED_DATA_URI on staging) and confirm rows clear their data column and gain bucket URLs.",
+        "timeframe": "7-15d"
+      },
+      "closureEvidence": {
+        "sha": "",
+        "verifierNote": "",
+        "attestation": ""
+      },
+      "notes": "Split out of LL-705b10bcd7 (which tracks the GCP rehearsal stack, now live-verified): same root defect, different deploy target and IAM principal. The data-URI fallback keeps prod images rendering (served inline from the DB), so user impact is degraded-not-broken for images; sounds/videos over the size cap are lost (errored_pending_url). Scope details and consumer inventory: ai-company-brain outputs/plans/2026-07-05-s3-private-bucket-read-path-scope.md."
     }
   ]
 }

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,15 +5,16 @@
 
 **Audited:** `scot/security/audit-erasure-admin-reads` @ `445336592ddaf838689df7e578829e94e140890d` on 2026-06-19  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 4 High
+**Headline (open + remediated-unverified):** 0 Critical / 5 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (45)
+## Open (46)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | **accepted** | audit-review | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
+| LL-9a09771121 |  | high | SOC2 | untriaged | audit-run | Render production (branch main) still hand-signs S3 POST policies with SigV2; every upload to the SSE-KMS uploads bucket fails and silently degrades to DB-stored data URIs | `lib/uploader.rb`:291 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | **accepted** | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
 | LL-52ff2a9a79 |  | medium | SOC2 | **accepted** | audit-run | CI security-scan job (Brakeman SAST, bundle-audit, npm audit, gitleaks) is entirely non-blocking | `.github/workflows/ci.yml`:107 |
@@ -129,4 +130,4 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 
 ---
 
-_93 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._
+_94 findings total. Re-run `ruby scripts/citation-check.rb` to validate every active citation._

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `445336592ddaf838689df7e578829e94e140890d`  
 **Audited ref:** `scot/security/audit-erasure-admin-reads`  
 **Run date:** 2026-06-19  
-**Page generated:** 2026-07-06T00:10:24Z
+**Page generated:** 2026-07-06T03:54:31Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **4** | 24 | 20 |
+| **0** | **5** | 24 | 20 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -27,6 +27,7 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 |---|---|---|---|---|---|
 | LL-705b10bcd7 |  | high | SOC2 | BoardDownstreamButtonSet S3 writes fail against KMS-encrypted bucket: 'Requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4' | (attestation) |
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
+| LL-9a09771121 |  | high | SOC2 | Render production (branch main) still hand-signs S3 POST policies with SigV2; every upload to the SSE-KMS uploads bucket fails and silently degrades to DB-stored data URIs | `lib/uploader.rb`:291 |
 | LL-a95e9c5f7c |  | high | SOC2 | lingolinq-worker's 512Mi memory limit is too small for ButtonImage/BoardDownstreamButtonSet jobs, causing continuous OOM kills that land as Resque::Failure instead of being requeued | (attestation) |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-0c6e931f47 |  | medium | WCAG | Sentence box (utterance bar) symbol chip images have no alt attribute | `app/frontend/app/templates/components/button-list.hbs`:21 |


### PR DESCRIPTION
## What

1. **LL-705b10bcd7** (GCP rehearsal S3 SigV4/KMS finding): appends the 2026-07-05 live-verification evidence to `closureEvidence.verifierNote` and bumps `lastSeen`. The synthetic ButtonImage test now passes end to end (object lands with `aws:kms` SSE under the expected CMK; delete path verified). **Status intentionally stays `remediated-unverified`**: flipping to `verified-closed` is Scot's call per the register governance rule.
2. **New finding LL-9a09771121** (high, open, untriaged): Render production runs branch `main`, which still hand-signs S3 POST policies with SigV2 (HMAC-SHA1). The shared uploads bucket enforces SSE-KMS, so every prod upload fails and silently degrades to DB-stored data URIs (49 of 94 `button_images` + 2 `button_sounds` in the prod DB). Evidence anchored to `lib/uploader.rb:291` at main's deployed commit `e4fd315ad`; citation-check passes. Remediation: land the two proven SigV4 commits (`77233fb19` + `afe03d2de`) on main (env prerequisites, KMS grant / NO_ACL / CDN, went live 2026-07-05), then re-drive the stored data URIs.

## Verification

- `citation-check.rb`: new finding PASS; failure count unchanged from baseline (10 pre-existing).
- All four `audit-artifacts-integrity` checks pass locally (`compliance-notion-publish --check`, `document-register-render --check`, `compliance-calendar-render --check`, `compliance-publication-status --check`); rendered artifacts committed.

## Related

- PR #531 (env vars for the GCP deploy), PR #536 (server-internal presigned fetches)
- Scope doc: ai-company-brain `outputs/plans/2026-07-05-s3-private-bucket-read-path-scope.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)