### PR TITLE
compliance(eu): dual-review fixes for the jurisdiction age gate (follow-up to #556)

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -79,7 +79,7 @@ class Api::IntegrationsController < ApplicationController
     # the cached per-host blob (@domain_overrides) is never mutated. With the
     # eu_consent_age feature OFF the injection is {}, so the payload is
     # byte-identical to today.
-    overrides = @domain_overrides.dup
+    overrides = (@domain_overrides || {}).dup
     overrides['settings'] = (overrides['settings'] || {}).merge(coppa_consent_age_injection)
     render json: overrides.to_json
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,13 +48,19 @@ class ApplicationController < ActionController::Base
   helper_method :coppa_consent_age_injection
 
   # Best jurisdiction signal available for THIS request, using only signals that
-  # already exist (no IP geolocation). Priority: a configured org/domain country
-  # or region, then locale, then an explicit ?locale= param, then the browser's
-  # Accept-Language header. LingoLinq::Jurisdiction resolves any of these.
+  # already exist (no IP geolocation). This is best-effort BROWSER-LOCALE
+  # detection: an explicit ?locale= param, then the Accept-Language header.
+  #
+  # Deliberately does NOT read a country/region/locale off @domain_overrides:
+  # host_settings carries no such key today (see Organization#process_params
+  # allowlist), so those reads would be dead and misrepresent the signal source.
+  # A region-less locale (bare 'pl') resolves to unknown and preserves the
+  # default age-13 gate. Wiring an AUTHORITATIVE org-configured EU-host country
+  # is a tracked follow-up and is required before eu_consent_age is relied on as
+  # a GDPR Art. 8 control (browser locale under-fires for EU users who send a
+  # bare language subtag).
   def jurisdiction_signal_for_request
-    ds = (@domain_overrides && @domain_overrides['settings']) || {}
-    ds['country'] || ds['region'] || ds['locale'] || ds['default_locale'] ||
-      params[:locale].presence || request.headers['Accept-Language'].presence
+    params[:locale].presence || request.headers['Accept-Language'].presence
   end
 
   def log_api_call

--- a/app/models/lingo_linq/jurisdiction.rb
+++ b/app/models/lingo_linq/jurisdiction.rb
@@ -61,6 +61,11 @@ module LingoLinq
     end
 
     # An explicit country/region field: trusted as a country case-insensitively.
+    # By contract the token is an ISO 3166-1 alpha-2 COUNTRY code. Note the token
+    # is not validated against the full ISO country list, so a value that is a
+    # US state code colliding with an ISO country (e.g. 'DE' = Delaware vs
+    # Germany) is read as the ISO country. Callers wiring this to a user field
+    # must pass ISO country codes, not subnational region codes.
     def self.trusted_country(val)
       return nil if val.nil?
       token = val.to_s.strip
@@ -79,9 +84,13 @@ module LingoLinq
       return nil if s.empty?
       # Uppercase 2-letter country token ('PL', 'US').
       return s.upcase if s.match?(/\A[A-Z]{2}\z/)
-      # Locale with a region subtag: 'pl-PL', 'de_DE', 'en-US'.
-      region = s.split(/[-_]/)[1]
-      return region.upcase if region && region.match?(/\A[A-Za-z]{2}\z/)
+      # Locale with a region subtag: 'pl-PL', 'de_DE', 'en-US', and script-tagged
+      # BCP-47 like 'sr-Latn-RS' / 'zh-Hant-HK'. The region is the 2-letter
+      # subtag AFTER the language (scripts are 4 letters, so scan past them);
+      # taking split[1] blindly would misread the script subtag ('Latn').
+      subtags = s.split(/[-_]/)
+      region = subtags[1..].find { |t| t.match?(/\A[A-Za-z]{2}\z/) }
+      return region.upcase if region
       # Bare lowercase language subtag ('pl', 'es'): ambiguous -> unknown.
       nil
     end

--- a/app/models/lingo_linq/jurisdiction.rb
+++ b/app/models/lingo_linq/jurisdiction.rb
@@ -84,13 +84,17 @@ module LingoLinq
       return nil if s.empty?
       # Uppercase 2-letter country token ('PL', 'US').
       return s.upcase if s.match?(/\A[A-Z]{2}\z/)
-      # Locale with a region subtag: 'pl-PL', 'de_DE', 'en-US', and script-tagged
-      # BCP-47 like 'sr-Latn-RS' / 'zh-Hant-HK'. The region is the 2-letter
-      # subtag AFTER the language (scripts are 4 letters, so scan past them);
-      # taking split[1] blindly would misread the script subtag ('Latn').
+      # Locale region subtag, read ONLY at its RFC 5646 grammatical position:
+      # immediately after the language and an optional 4-letter script, and
+      # before any singleton (extension '-t-' or private-use '-x-') or variant.
+      # Scanning all subtags for any 2-letter token would misread private-use /
+      # extension data as a country ('en-x-DE' -> 'DE', 'en-t-fr-FR' -> 'fr').
+      # A region is exactly two letters ('pl-PL' -> PL, 'sr-Latn-RS' -> RS).
       subtags = s.split(/[-_]/)
-      region = subtags[1..].find { |t| t.match?(/\A[A-Za-z]{2}\z/) }
-      return region.upcase if region
+      idx = 1
+      idx += 1 if subtags[idx] && subtags[idx].match?(/\A[A-Za-z]{4}\z/) # skip script
+      region = subtags[idx]
+      return region.upcase if region && region.match?(/\A[A-Za-z]{2}\z/)
       # Bare lowercase language subtag ('pl', 'es'): ambiguous -> unknown.
       nil
     end

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -155,6 +155,13 @@ module FeatureFlags
   # reads flags (window.enabled_frontend_features = ENABLED_FRONTEND_FEATURES),
   # since there is no user yet at signup. OFF by default (AVAILABLE-only) so the
   # registration flow stays identical to today until deliberately enabled.
+  #
+  # DEPENDENCY: EU-16 only actually GATES when the host also has
+  # coppa_parental_consent enabled (JsonApi::Json.coppa_parental_consent_enabled?).
+  # With this flag ON but that OFF, the register UI collects a parent email but
+  # the backend does not gate -- a cosmetic prompt. Enable BOTH together on an
+  # EU host. (And note the age gate itself trusts a client boolean; server-side
+  # enforcement is a separate hardening item, see the PR/plan.)
   def self.eu_consent_age_enabled?
     ENABLED_FRONTEND_FEATURES.include?('eu_consent_age')
   end

--- a/spec/controllers/api/integrations_controller_spec.rb
+++ b/spec/controllers/api/integrations_controller_spec.rb
@@ -465,4 +465,33 @@ describe Api::IntegrationsController, :type => :controller do
       expect(JsonApi::Json.current_domain['settings']).not_to have_key('coppa_consent_age')
     end
   end
+
+  # The layout (app/views/layouts/application.html.erb) injects window.domain_settings
+  # via exactly these helpers; test them directly so the primary (server-render)
+  # delivery path is covered, not only the JSON endpoint.
+  describe "#coppa_consent_age_injection (layout data source)" do
+    before(:each) { controller.instance_variable_set(:@domain_overrides, { 'settings' => {} }) }
+
+    it "is empty when the flag is OFF (layout injection is a no-op)" do
+      request.headers['Accept-Language'] = 'pl-PL,pl;q=0.9'
+      expect(controller.send(:coppa_consent_age_injection)).to eq({})
+    end
+
+    it "returns 16 for an EU (Poland) request when the flag is ON" do
+      stub_const('FeatureFlags::ENABLED_FRONTEND_FEATURES', FeatureFlags::ENABLED_FRONTEND_FEATURES + ['eu_consent_age'])
+      request.headers['Accept-Language'] = 'pl-PL,pl;q=0.9'
+      expect(controller.send(:coppa_consent_age_injection)).to eq({ 'coppa_consent_age' => 16 })
+    end
+
+    it "returns 13 for a non-EU (US) request when the flag is ON" do
+      stub_const('FeatureFlags::ENABLED_FRONTEND_FEATURES', FeatureFlags::ENABLED_FRONTEND_FEATURES + ['eu_consent_age'])
+      request.headers['Accept-Language'] = 'en-US,en;q=0.9'
+      expect(controller.send(:coppa_consent_age_injection)).to eq({ 'coppa_consent_age' => 13 })
+    end
+
+    it "uses the Accept-Language header as the jurisdiction signal (no org/domain signal wired)" do
+      request.headers['Accept-Language'] = 'pl-PL,pl;q=0.9'
+      expect(controller.send(:jurisdiction_signal_for_request)).to eq('pl-PL,pl;q=0.9')
+    end
+  end
 end

--- a/spec/models/lingo_linq/jurisdiction_spec.rb
+++ b/spec/models/lingo_linq/jurisdiction_spec.rb
@@ -23,6 +23,19 @@ describe LingoLinq::Jurisdiction do
       expect(LingoLinq::Jurisdiction.country_code('pl-PL,pl;q=0.9,en;q=0.8')).to eq('PL')
     end
 
+    it "finds the region subtag past a script subtag (BCP-47)" do
+      expect(LingoLinq::Jurisdiction.country_code('sr-Latn-RS')).to eq('RS')
+      expect(LingoLinq::Jurisdiction.country_code('zh-Hant-HK')).to eq('HK')
+      expect(LingoLinq::Jurisdiction.country_code('de-Latn-DE')).to eq('DE')
+    end
+
+    it "treats an explicit 2-letter token as its ISO country by contract" do
+      # 'DE' is Delaware as a US state code but Germany as ISO 3166-1; the
+      # primitive reads explicit country/region tokens as ISO country codes.
+      expect(LingoLinq::Jurisdiction.country_code({ 'region' => 'DE' })).to eq('DE')
+      expect(LingoLinq::Jurisdiction.eu?({ 'region' => 'DE' })).to eq(true)
+    end
+
     it "treats a bare lowercase language subtag as unknown (ambiguous)" do
       expect(LingoLinq::Jurisdiction.country_code('pl')).to eq(nil)
       expect(LingoLinq::Jurisdiction.country_code('es')).to eq(nil)

--- a/spec/models/lingo_linq/jurisdiction_spec.rb
+++ b/spec/models/lingo_linq/jurisdiction_spec.rb
@@ -29,6 +29,16 @@ describe LingoLinq::Jurisdiction do
       expect(LingoLinq::Jurisdiction.country_code('de-Latn-DE')).to eq('DE')
     end
 
+    it "does not read a country out of extension or private-use subtags (RFC 5646)" do
+      # Region only occupies its grammatical slot; 2-letter tokens inside a
+      # private-use ('-x-') or extension ('-t-') sequence are opaque, not a
+      # country. Scanning all subtags would wrongly resolve these to EU.
+      expect(LingoLinq::Jurisdiction.country_code('en-x-DE')).to eq(nil)
+      expect(LingoLinq::Jurisdiction.country_code('en-t-fr-FR')).to eq(nil)
+      expect(LingoLinq::Jurisdiction.eu?('en-x-DE')).to eq(false)
+      expect(LingoLinq::Jurisdiction.eu?('en-t-fr-FR')).to eq(false)
+    end
+
     it "treats an explicit 2-letter token as its ISO country by contract" do
       # 'DE' is Delaware as a US state code but Germany as ISO 3166-1; the
       # primitive reads explicit country/region tokens as ISO country codes.


### PR DESCRIPTION
## Follow-up to #556 (merged early, before these review fixes landed)

#556 (the `LingoLinq::Jurisdiction` primitive + jurisdiction-aware COPPA/GDPR age gate) was squash-merged to staging at its pre-review-fix commit while the dual reviewer (Codex + Claude adversary) was still running. The core feature is on staging and safe (flag OFF = identical to today). This PR lands the **in-scope dual-review fixes** that missed that merge.

Both reviewers confirmed the core guarantees hold (flag-OFF byte-identical, no cache poisoning). Codex found nothing; the Claude adversary found 2 High / 2 Medium / 2 Low (all verified). This PR applies the ones in scope for a dark-flag feature:

- **#2** `jurisdiction_signal_for_request`: remove dead `@domain_overrides` country/region/locale branches (host_settings carries none of them) and document that detection is best-effort browser-locale only. An authoritative org-configured EU-host country is a tracked follow-up before the flag is relied on as an Art. 8 control.
- **#3** `feature_flags.rb`: document the two-flag dependency (EU-16 only gates when the host also has `coppa_parental_consent` enabled) and the client-boolean enforcement caveat.
- **#4** add specs for the layout data source (`coppa_consent_age_injection` / `jurisdiction_signal_for_request`): empty flag-OFF, 16 EU / 13 non-EU flag-ON. Covers the server-render delivery path, not only the JSON endpoint.
- **#5** `jurisdiction.rb`: parse the BCP-47 region subtag past a script subtag (`sr-Latn-RS` → RS, was misreading `Latn`); document the ISO-country contract on `trusted_country`. Worth landing before Art. 50 calls `country_from_user`.
- **#6** `integrations#domain_settings`: `(@domain_overrides || {}).dup` restores the pre-PR null-safe behavior.

## Not in this PR (documented follow-up; gate flag-ON prod enablement)
- **#1 (High):** the age gate trusts a client-supplied `coppa_under_13` boolean; the backend never recomputes age (the birthdate is not sent). An EU 14/15-year-old can bypass consent by sending `coppa_under_13=false`. Pre-existing (same as COPPA-13) and explicitly out of scope for the original change (reuse existing consent gates, do not reimplement). **`eu_consent_age` must not be enabled in production as a GDPR Art. 8 control until #1 + a real jurisdiction source land.**

## Verification
`DB_USER=scotw RAILS_ENV=test bundle exec rspec` on the affected specs: **79 examples, 0 failures**. Additive only, flag OFF, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165vszi8WGZsg5hQaRxQFT2