### PR TITLE
compliance(docs): note Fable 5/Mythos 5 ZDR exclusion in AI governance memo

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -287,7 +287,7 @@
         "attestedBy": "Scot Wahlquist",
         "attestedDate": "2026-06-20"
       },
-      "contentHash": "1d0343d1bcbc137cb550898bdb750858186d3e457b34cf0423c615b5d0b7f9c8",
+      "contentHash": "a55ce4ecf81bf210215998a24e52349a814db348922a58932711629e9ce3439b",
       "bundles": [
         "compliance-records-set-2026-06"
       ],

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -34,7 +34,7 @@
 |---|---|---|---|---|---|---|---|---|---|---|
 | Accessibility Conformance Report (ACR / VPAT) | git | `docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md` | draft | WCAG | Scot Wahlquist | 2026-06-16 | 2026-09-16 | no | `e68ef80b2638` | school-dpa-package |
 | Accessibility Conformance Report (ACR / VPAT) (branded) | Drive | [open](https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit) | draft | WCAG | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| AI Governance Memo | git | `docs/legal/AI_GOVERNANCE_MEMO.md` | published | GDPR, COPPA | Scot Wahlquist | 2026-06-20 | 2026-09-20 | 2026-06-20 | `1d0343d1bcbc` | compliance-records-set-2026-06 |
+| AI Governance Memo | git | `docs/legal/AI_GOVERNANCE_MEMO.md` | published | GDPR, COPPA | Scot Wahlquist | 2026-06-20 | 2026-09-20 | 2026-06-20 | `a55ce4ecf81b` | compliance-records-set-2026-06 |
 | AI Governance Memo (branded) | Drive | [open](https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit) | published | GDPR, COPPA | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 | AWS Business Associate Agreement (signed PDF) | git | `docs/legal/AWS_BAA_2026-02.pdf` | published | HIPAA | Scot Wahlquist | 2026-05-11 | 2027-05-11 | 2026-02 | `55f28e00168c` |  |
 | Compliance & Security Program v1.0 (Attested) | Drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | published | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |

--- a/docs/legal/AI_GOVERNANCE_MEMO.md
+++ b/docs/legal/AI_GOVERNANCE_MEMO.md
@@ -40,14 +40,19 @@ Notes:
   (`rev-gemini-baa-annual`; section 7).
 - No persistent or autonomous AI agent runs against production user data. Prediction is
   request-scoped and stateless beyond logging.
