### PR TITLE
fix(ci): install gcloud beta component for worker-pools deploy

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -138,6 +138,11 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
+        with:
+          # `gcloud beta run worker-pools deploy` needs the beta component; gcloud 568+
+          # on the runner no longer preinstalls it, and the on-demand install prompt
+          # fails in a non-interactive job (run 28843502297, 2026-07-07).
+          install_components: beta
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker "${{ vars.GCP_REGION }}-docker.pkg.dev" --quiet


### PR DESCRIPTION
## Summary
Cutover deploy run [28843502297](https://github.com/lingolinq/LingoLinq-AAC/actions/runs/28843502297) (the first armed dispatch of `deploy-cloudrun.yml`) failed at the final **Deploy worker pool** step: the runner's gcloud 568.0.0 no longer preinstalls the `beta` component, so `gcloud beta run worker-pools deploy` triggered an interactive component-install prompt and exited 1 in the non-interactive job.

Everything before it went green (guard, image build+push, migrate Job, web deploy) — only the worker pool is still on the stale image.

## Change
One step: pin the component at SDK setup via `setup-gcloud@v3`'s `install_components: beta`, with a comment recording the failing run. No untrusted input; static value.

## Test plan
- Re-dispatch `deploy-cloudrun.yml` from staging after merge and watch the worker-pool step go green (this is the immediate next cutover action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)