### PR TITLE
compliance(eu): jurisdiction primitive + jurisdiction-aware COPPA/GDPR age gate

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -75,7 +75,13 @@ class Api::IntegrationsController < ApplicationController
   end
 
   def domain_settings
-    render json: @domain_overrides.to_json
+    # Merge the per-request jurisdiction-aware consent age into a FRESH copy so
+    # the cached per-host blob (@domain_overrides) is never mutated. With the
+    # eu_consent_age feature OFF the injection is {}, so the payload is
+    # byte-identical to today.
+    overrides = @domain_overrides.dup
+    overrides['settings'] = (overrides['settings'] || {}).merge(coppa_consent_age_injection)
+    render json: overrides.to_json
   end
 
   def focus_usage

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,28 @@ class ApplicationController < ActionController::Base
     true
   end
 
+  # EU launch (GDPR Art. 8): per-request jurisdiction-aware parental-consent age,
+  # delivered to the anonymous registration UI via domain_settings. Returns {}
+  # unless the eu_consent_age feature is enabled, so with the flag OFF the
+  # injected domain_settings are byte-identical to today. Callers MUST merge this
+  # into a fresh copy of the settings hash (never mutate @domain_overrides, which
+  # is the cached per-host blob from JsonApi::Json.load_domain).
+  def coppa_consent_age_injection
+    return {} unless FeatureFlags.eu_consent_age_enabled?
+    { 'coppa_consent_age' => JsonApi::Json.coppa_consent_age(jurisdiction_signal_for_request) }
+  end
+  helper_method :coppa_consent_age_injection
+
+  # Best jurisdiction signal available for THIS request, using only signals that
+  # already exist (no IP geolocation). Priority: a configured org/domain country
+  # or region, then locale, then an explicit ?locale= param, then the browser's
+  # Accept-Language header. LingoLinq::Jurisdiction resolves any of these.
+  def jurisdiction_signal_for_request
+    ds = (@domain_overrides && @domain_overrides['settings']) || {}
+    ds['country'] || ds['region'] || ds['locale'] || ds['default_locale'] ||
+      params[:locale].presence || request.headers['Accept-Language'].presence
+  end
+
   def log_api_call
     time = @time ? (Time.now - @time) : nil
     ApiCall.log(@token, @api_user, request, response, time)

--- a/app/frontend/app/controllers/register.js
+++ b/app/frontend/app/controllers/register.js
@@ -152,6 +152,19 @@ export default Controller.extend({
     return !!(ds && ds.coppa_parental_consent);
   }),
   coppa_age_group: null,
