### PR TITLE
fix(scripts): fail closed in sync-render-env when env-var read fails (hourly --apply wipe guard)

### DIFF
--- a/.github/workflows/sync-render-secrets.yml
+++ b/.github/workflows/sync-render-secrets.yml
@@ -58,7 +58,13 @@ jobs:
           OP_RENDER_SYNC_TOKEN: ${{ secrets.OP_RENDER_SYNC_TOKEN }}
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
         run: |
-          OUTPUT=$(node scripts/sync-render-env.js --source op 2>&1 || true)
+          # Capture output for the change detector, but PROPAGATE a non-zero
+          # exit: the script exits 1 when it could not read a service's
+          # current env vars (fail-closed wipe guard), and that must fail
+          # this run (triggering the failure notification) rather than be
+          # swallowed and read as "no changes".
+          DRYRUN_EXIT=0
+          OUTPUT=$(node scripts/sync-render-env.js --source op 2>&1) || DRYRUN_EXIT=$?
           echo "$OUTPUT"
           echo "output<<EOF" >> $GITHUB_OUTPUT
           echo "$OUTPUT" >> $GITHUB_OUTPUT
@@ -69,6 +75,11 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [ "$DRYRUN_EXIT" -ne 0 ]; then
+            echo "::error::sync-render-env dry-run failed (exit $DRYRUN_EXIT) -- see log; not applying."
+            exit "$DRYRUN_EXIT"
           fi
 
       - name: Apply changes to Render

