### PR TITLE
fix(uploads): backport SigV4 PresignedPost signing to main (Render prod uploads)

### DIFF
--- a/app/frontend/app/components/beta-feedback-form.js
+++ b/app/frontend/app/components/beta-feedback-form.js
@@ -6,6 +6,13 @@ import RSVP from 'rsvp';
 import modal from '../utils/modal';
 import i18n from '../utils/i18n';
 
+// post_url is the SigV4-signed regional S3 endpoint; upload_url stays the
+// canonical object URL other code matches self.url against. Fall back for
+// responses cached before post_url existed.
+export function uploadTargetUrl(remote_upload) {
+  return remote_upload.post_url || remote_upload.upload_url;
+}
+
 export default Component.extend({
   tagName: '',
 
@@ -380,9 +387,7 @@ export default Component.extend({
       fd.append('file', blob);
       return new RSVP.Promise(function(resolve, reject) {
         var xhr = new XMLHttpRequest();
-        // post_url is the SigV4-signed regional S3 endpoint; upload_url stays
-        // the canonical object URL other code matches self.url against.
-        xhr.open('POST', rec.remote_upload.post_url || rec.remote_upload.upload_url);
+        xhr.open('POST', uploadTargetUrl(rec.remote_upload));
         xhr.onload = function() {
           if (xhr.status >= 200 && xhr.status < 300) {
             resolve(rec);

--- a/app/frontend/app/components/beta-feedback-form.js
+++ b/app/frontend/app/components/beta-feedback-form.js
@@ -380,7 +380,9 @@ export default Component.extend({
       fd.append('file', blob);
       return new RSVP.Promise(function(resolve, reject) {
         var xhr = new XMLHttpRequest();
-        xhr.open('POST', rec.remote_upload.upload_url);
+        // post_url is the SigV4-signed regional S3 endpoint; upload_url stays
+        // the canonical object URL other code matches self.url against.
+        xhr.open('POST', rec.remote_upload.post_url || rec.remote_upload.upload_url);
         xhr.onload = function() {
           if (xhr.status >= 200 && xhr.status < 300) {
             resolve(rec);

--- a/app/frontend/app/services/content-grabbers.js
+++ b/app/frontend/app/services/content-grabbers.js
@@ -256,7 +256,10 @@ var contentGrabbers = Service.extend({
       }
 
       persistenceService.ajax({
-        url: params.upload_url,
+        // post_url is the SigV4-signed regional S3 endpoint; upload_url is the
+        // canonical global-style object URL other code matches self.url against,
+        // so it can't also be the POST target. Fall back for older cached data.
+        url: params.post_url || params.upload_url,
         type: 'POST',
         data: fd,
         processData: false,  // tell jQuery not to process the data

--- a/app/frontend/app/services/content-grabbers.js
+++ b/app/frontend/app/services/content-grabbers.js
@@ -230,6 +230,12 @@ var contentGrabbers = Service.extend({
     });
     return promise;
   },
+  // post_url is the SigV4-signed regional S3 endpoint; upload_url is the
+  // canonical global-style object URL other code matches self.url against,
+  // so it can't also be the POST target. Fall back for older cached data.
+  upload_target_url: function(params) {
+    return params.post_url || params.upload_url;
+  },
   upload_to_remote: function(params, extra) {
     var _this = this;
     var promise = new RSVP.Promise(function(resolve, reject) {
@@ -256,10 +262,7 @@ var contentGrabbers = Service.extend({
       }
 
       persistenceService.ajax({
-        // post_url is the SigV4-signed regional S3 endpoint; upload_url is the
-        // canonical global-style object URL other code matches self.url against,
-        // so it can't also be the POST target. Fall back for older cached data.
-        url: params.post_url || params.upload_url,
+        url: _this.upload_target_url(params),
         type: 'POST',
         data: fd,
         processData: false,  // tell jQuery not to process the data

--- a/app/frontend/tests/unit/components/beta-feedback-form-test.js
+++ b/app/frontend/tests/unit/components/beta-feedback-form-test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import { uploadTargetUrl } from 'frontend/components/beta-feedback-form';
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 
@@ -39,6 +40,16 @@ module('Unit | Component | beta feedback form', function(hooks) {
     assert.equal(options.selfBrowserSurface, 'include');
     assert.equal(options.surfaceSwitching, 'include');
     assert.equal(options.video.displaySurface, 'browser');
+  });
+
+  test('recording upload posts to post_url, falling back to legacy upload_url', function(assert) {
+    assert.equal(uploadTargetUrl({
+      post_url: 'https://bucket.s3.us-west-2.amazonaws.com/',
+      upload_url: 'https://bucket.s3.amazonaws.com/'
+    }), 'https://bucket.s3.us-west-2.amazonaws.com/');
+    assert.equal(uploadTargetUrl({
+      upload_url: 'https://bucket.s3.amazonaws.com/'
+    }), 'https://bucket.s3.amazonaws.com/');
   });
 
   test('recording upload strips codec parameters from content type', function(assert) {

--- a/app/frontend/tests/utils/content_grabbers-test.js
+++ b/app/frontend/tests/utils/content_grabbers-test.js
@@ -20,6 +20,18 @@ import progress_tracker from '../../utils/progress_tracker';
 import { run as emberRun } from '@ember/runloop';
 
 describe("contentGrabbers", function() {
+  describe('upload_target_url', function() {
+    it('should prefer post_url and fall back to legacy upload_url', function() {
+      expect(contentGrabbers.upload_target_url({
+        post_url: 'https://bucket.s3.us-west-2.amazonaws.com/',
+        upload_url: 'https://bucket.s3.amazonaws.com/'
+      })).toEqual('https://bucket.s3.us-west-2.amazonaws.com/');
+      expect(contentGrabbers.upload_target_url({
+        upload_url: 'https://bucket.s3.amazonaws.com/'
+      })).toEqual('https://bucket.s3.amazonaws.com/');
+    });
+  });
+
   var button, controller;
   var pictureGrabber = contentGrabbers.pictureGrabber;
   var soundGrabber = contentGrabbers.soundGrabber;

--- a/app/models/concerns/uploadable.rb
+++ b/app/models/concerns/uploadable.rb
@@ -270,7 +270,7 @@ module Uploadable
     post_params[:file] = file
 
     # upload to s3 from tempfile
-    res = Typhoeus.post(params[:upload_url], body: post_params)
+    res = Typhoeus.post(params[:post_url], body: post_params)
     if rasterize
       if res.success?
         self.settings['rasterized'] = 'from_filename'

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -63,7 +63,7 @@ module Uploader
     post_params[:file] = File.open(local_path, 'rb')
 
     # upload to s3 from tempfile
-    res = Typhoeus.post(params[:upload_url], body: post_params)
+    res = Typhoeus.post(params[:post_url], body: post_params)
     if res.success?
       return {url: params[:upload_url] + remote_path, path: remote_path, uploaded: true}
     else
@@ -259,49 +259,47 @@ module Uploader
     nil
   end
   
+  # SigV4-signed browser POST policy (via Aws::S3::PresignedPost). A hand-signed
+  # SigV2 policy (AWSAccessKeyId + HMAC-SHA1) can't satisfy buckets that require
+  # SSE-KMS ("Requests specifying Server Side Encryption with AWS KMS managed
+  # keys require AWS Signature Version 4") -- see LL-705b10bcd7.
   def self.remote_upload_params(remote_path, content_type, max_bytes: CONTENT_LENGTH_RANGE, private_upload: false)
     config = remote_upload_config
-    
-    res = {
-      :upload_url => config[:upload_url],
-      :upload_params => {
-        'AWSAccessKeyId' => config[:access_key]
-      }
-    }
-    
-    conditions = [
-      {'key' => remote_path},
-      ['content-length-range', 1, max_bytes],
-      {'bucket' => config[:bucket_name]},
-      {'success_action_status' => '200'},
-      {'content-type' => content_type}
-    ]
     use_acl = !private_upload && !ENV['UPLOADS_S3_NO_ACL'].to_s.match(/\A(1|true|yes)\z/i)
-    conditions.insert(1, {'acl' => 'public-read'}) if use_acl
 
-    policy = {
-      'expiration' => (S3_EXPIRATION_TIME).seconds.from_now.utc.iso8601,
-      'conditions' => conditions
+    post_options = {
+      key: remote_path,
+      content_type: content_type,
+      content_length_range: 1..max_bytes,
+      success_action_status: '200',
+      signature_expiration: S3_EXPIRATION_TIME.seconds.from_now
     }
-    # TODO: for pdfs, policy['conditions'] << {'content-disposition' => 'inline'}
+    post_options[:acl] = 'public-read' if use_acl
+    # TODO: for pdfs, post_options[:content_disposition] = 'inline'
 
-    policy_encoded = Base64.encode64(policy.to_json).gsub(/\n/, '')
-    signature = Base64.encode64(
-      OpenSSL::HMAC.digest(
-        OpenSSL::Digest.new('sha1'), config[:secret], policy_encoded
-      )
-    ).gsub(/\n/, '')
+    post = Aws::S3::PresignedPost.new(
+      Aws::Credentials.new(config[:access_key], config[:secret]),
+      s3_region,
+      config[:bucket_name],
+      post_options
+    )
 
-    upload_params = {
-       'key' => remote_path,
-       'policy' => policy_encoded,
-       'signature' => signature,
-       'Content-Type' => content_type,
-       'success_action_status' => '200'
+    {
+      # upload_url stays the static global-style endpoint (unchanged from the old
+      # SigV2 shape): every consumer that builds/matches a final object URL by
+      # concatenating upload_url + key (Uploader.remote_upload, uploadable.rb,
+      # media_object.rb, button_sound.rb, the *_controller.rb upload_success
+      # actions) -- and every helper that pattern-matches a stored self.url
+      # against it (valid_import_bundle_url?, removable_remote_url?, fronted_url,
+      # remote_remove) -- expects this exact global form, not a regional one.
+      # post_url is the actual SigV4 POST target: it MUST be the bucket's real
+      # regional endpoint, since the presigned policy's credential scope is
+      # bound to that region and posting cross-region would depend on 307
+      # redirect-following (which Typhoeus/browsers don't reliably do for POST).
+      :upload_url => config[:upload_url],
+      :post_url => "#{post.url}/",
+      :upload_params => post.fields
     }
-    upload_params['acl'] = 'public-read' if use_acl
-    res[:upload_params].merge!(upload_params)
-    res
   end
   
   def self.remote_upload_config

--- a/spec/lib/uploader_spec.rb
+++ b/spec/lib/uploader_spec.rb
@@ -14,7 +14,8 @@ describe Uploader do
     it "should post the upload, including a file handle" do
       expect(Uploader).to receive(:remote_upload_params).with("bacon", "text/plaintext").and_return({
         :upload_params => {:a => 1, :b => 2},
-        :upload_url => "http://www.upload.com/"
+        :upload_url => "http://www.upload.com/",
+        :post_url => "http://www.upload.com/"
       })
       res = OpenStruct.new(:success? => true)
       f = Tempfile.new("stash")
@@ -31,7 +32,8 @@ describe Uploader do
     it "should return the url to the uploaded object if successful" do
       expect(Uploader).to receive(:remote_upload_params).with("bacon", "text/plaintext").and_return({
         :upload_params => {:a => 1, :b => 2},
-        :upload_url => "http://www.upload.com/"
+        :upload_url => "http://www.upload.com/",
+        :post_url => "http://www.upload.com/"
       })
       res = OpenStruct.new(:success? => true)
       f = Tempfile.new("stash")
@@ -43,7 +45,8 @@ describe Uploader do
     it "should return nil if upload unsuccessful" do
       expect(Uploader).to receive(:remote_upload_params).with("bacon", "text/plaintext").and_return({
         :upload_params => {:a => 1, :b => 2},
-        :upload_url => "http://www.upload.com/"
+        :upload_url => "http://www.upload.com/",
+        :post_url => "http://www.upload.com/"
       })
       res = OpenStruct.new(:success? => false, body: 'nothing')
       f = Tempfile.new("stash")
@@ -65,7 +68,8 @@ describe Uploader do
 
       expect(Uploader).to receive(:remote_upload_params).with("a/b/chksmchksu/c", "text/plaintext").and_return({
         :upload_params => {:a => 1, :b => 2},
-        :upload_url => "http://www.upload.com/"
+        :upload_url => "http://www.upload.com/",
+        :post_url => "http://www.upload.com/"
       })
       res = OpenStruct.new(:success? => true)
       f = Tempfile.new("stash")
@@ -85,7 +89,8 @@ describe Uploader do
 
       expect(Uploader).to receive(:remote_upload_params).with("a/chksmchksu/b", "text/plaintext").and_return({
         :upload_params => {:a => 1, :b => 2},
-        :upload_url => "http://www.upload.com/"
+        :upload_url => "http://www.upload.com/",
+        :post_url => "http://www.upload.com/"
       })
       res = OpenStruct.new(:success? => true)
       f = Tempfile.new("stash")
@@ -102,7 +107,8 @@ describe Uploader do
     it "should remove any pending delete remote actions" do
       expect(Uploader).to receive(:remote_upload_params).with("bacon", "text/plaintext").and_return({
         :upload_params => {:a => 1, :b => 2},
-        :upload_url => "http://www.upload.com/"
+        :upload_url => "http://www.upload.com/",
+        :post_url => "http://www.upload.com/"
       })
       res = OpenStruct.new(:success? => true)
       f = Tempfile.new("stash")
@@ -136,7 +142,8 @@ describe Uploader do
 
       expect(Uploader).to receive(:remote_upload_params).with("a/b/chksmchksu/c", "text/plaintext").and_return({
         :upload_params => {:a => 1, :b => 2},
-        :upload_url => "http://www.upload.com/"
+        :upload_url => "http://www.upload.com/",
+        :post_url => "http://www.upload.com/"
       })
       res = OpenStruct.new(:success? => true)
       f = Tempfile.new("stash")
@@ -250,16 +257,33 @@ describe Uploader do
       allow(Uploader).to receive(:remote_upload_config).and_return(upload_config)
     end
 
-    it "should generate signed upload parameters" do
+    it "should generate a SigV4-signed upload policy (Aws::S3::PresignedPost)" do
       res = Uploader.remote_upload_params("downloads/file.png", "image/png")
-      expect(res[:upload_url]).to eq(Uploader.remote_upload_config[:upload_url])
+      # upload_url stays the canonical global-style endpoint -- every consumer that
+      # builds/matches a final object URL (valid_import_bundle_url?, removable_remote_url?,
+      # fronted_url, remote_remove, etc) depends on this exact form.
+      expect(res[:upload_url]).to eq(upload_config[:upload_url])
+      # post_url is the actual SigV4 POST target: the bucket's real regional endpoint,
+      # since the presigned policy's credential scope is bound to that region.
+      expect(res[:post_url]).to match(%r{\Ahttps://test-bucket\.s3[.\-][\w-]*\.amazonaws\.com/\z})
       expect(res[:upload_params]).not_to eq(nil)
-      expect(res[:upload_params]['AWSAccessKeyId']).not_to eq(nil)
+      expect(res[:upload_params]['AWSAccessKeyId']).to eq(nil)
+      expect(res[:upload_params]['signature']).to eq(nil)
       expect(res[:upload_params]['Content-Type']).to eq('image/png')
       expect(res[:upload_params]['key']).to eq('downloads/file.png')
       expect(res[:upload_params]['policy']).not_to eq(nil)
-      expect(res[:upload_params]['signature']).not_to eq(nil)
+      expect(res[:upload_params]['x-amz-algorithm']).to eq('AWS4-HMAC-SHA256')
+      expect(res[:upload_params]['x-amz-credential']).to start_with('test_key/')
+      expect(res[:upload_params]['x-amz-signature']).not_to eq(nil)
       expect(res[:upload_params]['success_action_status']).to eq('200')
+    end
+
+    it "should include acl unless private_upload or UPLOADS_S3_NO_ACL is set" do
+      res = Uploader.remote_upload_params("downloads/file.png", "image/png")
+      expect(res[:upload_params]['acl']).to eq('public-read')
+
+      res = Uploader.remote_upload_params("downloads/file.png", "image/png", private_upload: true)
+      expect(res[:upload_params]['acl']).to eq(nil)
     end
   end
 

--- a/spec/lib/uploader_spec.rb
+++ b/spec/lib/uploader_spec.rb
@@ -284,6 +284,19 @@ describe Uploader do
 
       res = Uploader.remote_upload_params("downloads/file.png", "image/png", private_upload: true)
       expect(res[:upload_params]['acl']).to eq(nil)
+
+      orig = ENV['UPLOADS_S3_NO_ACL']
+      begin
+        ENV['UPLOADS_S3_NO_ACL'] = '1'
+        res = Uploader.remote_upload_params("downloads/file.png", "image/png")
+        expect(res[:upload_params]['acl']).to eq(nil)
+      ensure
+        if orig.nil?
+          ENV.delete('UPLOADS_S3_NO_ACL')
+        else
+          ENV['UPLOADS_S3_NO_ACL'] = orig
+        end
+      end
     end
   end
 

--- a/spec/models/concerns/uploadable_spec.rb
+++ b/spec/models/concerns/uploadable_spec.rb
@@ -223,7 +223,9 @@ describe Uploadable, :type => :model do
       expect(Typhoeus).to receive(:get).and_return(res)
       res = OpenStruct.new(:success? => true)
       expect(Typhoeus).to receive(:post) { |url, args|
-        expect(url).to eq(Uploader.remote_upload_config[:upload_url])
+        # SigV4 presigned POSTs target the bucket's regional endpoint, not the
+        # static global "bucket.s3.amazonaws.com" host used by remote_upload_config.
+        expect(url).to match(%r{\Ahttps://#{Regexp.escape(Uploader.remote_upload_config[:bucket_name])}\.s3[.\-][\w-]*\.amazonaws\.com/\z})
       }.and_return(res)
       s.upload_to_remote("http://pic.com/cow.png")
       expect(s.url).not_to eq(nil)
@@ -237,7 +239,9 @@ describe Uploadable, :type => :model do
       expect(Typhoeus).to receive(:get).and_return(res)
       res = OpenStruct.new(:success? => true)
       expect(Typhoeus).to receive(:post) { |url, args|
-        expect(url).to eq(Uploader.remote_upload_config[:upload_url])
+        # SigV4 presigned POSTs target the bucket's regional endpoint, not the
+        # static global "bucket.s3.amazonaws.com" host used by remote_upload_config.
+        expect(url).to match(%r{\Ahttps://#{Regexp.escape(Uploader.remote_upload_config[:bucket_name])}\.s3[.\-][\w-]*\.amazonaws\.com/\z})
       }.and_return(res)
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,6 +63,7 @@ RSpec.configure do |config|
     if ENV['AWS_SECRET'].to_s.blank?
       allow(Uploader).to receive(:remote_upload_params).and_return(
         upload_url: 'https://example.com/',
+        post_url: 'https://example.com/',
         upload_params: {}
       )
     end


### PR DESCRIPTION
## Why

Render production deploys `main`, which still hand-signs S3 POST policies with SigV2 (HMAC-SHA1). The shared uploads bucket `lingolinq-prod-uploads` enforces SSE-KMS, which requires SigV4, so every prod upload fails and silently degrades to a DB-stored data URI (finding **LL-9a09771121**, register PR #537: 49 of 94 `button_images` + 2 `button_sounds` affected). The fix has been proven on staging and live-verified on the GCP rehearsal stack (finding LL-705b10bcd7).

## What

File-scoped backport of staging commits `77233fb19` + `afe03d2de` (code paths only):
- `lib/uploader.rb`: `remote_upload_params` builds an `Aws::S3::PresignedPost` (AWS4-HMAC-SHA256) and returns both `upload_url` (canonical global form, unchanged, for URL matching) and `post_url` (regional SigV4 POST target)
- `app/models/concerns/uploadable.rb`: POST call site uses `post_url` (main has one call site; staging's second is SvgSanitizer-only)
- `app/frontend`: `content-grabbers.js` + `beta-feedback-form.js` post to `post_url || upload_url`
- Specs updated; `spec/lib/uploader_spec.rb` + `spec/models/concerns/uploadable_spec.rb` **143/143 locally** (after clearing the known orphaned-rows test-DB pollution)

Deliberately excluded: `audit-reports/` register changes (register lives on staging) and Dockerfile / deploy-cloudrun.yml GCP-only changes.

## Prerequisites already live (2026-07-05)

KMS key-policy grant for `lingolinq-app` (`kms:GenerateDataKey`/`kms:Decrypt` on the CMK), `UPLOADS_S3_NO_ACL=1` and `UPLOADS_S3_CDN` on Render prod web + worker. So merging this makes prod uploads work immediately.

## After merge

Re-drive the ~51 stored data-URI records (`upload_to_remote` with the record's data URI) and confirm rows clear `data` and gain bucket URLs; then LL-9a09771121 is closable (Scot's call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)