+  // EU launch (GDPR Art. 8): the age below which registration requires
+  // verifiable parental consent. Gated by the eu_consent_age feature flag; with
+  // the flag OFF this is always 13 and the age gate is identical to today. When
+  // ON, the EU value (16) is computed server-side (LingoLinq::Jurisdiction) and
+  // delivered through domain_settings, so the single source of EU truth stays
+  // on the backend and this stays a dumb number consumer.
+  coppaConsentAge: computed('appState.feature_flags.eu_consent_age', 'appState.domain_settings.coppa_consent_age', function() {
+    var fallback = 13;
+    if(!this.get('appState.feature_flags.eu_consent_age')) { return fallback; }
+    var age = parseInt(this.get('appState.domain_settings.coppa_consent_age'), 10);
+    if(!age || age < 13 || age > 18) { return fallback; }
+    return age;
+  }),
   parent_consent_email: '',
   coppaParentEmailMissing: computed('triedToSave', 'coppa_age_group', 'parent_consent_email', function() {
     if(this.get('coppa_age_group') !== 'under_13') { return false; }
@@ -293,10 +306,15 @@ export default Controller.extend({
     var year = parseInt(this.get('birth_year'), 10);
     if(!month || !year) { return null; }
     var today = new Date();
-    var cutoffYear = today.getFullYear() - 13;
+    // Jurisdiction-aware consent age (13 by default, 16 for EU when the
+    // eu_consent_age flag is on). The returned labels 'under_13'/'over_13' are
+    // semantic ("under/over the applicable threshold"), not literally 13, and
+    // are consumed unchanged by the rest of the flow and the backend
+    // coppa_under_13 gate.
+    var cutoffYear = today.getFullYear() - this.get('coppaConsentAge');
     var cutoffMonth = today.getMonth() + 1;
-    // With month/year only, treat the cutoff month as under 13 until the
-    // exact birthday is known. This keeps Google off the ambiguous edge.
+    // With month/year only, treat the cutoff month as under the threshold until
+    // the exact birthday is known. This keeps Google off the ambiguous edge.
     if(year > cutoffYear || (year === cutoffYear && month >= cutoffMonth)) {
       return 'under_13';
     }

--- a/app/models/lingo_linq/jurisdiction.rb
+++ b/app/models/lingo_linq/jurisdiction.rb
@@ -1,0 +1,104 @@
+module LingoLinq
+  # Small, dependency-free jurisdiction primitive.
+  #
+  # Determines whether a registration/account context is in the EU (for GDPR
+  # purposes, e.g. the Art. 8 digital-consent age) from locale/region/country
+  # signals that ALREADY exist on a user or request. It deliberately does NOT
+  # perform IP geolocation and pulls in no external gem: it normalizes an
+  # explicit country code or a locale's region subtag to an ISO 3166-1 alpha-2
+  # country and checks membership in the EU set.
+  #
+  # Accepted signals (see .country_code): a String (locale like 'pl-PL' /
+  # 'pl_PL', a country code like 'PL', or an Accept-Language header value like
+  # 'pl-PL,pl;q=0.9'), a User-like object (reads settings country/region/
+  # locale), a Hash of { country:/region:/locale: }, or nil.
+  #
+  # Ambiguity policy: an EXPLICIT country/region field (a Hash 'country'/
+  # 'region' key, or the same on a user's settings) is trusted case-insensitive
+  # as a country. A LOCALE-derived value only yields a country when it carries a
+  # region subtag ('pl-PL' -> PL) or is an uppercase 2-letter country token
+  # ('PL'); a bare lowercase language subtag ('pl', 'es', 'fr') is treated as
+  # UNKNOWN (nil), because language alone is ambiguous across EU and non-EU
+  # countries ('es' -> ES/MX, 'pt' -> PT/BR, 'fr' -> FR/CA). Returning nil there
+  # makes .eu? false, which preserves today's (non-EU, age-13) behavior. That is
+  # the safe default: over-classifying non-EU users as EU would change their
+  # flow, which must stay exactly as today.
+  module Jurisdiction
+    # EU-27 member states (ISO 3166-1 alpha-2). GDPR Art. 8 lets each member
+    # state set its digital-consent age between 13 and 16; the consumer of this
+    # primitive applies the EU maximum (16). EEA-but-not-EU states (IS, LI, NO)
+    # and the UK are intentionally excluded here; add them when their own
+    # consent regimes are in scope.
+    EU_COUNTRY_CODES = %w[
+      AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK
+      SI ES SE
+    ].to_set.freeze
+
+    # Normalize a signal to an ISO 3166-1 alpha-2 country code (upcased String)
+    # when one can be determined, otherwise nil. Returns non-EU codes too (e.g.
+    # 'US') so callers can reason about non-EU countries.
+    def self.country_code(signal)
+      return nil if signal.nil?
+
+      if signal.respond_to?(:settings)
+        return country_from_user(signal)
+      end
+
+      if signal.is_a?(Hash)
+        h = signal.transform_keys { |k| k.to_s }
+        explicit = trusted_country(h['country']) || trusted_country(h['region'])
+        return explicit if explicit
+        return country_from_locale(h['locale'] || h['default_locale'])
+      end
+
+      country_from_locale(signal.to_s)
+    end
+
+    # True when the signal resolves to an EU-27 country.
+    def self.eu?(signal)
+      code = country_code(signal)
+      !code.nil? && EU_COUNTRY_CODES.include?(code)
+    end
+
+    # An explicit country/region field: trusted as a country case-insensitively.
+    def self.trusted_country(val)
+      return nil if val.nil?
+      token = val.to_s.strip
+      return nil unless token.match?(/\A[A-Za-z]{2}\z/)
+      token.upcase
+    end
+    private_class_method :trusted_country
+
+    # A locale/Accept-Language string: only yields a country from a region
+    # subtag or an uppercase 2-letter country token (see ambiguity policy).
+    def self.country_from_locale(str)
+      s = str.to_s.strip
+      return nil if s.empty?
+      # Accept-Language / multi-tag: take the first tag only.
+      s = s.split(/[,;\s]/).first.to_s.strip
+      return nil if s.empty?
+      # Uppercase 2-letter country token ('PL', 'US').
+      return s.upcase if s.match?(/\A[A-Z]{2}\z/)
+      # Locale with a region subtag: 'pl-PL', 'de_DE', 'en-US'.
+      region = s.split(/[-_]/)[1]
+      return region.upcase if region && region.match?(/\A[A-Za-z]{2}\z/)
+      # Bare lowercase language subtag ('pl', 'es'): ambiguous -> unknown.
+      nil
+    end
+    private_class_method :country_from_locale
+
+    # Best country signal from a User-like object, using only fields that
+    # already exist on the settings blob. No new columns.
+    def self.country_from_user(user)
+      s = user.settings || {}
+      prefs = s['preferences'] || {}
+      explicit = trusted_country(s['country']) || trusted_country(prefs['country']) ||
+                 trusted_country(s['region']) || trusted_country(prefs['region'])
+      return explicit if explicit
+      country_from_locale(prefs['locale'] || s['locale'])
+    rescue StandardError
+      nil
+    end
+    private_class_method :country_from_user
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,7 +58,7 @@
   <%# window.domain_settings must be defined in <head> so it runs before application.js (deferred or dynamically inserted in boards/index). %>
   <% if @domain_overrides && @domain_overrides['settings'] %>
     <script type="text/javascript">
-      window.domain_settings = <%= (@domain_overrides['settings'] || {}).to_json.html_safe %>;
+      window.domain_settings = <%= (@domain_overrides['settings'] || {}).merge(coppa_consent_age_injection).to_json.html_safe %>;
       window.domain_settings['domain'] = "<%= j((@domain_overrides['domain'].presence || @domain_overrides['host']).to_s) %>";
     </script>
   <% end %>

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -29,7 +29,13 @@ module FeatureFlags
               'portrait_orientation_overlay', 'signup_default_library_boards',
               'english_first_board_generation', 'signup_spanish_library_boards',
               'dashboard_drag_layout', 'boards_page_owner_dedup', 'edit_sidebar',
-              'sentence_bar_editing']
+              'sentence_bar_editing',
+              # EU launch (GDPR Art. 8): make the registration parental-consent
+              # age gate jurisdiction-aware (EU under-16 vs default under-13).
+              # AVAILABLE-only => OFF for everyone by default; with it OFF the
+              # registration flow is identical to today. Add to
+              # ENABLED_FRONTEND_FEATURES to activate (see eu_consent_age_enabled?).
+              'eu_consent_age']
   ENABLED_FRONTEND_FEATURES = ['subscriptions', 'assessments', 'custom_sidebar', 'snapshots',
               'video_recording', 'goals', 'modeling', 'geo_sidebar', 'edit_before_copying',
               'core_reports', 'lessonpix', 'translation', 'fast_render',
@@ -142,6 +148,15 @@ module FeatureFlags
     return false unless AI_FEATURES.include?(feature)
     return false unless ai_enabled_for?(user)
     feature_enabled_for?(feature, user)
+  end
+
+  # EU launch (GDPR Art. 8): whether the jurisdiction-aware registration
+  # consent-age gate is globally active. Mirrors how anonymous registration
+  # reads flags (window.enabled_frontend_features = ENABLED_FRONTEND_FEATURES),
+  # since there is no user yet at signup. OFF by default (AVAILABLE-only) so the
+  # registration flow stays identical to today until deliberately enabled.
+  def self.eu_consent_age_enabled?
+    ENABLED_FRONTEND_FEATURES.include?('eu_consent_age')
   end
 
   # COPPA Final Rule (16 CFR 312.5) hard-gate. Default ON.

--- a/lib/json_api/json.rb
+++ b/lib/json_api/json.rb
@@ -128,6 +128,22 @@ module JsonApi::Json
     !!(current_domain && current_domain['settings'] && current_domain['settings']['coppa_parental_consent'])
   end
 
+  # Default digital-consent age for the registration parental-consent gate.
+  # US COPPA baseline; used for every non-EU jurisdiction.
+  DEFAULT_COPPA_CONSENT_AGE = 13
+  # EU maximum (GDPR Art. 8). Poland and other EU member states require
+  # verifiable parental consent below this age.
+  EU_COPPA_CONSENT_AGE = 16
+
+  # Resolve the applicable parental-consent age for a jurisdiction signal
+  # (locale/region/country String, User-like object, Hash, or nil). Returns 16
+  # for EU jurisdictions, 13 otherwise. Pure: the feature-flag gate lives at the
+  # delivery point (ApplicationController#coppa_consent_age_injection), so an
+  # unflagged call still resolves the honest age without changing behavior.
+  def self.coppa_consent_age(signal)
+    LingoLinq::Jurisdiction.eu?(signal) ? EU_COPPA_CONSENT_AGE : DEFAULT_COPPA_CONSENT_AGE
+  end
+
   # Truthy: true, 1, yes, on (case-insensitive). Matches typical .env conventions.
   def self.coppa_parental_consent_from_env?
     v = ENV['COPPA_PARENTAL_CONSENT'].to_s.strip.downcase

--- a/spec/controllers/api/integrations_controller_spec.rb
+++ b/spec/controllers/api/integrations_controller_spec.rb
@@ -433,4 +433,36 @@ describe Api::IntegrationsController, :type => :controller do
       expect(focus_set.applied_count).to eq(1)
     end
   end
+
+  describe "domain_settings coppa_consent_age injection" do
+    it "does not inject coppa_consent_age when the flag is OFF (identical to today)" do
+      request.headers['Accept-Language'] = 'pl-PL,pl;q=0.9'
+      get 'domain_settings'
+      json = JSON.parse(response.body)
+      expect(json['settings']).not_to have_key('coppa_consent_age')
+    end
+
+    it "injects 16 for an EU (Poland) request when the flag is ON" do
+      stub_const('FeatureFlags::ENABLED_FRONTEND_FEATURES', FeatureFlags::ENABLED_FRONTEND_FEATURES + ['eu_consent_age'])
+      request.headers['Accept-Language'] = 'pl-PL,pl;q=0.9'
+      get 'domain_settings'
+      json = JSON.parse(response.body)
+      expect(json['settings']['coppa_consent_age']).to eq(16)
+    end
+
+    it "injects 13 for a non-EU (US) request when the flag is ON" do
+      stub_const('FeatureFlags::ENABLED_FRONTEND_FEATURES', FeatureFlags::ENABLED_FRONTEND_FEATURES + ['eu_consent_age'])
+      request.headers['Accept-Language'] = 'en-US,en;q=0.9'
+      get 'domain_settings'
+      json = JSON.parse(response.body)
+      expect(json['settings']['coppa_consent_age']).to eq(13)
+    end
+
+    it "does not mutate the cached per-host domain blob" do
+      stub_const('FeatureFlags::ENABLED_FRONTEND_FEATURES', FeatureFlags::ENABLED_FRONTEND_FEATURES + ['eu_consent_age'])
+      request.headers['Accept-Language'] = 'pl-PL'
+      get 'domain_settings'
+      expect(JsonApi::Json.current_domain['settings']).not_to have_key('coppa_consent_age')
+    end
+  end
 end

--- a/spec/lib/feature_flags_spec.rb
+++ b/spec/lib/feature_flags_spec.rb
@@ -135,4 +135,17 @@ describe FeatureFlags do
       expect(FeatureFlags.coppa_blocks_ai_for?(u)).to eq(false)
     end
   end
+
+  describe "eu_consent_age" do
+    it "is registered as available but OFF by default" do
+      expect(FeatureFlags::AVAILABLE_FRONTEND_FEATURES).to include('eu_consent_age')
+      expect(FeatureFlags::ENABLED_FRONTEND_FEATURES).not_to include('eu_consent_age')
+      expect(FeatureFlags.eu_consent_age_enabled?).to eq(false)
+    end
+
+    it "reports enabled once added to the enabled list" do
+      stub_const('FeatureFlags::ENABLED_FRONTEND_FEATURES', FeatureFlags::ENABLED_FRONTEND_FEATURES + ['eu_consent_age'])
+      expect(FeatureFlags.eu_consent_age_enabled?).to eq(true)
+    end
+  end
 end

--- a/spec/lib/json_api/coppa_consent_age_spec.rb
+++ b/spec/lib/json_api/coppa_consent_age_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe JsonApi::Json do
+  describe ".coppa_consent_age" do
+    it "returns 16 for an EU jurisdiction (Poland and others)" do
+      expect(JsonApi::Json.coppa_consent_age('PL')).to eq(16)
+      expect(JsonApi::Json.coppa_consent_age('pl-PL')).to eq(16)
+      expect(JsonApi::Json.coppa_consent_age('pl-PL,pl;q=0.9')).to eq(16)
+      expect(JsonApi::Json.coppa_consent_age({ 'country' => 'DE' })).to eq(16)
+    end
+
+    it "returns 13 for a non-EU jurisdiction" do
+      expect(JsonApi::Json.coppa_consent_age('US')).to eq(13)
+      expect(JsonApi::Json.coppa_consent_age('en-US')).to eq(13)
+      expect(JsonApi::Json.coppa_consent_age('GB')).to eq(13)
+    end
+
+    it "returns the default (13) when jurisdiction is unknown" do
+      expect(JsonApi::Json.coppa_consent_age(nil)).to eq(13)
+      expect(JsonApi::Json.coppa_consent_age('')).to eq(13)
+      expect(JsonApi::Json.coppa_consent_age('pl')).to eq(13) # bare language, ambiguous
+    end
+  end
+end

--- a/spec/models/lingo_linq/jurisdiction_spec.rb
+++ b/spec/models/lingo_linq/jurisdiction_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe LingoLinq::Jurisdiction do
+  describe ".country_code" do
+    it "returns nil for nil / blank" do
+      expect(LingoLinq::Jurisdiction.country_code(nil)).to eq(nil)
+      expect(LingoLinq::Jurisdiction.country_code('')).to eq(nil)
+      expect(LingoLinq::Jurisdiction.country_code('   ')).to eq(nil)
+    end
+
+    it "normalizes an explicit uppercase country token" do
+      expect(LingoLinq::Jurisdiction.country_code('PL')).to eq('PL')
+      expect(LingoLinq::Jurisdiction.country_code('US')).to eq('US')
+    end
+
+    it "derives the region subtag from a locale" do
+      expect(LingoLinq::Jurisdiction.country_code('pl-PL')).to eq('PL')
+      expect(LingoLinq::Jurisdiction.country_code('de_DE')).to eq('DE')
+      expect(LingoLinq::Jurisdiction.country_code('en-US')).to eq('US')
+    end
+
+    it "takes the first tag of an Accept-Language header" do
+      expect(LingoLinq::Jurisdiction.country_code('pl-PL,pl;q=0.9,en;q=0.8')).to eq('PL')
+    end
+
+    it "treats a bare lowercase language subtag as unknown (ambiguous)" do
+      expect(LingoLinq::Jurisdiction.country_code('pl')).to eq(nil)
+      expect(LingoLinq::Jurisdiction.country_code('es')).to eq(nil)
+      expect(LingoLinq::Jurisdiction.country_code('en')).to eq(nil)
+    end
+
+    it "trusts an explicit country/region hash field case-insensitively" do
+      expect(LingoLinq::Jurisdiction.country_code({ 'country' => 'pl' })).to eq('PL')
+      expect(LingoLinq::Jurisdiction.country_code({ country: 'de' })).to eq('DE')
+      expect(LingoLinq::Jurisdiction.country_code({ 'region' => 'US' })).to eq('US')
+    end
+
+    it "falls back to a hash locale when no explicit country/region" do
+      expect(LingoLinq::Jurisdiction.country_code({ 'locale' => 'pl-PL' })).to eq('PL')
+      expect(LingoLinq::Jurisdiction.country_code({ 'locale' => 'pl' })).to eq(nil)
+    end
+  end
+
+  describe ".eu?" do
+    it "is true for an EU member state (Poland)" do
+      expect(LingoLinq::Jurisdiction.eu?('PL')).to eq(true)
+      expect(LingoLinq::Jurisdiction.eu?('pl-PL')).to eq(true)
+      expect(LingoLinq::Jurisdiction.eu?({ 'country' => 'PL' })).to eq(true)
+    end
+
+    it "is true for other EU member states" do
+      expect(LingoLinq::Jurisdiction.eu?('de-DE')).to eq(true)
+      expect(LingoLinq::Jurisdiction.eu?('FR')).to eq(true)
+      expect(LingoLinq::Jurisdiction.eu?('es-ES')).to eq(true)
+    end
+
+    it "is false for a non-EU country (United States)" do
+      expect(LingoLinq::Jurisdiction.eu?('US')).to eq(false)
+      expect(LingoLinq::Jurisdiction.eu?('en-US')).to eq(false)
+    end
+
+    it "is false for EEA-but-not-EU and other non-EU signals" do
+      expect(LingoLinq::Jurisdiction.eu?('NO')).to eq(false) # Norway (EEA, not EU)
+      expect(LingoLinq::Jurisdiction.eu?('GB')).to eq(false) # UK
+      expect(LingoLinq::Jurisdiction.eu?('CA')).to eq(false) # Canada
+    end
+
+    it "is false when jurisdiction is unknown (fails toward non-EU)" do
+      expect(LingoLinq::Jurisdiction.eu?(nil)).to eq(false)
+      expect(LingoLinq::Jurisdiction.eu?('')).to eq(false)
+      expect(LingoLinq::Jurisdiction.eu?('pl')).to eq(false) # bare language, ambiguous
+    end
+
+    it "reads locale/country signals off a User-like object" do
+      eu_user = double('user', settings: { 'preferences' => { 'locale' => 'pl-PL' } })
+      us_user = double('user', settings: { 'preferences' => { 'locale' => 'en-US' } })
+      explicit_eu = double('user', settings: { 'country' => 'pl' })
+      no_signal = double('user', settings: {})
+      expect(LingoLinq::Jurisdiction.eu?(eu_user)).to eq(true)
+      expect(LingoLinq::Jurisdiction.eu?(us_user)).to eq(false)
+      expect(LingoLinq::Jurisdiction.eu?(explicit_eu)).to eq(true)
+      expect(LingoLinq::Jurisdiction.eu?(no_signal)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## EU launch readiness (Poland): the two engineering gates before the first EU user signs up

Poland is sold through a distributor we host, which makes GDPR active. GDPR Art. 8 sets the digital-consent age at up to 16 (Poland uses 16); today the registration age gate assumes the US COPPA age-13 threshold. This PR adds a jurisdiction primitive and makes the consent-age threshold jurisdiction-aware, behind a feature flag that is OFF by default.

Two atomic commits, each with RSpec.

### Commit 1 — `LingoLinq::Jurisdiction` primitive
`app/models/lingo_linq/jurisdiction.rb`, exposing `LingoLinq::Jurisdiction.eu?(signal)` and `.country_code(signal)`.

- Derives an ISO 3166-1 alpha-2 country from signals that **already exist** on a user or request: a locale (`pl-PL`), an explicit country (`PL`), an `Accept-Language` header, a User-like object (`settings` country/region/locale), or a Hash. **No IP geolocation, no new gem.**
- Ambiguity policy: an explicit `country`/`region` field is trusted; a bare lowercase language subtag (`pl`, `es`, `fr`) is treated as **unknown** so non-EU speakers of EU languages are never misclassified as EU. Unknown ⇒ `eu? == false` ⇒ today's behavior.
- EU-27 set; EEA-not-EU (IS/LI/NO) and the UK are intentionally excluded.
- File is namespaced under `lingo_linq/` because Zeitwerk requires the `LingoLinq::Jurisdiction` constant to live there; a bare `app/models/jurisdiction.rb` defining that constant breaks eager loading. `rails zeitwerk:check` passes.

### Commit 2 — jurisdiction-aware age gate
The age threshold lives **only** on the frontend (`register.js#_classifyCommunicatorAge`, `getFullYear() - 13`); the backend trusts the boolean `coppa_under_13` and never sees the birthdate, so its consent-triggering gate needs **no** change. The EU→16 value is computed server-side and delivered to the anonymous register UI via `domain_settings`.

- New frontend feature flag **`eu_consent_age`** in `AVAILABLE_FRONTEND_FEATURES` only ⇒ **OFF for everyone by default**. `FeatureFlags.eu_consent_age_enabled?` mirrors how anonymous registration reads flags (`ENABLED_FRONTEND_FEATURES`).
- `JsonApi::Json.coppa_consent_age(signal)` ⇒ 16 (EU) / 13 (else) via the primitive.
- `ApplicationController#coppa_consent_age_injection` (a `helper_method`) injects `coppa_consent_age` **only when the flag is on**, using a per-request jurisdiction signal (org/domain country/region/locale → `?locale=` → `Accept-Language`). Merged into a **fresh** copy of the settings hash in `application.html.erb` and `api/integrations#domain_settings` so the **cached per-host blob is never mutated**.
- `register.js`: new `coppaConsentAge` computed (flag- and value-guarded, 13 fallback) used as the classifier cutoff. The `under_13`/`over_13` labels are kept as semantic "under/over threshold", so nothing downstream ripples.

### Flag OFF = identical to today
Flag in `AVAILABLE_` only ⇒ backend injects nothing (byte-identical `domain_settings`) **and** the frontend `coppaConsentAge` returns 13, so the cutoff is exactly the original `getFullYear() - 13`.

### Verification
- `DB_USER=scotw RAILS_ENV=test bundle exec rspec` on the new/changed specs: **73 examples, 0 failures**. Covers EU (Poland + others), non-EU (US/UK/NO/CA), ambiguous/unknown, User/Hash signals; `coppa_consent_age` EU/non-EU/unknown; flag registration + gate; and `domain_settings` injection present only when ON (16 EU / 13 non-EU), **absent when OFF**, with **no cache mutation**.
- `rails zeitwerk:check` passes.
- Frontend JS syntax-checked under Node 20. Ember unit specs do not execute here (AMD loader defect), so the register step-machine still needs a **manual browser drive**: `foreman start`, temporarily add `eu_consent_age` to `ENABLED_FRONTEND_FEATURES`, set browser `Accept-Language` to `pl-PL` ⇒ under-16 routes to the parental-consent step; `en-US` or flag OFF ⇒ under-13. (Build check in progress.)

### Scope notes
- Additive and reversible: no migrations, flag OFF by default.
- Stayed out of `docs/legal/**` and the EU AI Act Article 50 / AI-consent code (separate thread). This PR creates the `Jurisdiction` primitive the Art. 50 thread will reuse, and must merge first to avoid a collision on `jurisdiction.rb` + `feature_flags.rb`.

### Known follow-up (not shipped, keeps flag-OFF byte-identical)
Under-threshold copy `coppa_parent_email_required` says "under 13" literally. Correct while the flag is OFF (the gate IS 13). Making it age-dynamic needs an i18n regeneration pass (`i18n_generator.rb`) and is deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165vszi8WGZsg5hQaRxQFT2

---

## Dual-review outcome (Codex + Claude adversary)

Codex senior-dev pass: no findings. Claude adversary pass: 2 High, 2 Medium, 2 Low (all verified). Both confirm the core guarantees hold: **flag-OFF is byte-identical** and **the cached per-host domain blob is never poisoned**. The dark merge (flag OFF) is regression-free.

Addressed in commit `dce829ea3` (in-scope for the dark merge): #2 removed dead jurisdiction-signal branches + honest best-effort labeling; #3 documented the two-flag coupling; #4 added specs for the layout data source; #5 fixed the BCP-47 region-subtag parse and documented the ISO-country contract; #6 restored null-safety.

**Documented follow-ups (do NOT enable `eu_consent_age` in production as a GDPR Art. 8 control until these land):**
- **#1 (High):** the age gate trusts a client-supplied `coppa_under_13` boolean; the backend never recomputes age (the birthdate is not sent). An EU 14/15-year-old can bypass consent by sending `coppa_under_13=false`. This is pre-existing (same trust model as COPPA-13) and was explicitly out of scope here (reuse the existing consent gates, do not reimplement). Server-side age enforcement is required before relying on this as an enforceable control.
- **Jurisdiction detection is best-effort browser-locale only** (bare `pl` resolves to age 13). An authoritative org-configured EU-host country should be wired, and the region-present rate measured, before this is represented to EU customers/auditors as a compliance control.

As shipped (flag OFF), this is safe infrastructure; as a flag-ON control it is a more-protective-when-it-fires UI nudge, not yet an enforceable consent gate.