### PR TITLE
compliance(notion): make document-register canonicalLocation URLs clickable

### DIFF
--- a/scripts/document-register-notion-sync.rb
+++ b/scripts/document-register-notion-sync.rb
@@ -68,6 +68,17 @@ def rich(text)
   t.empty? ? [] : [{ 'text' => { 'content' => t[0, 1900] } }]
 end
 
+# Like rich, but when the value is an http(s) URL (e.g. a Drive or Notion
+# canonicalLocation) it attaches a Notion link annotation so the cell is
+# clickable in the board. Non-URL values (git repo paths) stay plain text.
+def rich_link(text)
+  t = text.to_s
+  return [] if t.empty?
+  return rich(t) unless t.start_with?('http://', 'https://')
+
+  [{ 'text' => { 'content' => t[0, 1900], 'link' => { 'url' => t } } }]
+end
+
 def cap(s)
   s = s.to_s
   s.empty? ? s : s[0].upcase + s[1..].to_s
@@ -96,7 +107,7 @@ def properties_for(doc)
     'Type'               => { 'select' => { 'name' => doc['type'].to_s } },
     'System'             => { 'select' => { 'name' => cap(doc['canonicalSystem']) } },
     'Owner'              => { 'rich_text' => rich(doc['owner']) },
-    'Canonical location' => { 'rich_text' => rich(doc['canonicalLocation']) },
+    'Canonical location' => { 'rich_text' => rich_link(doc['canonicalLocation']) },
     'Status'             => { 'select' => { 'name' => doc['status'].to_s } },
     'Frameworks'         => { 'multi_select' => (doc['frameworks'] || []).map { |x| { 'name' => x } } },
     'Bundles'            => { 'multi_select' => (doc['bundles'] || []).map { |x| { 'name' => x } } },


### PR DESCRIPTION
## What
The **Compliance Documents (LL)** Notion board wrote each document's `canonicalLocation` as plain `rich_text`, so the 23 Google Drive document URLs (and the Notion URLs) showed as non-clickable text. This adds a `rich_link` helper that attaches a Notion link annotation when the value is an `http(s)` URL, and leaves `git` repo paths as plain text.

## Why
Part of consolidating compliance into the new Notion **Compliance** teamspace: the goal is to reach every compliance document from one place. The register already carries the Drive URLs; this makes the board itself click-through.

## Scope / safety
- One file: `scripts/document-register-notion-sync.rb` (new `rich_link` helper + line 99 uses it).
- **No register data change** — `audit-reports/DOCUMENT-REGISTER.json` is untouched, so the artifact-integrity checks are unaffected.
- `ruby -c` passes; helper unit-tested (URL → linked, path → plain, empty → []).
- Live board updates on the next credentialed `document-register-notion-sync` run (this environment has no `NOTION_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)