### PR TITLE
compliance(audit): close two CEO-attested High findings (LL-47117a3443, LL-85038c0a7b)

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "7007e747f2b437281d04d78a530203c9c6b06f34ddf045f0a4895d60bf190fe1",
+      "contentHash": "2b1903d726c483248b9976849c43b8f673954189881474697842bcc4b0559a0a",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `7007e747f2b4` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `2b1903d726c4` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -3415,7 +3415,7 @@
         "GDPR",
         "FERPA"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/controllers/parental_consents_controller.rb",
@@ -3428,12 +3428,12 @@
       "owner": "unassigned",
       "remediation": {
         "options": "On successful grant_parental_consent! completion emit an immutable AuditEvent (mirroring api/users#create school-authorization basis and closed supervisor-consent control LL-46fd4aa824) capturing user global_id, request IP, user-agent, grant timestamp and privacy_policy_version, so verifiable-consent record-keeping is tamper-evident and independent of the mutable user.settings coppa blob.",
-        "timeframe": "15-30d"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "5ca663ad491c2e337977be44440862e66b740b4a",
+        "verifierNote": "Verified 2026-07-08: User#grant_parental_consent! now emits an immutable AuditEvent (event_type parental_consent_grant) atomically with the consent write inside with_lock(requires_new: true) -- an audit-insert failure rolls back the grant and the token stays retryable, and concurrent grants serialize. Payload carries method, ip, user_agent, privacy_policy_version, the persisted granted_at, and a stable record_id. Specs: spec/models/user_spec.rb (grant + rollback) and spec/controllers/parental_consents_controller_spec.rb. Remediated in #552 (merge 5ca663ad4).",
+        "attestation": "Scot Wahlquist 2026-07-08: attested verified-closed; remediated in #552, mirrors the canonical grant_ai_consent! atomic-audit pattern the finding called for."
       },
       "notes": "Surfaced by privacy finder on 2026-07-08. COPPA 16 CFR 312.5 requires operators to obtain AND maintain records of verifiable parental consent. grant_parental_consent! (user.rb:385-423) records granted_at/policy_version only in the mutable settings JSON and calls self.save with no AuditEvent; the controller complete action writes none either. Codebase deliberately emits immutable AuditEvents for the parallel COPPA school-official exception (user.rb:1332 comment) and supervisor consent (LL-46fd4aa824 verified-closed), so this is an inconsistent gap on the most COPPA-central consent event. Distinct from LL-46fd4aa824 and eval-narrator-no-coppa-consent-gate. NEW. | adversary: confirmed -- no immutable AuditEvent on grant_parental_consent! (user.rb ~385-423) nor ParentalConsentsController#complete; contrast grant_ai_consent!/revoke_ai_consent! (user.rb:540,581) which each emit an AuditEvent. Nuance: User has_paper_trail :only [:settings,:user_name] (user.rb:44) DOES version the settings diff, but as a mutable versions-table row with nil whodunnit (unauthenticated email-link GET), so the no-IMMUTABLE-audit claim holds while no-audit-trail-at-all would overstate it."
     },
@@ -3569,7 +3569,7 @@
       "severity": "high",
       "confidence": "high",
       "frameworks": [],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "app/controllers/api/button_sets_controller.rb",
