### PR TITLE
fix(security): protected_image no longer leaks a permanent user_token

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -942,7 +942,7 @@ class Api::UsersController < ApplicationController
 
   def protected_image
     user = User.find_by_path(params['user_id'])
-    api_user = User.find_by_token(params['user_token'])
+    api_user = User.find_by_protected_image_token(params['user_token'])
     valid_result = nil
     if !api_user
       expires_in 30.minutes, :public => true

--- a/app/frontend/app/controllers/application.js
+++ b/app/frontend/app/controllers/application.js
@@ -1692,7 +1692,7 @@ export default Controller.extend({
     if(image && image.get('personalized_url') && !button.no_skin) {
       image_url = image.get('personalized_url');
     } else if(button.get('original_image_url') && LingoLinqImage.personalize_url) {
-      image_url = LingoLinqImage.personalize_url(button.get('original_image_url'), _this.appState.get('currentUser.user_token'), _this.appState.get('referenced_user.preferences.skin'), button.no_skin);
+      image_url = LingoLinqImage.personalize_url(button.get('original_image_url'), _this.appState.get('currentUser.protected_image_token'), _this.appState.get('referenced_user.preferences.skin'), button.no_skin);
     }
     var obj = {
       label: button.label,

--- a/app/frontend/app/models/buttonset.js
+++ b/app/frontend/app/models/buttonset.js
@@ -779,7 +779,7 @@ LingoLinq.Buttonset = BaseModel.extend({
             }
             emberSet(button, 'image', emberGet(button, 'image') || templateHelpers.path('images/blank.gif'));
             if(emberGet(button, 'image') && LingoLinqImage.personalize_url) {
-              emberSet(button, 'image', LingoLinqImage.personalize_url(button.image, _this.appState.get('currentUser.user_token'), _this.appState.get('referenced_user.preferences.skin'), button.no_skin));
+              emberSet(button, 'image', LingoLinqImage.personalize_url(button.image, _this.appState.get('currentUser.protected_image_token'), _this.appState.get('referenced_user.preferences.skin'), button.no_skin));
             }
             emberSet(button, 'on_same_board', emberGet(button, 'steps') === 0);
   
@@ -1188,7 +1188,7 @@ LingoLinq.Buttonset = BaseModel.extend({
 
 LingoLinq.Buttonset.fix_image = function(button, images) {
   if(button.image && LingoLinqImage.personalize_url) {
-    button.image = LingoLinqImage.personalize_url(button.image, app_state.get('currentUser.user_token'), app_state.get('referenced_user.preferences.skin'), button.no_skin);
+    button.image = LingoLinqImage.personalize_url(button.image, app_state.get('currentUser.protected_image_token'), app_state.get('referenced_user.preferences.skin'), button.no_skin);
   }
   var image = images.find(function(img) { return img.get('id') === button.image_id; });
   if(image) {

--- a/app/frontend/app/models/image.js
+++ b/app/frontend/app/models/image.js
@@ -118,12 +118,12 @@ LingoLinq.Image = BaseModel.extend({
       var alternate = (this.get('alternates') || []).find(function(a) { return a.library == preferred_symbols; });
       if(alternate) { url = rewriteBrokenSymbolUrl(alternate.url); }
     }
-    return LingoLinq.Image.personalize_url(url, this.get('appState.currentUser.user_token'), this.get('appState.referenced_user.preferences.skin'), LingoLinq.Image.unskins[this.get('id')]);
+    return LingoLinq.Image.personalize_url(url, this.get('appState.currentUser.protected_image_token'), this.get('appState.referenced_user.preferences.skin'), LingoLinq.Image.unskins[this.get('id')]);
   },
-  personalized_url: computed('url', 'appState.currentUser.user_token', 'appState.referenced_user.preferences.skin', 'appState.referenced_user.preferences.preferred_symbols', 'appState.edit_mode', function() {
+  personalized_url: computed('url', 'appState.currentUser.protected_image_token', 'appState.referenced_user.preferences.skin', 'appState.referenced_user.preferences.preferred_symbols', 'appState.edit_mode', function() {
     return this.personalizing_url();
   }),
-  personalized_url_without_preferred_symbols: computed('url', 'appState.currentUser.user_token', 'appState.referenced_user.preferences.skin', 'appState.referenced_user.preferences.preferred_symbols', 'appState.edit_mode', function() {
+  personalized_url_without_preferred_symbols: computed('url', 'appState.currentUser.protected_image_token', 'appState.referenced_user.preferences.skin', 'appState.referenced_user.preferences.preferred_symbols', 'appState.edit_mode', function() {
     return this.personalizing_url(true);
   }),
   best_url: computed('personalized_url', 'appState.referenced_user.preferences.preferred_symbols', 'data_url', function() {

--- a/app/frontend/app/models/user.js
+++ b/app/frontend/app/models/user.js
@@ -34,6 +34,7 @@ LingoLinq.User = BaseModel.extend({
   },
   user_name: attr('string'),
   user_token: attr('string'),
+  protected_image_token: attr('string'),
   link: attr('string'),
   joined: attr('date'),
   sync_stamp: attr('string'),

--- a/app/frontend/app/services/content-grabbers.js
+++ b/app/frontend/app/services/content-grabbers.js
@@ -976,7 +976,7 @@ var pictureGrabber = EmberObject.extend({
     return persistenceService.ajax('/api/v1/search/protected_symbols?library=' + encodeURIComponent(library) + '&q=' + encodeURIComponent(text) + '&user_name=' + encodeURIComponent(user_name), { type: 'GET'
     }).then(function(data) {
       data.forEach(function(img) {
-        img.image_url = LingoLinq.Image.personalize_url(img.image_url, appStateService.get('currentUser.user_token'), appStateService.get('referenced_user.preferences.skin'));
+        img.image_url = LingoLinq.Image.personalize_url(img.image_url, appStateService.get('currentUser.protected_image_token'), appStateService.get('referenced_user.preferences.skin'));
       });
       return data;
     }, function(xhr, message) {

--- a/app/frontend/app/services/persistence.js
+++ b/app/frontend/app/services/persistence.js
@@ -3293,7 +3293,7 @@ var persistence = Service.extend({
                   // TODO: should this be app_state.currentUser instead of the currently-syncing user?
                   var personalized = image.url;
                   if(LingoLinq.Image && LingoLinq.Image.personalize_url) {
-                    personalized = LingoLinq.Image.personalize_url(image.url, user.get('user_token'), user.get('preferences.skin'));
+                    personalized = LingoLinq.Image.personalize_url(image.url, user.get('protected_image_token'), user.get('preferences.skin'));
                   }
 
                   if(!_sync.store_url_quick_check(personalized, 'image')) {

--- a/app/frontend/app/utils/persistence.js
+++ b/app/frontend/app/utils/persistence.js
@@ -3266,7 +3266,7 @@ var persistence = EmberObject.extend({
                   // TODO: should this be app_state.currentUser instead of the currently-syncing user?
                   var personalized = image.url;
                   if(LingoLinq.Image && LingoLinq.Image.personalize_url) {
-                    personalized = LingoLinq.Image.personalize_url(image.url, user.get('user_token'), user.get('preferences.skin'));
+                    personalized = LingoLinq.Image.personalize_url(image.url, user.get('protected_image_token'), user.get('preferences.skin'));
                   }
 
                   if(!persistence.store_url_quick_check(personalized, 'image')) {

--- a/app/frontend/tests/models/image-test.js
+++ b/app/frontend/tests/models/image-test.js
@@ -80,7 +80,7 @@ describe('Image', function() {
     it('should return the right value', function() {
       var image = LingoLinq.store.createRecord('image', {url: 'http://www.example.com/api/v1/users/2/protected_image/lessonpix/asdf'});
       expect(image.get('personalized_url')).toEqual('http://www.example.com/api/v1/users/2/protected_image/lessonpix/asdf');
-      image.set('app_state', {currentUser: {user_token: 'asdf'}});
+      image.set('app_state', {currentUser: {protected_image_token: 'asdf'}});
       expect(image.get('personalized_url')).toEqual('http://www.example.com/api/v1/users/2/protected_image/lessonpix/asdf?user_token=asdf');
       image.set('url', 'http://www.example.com/pic.png');
       expect(image.get('personalized_url')).toEqual('http://www.example.com/pic.png');

--- a/app/models/button_image.rb
+++ b/app/models/button_image.rb
@@ -436,10 +436,7 @@ class ButtonImage < ApplicationRecord
     if preserve_source_image?
       settings['used_library'] = 'original'
       settings['url'] = self.best_url
-      token = user && user.user_token
-      if token && settings['url'] && settings['url'].match(/\/api\/v1\/users\/.+\/protected_image/)
-        settings['url'] = settings['url'] + (settings['url'].match(/\?/) ? '&' : '?') + "user_token=#{token}"
-      end
+      settings['url'] = Uploadable.tokenize_protected_image_url(settings['url'], user)
       return settings
     end
     if self.settings['library_alternates']
@@ -471,10 +468,7 @@ class ButtonImage < ApplicationRecord
       end
     end
     settings['used_library'] = used_library
-    token = user && user.user_token
-    if token && settings['url'] && settings['url'].match(/\/api\/v1\/users\/.+\/protected_image/)
-      settings['url'] = settings['url'] + (settings['url'].match(/\?/) ? '&' : '?') + "user_token=#{token}"
-    end
+    settings['url'] = Uploadable.tokenize_protected_image_url(settings['url'], user)
     settings
   end
 

--- a/app/models/concerns/uploadable.rb
+++ b/app/models/concerns/uploadable.rb
@@ -12,6 +12,15 @@ module Uploadable
   # 512KB is enough for typical button images (400x400) but blocks oversized photos.
   DATA_URI_STORE_MAX_BYTES = 512 * 1024
 
+  PROTECTED_IMAGE_URL_MATCHER = /\/api\/v1\/users\/.+\/protected_image/
+
+  # Shared by url_for and ButtonImage#settings_for so the protected_image
+  # token-minting logic (and any future changes to it) lives in one place.
+  def self.tokenize_protected_image_url(url, user)
+    return url unless user && url && url.match(PROTECTED_IMAGE_URL_MATCHER)
+    url + (url.match(/\?/) ? '&' : '?') + "user_token=#{user.protected_image_token}"
+  end
+
   def file_type 
     if self.is_a?(ButtonImage)
       'images'
@@ -52,10 +61,7 @@ module Uploadable
   end
   
   def url_for(user)
-    token = user && user.user_token
-    return self.url if !token
-    return self.url unless self.url.match(/\/api\/v1\/users\/.+\/protected_image/)
-    self.url + (self.url.match(/\?/) ? '&' : '?') + "user_token=#{token}"
+    Uploadable.tokenize_protected_image_url(self.url, user)
   end
   
   def file_prefix

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2660,10 +2660,17 @@ class User < ApplicationRecord
   # Accepts the newer expiring protected_image_token format (3 hyphen-separated parts)
   # or falls back to the legacy permanent user_token format (2 parts), so image URLs
   # embedded in boards cached client-side before this format existed keep resolving.
+  # The legacy branch is logged (not just silently accepted) because it's the residual
+  # of LL-310b464be4 this PR intentionally leaves open: sunsetting it needs evidence of
+  # how often it's still hit, not a guess.
   def self.find_by_protected_image_token(token)
     return nil unless token
     parts = token.to_s.split(/-/)
-    return find_by_token(token) unless parts.length == 3
+    unless parts.length == 3
+      user = find_by_token(token)
+      Rails.logger.info("[protected_image_legacy_token] accepted permanent-format token for #{user.global_id}") if user
+      return user
+    end
     user_id, expires_at, sig = parts
     return nil unless expires_at.match?(/\A\d+\z/)
     verifier = GoSecure.sha512("#{user_id}-#{expires_at}", 'protected_image_token verifier')[0, 30]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2643,7 +2643,35 @@ class User < ApplicationRecord
     return nil unless hash == verifier
     User.find_by_global_id(user_id)
   end
-    
+
+  # Unlike user_token above, this is a purpose-scoped, time-limited credential for
+  # protected_image only: bounds how long a leaked URL (query-string tokens land in
+  # access logs, browser history, and Referer headers) stays valid. The default outlasts
+  # the 12-day CDN cache-control window protected_image already sets on successful
+  # redirects, so it won't expire while a synced board is still relying on the cached copy.
+  PROTECTED_IMAGE_TOKEN_LIFESPAN = 30.days
+
+  def protected_image_token(lifespan=PROTECTED_IMAGE_TOKEN_LIFESPAN)
+    expires_at = (Time.now + lifespan).to_i
+    sig = GoSecure.sha512("#{self.global_id}-#{expires_at}", 'protected_image_token verifier')[0, 30]
+    "#{self.global_id}-#{expires_at}-#{sig}"
+  end
+
+  # Accepts the newer expiring protected_image_token format (3 hyphen-separated parts)
+  # or falls back to the legacy permanent user_token format (2 parts), so image URLs
+  # embedded in boards cached client-side before this format existed keep resolving.
+  def self.find_by_protected_image_token(token)
+    return nil unless token
+    parts = token.to_s.split(/-/)
+    return find_by_token(token) unless parts.length == 3
+    user_id, expires_at, sig = parts
+    return nil unless expires_at.match?(/\A\d+\z/)
+    verifier = GoSecure.sha512("#{user_id}-#{expires_at}", 'protected_image_token verifier')[0, 30]
+    return nil unless sig == verifier
+    return nil if expires_at.to_i < Time.now.to_i
+    User.find_by_global_id(user_id)
+  end
+
   def notify_on(attributes, notification_type)
     # TODO: ...
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2674,7 +2674,7 @@ class User < ApplicationRecord
     user_id, expires_at, sig = parts
     return nil unless expires_at.match?(/\A\d+\z/)
     verifier = GoSecure.sha512("#{user_id}-#{expires_at}", 'protected_image_token verifier')[0, 30]
-    return nil unless sig == verifier
+    return nil unless ActiveSupport::SecurityUtils.secure_compare(sig, verifier)
     return nil if expires_at.to_i < Time.now.to_i
     User.find_by_global_id(user_id)
   end

--- a/lib/json_api/user.rb
+++ b/lib/json_api/user.rb
@@ -39,6 +39,7 @@ module JsonApi::User
       json['unread_messages'] = user.settings['unread_messages'] || 0
       json['unread_alerts'] = user.settings['unread_alerts'] || 0
       json['user_token'] = user.user_token
+      json['protected_image_token'] = user.protected_image_token
       json['access_methods'] = user.access_methods
       if user.settings['external_device']
         json['external_device'] = user.settings['external_device']

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -3185,8 +3185,28 @@ describe Api::UsersController, :type => :controller do
       expect(response).to be_redirect
       expect(response.location).to eq('http://www.example.com/pic.png')
     end
+
+    it 'should accept the newer expiring protected_image_token format' do
+      u = User.create
+      bi = ButtonImage.create(user: u, url: 'lingolinq://protected_image/lessonpix/12345', settings: {'cached_copy_url' => 'http://www.example.com/pic.png'})
+      expect(Uploader).to receive(:lessonpix_credentials).with(u).and_return({})
+      get 'protected_image', params: {'user_id' => u.global_id, 'user_token' => u.protected_image_token, 'library' => 'lessonpix', 'image_id' => '12345'}
+      expect(response).to be_redirect
+      expect(response.location).to eq('http://www.example.com/pic.png')
+    end
+
+    it 'should reject an expired protected_image_token and fall back to the anonymous path' do
+      now = Time.utc(2026, 7, 5, 12, 0, 0)
+      allow(Time).to receive(:now).and_return(now)
+      u = User.create
+      token = u.protected_image_token(1.day)
+      allow(Time).to receive(:now).and_return(now + 2.days)
+      get 'protected_image', params: {'user_id' => u.global_id, 'user_token' => token, 'library' => 'whatever', 'image_id' => '123'}
+      expect(response).to be_redirect
+      expect(response.location).to eq('http://test.host/images/square.svg')
+    end
   end
-  
+
   describe "word_map" do
     it "should require an api token" do
       get 'word_map', params: {'user_id' => 'asdf'}

--- a/spec/lib/converters/lingo_linq_spec.rb
+++ b/spec/lib/converters/lingo_linq_spec.rb
@@ -1159,7 +1159,52 @@ describe Converters::LingoLinq do
         expect(zipper.read("board_#{b2.global_id}.obf")).to eq(nil)
       end
     end
-    
+
+    it "should embed a working protected_image token at export time, and let it expire per LL-310b464be4" do
+      res = OpenStruct.new(:success? => true, :body => "abc", :headers => {'Content-Type' => 'image/png'})
+      allow(Typhoeus).to receive(:get).and_return(res)
+      allow(OBF::Utils).to receive(:image_attrs).and_return({})
+
+      u = User.create
+      bi = ButtonImage.create(:user => u, :url => "https://example.com/api/v1/users/#{u.global_id}/protected_image/lessonpix/abc123")
+      bi.settings['protected'] = true
+      bi.settings['protected_source'] = 'lessonpix'
+      bi.settings['content_type'] = 'image/png'
+      bi.settings['width'] = 100
+      bi.settings['height'] = 100
+      bi.save!
+      b = Board.new(:user => u, :settings => {'name' => 'Protected Export Test'})
+      b.settings['buttons'] = [{'id' => '1', 'label' => 'btn', 'image_id' => bi.global_id}]
+      b.settings['grid'] = {'rows' => 1, 'columns' => 1, 'order' => [['1']]}
+      b.instance_variable_set('@buttons_changed', true)
+      b.save
+
+      path = OBF::Utils.temp_path(['obz_protected_token', '.obz'])
+      Converters::LingoLinq.to_obz(b.reload, path, {'user' => u})
+
+      exported_url = nil
+      OBF::Utils.load_zip(path) do |zipper|
+        manifest = JSON.parse(zipper.read('manifest.json'))
+        board_json = JSON.parse(zipper.read(manifest['root']))
+        exported_url = board_json['images'][0]['url']
+      end
+      File.unlink(path) if File.exist?(path)
+
+      expect(exported_url).to match(/user_token=/)
+      token = exported_url.match(/user_token=([^&]+)/)[1]
+
+      # Right after export the embedded token is live, so the protected image
+      # resolves for whoever opens the freshly-exported .obz.
+      expect(User.find_by_protected_image_token(token)).to eq(u)
+
+      # There's no refresh mechanism for a token baked into an already-exported
+      # file, so once the 30-day window passes the same URL goes dark -- a
+      # tradeoff of the expiring-token fix (LL-310b464be4) that's flagged in
+      # the PR description, not silently regressed.
+      allow(Time).to receive(:now).and_return(Time.now + 31.days)
+      expect(User.find_by_protected_image_token(token)).to eq(nil)
+    end
+
     it "should include images" do
       res = OpenStruct.new(:success? => true, :body => "abc", :headers => {'Content-Type' => 'text/plaintext'})
       expect(OBF::Utils).to receive(:image_attrs).and_return({})

--- a/spec/models/button_image_spec.rb
+++ b/spec/models/button_image_spec.rb
@@ -731,12 +731,14 @@ describe ButtonImage, :type => :model do
       bi.settings = {'a' => 1, 'library_alternates' => {'pcs' => {'url' => '/api/v1/users/asdf/protected_image'}}}
       bi.url = "http://www.example.com/pic.png"
       hash = bi.settings_for(u, nil, nil)
-      expect(hash).to eq({
-        'url' => "/api/v1/users/asdf/protected_image?user_token=#{u.user_token}", 
+      expect(hash['url']).to match(/\A\/api\/v1\/users\/asdf\/protected_image\?user_token=.+\z/)
+      token = hash['url'].split('user_token=').last
+      expect(User.find_by_protected_image_token(token)).to eq(u)
+      expect(hash.except('url')).to eq({
         'used_library' => 'pcs',
         'protected' => true,
         'protected_source' => 'pcs',
-      })      
+      })
     end
 
     it "should fall back to the user preference if none specified" do

--- a/spec/models/concerns/uploadable_spec.rb
+++ b/spec/models/concerns/uploadable_spec.rb
@@ -484,9 +484,14 @@ describe Uploadable, :type => :model do
       u = User.create
       i = ButtonImage.new(url: 'http://www.example.com/api/v1/users/1234/protected_images/bacon')
       expect(i.url_for(nil)).to eq('http://www.example.com/api/v1/users/1234/protected_images/bacon')
-      expect(i.url_for(u)).to eq("http://www.example.com/api/v1/users/1234/protected_images/bacon?user_token=#{u.user_token}")
+      result = i.url_for(u)
+      expect(result).to match(/\Ahttp:\/\/www\.example\.com\/api\/v1\/users\/1234\/protected_images\/bacon\?user_token=.+\z/)
+      expect(User.find_by_protected_image_token(result.split('user_token=').last)).to eq(u)
+
       i.url = "http://www.example.com/api/v1/users/1234/protected_images/bacon?a=1"
-      expect(i.url_for(u)).to eq("http://www.example.com/api/v1/users/1234/protected_images/bacon?a=1&user_token=#{u.user_token}")
+      result = i.url_for(u)
+      expect(result).to match(/\Ahttp:\/\/www\.example\.com\/api\/v1\/users\/1234\/protected_images\/bacon\?a=1&user_token=.+\z/)
+      expect(User.find_by_protected_image_token(result.split('user_token=').last)).to eq(u)
     end
   end
   

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3333,7 +3333,72 @@ describe User, :type => :model do
       expect(User.find_by_token(nil)).to eq(nil)
     end
   end
-  
+
+  describe "protected_image_token" do
+    it 'should return a signed token that expires after the default lifespan' do
+      now = Time.utc(2026, 7, 5, 12, 0, 0)
+      allow(Time).to receive(:now).and_return(now)
+      u = User.create
+      expires_at = (now + User::PROTECTED_IMAGE_TOKEN_LIFESPAN).to_i
+      sig = GoSecure.sha512("#{u.global_id}-#{expires_at}", 'protected_image_token verifier')[0, 30]
+      expect(u.protected_image_token).to eq("#{u.global_id}-#{expires_at}-#{sig}")
+    end
+
+    it 'should respect a custom lifespan' do
+      now = Time.utc(2026, 7, 5, 12, 0, 0)
+      allow(Time).to receive(:now).and_return(now)
+      u = User.create
+      expires_at = (now + 7.days).to_i
+      sig = GoSecure.sha512("#{u.global_id}-#{expires_at}", 'protected_image_token verifier')[0, 30]
+      expect(u.protected_image_token(7.days)).to eq("#{u.global_id}-#{expires_at}-#{sig}")
+    end
+  end
+
+  describe "find_by_protected_image_token" do
+    it 'should find the correct user for a valid, unexpired token' do
+      u = User.create
+      expect(User.find_by_protected_image_token(u.protected_image_token)).to eq(u)
+    end
+
+    it 'should fall back to the legacy permanent user_token format' do
+      u = User.create
+      expect(User.find_by_protected_image_token(u.user_token)).to eq(u)
+    end
+
+    it 'should return nil for an expired token' do
+      now = Time.utc(2026, 7, 5, 12, 0, 0)
+      allow(Time).to receive(:now).and_return(now)
+      u = User.create
+      token = u.protected_image_token(1.day)
+      allow(Time).to receive(:now).and_return(now + 2.days)
+      expect(User.find_by_protected_image_token(token)).to eq(nil)
+    end
+
+    it 'should return nil for a tampered signature' do
+      u = User.create
+      parts = u.protected_image_token.split('-')
+      parts[-1] = 'a' * 30
+      expect(User.find_by_protected_image_token(parts.join('-'))).to eq(nil)
+    end
+
+    it 'should return nil for a tampered expiry' do
+      u = User.create
+      parts = u.protected_image_token.split('-')
+      parts[-2] = (parts[-2].to_i + 100).to_s
+      expect(User.find_by_protected_image_token(parts.join('-'))).to eq(nil)
+    end
+
+    it 'should return nil when the expiry segment is not numeric' do
+      u = User.create
+      expect(User.find_by_protected_image_token("#{u.global_id}-notanumber-#{'a' * 30}")).to eq(nil)
+    end
+
+    it 'should return nil for garbage or missing input' do
+      expect(User.find_by_protected_image_token('asdf')).to eq(nil)
+      expect(User.find_by_protected_image_token(nil)).to eq(nil)
+    end
+  end
+
   describe "versions" do
     it "should track versions correctly" do
       PaperTrail.request.whodunnit = 'user:bob'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3365,6 +3365,18 @@ describe User, :type => :model do
       expect(User.find_by_protected_image_token(u.user_token)).to eq(u)
     end
 
+    it 'should log when the legacy permanent-token fallback is used' do
+      u = User.create
+      expect(Rails.logger).to receive(:info).with(/\[protected_image_legacy_token\] accepted permanent-format token for #{Regexp.escape(u.global_id)}/)
+      User.find_by_protected_image_token(u.user_token)
+    end
+
+    it 'should not log for the newer expiring token format' do
+      u = User.create
+      expect(Rails.logger).to_not receive(:info).with(/protected_image_legacy_token/)
+      User.find_by_protected_image_token(u.protected_image_token)
+    end
+
     it 'should return nil for an expired token' do
       now = Time.utc(2026, 7, 5, 12, 0, 0)
       allow(Time).to receive(:now).and_return(now)


### PR DESCRIPTION
## Summary
- Plan E of the Fable 5 Blitz sprint (LL-310b464be4): `protected_image` (`api/users_controller.rb`) accepted a **permanent, non-expiring** `user_token` via URL query param -- once captured (access logs, browser history, or a cross-origin Referer header on the fallback/CDN redirect), it stays valid forever.
- Adds `User#protected_image_token` / `User.find_by_protected_image_token`: a 30-day signed, expiring token, modeled on the existing `GoSecure` token-signing primitive already used elsewhere in this codebase (`GoSecure.browser_token`/`valid_browser_token?`), but using epoch-timestamp math rather than that helper's day-of-year arithmetic.
- 30-day expiry deliberately outlasts the 12-day CDN `expires_in` window `protected_image` already sets on successful redirects, so it won't expire while a synced board is still relying on the cached copy.
- Consolidates the token-append logic, previously duplicated identically in three places (`Uploadable#url_for`, `ButtonImage#settings_for` x2), into one shared `Uploadable.tokenize_protected_image_url` helper.
- The client independently reconstructs `protected_image` URLs in several places (`LingoLinq.Image.personalize_url` and its ~7 callers) using the raw `currentUser.user_token` value transmitted at login. Added a dedicated `protected_image_token` field (server: `lib/json_api/user.rb`; client: `models/user.js`) so the client uses the new expiring token for this purpose instead of the permanent one, without changing the semantics of `user_token` itself (still used, out of scope, for public board-by-token rendering and lesson viewing).

## This narrows, but does not close, LL-310b464be4

Adversary review of this PR correctly flagged that the fix is incomplete as a security remediation, not just as a compatibility nicety:

- `find_by_protected_image_token` still accepts the **legacy permanent format** indefinitely (2-segment token -> `find_by_token`), by deliberate design -- so boards/images already cached client-side (offline/IndexedDB) before this ships keep resolving after deploy. `User#global_id` is confirmed hyphen-free for User records (the `@sub_id` suffix mechanism is Board-only), so the segment count safely disambiguates old vs. new format.
- But `user_token` itself is **unchanged and still broadly exposed**: it's still serialized to every client on login (`lib/json_api/user.rb:41`), still embedded in lesson-share links and iframe `data-user_token` attributes, and still valid forever. Anyone who captures a `user_token` through any of those surfaces can still hand-build a `protected_image` URL that authenticates permanently -- this PR only stops *newly generated* image URLs from carrying that permanent token; it does not revoke or time-box the token itself.
- Net effect: this PR closes the "new image URLs leak a forever-valid credential" gap and adds observability for the deferred one, but the underlying permanent-token exposure this finding named is still live via the fallback and via `user_token`'s other uses. **Do not mark LL-310b464be4 closed on this PR** -- it should stay open, narrowed, with this residual documented (matching how PR #535 narrowed rather than closed LL-1890f6a922).
- Added: the legacy-fallback branch now logs each time it's hit (`[protected_image_legacy_token]`, includes the resolved user's global_id, not the token) so a future decision to sunset it has usage evidence instead of a guess.
- Also surfaced by adversary review: the 30-day expiry means an exported `.obf`/`.obz` file containing protected images (`lib/converters/lingo_linq.rb:192,268` embed the token via the same `url_for`/`settings_for` path) will have those specific image links stop working 30 days after export, with no refresh mechanism (unlike a live device, which reconnects and gets a fresh token). This is a real usability tradeoff of the 30-day window, not a defect -- flagging it since it wasn't visible when the window was chosen. Now pinned by a regression test (see below).
- Out of scope (per the register finding, which cites only `protected_image`): `User#user_token`/`User.find_by_token` themselves, and their other callers (`boards_controller.rb` public board rendering, `api/lessons_controller.rb` lesson viewing).

## Round 3: Copilot review + final adversary pass (commit 0da283509)

Copilot reviewed the PR after the logging commit and found two more Medium issues, both fixed:

- **Constant-time signature compare**: `find_by_protected_image_token`'s signature check used `==` (variable-time). Switched to `ActiveSupport::SecurityUtils.secure_compare` to remove the timing side-channel. (The legacy `find_by_token` path still uses `==`, called out by the follow-up adversary pass as a pre-existing Low, deferred to the eventual `user_token` retirement rather than fixed here.)
- **OBZ export regression test**: added a test (`spec/lib/converters/lingo_linq_spec.rb`) that exports a board with a protected image, confirms the embedded token resolves to the exporting user immediately, then time-travels 31 days and confirms the same URL now correctly fails to resolve -- pinning the export-consequence noted above as tested behavior, not just prose.
- The automated compliance-PR-checklist COPPA checkbox on this PR is checked: the only `users_controller.rb` change is the token-lookup swap inside `protected_image`, no consent/registration/data-collection logic is touched.
- A fresh adversary review was run against this exact commit (not the earlier one from before the logging/Copilot fixes). Verdict: **Approve**, no Critical/High findings. Three Low/informational notes, none requiring further action this PR: (1) the legacy fallback's `find_by_token` still isn't constant-time -- accepted, tracked with the eventual `user_token` retirement; (2) the legacy-fallback log line is per-request rather than a sampled metric -- fine for now, only logs a global_id, no PII; (3) confirmed the OBZ-embedded token really is a 30-day bearer credential for the exporter's own protected symbol images (not student PII) -- a strict improvement over the prior permanent token, already covered by the new test.

## Test plan
- [x] `spec/models/user_spec.rb`: new `protected_image_token`/`find_by_protected_image_token` coverage -- valid round-trip, custom lifespan, expired token, tampered signature, tampered expiry, non-numeric expiry, garbage/nil input, legacy-format fallback, legacy-fallback logging (present and absent).
- [x] `spec/controllers/api/users_controller_spec.rb`: new cases for the expiring-token format and an expired-token rejection; all pre-existing legacy-`user_token` cases left unchanged (they pass unmodified, validating the backward-compat fallback).
- [x] `spec/models/button_image_spec.rb` / `spec/models/concerns/uploadable_spec.rb`: updated to assert the token round-trips to the correct user via `find_by_protected_image_token` rather than a hardcoded string (avoids flakiness from the token's embedded timestamp).
- [x] `spec/lib/converters/lingo_linq_spec.rb`: new OBZ export test (see Round 3 above).
- [x] `bundle exec rspec spec/models/user_spec.rb spec/models/button_image_spec.rb spec/models/concerns/uploadable_spec.rb spec/controllers/api/users_controller_spec.rb spec/lib/converters/lingo_linq_spec.rb` -- 861 examples, 0 failures attributable to this change (11 pre-existing `AuditEvent.count` baseline failures reproduce identically on an unrelated, unmodified branch -- known shared-test-DB drift, not caused by this PR).
- [x] Three review passes complete: Codex senior-dev (`/review-pr`), Claude adversary (twice -- pre- and post-Copilot-fixes), and GitHub Copilot. All findings addressed or documented above as accepted residuals for Scot's triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)