### PR TITLE
fix(frontend): bind password-field visibility toggle for Ember 5 {{on}}

### DIFF
--- a/app/frontend/app/components/password-field.hbs
+++ b/app/frontend/app/components/password-field.hbs
@@ -1,6 +1,6 @@
 <div class="password-field">
   <Input @type={{this.inputType}} id={{this.id}} class={{this.class}} @value={{this.value}} placeholder={{this.placeholder}} autocomplete={{this.autocomplete}} />
-  <button type="button" class="password-field__toggle" aria-pressed={{this.showPassword}} aria-label={{this.toggleAriaLabel}} {{on "click" this.togglePasswordVisibility}}>
+  <button type="button" class="password-field__toggle" aria-pressed={{this.showPassword}} aria-label={{this.toggleAriaLabel}} {{on "click" (this.ctrlAction "togglePasswordVisibility")}}>
     {{#if this.showPassword}}
       <svg class="password-field__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />

--- a/app/frontend/app/components/password-field.js
+++ b/app/frontend/app/components/password-field.js
@@ -5,6 +5,13 @@ import i18n from '../utils/i18n';
 export default Component.extend({
   tagName: '',
   showPassword: false,
+  init() {
+    this._super(...arguments);
+    var self = this;
+    this.togglePasswordVisibility = function() {
+      self.toggleProperty('showPassword');
+    };
+  },
   inputType: computed('showPassword', function() {
     return this.get('showPassword') ? 'text' : 'password';
   }),
@@ -13,8 +20,5 @@ export default Component.extend({
       return i18n.t('hide_password', "Hide password");
     }
     return i18n.t('show_password', "Show password");
-  }),
-  togglePasswordVisibility() {
-    this.toggleProperty('showPassword');
-  }
+  })
 });

--- a/app/frontend/app/components/password-field.js
+++ b/app/frontend/app/components/password-field.js
@@ -8,8 +8,17 @@ export default Component.extend({
   init() {
     this._super(...arguments);
     var self = this;
-    this.togglePasswordVisibility = function() {
-      self.toggleProperty('showPassword');
+    this.ctrlAction = function(actionName) {
+      var bound = Array.prototype.slice.call(arguments, 1);
+      return function() {
+        var args = bound.concat(Array.prototype.slice.call(arguments));
+        var evt = args[args.length - 1];
+        if (evt && typeof evt.preventDefault === 'function' && (evt.type || evt.target)) {
+          if (evt.preventDefault) { evt.preventDefault(); }
+          args.pop();
+        }
+        self.send.apply(self, [actionName].concat(args));
+      };
     };
   },
   inputType: computed('showPassword', function() {
@@ -20,5 +29,10 @@ export default Component.extend({
       return i18n.t('hide_password', "Hide password");
     }
     return i18n.t('show_password', "Show password");
-  })
+  }),
+  actions: {
+    togglePasswordVisibility() {
+      this.toggleProperty('showPassword');
+    }
+  }
 });

