### PR TITLE
security(user): constant-time compare in User.find_by_token (LL-90045bb29c)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2795,7 +2795,10 @@ class User < ApplicationRecord
     user_id, hash = token.split(/-/)
     return nil unless user_id && hash
     verifier = GoSecure.sha512("#{user_id}-", 'user_token verifier')[0, 30]
-    return nil unless hash == verifier
+    # Constant-time compare so a timing side-channel can't be used to recover the
+    # verifier byte-by-byte (LL-90045bb29c). Same pattern as find_by_protected_image_token
+    # below; secure_compare returns false on a length mismatch, so behavior is unchanged.
+    return nil unless ActiveSupport::SecurityUtils.secure_compare(hash, verifier)
     User.find_by_global_id(user_id)
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3452,6 +3452,14 @@ describe User, :type => :model do
       expect(User.find_by_token("#{u.global_id}-whatever")).to eq(nil)
       expect(User.find_by_token(nil)).to eq(nil)
     end
+
+    it 'should use a constant-time comparison to guard against timing attacks (LL-90045bb29c)' do
+      u = User.create
+      token = "#{u.global_id}-"
+      token = token + GoSecure.sha512(token, 'user_token verifier')[0, 30]
+      expect(ActiveSupport::SecurityUtils).to receive(:secure_compare).and_call_original
+      expect(User.find_by_token(token)).to eq(u)
+    end
   end
 
   describe "protected_image_token" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3460,6 +3460,15 @@ describe User, :type => :model do
       expect(ActiveSupport::SecurityUtils).to receive(:secure_compare).and_call_original
       expect(User.find_by_token(token)).to eq(u)
     end
+
+    it 'should still use the constant-time comparison on the mismatch path, not just the happy path (LL-90045bb29c)' do
+      u = User.create
+      # Correct length (30 hex chars) but wrong verifier: exercises the branch a
+      # timing attack targets, so a future fast-path/early-return on mismatch fails here.
+      wrong_token = "#{u.global_id}-" + ('0' * 30)
+      expect(ActiveSupport::SecurityUtils).to receive(:secure_compare).and_call_original
+      expect(User.find_by_token(wrong_token)).to eq(nil)
+    end
   end
 
   describe "protected_image_token" do


### PR DESCRIPTION
## What

Remediates finding **LL-90045bb29c** (remediation option **(a)**, the cheap win approved 2026-07-08): a recoverable timing side-channel in `User.find_by_token`.

`find_by_token` compared the attacker-supplied token hash against the server-derived verifier with plain string `==`, which short-circuits on the first differing byte. That leaks per-byte timing, letting an attacker recover the 30-char HMAC verifier byte-by-byte.

## Change

- Swap `hash == verifier` for `ActiveSupport::SecurityUtils.secure_compare(hash, verifier)` — the exact primitive already proven one method down in `find_by_protected_image_token`.
- `secure_compare` returns `false` (does not raise) on a length mismatch, so behavior is **byte-for-byte identical** on every reachable input: valid token resolves, malformed/nil/wrong-length returns `nil`, and the legacy 2-part `protected_image` fallback that delegates here is unchanged.
- `secure_compare` (not `fixed_length_secure_compare`) is the correct primitive: `hash` is attacker-controlled variable length, and `fixed_length_secure_compare` raises `ArgumentError` on a length mismatch, which would turn every malformed token into a 500.

## Tests

15 examples across `find_by_token` / `user_token` / `protected_image_token`, 0 failures. Two regression specs:
1. asserts `secure_compare` is invoked on the happy path (can't silently revert to `==`);
2. **mismatch-path** case (correct length, wrong hash → `nil`, still via `secure_compare`) so a future fast-path on the branch a timing attack targets fails the build.

## Review

Dual-reviewer pass, both clean:
- **Codex senior-dev pass** (`/review-pr`): Approve, no Critical/High.
- **Claude adversary pass**: verdict Ship. Verified behavioral equivalence against the actual Rails 7.2.3.1 `secure_compare` source (`a.bytesize == b.bytesize && fixed_length_secure_compare`), all three external callers, and the `find_by_protected_image_token` delegation. The only finding (Low: happy-path-only proxy assertion) is addressed by the second commit's mismatch-path spec.

## Notes

- Behavior-preserving internal hardening: no user-facing strings (no i18n/em-dash concern), no feature flag needed, no PII in the diff.
- Options (b) (~45d expiring share tokens) and (c) (user_token rotation) of LL-90045bb29c remain open; per audit rules this PR does not close the finding — that's Scot's attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fYhA53ubbtwPnpbn8qani