### PR TITLE
docs(privacy): correct inaccurate AiApiLog "retained for 2 years" claim

### DIFF
--- a/app/frontend/app/templates/privacy.hbs
+++ b/app/frontend/app/templates/privacy.hbs
@@ -90,7 +90,7 @@
                 <ul>
                   <li>{{t "Active account data: retained for the life of the account, plus up to 2 years of continuous inactivity, after which the account is soft-deleted and queued for purge." key="privacy_security_retention_active"}}</li>
                   <li>{{t "Inactive accounts: accounts inactive for 12 months are flagged for automatic deletion, subject to a 10-day grace period for accidental deletions." key="privacy_security_retention_inactive"}}</li>
-                  <li>{{t "AI request logs: the audit record (AiApiLog) is retained for 2 years; IP addresses on those records are redacted at 90 days." key="privacy_security_retention_ai_logs"}}</li>
+                  <li>{{t "AI request logs: the audit record (AiApiLog) is deleted when the account is deleted; IP addresses on those records are redacted at 90 days." key="privacy_security_retention_ai_logs"}}</li>
                   <li>{{t "Voice and audio recordings (button sounds you record): retained for the life of the user account and deleted when the account is deleted." key="privacy_security_retention_voice"}}</li>
                   <li>{{t "Dwell, eye-gaze, and head-tracking timing data (stored within communication logs): retained for 3 years by default, configurable to a shorter window per user or organization." key="privacy_security_retention_dwell"}}</li>
                   <li>{{t "School and district tenant data: deleted within 90 days after the customer contract ends, unless a shorter window is specified in the data processing addendum." key="privacy_security_retention_tenant"}}</li>

--- a/app/frontend/app/templates/privacy.hbs
+++ b/app/frontend/app/templates/privacy.hbs
@@ -90,7 +90,7 @@
                 <ul>
                   <li>{{t "Active account data: retained for the life of the account, plus up to 2 years of continuous inactivity, after which the account is soft-deleted and queued for purge." key="privacy_security_retention_active"}}</li>
                   <li>{{t "Inactive accounts: accounts inactive for 12 months are flagged for automatic deletion, subject to a 10-day grace period for accidental deletions." key="privacy_security_retention_inactive"}}</li>
-                  <li>{{t "AI request logs: the audit record (AiApiLog) is deleted when the account is deleted; IP addresses on those records are redacted at 90 days." key="privacy_security_retention_ai_logs"}}</li>
+                  <li>{{t "AI request logs: the audit record (AiApiLog) tied to a user account is deleted when that account is deleted; IP addresses on those records are redacted at 90 days." key="privacy_security_retention_ai_logs"}}</li>
                   <li>{{t "Voice and audio recordings (button sounds you record): retained for the life of the user account and deleted when the account is deleted." key="privacy_security_retention_voice"}}</li>
                   <li>{{t "Dwell, eye-gaze, and head-tracking timing data (stored within communication logs): retained for 3 years by default, configurable to a shorter window per user or organization." key="privacy_security_retention_dwell"}}</li>
                   <li>{{t "School and district tenant data: deleted within 90 days after the customer contract ends, unless a shorter window is specified in the data processing addendum." key="privacy_security_retention_tenant"}}</li>

--- a/app/views/shared/_privacy.html.erb
+++ b/app/views/shared/_privacy.html.erb
@@ -71,7 +71,7 @@
         <ul>
           <li>Active account data: retained for the life of the account, plus up to 2 years of continuous inactivity, after which the account is soft-deleted and queued for purge.</li>
           <li>Inactive accounts: accounts inactive for 12 months are flagged for automatic deletion, subject to a 10-day grace period for accidental deletions.</li>
-          <li>AI request logs: the audit record (AiApiLog) is retained for 2 years; IP addresses on those records are redacted at 90 days.</li>
+          <li>AI request logs: the audit record (AiApiLog) is deleted when the account is deleted; IP addresses on those records are redacted at 90 days.</li>
           <li>Voice and audio recordings (button sounds you record): retained for the life of the user account and deleted when the account is deleted.</li>
           <li>Dwell, eye-gaze, and head-tracking timing data (stored within communication logs): retained for 3 years by default, configurable to a shorter window per user or organization.</li>
           <li>School and district tenant data: deleted within 90 days after the customer contract ends, unless a shorter window is specified in the data processing addendum.</li>

