### PR TITLE
security(deps): backport gem CVE patches from staging to main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,8 @@ gem 'benchmark'
 gem 'mutex_m'
 gem 'matrix'
 
-gem 'concurrent-ruby', '~> 1.3'
+# CVE-2026-54904/54905/54906; bundler-audit minimum
+gem 'concurrent-ruby', '>= 1.3.7'
 
 # Rails 7.2 with Ruby 3.4 support (Phase 3: final upgrade)
 # 7.2.3.1+ addresses Active Storage proxy DoS (GHSA-p9fm-f462-ggrg / CVE-2026-33658)
@@ -39,7 +40,8 @@ gem 'json', '>= 2.19.2'
 # oj is a faster JSON parser/generator (5-10x faster than stdlib json).
 # Used via Oj.mimic_JSON in config/initializers/oj.rb to transparently
 # replace the JSON module across the app, including Rails internals.
-gem 'oj', '~> 3.16'
+# CVE-2026-54500/54502/54592; bundler-audit minimum
+gem 'oj', '>= 3.17.3'
 # GHSA-46fp-8f5p-pf2m (allowed_uri?); rails-html-sanitizer 1.7.0 depends on loofah ~> 2.25; ensure >= 2.25.1
 gem 'loofah', '>= 2.25.1'
 # ERB @_init deserialization guard bypass (def_module/def_method/def_class); pulled transitively, pin patched 6.x
@@ -84,6 +86,8 @@ gem 'ttfunk', '1.7'
 gem 'ruby-saml'
 gem 'rotp'
 gem 'googleauth', '~> 1.11'
+# CVE-2026-54297; bundler-audit minimum (transitive via googleauth, stripe, etc.)
+gem 'faraday', '>= 2.14.3'
 
 gem 'clowne', '~> 1.4' # Declarative model cloning DSL for board copy optimization
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,9 +155,9 @@ GEM
     cgi (0.5.1)
     clowne (1.5.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
@@ -168,7 +168,7 @@ GEM
     ethon (0.15.0)
       ffi (>= 1.15.0)
     event_stream_parser (1.0.0)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -230,7 +230,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.19.5)
+    json (2.20.0)
     jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.5)
@@ -267,7 +267,7 @@ GEM
     nenv (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -278,23 +278,23 @@ GEM
       net-protocol
     nio4r (2.7.5)
     nkf (0.2.0)
-    nokogiri (1.19.3-aarch64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-aarch64-linux-musl)
+    nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-gnu)
+    nokogiri (1.19.4-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-musl)
+    nokogiri (1.19.4-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x64-mingw-ucrt)
+    nokogiri (1.19.4-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-darwin)
+    nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-musl)
+    nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -307,7 +307,7 @@ GEM
       prawn
       rubyzip
       typhoeus
-    oj (3.16.12)
+    oj (3.17.3)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     os (1.1.4)
@@ -592,10 +592,11 @@ DEPENDENCIES
   brakeman
   bundler-audit
   clowne (~> 1.4)
-  concurrent-ruby (~> 1.3)
+  concurrent-ruby (>= 1.3.7)
   dotenv
   drb
   erb (>= 6.0.4)
+  faraday (>= 2.14.3)
   geokit
   go_secure
   googleauth (~> 1.11)
@@ -608,7 +609,7 @@ DEPENDENCIES
   matrix
   mutex_m
   obf
-  oj (~> 3.16)
+  oj (>= 3.17.3)
   paper_trail (~> 15.0)
   permissable-coughdrop
   pg (~> 1.5)


### PR DESCRIPTION
## Why

PR #538's required security scan fails because `main` carries vulnerable gem versions that staging already patched. Per Copilot's review, this narrowly-scoped dependency backport lands first so #538 can merge on a green scan.

## What

Gemfile pins copied verbatim from staging (three security minimums with CVE annotations: `concurrent-ruby >= 1.3.7`, `oj >= 3.17.3`, `faraday >= 2.14.3`); the rest is lockfile-only:

| gem | main | this PR |
|---|---|---|
| concurrent-ruby | 1.3.6 | 1.3.7 |
| oj | 3.16.12 | 3.17.3 |
| faraday | 2.14.2 | 2.14.3 |
| nokogiri | 1.19.3 | 1.19.4 |
| crass | 1.0.6 | 1.0.7 |
| json | 2.19.5 | 2.20.0 |
| net-imap | 0.6.4 | 0.6.4.1 |

No code changes.

## Verification

- `bundler-audit check --update`: **No vulnerabilities found** locally
- `spec/lib/uploader_spec.rb` 83/83 as a boot smoke test

## Merge order

1. This PR
2. PR #538 (SigV4 upload fix) rebases/merges on top with a green scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)