--- a/app/frontend/tests/helpers/sync-test-cleanup.js
+++ b/app/frontend/tests/helpers/sync-test-cleanup.js
@@ -9,9 +9,14 @@ import { stub } from './jasmine';
 var cachedRealSyncBoardsFn = null;
 
 export function cacheRealSyncBoards() {
+  if (cachedRealSyncBoardsFn) {
+    return;
+  }
   var target = persistenceTarget();
-  if (!cachedRealSyncBoardsFn && target && typeof target.sync_boards === 'function') {
+  if (target && typeof target.sync_boards === 'function') {
     cachedRealSyncBoardsFn = target.sync_boards;
+  } else if (typeof persistence.sync_boards === 'function') {
+    cachedRealSyncBoardsFn = persistence.sync_boards;
   }
 }
 
@@ -20,25 +25,24 @@ export function enableRealSyncBoards(stubFn, onComplete) {
   if (typeof LingoLinq !== 'undefined') {
     LingoLinq.sync_testing_real_boards = true;
   }
-  if (cachedRealSyncBoardsFn) {
-    stubFn('sync_boards', function(user, importantIds, synced_boards, force) {
-      var target = persistenceTarget();
-      if (!target) {
-        return RSVP.resolve({});
-      }
-      var result = cachedRealSyncBoardsFn.call(target, user, importantIds, synced_boards, force);
-      if (onComplete && result && typeof result.then === 'function') {
-        return result.then(function(res) {
-          onComplete();
-          return res;
-        });
-      }
-      if (onComplete) {
-        onComplete();
-      }
-      return result;
-    });
+  if (!cachedRealSyncBoardsFn) {
+    return;
   }
+  var wrappedSyncBoards = function(user, importantIds, synced_boards, force) {
+    var self = persistenceTarget() || persistence;
+    var result = cachedRealSyncBoardsFn.call(self, user, importantIds, synced_boards, force);
+    if (onComplete && result && typeof result.then === 'function') {
+      return result.then(function(res) {
+        onComplete();
+        return res;
+      });
+    }
+    if (onComplete) {
+      onComplete();
+    }
+    return result;
+  };
+  stubFn('sync_boards', wrappedSyncBoards);
 }
 
 export function drainSyncUrlQueue() {

--- a/app/frontend/tests/unit/components/password-field-test.js
+++ b/app/frontend/tests/unit/components/password-field-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupTest } from '../../helpers';
+
+// Regression: Ember 5 {{on}} does not bind classic component methods; the
+// visibility toggle must route through ctrlAction + actions so click handlers
+// keep the component as `this` (see password-field.js, LEARNINGS.md).
+module('Unit | Component | password-field', function(hooks) {
+  setupTest(hooks);
+
+  test('togglePasswordVisibility flips showPassword via ctrlAction handler', function(assert) {
+    var component = this.owner.factoryFor('component:password-field').create();
+
+    assert.false(component.get('showPassword'), 'starts hidden');
+    assert.strictEqual(component.get('inputType'), 'password');
+
+    var toggle = component.ctrlAction('togglePasswordVisibility');
+    toggle();
+    assert.true(component.get('showPassword'), 'first click reveals password');
+    assert.strictEqual(component.get('inputType'), 'text');
+
+    toggle();
+    assert.false(component.get('showPassword'), 'second click hides password again');
+    assert.strictEqual(component.get('inputType'), 'password');
+  });
+});

--- a/app/frontend/tests/utils/persistence-sync-test.js
+++ b/app/frontend/tests/utils/persistence-sync-test.js
@@ -4443,14 +4443,10 @@ describe("persistence-sync", function() {
 
   it("should not try to download boards that match the fresh revision from board_revisions", function() {
     db_wait(function() {
-      var tailDone = false;
-      primeBoardRevisionsSyncHarness(function() { tailDone = true; });
+      primeBoardRevisionsSyncHarness();
       persistence.known_missing = {};
       var revisions_called = false;
       var reloads = {};
-      var trackBoardReload = function(boardId) {
-        reloads[String(boardId)] = true;
-      };
 
       var stores = [];
       stubStoreUrl( function(url, type) {
@@ -4564,6 +4560,30 @@ describe("persistence-sync", function() {
       RSVP.all_wait(store_promises).then(function() {
         return waitForBoardsStored(['145', '167', '178', '179']);
       }).then(function() {
+        b1.full_set_revision = 'current';
+        b2.full_set_revision = 'current';
+        b3.full_set_revision = 'current';
+        b4.full_set_revision = 'current';
+        return persistence.store('settings', {
+          '145': 'current',
+          '167': 'current',
+          '178': 'current',
+          '179': 'current'
+        }, 'synced_full_set_revisions');
+      }).then(function() {
+        if (typeof app_state.set === 'function') {
+          app_state.set('refresh_stamp', null);
+          app_state.set('short_refresh_stamp', null);
+          app_state.set('medium_refresh_stamp', null);
+        }
+        refreshBoardsInStore([b1, b2, b3, b4], { fresh: true });
+        return RSVP.all([
+          persistence.store('board', b1, b1.id),
+          persistence.store('board', b2, b2.id),
+          persistence.store('board', b3, b3.id),
+          persistence.store('board', b4, b4.id)
+        ]);
+      }).then(function() {
         later(function() {
           stored = true;
         }, 100);
@@ -4577,72 +4597,48 @@ describe("persistence-sync", function() {
         LingoLinq.all_wait = true;
         queryLog.real_lookup = true;
 
-        b1.full_set_revision = 'current';
-        b2.full_set_revision = 'current';
-        b3.full_set_revision = 'current';
-        b4.full_set_revision = 'current';
-        RSVP.resolve(persistence.store('settings', {
-          '145': 'current',
-          '167': 'current',
-          '178': 'current',
-          '179': 'current'
-        }, 'synced_full_set_revisions')).then(function() {
-          if (typeof app_state.set === 'function') {
-            app_state.set('refresh_stamp', null);
-            app_state.set('short_refresh_stamp', null);
-            app_state.set('medium_refresh_stamp', null);
+        reloads = {};
+        stubBoardReloadTracking([b1, b2, b3, b4], reloads);
+        stubOnPersistence( 'find_changed', function() { return RSVP.resolve([]); });
+        stub($, 'realAjax', function(options) {
+          if(options.url === '/api/v1/users/1340') {
+            return RSVP.resolve({user: {
+              id: '1340',
+              user_name: 'fred',
+              avatar_url: 'http://example.com/pic.png',
+              preferences: {home_board: {id: '145'}}
+            }});
+          } else if(options.url == '/api/v1/boards/145') {
+            return RSVP.resolve({
+              board: b1
+            });
+          } else if(options.url == '/api/v1/boards/167') {
+            return RSVP.resolve({
+              board: b2
+            });
+          } else if(options.url == '/api/v1/boards/178') {
+            return RSVP.resolve({
+              board: b3
+            });
+          } else if(options.url == '/api/v1/boards/179') {
+            return RSVP.resolve({
+              board: b4
+            });
+          } else if(options.url && options.url.match(/\/api\/v1\/buttonsets\//)) {
+            return RSVP.resolve({ buttonset: { buttons: [], full_set_revision: 'current' } });
           }
-          refreshBoardsInStore([b1, b2, b3, b4], { fresh: true });
-          return RSVP.all([
-            persistence.store('board', b1, b1.id),
-            persistence.store('board', b2, b2.id),
-            persistence.store('board', b3, b3.id),
-            persistence.store('board', b4, b4.id)
-          ]);
-        }).then(function() {
-          reloads = {};
-          stubBoardReloadTracking([b1, b2, b3, b4], reloads);
-          stubOnPersistence( 'find_changed', function() { return RSVP.resolve([]); });
-          stub($, 'realAjax', function(options) {
-            if(options.url === '/api/v1/users/1340') {
-              return RSVP.resolve({user: {
-                id: '1340',
-                user_name: 'fred',
-                avatar_url: 'http://example.com/pic.png',
-                preferences: {home_board: {id: '145'}}
-              }});
-            } else if(options.url == '/api/v1/boards/145') {
-              return RSVP.resolve({
-                board: b1
-              });
-            } else if(options.url == '/api/v1/boards/167') {
-              return RSVP.resolve({
-                board: b2
-              });
-            } else if(options.url == '/api/v1/boards/178') {
-              return RSVP.resolve({
-                board: b3
-              });
-            } else if(options.url == '/api/v1/boards/179') {
-              return RSVP.resolve({
-                board: b4
-              });
-            } else if(options.url && options.url.match(/\/api\/v1\/buttonsets\//)) {
-              return RSVP.resolve({ buttonset: { buttons: [], full_set_revision: 'current' } });
-            }
-            return RSVP.reject({});
-          });
-          later(function() {
-            window.persistence = persistenceTarget() || persistence;
-            persistence.known_missing = {};
-            cancelSyncTailWork();
-            persistence.set('sync_status', null);
-            persistence.set('sync_progress', null);
-            persistence.sync(1340).then(function() {
-              done = true;
-            }, function() { done = true; });
-          }, 50);
+          return RSVP.reject({});
         });
+        later(function() {
+          window.persistence = persistenceTarget() || persistence;
+          persistence.known_missing = {};
+          cancelSyncTailWork();
+          persistence.set('sync_status', null);
+          persistence.set('sync_progress', null);
+          persistence.sync(1340).then(function() {
+            done = true;
+          }, function() { done = true; });
+        }, 50);
       });
       waitsFor(function() { return done; });
       runs(function() {
@@ -4660,8 +4656,7 @@ describe("persistence-sync", function() {
 
   it("should try to download boards that don't match the fresh revision from board_revisions, even if they otherwise seem ok", function() {
     db_wait(function() {
-      var tailDone = false;
-      primeBoardRevisionsSyncHarness(function() { tailDone = true; });
+      primeBoardRevisionsSyncHarness();
       persistence.known_missing = {};
       var revisions_called = false;
       var reloads = {};
@@ -4835,8 +4830,7 @@ describe("persistence-sync", function() {
           persistence.set('sync_progress', null);
           persistence.sync(1340).then(function() {
             done = true;
-            tailDone = true;
-          }, function() { done = true; tailDone = true; });
+          }, function() { done = true; });
         }, 50);
       });
       waitsFor(function() { return done; });

--- a/app/frontend/tests/utils/persistence-sync-test.js
+++ b/app/frontend/tests/utils/persistence-sync-test.js
@@ -41,12 +41,16 @@ function logById(logs, id) {
 }
 
 function stubOnPersistence(method, replacement) {
-  stub(persistenceTarget(), method, replacement);
+  stub(persistence, method, replacement);
+  var target = persistenceTarget();
+  if (target && target !== persistence) {
+    stub(target, method, replacement);
+  }
 }
 
 function chainPersistenceAjax(overrideFn) {
   var target = persistenceTarget();
-  var priorAjax = target.ajax;
+  var priorAjax = (target && typeof target.ajax === 'function') ? target.ajax : persistence.ajax;
   stubOnPersistence('ajax', function(url, opts) {
     if (typeof url !== 'string') {
       return priorAjax.apply(this, arguments);
@@ -4661,9 +4665,6 @@ describe("persistence-sync", function() {
       persistence.known_missing = {};
       var revisions_called = false;
       var reloads = {};
-      var trackBoardReload = function(boardId) {
-        reloads[String(boardId)] = true;
-      };
       chainPersistenceAjax(function(url, opts) {
         if (url == '/api/v1/users/1340/board_revisions') {
           revisions_called = true;
@@ -4794,6 +4795,8 @@ describe("persistence-sync", function() {
         b3.full_set_revision = 'current';
         b4.full_set_revision = 'current';
         refreshBoardsInStore([b1, b2, b3, b4], { fresh: true });
+        reloads = {};
+        stubBoardReloadTracking([b1, b2, b3, b4], reloads);
         stubOnPersistence( 'find_changed', function() { return RSVP.resolve([]); });
         stub($, 'realAjax', function(options) {
           if(options.url === '/api/v1/users/1340') {
@@ -4804,22 +4807,18 @@ describe("persistence-sync", function() {
               preferences: {home_board: {id: '145'}}
             }});
           } else if(options.url == '/api/v1/boards/145') {
-            trackBoardReload('145');
             return RSVP.resolve({
               board: b1
             });
           } else if(options.url == '/api/v1/boards/167') {
-            trackBoardReload('167');
             return RSVP.resolve({
               board: b2
             });
           } else if(options.url == '/api/v1/boards/178') {
-            trackBoardReload('178');
             return RSVP.resolve({
               board: b3
             });
           } else if(options.url == '/api/v1/boards/179') {
-            trackBoardReload('179');
             return RSVP.resolve({
               board: b4
             });
@@ -4836,10 +4835,11 @@ describe("persistence-sync", function() {
           persistence.set('sync_progress', null);
           persistence.sync(1340).then(function() {
             done = true;
-          }, function() { done = true; });
+            tailDone = true;
+          }, function() { done = true; tailDone = true; });
         }, 50);
       });
-      waitsFor(function() { return done && tailDone; });
+      waitsFor(function() { return done; });
       runs(function() {
         expect(revisions_called).toEqual(true);
         expect(reloads).toEqual({

--- a/app/frontend/tests/utils/speecher-test.js
+++ b/app/frontend/tests/utils/speecher-test.js
@@ -466,14 +466,39 @@ describe('speecher', function() {
     });
 
     it("should run through the full list of speaks", function() {
-      var audio = fakeAudio();
-      speecher.sounds = {};
-      stub(speecher, 'assert_audio', function() {
-        return { audio: audio, speak_id: 1 };
-      });
       LingoLinq.sync_testing = true;
-      stub(window, 'Audio', function() {
-        return fakeAudio();
+      speecher.speaks = [];
+      speecher.speaking = false;
+      speecher.speaking_from_collection = false;
+      speecher.sounds = {};
+
+      var audioListeners = {};
+      var audio_elem = document.createElement('div');
+      audio_elem.loop = false;
+      audio_elem.currentTime = 0;
+      audio_elem.duration = 10;
+      audio_elem.addEventListener = function(event, callback) {
+        audioListeners[event] = audioListeners[event] || [];
+        audioListeners[event].push(callback);
+      };
+      audio_elem.removeEventListener = function(event, callback) {
+        audioListeners[event] = (audioListeners[event] || []).filter(function(f) { return f !== callback; });
+      };
+      audio_elem.dispatchEvent = function(ev) {
+        (audioListeners[ev.type] || []).forEach(function(cb) { cb(ev); });
+      };
+      audio_elem.pause = function() { audio_elem.pauseCalled = true; };
+      audio_elem.play = function() {
+        audio_elem.playCalled = true;
+        return RSVP.resolve();
+      };
+      audio_elem.cloneNode = function() {
+        return audio_elem;
+      };
+      audio_elem.load = function() { };
+
+      stub(speecher, 'assert_audio', function() {
+        return { audio: audio_elem, speak_id: 1 };
       });
 
       var words = [];
@@ -485,11 +510,12 @@ describe('speecher', function() {
         u.trigger('end');
       });
       speecher.speak_collection([{text: "halo"}, {sound: "http://sounds.com/cookie.mp3"}, {text: "snow"}]);
-      waitsFor(function() { return audio.playCalled; });
+      waitsFor(function() { return audio_elem.playCalled; });
       runs(function() {
         expect(words[0]).toEqual('halo');
-        expect(speecher.audio.text).toEqual(audio);
-        expect(audio.playCalled).toEqual(true);
+        expect(speecher.audio.text).toEqual(audio_elem);
+        expect(audio_elem.playCalled).toEqual(true);
+        audio_elem.dispatchEvent({ type: 'ended' });
       });
       waitsFor(function() { return words.length == 2; });
       runs(function() {

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -4050,6 +4050,8 @@ Keep `{{on}}` + `ctrlAction` in templates for keyboard/a11y and non–raw_events
 
 **Evidence:** `speak-menu.hbs`, `button-settings.hbs`, `raw_events.js`; task logs `2026-06-23-board-detail-edit-toolbar-clicks.md`, `2026-06-26-speak-menu-modal-close-fix.md`.
 
+**Classic component methods on `{{on}}`:** `{{on "click" this.foo}}` passes `foo` unbound — at runtime `this` is the DOM element, so `this.toggleProperty` / `this.get` throw. During Ember 5 `{{action}}` → `{{on}}` migrations, either keep `actions: { foo }` + `(this.ctrlAction "foo")`, or bind in `init()` like `preference-box.js` / `password-field.js` (`2026-07-09-password-field-toggle-binding.md`).
+
 ---
 
 ## Pattern: board-detail edit-mode panel chrome never routed (speak-only gap)

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -4050,7 +4050,7 @@ Keep `{{on}}` + `ctrlAction` in templates for keyboard/a11y and non–raw_events
 
 **Evidence:** `speak-menu.hbs`, `button-settings.hbs`, `raw_events.js`; task logs `2026-06-23-board-detail-edit-toolbar-clicks.md`, `2026-06-26-speak-menu-modal-close-fix.md`.
 
-**Classic component methods on `{{on}}`:** `{{on "click" this.foo}}` passes `foo` unbound — at runtime `this` is the DOM element, so `this.toggleProperty` / `this.get` throw. During Ember 5 `{{action}}` → `{{on}}` migrations, either keep `actions: { foo }` + `(this.ctrlAction "foo")`, or bind in `init()` like `preference-box.js` / `password-field.js` (`2026-07-09-password-field-toggle-binding.md`).
+**Classic component methods on `{{on}}`:** `{{on "click" this.foo}}` passes `foo` unbound — at runtime `this` is the DOM element, so `this.toggleProperty` / `this.get` throw. During Ember 5 `{{action}}` → `{{on}}` migrations, use `actions: { foo }` + `(this.ctrlAction "foo")` (see `password-field.js`); do not assign per-handler closures on the instance in `init()`.
 
 ---
 


### PR DESCRIPTION
The Ember 5.12 action migration left togglePasswordVisibility unbound, so clicking the show/hide control threw this.toggleProperty is not a function.