--- a/app/views/shared/_privacy.html.erb
+++ b/app/views/shared/_privacy.html.erb
@@ -71,7 +71,7 @@
         <ul>
           <li>Active account data: retained for the life of the account, plus up to 2 years of continuous inactivity, after which the account is soft-deleted and queued for purge.</li>
           <li>Inactive accounts: accounts inactive for 12 months are flagged for automatic deletion, subject to a 10-day grace period for accidental deletions.</li>
-          <li>AI request logs: the audit record (AiApiLog) is deleted when the account is deleted; IP addresses on those records are redacted at 90 days.</li>
+          <li>AI request logs: the audit record (AiApiLog) tied to a user account is deleted when that account is deleted; IP addresses on those records are redacted at 90 days.</li>
           <li>Voice and audio recordings (button sounds you record): retained for the life of the user account and deleted when the account is deleted.</li>
           <li>Dwell, eye-gaze, and head-tracking timing data (stored within communication logs): retained for 3 years by default, configurable to a shorter window per user or organization.</li>
           <li>School and district tenant data: deleted within 90 days after the customer contract ends, unless a shorter window is specified in the data processing addendum.</li>

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -6950,7 +6950,7 @@
   "privacy_security_retention_intro": "We retain personal data only as long as necessary for the purpose it was collected, with category-specific windows that align with our Data Retention Schedule.",
   "privacy_security_retention_active": "Active account data: retained for the life of the account, plus up to 2 years of continuous inactivity, after which the account is soft-deleted and queued for purge.",
   "privacy_security_retention_inactive": "Inactive accounts: accounts inactive for 12 months are flagged for automatic deletion, subject to a 10-day grace period for accidental deletions.",
-  "privacy_security_retention_ai_logs": "AI request logs: the audit record (AiApiLog) is retained for 2 years; IP addresses on those records are redacted at 90 days.",
+  "privacy_security_retention_ai_logs": "AI request logs: the audit record (AiApiLog) is deleted when the account is deleted; IP addresses on those records are redacted at 90 days.",
   "privacy_security_retention_voice": "Voice and audio recordings (button sounds you record): retained for the life of the user account and deleted when the account is deleted.",
   "privacy_security_retention_dwell": "Dwell, eye-gaze, and head-tracking timing data (stored within communication logs): retained for 3 years by default, configurable to a shorter window per user or organization.",
   "privacy_security_retention_tenant": "School and district tenant data: deleted within 90 days after the customer contract ends, unless a shorter window is specified in the data processing addendum.",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -6950,7 +6950,7 @@
   "privacy_security_retention_intro": "We retain personal data only as long as necessary for the purpose it was collected, with category-specific windows that align with our Data Retention Schedule.",
   "privacy_security_retention_active": "Active account data: retained for the life of the account, plus up to 2 years of continuous inactivity, after which the account is soft-deleted and queued for purge.",
   "privacy_security_retention_inactive": "Inactive accounts: accounts inactive for 12 months are flagged for automatic deletion, subject to a 10-day grace period for accidental deletions.",
-  "privacy_security_retention_ai_logs": "AI request logs: the audit record (AiApiLog) is deleted when the account is deleted; IP addresses on those records are redacted at 90 days.",
+  "privacy_security_retention_ai_logs": "AI request logs: the audit record (AiApiLog) tied to a user account is deleted when that account is deleted; IP addresses on those records are redacted at 90 days.",
   "privacy_security_retention_voice": "Voice and audio recordings (button sounds you record): retained for the life of the user account and deleted when the account is deleted.",
   "privacy_security_retention_dwell": "Dwell, eye-gaze, and head-tracking timing data (stored within communication logs): retained for 3 years by default, configurable to a shorter window per user or organization.",
   "privacy_security_retention_tenant": "School and district tenant data: deleted within 90 days after the customer contract ends, unless a shorter window is specified in the data processing addendum.",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -6936,7 +6936,7 @@
   "privacy_security_retention_intro": "*** We retain personal data only as long as necessary for the purpose it was collected, with category-specific windows that align with our Data Retention Schedule.",
   "privacy_security_retention_active": "*** Active account data: retained for the life of the account, plus up to 2 years of continuous inactivity, after which the account is soft-deleted and queued for purge.",
   "privacy_security_retention_inactive": "*** Inactive accounts: accounts inactive for 12 months are flagged for automatic deletion, subject to a 10-day grace period for accidental deletions.",
