### PR TITLE
docs(compliance): backfill one-way Notion publish page id

### DIFF
--- a/audit-reports/notion/README.md
+++ b/audit-reports/notion/README.md
@@ -27,8 +27,11 @@ shared place to see current posture - without a drift-prone bidirectional mirror
    - Every run after: overwrite that page's content with the new body via the Notion MCP
      (`notion-update-page` / replace-content on the recorded page id).
 
-   **Page id:** _(to be filled in when the page is first created; until then the publish is
-   generate-only and nothing has been pushed.)_
+   **Page id:** `37f5fe82-15c2-814c-9904-feb6c2a8c13e` (Notion "Compliance & Audit Posture
+   (GENERATED ...)" in the Master Inbox). First created + pushed on the 2026-06-19 run; the id
+   was backfilled here on 2026-07-08 after it had to be rediscovered by search. On each run,
+   UPDATE this page in place (`notion-update-page` replace_content + the Name property); never
+   create a new page.
 
 ## Hard rules (non-negotiable)
 


### PR DESCRIPTION
Backfills the `audit-reports/notion/README.md` **Page id** field, which was never filled in after the first Notion publish on 2026-06-19.

## Why
The README still read *"until then the publish is generate-only and nothing has been pushed"* even though a live generated mirror page has existed since 2026-06-19. During the 2026-07-08 audit-refresh publish, that stale note forced a rediscover-by-search step (and a duplicate-creation risk) before the page could be updated in place.

## What
- Record the real page id `37f5fe82-15c2-814c-9904-feb6c2a8c13e` ("Compliance & Audit Posture (GENERATED ...)" in the Master Inbox).
- Restate the "update in place, never create a new page" rule with the concrete MCP command.

Docs only. No `FINDINGS.json`, no code, no generated-artifact change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178kTWqKrbGNf6GsM2sd2b4