@@ -3582,12 +3582,12 @@
       "owner": "unassigned",
       "remediation": {
         "options": "Drop the `backtrace` key from the rendered JSON (keep it only in Rails.logger.error, already logged two lines above); standardize on the same {error: message} shape the rest of the API uses. Also consider gating debug_sync behind an admin check or removing it now that the async Progress path exists.",
-        "timeframe": "advisory"
+        "timeframe": "done"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "5ca663ad491c2e337977be44440862e66b740b4a",
+        "verifierNote": "Verified 2026-07-08: buttonsets#generate debug_sync=1 rescue no longer returns e.backtrace; renders {error: e.message} only (backtrace stays in Rails.logger). Regression spec asserts the 500 body has no backtrace key. Remediated in #552 (merge 5ca663ad4).",
+        "attestation": "Scot Wahlquist 2026-07-08: attested verified-closed; remediated in #552."
       },
       "notes": "Surfaced by api finder on 2026-07-08. New; not present in FINDINGS.json. Error-format break -- also leaks internal file paths/gem versions. Route config/routes.rb:252 (POST buttonsets/:id/generate); no frontend caller passes debug_sync -- undocumented server-only code path reachable by any caller with board view permission. | adversary: confirmed -- backtrace is hand-serialized into the JSON body (Rails prod exception suppression irrelevant); branch reachable via POST buttonsets/:id/generate (routes.rb:252) gated only by require_api_token + allowed?(board,view) + caller-supplied debug_sync==1, no admin/env gate; every other error path in the file uses {error:...} with no backtrace."
     },

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,18 +5,16 @@
 
 **Audited:** `scot/compliance/audit-refresh-2026-07-07` @ `20953ab3d5a80c3a9cbb249f37a79357b7f1baf1` on 2026-07-08  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 7 High
+**Headline (open + remediated-unverified):** 0 Critical / 5 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (57)
+## Open (55)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | **accepted** | audit-review | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
 | LL-9a09771121 |  | high | SOC2 | untriaged | audit-run | Render production (branch main) still hand-signs S3 POST policies with SigV2; every upload to the SSE-KMS uploads bucket fails and silently degrades to DB-stored data URIs | `lib/uploader.rb`:291 |
-| LL-47117a3443 |  | high | COPPA, GDPR, FERPA | untriaged | audit-run | COPPA verifiable parental consent is granted with no immutable AuditEvent | `app/controllers/parental_consents_controller.rb`:14 |
-| LL-85038c0a7b |  | high |  | untriaged | audit-run | buttonsets#generate debug_sync=1 path returns raw exception message and full Ruby backtrace as JSON error body | `app/controllers/api/button_sets_controller.rb`:83 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-90045bb29c |  | medium | FERPA | untriaged | audit-run | User#user_token is a permanent, non-expiring credential serialized on login and embedded in navigable lesson/board share URLs | `lib/json_api/user.rb`:41 |
 | LL-b5c30235d3 |  | medium | SOC2, HIPAA, FERPA | **accepted** | audit-run | infra-auditor runtime/CLI evidence relies on instruction-only control against secret/PII leakage | `.claude/agents/infra-auditor.md`:31 |
@@ -79,7 +77,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-705b10bcd7 |  | high | SOC2 | untriaged | audit-run | BoardDownstreamButtonSet S3 writes fail against KMS-encrypted bucket: 'Requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4' | (attestation) |
 | LL-5954bcbbe6 |  | medium | SOC2 | untriaged | audit-run | Pre-existing Resque background-job failures: ImageMagick identify missing in Cloud Run image, stale job_stash lookups, and a call to a removed Board method | (attestation) |
 
-## Verified closed (40)
+## Verified closed (42)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -99,6 +97,8 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-080a21089f |  | high | FERPA, HIPAA, GDPR | untriaged | audit-run | Account deletion / right-to-erasure path writes no AuditEvent | `app/controllers/api/users_controller.rb`:388 |
 | LL-7acd0e7416 |  | high | FERPA, HIPAA | untriaged | audit-run | Admin-support reads of individual student records (version history, daily usage) write no AuditEvent | `app/controllers/api/users_controller.rb`:485 |
 | LL-9b5d0f1381 |  | high | WCAG | **fixed** | audit-run | Find-a-button search input has no accessible name (placeholder-only, non-i18n) | `app/frontend/app/templates/find-button.hbs`:8 |