-  "privacy_security_retention_ai_logs": "*** AI request logs: the audit record (AiApiLog) is deleted when the account is deleted; IP addresses on those records are redacted at 90 days.",
+  "privacy_security_retention_ai_logs": "*** AI request logs: the audit record (AiApiLog) tied to a user account is deleted when that account is deleted; IP addresses on those records are redacted at 90 days.",
   "privacy_security_retention_voice": "*** Voice and audio recordings (button sounds you record): retained for the life of the user account and deleted when the account is deleted.",
   "privacy_security_retention_dwell": "*** Dwell, eye-gaze, and head-tracking timing data (stored within communication logs): retained for 3 years by default, configurable to a shorter window per user or organization.",
   "privacy_security_retention_tenant": "*** School and district tenant data: deleted within 90 days after the customer contract ends, unless a shorter window is specified in the data processing addendum.",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -6936,7 +6936,7 @@
   "privacy_security_retention_intro": "*** We retain personal data only as long as necessary for the purpose it was collected, with category-specific windows that align with our Data Retention Schedule.",
   "privacy_security_retention_active": "*** Active account data: retained for the life of the account, plus up to 2 years of continuous inactivity, after which the account is soft-deleted and queued for purge.",
   "privacy_security_retention_inactive": "*** Inactive accounts: accounts inactive for 12 months are flagged for automatic deletion, subject to a 10-day grace period for accidental deletions.",
-  "privacy_security_retention_ai_logs": "*** AI request logs: the audit record (AiApiLog) is retained for 2 years; IP addresses on those records are redacted at 90 days.",
+  "privacy_security_retention_ai_logs": "*** AI request logs: the audit record (AiApiLog) is deleted when the account is deleted; IP addresses on those records are redacted at 90 days.",
   "privacy_security_retention_voice": "*** Voice and audio recordings (button sounds you record): retained for the life of the user account and deleted when the account is deleted.",
   "privacy_security_retention_dwell": "*** Dwell, eye-gaze, and head-tracking timing data (stored within communication logs): retained for 3 years by default, configurable to a shorter window per user or organization.",
   "privacy_security_retention_tenant": "*** School and district tenant data: deleted within 90 days after the customer contract ends, unless a shorter window is specified in the data processing addendum.",


### PR DESCRIPTION
## What

The user-facing privacy notice claims **AI request logs (AiApiLog) are "retained for 2 years."** That is not true. Corrects the copy to describe actual behavior.

## Evidence (verified against code)

- The only scheduled AiApiLog jobs are `redact_old_ip_addresses!` (90-day IP scrub) and `purge_old_eu_logs!` (EU purge) — `lib/tasks/scheduler.rake:142,147`.
- **No 2-year age-based purge exists** anywhere: no AiApiLog reference in `lib/data_policy_enforcer.rb`; no `delete/destroy/purge` by age in `lib/`/`app/`.
- AiApiLog rows persist until the account is deleted, at which point `Flusher` destroys them — `lib/flusher.rb:29` → `flush_record` → `record.destroy`.

So the honest statement is: **deleted when the account is deleted; IP addresses redacted at 90 days** — mirroring the existing "Voice and audio recordings" bullet.

## Change

| Surface | File |
|---|---|
| Ember template | `app/frontend/app/templates/privacy.hbs:93` |
| Server-rendered partial | `app/views/shared/_privacy.html.erb:74` |
| English locale | `public/locales/en.json` (`privacy_security_retention_ai_logs`) |
| Spanish locale | `public/locales/es.json` (keeps existing `*** ` untranslated marker) |

Before: "...retained for 2 years; IP addresses on those records are redacted at 90 days."
After: "...deleted when the account is deleted; IP addresses on those records are redacted at 90 days."

## Why now (separate from the schedule work)

Surfaced by the review of #555. The old copy is an **independent, inaccurate user-facing retention promise** (FTC Section 5 say/do exposure) that should not wait on the larger retention rework. The precise numeric window stays governed by `DATA_RETENTION.md`, whose AiApiLog row (EU 5-year purge, jurisdiction stamping, legal-basis cells) is being reconciled under the **EU AI Act Article 50 / VPC Phase 4** work — see #555 for the disposition.

## Scope

User-facing copy + locales only. No code, no behavior change. i18n preserved (double-quoted user-facing strings, en + es).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwRwb8SJE6Nuh8BQ73yq3d