-- **Fable 5 / Mythos 5 are not ZDR-eligible and must never carry identifiable student or
-  patient data.** Anthropic requires 30-day retention on these "Covered Models" for safety
-  review, overriding any org-wide zero-data-retention agreement (confirmed 2026-07-06 against
-  Anthropic's own Privacy Center: [Data retention practices for Mythos-class models](https://privacy.claude.com/en/articles/15425996-data-retention-practices-for-mythos-class-models)).
-  This applies specifically to the `EVAL_NARRATOR_MODEL` override in `lib/eval_narrator.rb:102`
-  (default `claude-opus-4-7`, env-overridable) and to any other model-override env var: neither
-  may ever be pointed at Fable 5 or Mythos 5. The current runtime AI inventory (Claude Haiku
-  4.5, Claude Opus 4.7) is unaffected and remains ZDR-eligible.
+- **No Anthropic "Covered Model" is ZDR-eligible; none may ever carry identifiable student or
+  patient data.** Anthropic requires 30-day retention on its designated "Covered Models" for
+  safety review, overriding any org-wide zero-data-retention agreement (confirmed 2026-07-06
+  against Anthropic's own Privacy Center: [Data retention practices for Mythos-class models](https://privacy.claude.com/en/articles/15425996-data-retention-practices-for-mythos-class-models)).
+  The Covered Models designated as of this writing are Fable 5 and Mythos 5, but the category is
+  defined by Anthropic and expands whenever Anthropic designates a new one, so this control is
+  written against the category, not the two current names. It applies specifically to the
+  `EVAL_NARRATOR_MODEL` override in `lib/eval_narrator.rb:102` (default `claude-opus-4-7`,
+  env-overridable) and to any other model-override env var: none may ever be pointed at any
+  Anthropic Covered Model, current or future-designated. Before repointing any model-override
+  env var at a new Anthropic model, confirm it is not a Covered Model against the Privacy Center
+  page above. The current runtime AI inventory (Claude Haiku 4.5, Claude Opus 4.7) is unaffected
+  and remains ZDR-eligible.
 
 ### 2.1 COPPA and under-13 AI training disclosure
 
@@ -192,8 +197,10 @@ the `EVAL_NARRATOR_MODEL` override; `PiiScrubber.redact_for_ai` at `lib/ai_word_
 LL-11db0dc848 and LL-6619cc1811 open). They remain point-in-time and must be re-verified at each
 future publish._
 
-_Amended 2026-07-08: added a Fable 5 / Mythos 5 ZDR-exclusion guardrail note to section 2
-(model inventory). This is non-substantive preventive-control documentation; it does not alter
+_Amended 2026-07-08: added an Anthropic "Covered Model" ZDR-exclusion guardrail note to section
+2 (model inventory), written against the Covered-Model category (Fable 5 / Mythos 5 today, plus
+any Anthropic later designates) rather than the two current names. This is non-substantive
+preventive-control documentation; it does not alter
 the attested scope, controls, or claims, so no full re-attestation is required per the
 living-document policy in the header. The new code citation (`lib/eval_narrator.rb:102`,
 `EVAL_NARRATOR_MODEL` override) was re-verified against live code on 2026-07-08._

--- a/docs/legal/AI_GOVERNANCE_MEMO.md
+++ b/docs/legal/AI_GOVERNANCE_MEMO.md
@@ -40,6 +40,14 @@ Notes:
   (`rev-gemini-baa-annual`; section 7).
 - No persistent or autonomous AI agent runs against production user data. Prediction is
   request-scoped and stateless beyond logging.
+- **Fable 5 / Mythos 5 are not ZDR-eligible and must never carry identifiable student or
+  patient data.** Anthropic requires 30-day retention on these "Covered Models" for safety
+  review, overriding any org-wide zero-data-retention agreement (confirmed 2026-07-06 against
+  Anthropic's own Privacy Center: [Data retention practices for Mythos-class models](https://privacy.claude.com/en/articles/15425996-data-retention-practices-for-mythos-class-models)).
+  This applies specifically to the `EVAL_NARRATOR_MODEL` override in `lib/eval_narrator.rb:102`
+  (default `claude-opus-4-7`, env-overridable) and to any other model-override env var: neither
+  may ever be pointed at Fable 5 or Mythos 5. The current runtime AI inventory (Claude Haiku
+  4.5, Claude Opus 4.7) is unaffected and remains ZDR-eligible.
 
 ### 2.1 COPPA and under-13 AI training disclosure
 
@@ -183,3 +191,9 @@ attestation (confirmed: `claude-haiku-4-5-20251001`, `gemini-2.5-flash`, `claude
 the `EVAL_NARRATOR_MODEL` override; `PiiScrubber.redact_for_ai` at `lib/ai_word_predictor.rb:55`;
 LL-11db0dc848 and LL-6619cc1811 open). They remain point-in-time and must be re-verified at each
 future publish._
+
+_Amended 2026-07-08: added a Fable 5 / Mythos 5 ZDR-exclusion guardrail note to section 2
+(model inventory). This is non-substantive preventive-control documentation; it does not alter
+the attested scope, controls, or claims, so no full re-attestation is required per the
+living-document policy in the header. The new code citation (`lib/eval_narrator.rb:102`,
+`EVAL_NARRATOR_MODEL` override) was re-verified against live code on 2026-07-08._


### PR DESCRIPTION
## Summary
- Adds a Section 2 (model inventory) note to `docs/legal/AI_GOVERNANCE_MEMO.md`: Fable 5 / Mythos 5 are not ZDR-eligible (Anthropic requires 30-day retention on these "Covered Models" for safety review, overriding org-wide ZDR agreements) and must never be the target of `EVAL_NARRATOR_MODEL` or any other model-override env var. Current runtime inventory (Claude Haiku 4.5, Claude Opus 4.7) is unaffected.
- Citation: [Data retention practices for Mythos-class models](https://privacy.claude.com/en/articles/15425996-data-retention-practices-for-mythos-class-models) (Anthropic Privacy Center), verified 2026-07-06.
- Adds a dated Section 8 amendment line documenting this as non-substantive preventive-control documentation that does not alter the attested scope/controls/claims — no full CEO re-attestation required per the memo's own living-document policy (header) and the precedent set by section 4.1.
- `lib/eval_narrator.rb:102` citation (the `EVAL_NARRATOR_MODEL` override site) re-verified against live code 2026-07-08.

Follow-up from PR #125 (ai-company-brain), which verified the same ZDR-exclusion claim and updated company-wide CLAUDE.md/AGENTS.md instructions. This PR applies that same verified fact to the one concrete risk surface in this repo.

## Test plan
- [ ] Docs-only change; no code paths affected. Confirm the new bullet reads correctly in rendered Markdown and the citation link resolves.
- [ ] Scot: confirm you're comfortable with the addendum framing (no fresh full re-attestation) vs. wanting a new attestation date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)