+| LL-47117a3443 |  | high | COPPA, GDPR, FERPA | untriaged | audit-run | COPPA verifiable parental consent is granted with no immutable AuditEvent | `app/controllers/parental_consents_controller.rb`:14 |
+| LL-85038c0a7b |  | high |  | untriaged | audit-run | buttonsets#generate debug_sync=1 path returns raw exception message and full Ruby backtrace as JSON error body | `app/controllers/api/button_sets_controller.rb`:83 |
 | LL-efef111d59 | Dep-nokogiri-1194 | high | SOC2 | untriaged | audit-run | nokogiri 1.19.3 vulnerable to six published advisories (fixed in 1.19.4) | `Gemfile.lock`:281 |
 | LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | **fixed** | audit-run | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |
 | LL-c6dd65a2aa | Infra-P1-3 | high | SOC2 | **fixed** | audit-run | Static cache_token='abc' never rotates (stale permission cache) | `config/initializers/resque.rb`:29 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `20953ab3d5a80c3a9cbb249f37a79357b7f1baf1`  
 **Audited ref:** `scot/compliance/audit-refresh-2026-07-07`  
 **Run date:** 2026-07-08  
-**Page generated:** 2026-07-08T17:53:12Z
+**Page generated:** 2026-07-09T00:38:35Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **7** | 27 | 26 |
+| **0** | **5** | 27 | 26 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -25,10 +25,8 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 
 | ID | Legacy | Severity | Frameworks | Title | Evidence |
 |---|---|---|---|---|---|
-| LL-47117a3443 |  | high | COPPA, GDPR, FERPA | COPPA verifiable parental consent is granted with no immutable AuditEvent | `app/controllers/parental_consents_controller.rb`:14 |
 | LL-705b10bcd7 |  | high | SOC2 | BoardDownstreamButtonSet S3 writes fail against KMS-encrypted bucket: 'Requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4' | (attestation) |
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
-| LL-85038c0a7b |  | high |  | buttonsets#generate debug_sync=1 path returns raw exception message and full Ruby backtrace as JSON error body | `app/controllers/api/button_sets_controller.rb`:83 |
 | LL-9a09771121 |  | high | SOC2 | Render production (branch main) still hand-signs S3 POST policies with SigV2; every upload to the SSE-KMS uploads bucket fails and silently degrades to DB-stored data URIs | `lib/uploader.rb`:291 |
 | LL-a95e9c5f7c |  | high | SOC2 | lingolinq-worker's 512Mi memory limit is too small for ButtonImage/BoardDownstreamButtonSet jobs, causing continuous OOM kills that land as Resque::Failure instead of being requeued | (attestation) |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |


### PR DESCRIPTION
Records Scot's sign-off closing the two High audit findings whose fixes merged in #552 (merge `5ca663ad4`).

## Closures (status → verified-closed, CEO-attested)
- **`LL-47117a3443`** COPPA parental-consent audit trail — `grant_parental_consent!` now writes an immutable AuditEvent atomically with the grant.
- **`LL-85038c0a7b`** debug_sync backtrace leak — error response no longer returns `e.backtrace`.

Each carries `closureEvidence` (fix SHA, verifier note, attestation: *"Scot Wahlquist 2026-07-08: attested verified-closed"*). No other finding touched.

## Headline
Actionable (open + remediated-unverified) drops **0C/7H → 0C/5H**. Medium/Low unchanged.

## Notes
- `evidence.sha`/snippet stay pinned at the audited SHA `20953ab3d` so citation-check still validates each finding as originally observed; the fix SHA lives in `closureEvidence`.
- Regenerated: `FINDINGS.md`, `notion/compliance-audit-page.md`, `DOCUMENT-REGISTER.{json,md}`, `COMPLIANCE-PUBLICATION-STATUS.md`.
- Gates: citation-check 95 PASS / 0 FAIL / 10 SKIP; notion / document-register / publication-status `--check` all OK.
- The live Notion posture page will be refreshed in place after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178kTWqKrbGNf6GsM2sd2b4