--- a/scripts/sync-render-env.js
+++ b/scripts/sync-render-env.js
@@ -198,16 +198,43 @@ function renderApiRequest(method, reqPath, body = null) {
 }
 
 async function getRenderEnvVars(serviceId) {
-  try {
-    // Render API paginates at 20 by default -- use limit=100 to get all
-    const result = await renderApiRequest('GET', `/services/${serviceId}/env-vars?limit=100`);
-    if (!Array.isArray(result)) return [];
+  // Fail CLOSED: any failure here must THROW, never degrade to []. Render's
+  // env-vars PUT replaces the service's ENTIRE list, and the apply path
+  // builds its payload from this read -- so a swallowed error (e.g. a 401
+  // from a revoked API key) that returned [] would turn --apply into "wipe
+  // every unmanaged var on prod" (2026-07-06 near-miss during the Render
+  // key rotation; this script runs hourly with --apply via
+  // .github/workflows/sync-render-secrets.yml, unattended).
+  const vars = [];
+  let cursor = null;
+  const PAGE_LIMIT = 100;
+  const MAX_PAGES = 50; // far beyond any real service; a loop guard, not a cap
+  const seenCursors = new Set();
+  for (let page = 0; ; page++) {
+    if (page >= MAX_PAGES) {
+      throw new Error(`Pagination for ${serviceId} exceeded ${MAX_PAGES} pages -- aborting rather than trusting the read`);
+    }
+    const cursorParam = cursor ? `&cursor=${encodeURIComponent(cursor)}` : '';
+    const result = await renderApiRequest(
+      'GET',
+      `/services/${serviceId}/env-vars?limit=${PAGE_LIMIT}${cursorParam}`
+    );
+    if (!Array.isArray(result)) {
+      throw new Error(`Unexpected env-vars response for ${serviceId}: ${JSON.stringify(result).slice(0, 200)}`);
+    }
+    if (result.length === 0) break;
     // Render wraps each var in { envVar: { key, value }, cursor }
-    return result.map(item => item.envVar || item);
-  } catch (err) {
-    console.warn(`  Warning: Could not read env vars for ${serviceId}: ${err.message}`);
-    return [];
+    for (const item of result) vars.push(item.envVar || item);
+    // Follow the cursor so a service with more vars than one page is read
+    // completely -- a truncated read has the same wipe effect as a failed one.
+    cursor = result[result.length - 1].cursor;
+    if (result.length < PAGE_LIMIT || !cursor) break;
+    if (seenCursors.has(cursor)) {
+      throw new Error(`Pagination for ${serviceId} repeated cursor ${cursor} -- aborting rather than trusting the read`);
+    }
+    seenCursors.add(cursor);
   }
+  return vars;
 }
 
 async function updateRenderEnvVars(serviceId, envVars) {
@@ -254,6 +281,20 @@ function maskValue(val) {
   return val.slice(0, 4) + '...' + val.slice(-4);
 }
 
+// Services that failed to sync: current env vars unreadable, read as
+// suspiciously empty in apply mode, or the update PUT itself failed.
+// Non-empty at exit -> exit code 1, so the GitHub Actions workflow (and any
+// wrapper) sees the failure instead of a clean "Done."
+const syncFailures = [];
+
+function reportEnvReadFailure(serviceName, reason) {
+  console.error(`  ERROR: ${reason}`);
+  console.error(`  Skipping ${serviceName}: without a trusted read of its current env vars,`);
+  console.error('  an apply would replace the ENTIRE env-var list with only the managed');
+  console.error('  keys and wipe everything unmanaged (UPLOADS_S3_*, etc.).');
+  syncFailures.push(serviceName);
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -263,9 +304,15 @@ async function audit(services) {
 
   for (const [envName, svc] of Object.entries(services)) {
     console.log(`--- ${envName.toUpperCase()} (${svc.name}) ---`);
-    const vars = await getRenderEnvVars(svc.id);
+    let vars;
+    try {
+      vars = await getRenderEnvVars(svc.id);
+    } catch (err) {
+      console.warn(`  Warning: Could not read env vars: ${err.message}\n`);
+      continue;
+    }
     if (vars.length === 0) {
-      console.log('  (no vars found or access denied)\n');
+      console.log('  (no vars found)\n');
       continue;
     }
 
@@ -281,8 +328,12 @@ async function audit(services) {
   console.log('--- Cross-Environment Comparison ---');
   const allVars = {};
   for (const [envName, svc] of Object.entries(services)) {
-    const vars = await getRenderEnvVars(svc.id);
-    allVars[envName] = new Set(vars.map(v => v.key));
+    try {
+      const vars = await getRenderEnvVars(svc.id);
+      allVars[envName] = new Set(vars.map(v => v.key));
+    } catch (err) {
+      console.warn(`  Warning: skipping ${envName} in comparison (read failed: ${err.message})`);
+    }
   }
 
   const allKeys = new Set();
@@ -291,18 +342,25 @@ async function audit(services) {
   }
 
   const missing = [];
+  const comparedEnvs = Object.keys(allVars);
   for (const key of [...allKeys].sort()) {
     const present = Object.entries(allVars)
       .filter(([, keys]) => keys.has(key))
       .map(([env]) => env);
-    if (present.length < Object.keys(services).length) {
-      const absent = Object.keys(services).filter(e => !present.includes(e));
+    if (present.length < comparedEnvs.length) {
+      const absent = comparedEnvs.filter(e => !present.includes(e));
       missing.push({ key, present, absent });
     }
   }
 
+  if (comparedEnvs.length < Object.keys(services).length) {
+    const unread = Object.keys(services).filter(e => !comparedEnvs.includes(e));
+    console.log(`  Comparison INCOMPLETE: could not read [${unread.join(', ')}].`);
+  }
   if (missing.length === 0) {
-    console.log('  All environments have the same variables.\n');
+    console.log(comparedEnvs.length === Object.keys(services).length
+      ? '  All environments have the same variables.\n'
+      : '  No differences among the environments that could be read.\n');
   } else {
     console.log('  Variables missing from some environments:');
     for (const m of missing) {
@@ -376,7 +434,13 @@ async function sync(services, source, apply) {
   // Compare and update each service
   for (const [envName, svc] of Object.entries(services)) {
     console.log(`\n--- ${envName.toUpperCase()} (${svc.name}) ---`);
-    const currentVars = await getRenderEnvVars(svc.id);
+    let currentVars;
+    try {
+      currentVars = await getRenderEnvVars(svc.id);
+    } catch (err) {
+      reportEnvReadFailure(svc.name, `Could not read current env vars: ${err.message}`);
+      continue;
+    }
     const currentMap = {};
     for (const v of currentVars) {
       currentMap[v.key] = v.value;
@@ -423,6 +487,14 @@ async function sync(services, source, apply) {
     }
 
     if (apply) {
+      // Belt-and-suspenders: every LingoLinq service carries unmanaged vars
+      // (DATABASE_URL, UPLOADS_S3_*, ...), so a zero-var read in apply mode
+      // is almost certainly a bad read, not a bare service. There is
+      // deliberately no override flag; verify in the Render dashboard.
+      if (currentVars.length === 0) {
+        reportEnvReadFailure(svc.name, 'Current env-var list read as EMPTY.');
+        continue;
+      }
       // Merge: keep existing vars, add new ones, update changed ones
       const mergedVars = [...currentVars];
       for (const a of additions) {
@@ -446,6 +518,7 @@ async function sync(services, source, apply) {
         }
       } catch (err) {
         console.error(`  Error updating ${svc.name}: ${err.message}`);
+        syncFailures.push(svc.name);
       }
     } else {
       console.log(`  (dry-run -- use --apply to push changes)`);
@@ -517,7 +590,10 @@ async function notifyKeyRotation(appliedChanges) {
 async function exportToOp() {
   console.log('\n=== Export .env Keys to 1Password ===\n');
   console.log('This generates the `op` CLI commands to populate your 1Password vault.');
-  console.log('Install 1Password CLI first: https://developer.1password.com/docs/cli/get-started\n');
+  console.log('Install 1Password CLI first: https://developer.1password.com/docs/cli/get-started');
+  console.log('WARNING: the commands below contain PLAINTEXT secret values.');
+  console.log('Run this only in a terminal whose scrollback you control, and clear it after.');
+  console.log('Replace <VAULT> with the target vault (see VAULTS at the top of this script).\n');
 
   const envVars = loadEnvFile(ENV_FILE_PATH);
   const categories = {
@@ -550,8 +626,10 @@ async function exportToOp() {
     console.log(`  Creating: ${itemName} (${fields.length} fields)`);
     const fieldArgs = fields.map(f => `--field "${f}"`).join(' ');
 
-    // Print command for review (don't auto-execute to be safe)
-    console.log(`    op item create --vault "${OP_VAULT}" --category "API Credential" --title "${itemName}" ${fieldArgs}`);
+    // Print command for review (don't auto-execute to be safe).
+    // <VAULT> is a deliberate placeholder: the 4-vault structure means the
+    // right vault differs per item, so the operator must choose it.
+    console.log(`    op item create --vault "<VAULT>" --category "API Credential" --title "${itemName}" ${fieldArgs}`);
   }
 
   console.log('\nReview the commands above and run them manually to populate 1Password.');
@@ -593,10 +671,20 @@ async function main() {
     await audit(services);
   } else {
     await sync(services, source, apply);
+    if (syncFailures.length > 0) {
+      console.error(`\nSync INCOMPLETE -- ${syncFailures.length} service(s) skipped or failed: ${[...new Set(syncFailures)].join(', ')}`);
+      process.exit(1);
+    }
   }
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Fatal error:', err.message);
+    process.exit(1);
+  });
+}
+
+// Exported for tests (scripts/sync-render-env.test.js); CLI behavior is
+// unchanged because main() only runs when invoked directly.
+module.exports = { getRenderEnvVars, sync, syncFailures };

--- a/scripts/sync-render-env.test.js
+++ b/scripts/sync-render-env.test.js
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+// sync-render-env.test.js -- regression tests for the env-var wipe guard in
+// scripts/sync-render-env.js.
+//
+// Covers the 2026-07-06 near-miss found during the Render API key rotation:
+// getRenderEnvVars() swallowed read errors (e.g. a 401 from a revoked key)
+// and returned [], and the --apply path builds its PUT payload from that
+// list. Render's env-vars PUT replaces the service's ENTIRE list, so a
+// failed read + --apply would have replaced prod's env vars with only the
+// managed keys, wiping everything unmanaged (UPLOADS_S3_NO_ACL,
+// UPLOADS_S3_CDN, ...). This copy of the script runs HOURLY with --apply,
+// unattended, via .github/workflows/sync-render-secrets.yml. The fix: reads
+// fail CLOSED (throw), sync skips the service and exits non-zero, apply
+// refuses a zero-var read, and reads follow pagination cursors so a long
+// list is never silently truncated.
+//
+// Run directly: node scripts/sync-render-env.test.js
+
+const https = require('https');
+const { EventEmitter } = require('events');
+
+// --- https mock (patch before exercising the module under test) ------------
+
+let routeHandler = null; // (options, bodyStr) => { statusCode, body }
+const recordedRequests = [];
+
+https.request = (options, cb) => {
+  let bodyStr = '';
+  return {
+    on: () => {},
+    write: (d) => { bodyStr += d; },
+    end: () => {
+      recordedRequests.push({ method: options.method, path: options.path, body: bodyStr });
+      const { statusCode, body } = routeHandler(options, bodyStr);
+      const res = new EventEmitter();
+      res.statusCode = statusCode;
+      cb(res);
+      process.nextTick(() => {
+        res.emit('data', body);
+        res.emit('end');
+      });
+    },
+  };
+};
+
+process.env.RENDER_API_KEY = 'test-key-never-used-for-real-calls';
+// Keep notifyKeyRotation on its deterministic "skipping" path.
+delete process.env.GOOGLE_CHAT_WEBHOOK_KEY_ROTATION;
+
+const { getRenderEnvVars, sync, syncFailures } = require('./sync-render-env.js');
+
+// --- tiny harness -----------------------------------------------------------
+
+let pass = 0;
+let fail = 0;
+function check(label, ok, detail) {
+  if (ok) {
+    console.log(`PASS: ${label}`);
+    pass++;
+  } else {
+    console.log(`FAIL: ${label}${detail ? ` -- ${detail}` : ''}`);
+    fail++;
+  }
+}
+
+function resetState() {
+  recordedRequests.length = 0;
+  syncFailures.length = 0;
+}
+
+function putRequests() {
+  return recordedRequests.filter(r => r.method === 'PUT');
+}
+
+function envVarPage(pairs, withCursor) {
+  return JSON.stringify(pairs.map(([key, value], i) => ({
+    envVar: { key, value },
+    ...(withCursor ? { cursor: `cur-${key}-${i}` } : {}),
+  })));
+}
+
+// --- tests ------------------------------------------------------------------
+
+async function testReadFailureThrows() {
+  resetState();
+  routeHandler = () => ({ statusCode: 401, body: 'Unauthorized' });
+  let threw = false;
+  try {
+    await getRenderEnvVars('srv-x');
+  } catch (err) {
+    threw = /401/.test(err.message);
+  }
+  check('getRenderEnvVars throws on 401 instead of returning []', threw);
+}
+
+async function testNonArrayResponseThrows() {
+  resetState();
+  routeHandler = () => ({ statusCode: 200, body: JSON.stringify({ message: 'weird shape' }) });
+  let threw = false;
+  try {
+    await getRenderEnvVars('srv-x');
+  } catch (err) {
+    threw = /Unexpected env-vars response/.test(err.message);
+  }
+  check('getRenderEnvVars throws on non-array 200 response', threw);
+}
+
+async function testEmptyOkReadReturnsEmpty() {
+  resetState();
+  routeHandler = () => ({ statusCode: 200, body: '[]' });
+  const vars = await getRenderEnvVars('srv-x');
+  check('genuinely empty 200 read returns []', Array.isArray(vars) && vars.length === 0);
+}
+
+async function testPaginationFollowsCursor() {
+  resetState();
+  const page1 = Array.from({ length: 100 }, (_, i) => [`KEY_${i}`, `v${i}`]);
+  const page2 = Array.from({ length: 30 }, (_, i) => [`KEY_${100 + i}`, `v${100 + i}`]);
+  routeHandler = (options) => {
+    if (options.path.includes('cursor=')) {
+      return { statusCode: 200, body: envVarPage(page2, true) };
+    }
+    return { statusCode: 200, body: envVarPage(page1, true) };
+  };
+  const vars = await getRenderEnvVars('srv-x');
+  check('pagination: full page triggers a cursor follow-up read', recordedRequests.length === 2);
+  check('pagination: second request carries the last cursor',
+    recordedRequests.length === 2 && recordedRequests[1].path.includes('cursor=cur-KEY_99-99'),
+    recordedRequests[1] && recordedRequests[1].path);
+  check('pagination: all 130 vars returned across pages', vars.length === 130);
+}
+
+async function testShortPageStopsPagination() {
+  resetState();
+  routeHandler = () => ({ statusCode: 200, body: envVarPage([['A', '1'], ['B', '2']], true) });
+  const vars = await getRenderEnvVars('srv-x');
+  check('pagination: short page stops after one request even with cursors present',
+    recordedRequests.length === 1 && vars.length === 2);
+}
+
+async function testRepeatedCursorThrows() {
+  resetState();
+  const fullPage = Array.from({ length: 100 }, (_, i) => [`KEY_${i}`, `v${i}`]);
+  routeHandler = () => ({ statusCode: 200, body: envVarPage(fullPage, true) });
+  let threw = false;
+  try {
+    await getRenderEnvVars('srv-x');
+  } catch (err) {
+    threw = /repeated cursor/.test(err.message);
+  }
+  check('pagination: repeated cursor throws instead of looping forever', threw);
+}
+
+const TEST_SERVICE = { prod: { id: 'srv-test-prod', name: 'test-prod', branch: 'main' } };
+
+async function testApplySkipsOnReadFailure() {
+  resetState();
+  routeHandler = () => ({ statusCode: 401, body: 'Unauthorized' });
+  await sync(TEST_SERVICE, 'env', true);
+  check('apply: failed read pushes the service onto syncFailures',
+    syncFailures.includes('test-prod'));
+  check('apply: failed read issues NO PUT', putRequests().length === 0);
+}
+
+async function testApplyRefusesEmptyCurrentList() {
+  resetState();
+  routeHandler = () => ({ statusCode: 200, body: '[]' });
+  await sync(TEST_SERVICE, 'env', true);
+  check('apply: zero-var read is treated as a failure, not a bare service',
+    syncFailures.includes('test-prod'));
+  check('apply: zero-var read issues NO PUT', putRequests().length === 0);
+}
+
+async function testApplyPreservesUnmanagedVars() {
+  resetState();
+  const current = [
+    ['UPLOADS_S3_NO_ACL', 'true'],
+    ['UPLOADS_S3_CDN', 'https://cdn.example'],
+    ['LD_PRELOAD', 'stale-value-to-update'],
+  ];
+  routeHandler = (options) => {
+    if (options.method === 'GET') {
+      return { statusCode: 200, body: envVarPage(current, true) };
+    }
+    return { statusCode: 200, body: '[]' };
+  };
+  await sync(TEST_SERVICE, 'env', true);
+  const puts = putRequests();
+  check('apply: happy path issues exactly one PUT', puts.length === 1);
+  if (puts.length === 1) {
+    const payload = JSON.parse(puts[0].body);
+    const byKey = Object.fromEntries(payload.map(v => [v.key, v.value]));
+    check('apply: unmanaged UPLOADS_S3_NO_ACL preserved in PUT payload',
+      byKey.UPLOADS_S3_NO_ACL === 'true');
+    check('apply: unmanaged UPLOADS_S3_CDN preserved in PUT payload',
+      byKey.UPLOADS_S3_CDN === 'https://cdn.example');
+    check('apply: managed LD_PRELOAD updated to manifest default',
+      byKey.LD_PRELOAD === '/usr/lib/x86_64-linux-gnu/libjemalloc.so.2');
+    check('apply: PUT payload is a superset of the current list',
+      payload.length >= current.length);
+  }
+  check('apply: happy path records no failures', syncFailures.length === 0);
+}
+
+async function testPartialReadThrowsAndNeverPuts() {
+  // The truncation boundary: page 1 succeeds, page 2 fails. A partial list
+  // must never survive into a PUT -- it wipes the tail the same as a failed
+  // read wipes everything.
+  resetState();
+  const page1 = Array.from({ length: 100 }, (_, i) => [`KEY_${i}`, `v${i}`]);
+  routeHandler = (options) => {
+    if (options.method === 'GET' && !options.path.includes('cursor=')) {
+      return { statusCode: 200, body: envVarPage(page1, true) };
+    }
+    return { statusCode: 401, body: 'Unauthorized' };
+  };
+  let threw = false;
+  try {
+    await getRenderEnvVars('srv-x');
+  } catch (err) {
+    threw = /401/.test(err.message);
+  }
+  check('partial read: page-2 failure throws (no partial list returned)', threw);
+
+  resetState();
+  routeHandler = (options) => {
+    if (options.method === 'GET' && !options.path.includes('cursor=')) {
+      return { statusCode: 200, body: envVarPage(page1, true) };
+    }
+    return { statusCode: 401, body: 'Unauthorized' };
+  };
+  await sync(TEST_SERVICE, 'env', true);
+  check('partial read: apply skips the service and records the failure',
+    syncFailures.includes('test-prod'));
+  check('partial read: apply issues NO PUT', putRequests().length === 0);
+}
+
+function testMainExitsNonZeroOnReadFailure() {
+  // Drive the real CLI entrypoint in a child process, with an https mock
+  // preloaded via --require so no real network is touched, and assert the
+  // process-level exit-1 contract the GitHub Actions workflow depends on.
+  const { execFileSync } = require('child_process');
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const mockPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'sre-test-')), 'https-401-mock.js');
+  fs.writeFileSync(mockPath, `
+    const https = require('https');
+    const { EventEmitter } = require('events');
+    https.request = (options, cb) => ({
+      on: () => {},
+      write: () => {},
+      end: () => {
+        const res = new EventEmitter();
+        res.statusCode = 401;
+        cb(res);
+        process.nextTick(() => { res.emit('data', 'Unauthorized'); res.emit('end'); });
+      },
+    });
+  `);
+  let exitCode = 0;
+  let output = '';
+  try {
+    output = execFileSync(
+      process.execPath,
+      ['--require', mockPath, path.join(__dirname, 'sync-render-env.js'), '--source', 'env'],
+      { encoding: 'utf8', env: { ...process.env, RENDER_API_KEY: 'test-key' }, stdio: 'pipe' }
+    );
+  } catch (err) {
+    exitCode = err.status;
+    output = `${err.stdout || ''}${err.stderr || ''}`;
+  }
+  check('main: exits 1 when services are skipped (contract the CI workflow relies on)',
+    exitCode === 1, `exit code was ${exitCode}`);
+  check('main: failure summary names the skipped services',
+    /Sync INCOMPLETE/.test(output));
+  check('main: failed dry-run output contains no NEW/CHANGED wipe-diff lines',
+    !/NEW \([0-9]+\)|CHANGED \([0-9]+\)/.test(output));
+}
+
+async function testDryRunNeverPuts() {
+  resetState();
+  routeHandler = () => ({ statusCode: 200, body: envVarPage([['ONLY_VAR', 'x']], true) });
+  await sync(TEST_SERVICE, 'env', false);
+  check('dry-run: issues NO PUT even with pending changes', putRequests().length === 0);
+}
+
+// --- run --------------------------------------------------------------------
+
+(async () => {
+  await testReadFailureThrows();
+  await testNonArrayResponseThrows();
+  await testEmptyOkReadReturnsEmpty();
+  await testPaginationFollowsCursor();
+  await testShortPageStopsPagination();
+  await testRepeatedCursorThrows();
+  await testApplySkipsOnReadFailure();
+  await testApplyRefusesEmptyCurrentList();
+  await testApplyPreservesUnmanagedVars();
+  await testPartialReadThrowsAndNeverPuts();
+  testMainExitsNonZeroOnReadFailure();
+  await testDryRunNeverPuts();
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail > 0 ? 1 : 0);
+})();


### PR DESCRIPTION
## Why this is urgent

This repo's `scripts/sync-render-env.js` runs **hourly with `--apply`, unattended**, via `.github/workflows/sync-render-secrets.yml`. It carries the same wipe bug found as a near-miss in ai-company-brain during the 2026-07-06 Render key rotation (fixed there in lingolinq/ai-company-brain#123): a failed read of a service's current env vars degraded to `[]`, and Render's env-vars PUT replaces the **entire** list.

Failure chain under the old code: the `RENDER_API_KEY` repo secret gets rotated/revoked → the hourly dry-run's reads 401 and read as empty → every managed key prints as `NEW (24)` → the workflow's `grep` change detector sets `has_changes=true` → the apply step PUTs only the managed keys → **every unmanaged var on dev/staging/prod is wiped** (`UPLOADS_S3_NO_ACL`, `UPLOADS_S3_CDN`, `LEADER_POSTGRES_URL`, ...), with a green "changes applied" notification.

## Changes

- **Fail-closed reads**: `getRenderEnvVars` throws on any error or non-array response instead of returning `[]`
- **Pagination**: follows Render's cursor so >100-var services are never silently truncated; repeated-cursor + 50-page guards throw
- **Apply guards**: skip a service whose read fails; refuse to apply against a zero-var read (deliberately no override flag); failed PUTs recorded; `main()` exits 1 when anything was skipped
- **Workflow**: dry-run step propagates the script's exit code (was `|| true`), so a failed read fails the run and fires the existing ❌ notification instead of reading as "no changes"
- **audit**: reports "Comparison INCOMPLETE" instead of a false all-clear on unreadable envs
- **exportToOp**: fix `OP_VAULT` ReferenceError + plaintext-output warning
- **Tests**: `scripts/sync-render-env.test.js`, 25 tests over a mocked `https.request` (no real network), run under Node 20 — including "failed dry-run output contains no NEW/CHANGED lines", which pins the exact input the workflow's change detector greps

## Review lineage

The fix design had a red-team (adversary) pass on the brain PR; this port was the adversary's one **Critical** finding (unattended hourly apply runs the unfixed copy). Script diff touches `scripts/` + `.github/workflows/` only — no fixtures, seeds, or data-bearing paths.

## Verification

- 25/25 tests pass under Node 20 (`node scripts/sync-render-env.test.js`)
- Same guard verified live in the brain repo against the real Render API: revoked key → all services refused with explicit errors, exit 1; valid key → clean reads, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)