### PR TITLE
fix(eval): persist tiered-eval log data through the real create path

### DIFF
--- a/app/models/log_session.rb
+++ b/app/models/log_session.rb
@@ -281,19 +281,34 @@ class LogSession < ApplicationRecord
       self.data['duration'] = (self.ended_at - self.started_at).to_i rescue nil
     elsif self.data['eval_mode']
       # Tiered eval report (Quick Screen / Targeted / Comprehensive) -- distinct from the
-      # legacy singular data['eval'] shape above. Override (not ||=) rather than trust
-      # started_at/ended_at from the events-timestamp derivation earlier in this method:
-      # that code is designed for realtime button-press 'session' logs keyed on
-      # event['timestamp'] in SECONDS, and would silently corrupt these fields with a
-      # bogus far-future date if a tiered-eval event ever carried a 'timestamp' key in JS
-      # milliseconds. EvalSession#recordEvent currently keys events on 'ts', not
-      # 'timestamp' (app/frontend/app/utils/eval_session.js), so that derivation is a
-      # no-op today -- but this branch must not depend on that key-naming accident for
-      # correctness, so it always derives from the authoritative duration_s instead.
+      # legacy singular data['eval'] shape above.
+      #
+      # started_at/ended_at must be derived idempotently (same result every save), for two
+      # reasons that rule out both a plain ||= and a plain "only set once" guard:
+      #   1. The events-timestamp derivation earlier in this method is designed for
+      #      realtime button-press 'session' logs keyed on event['timestamp'] in SECONDS,
+      #      and runs UNCONDITIONALLY on every save, before this branch. For tiered eval it
+      #      always resolves to nil (first/last['timestamp'] is nil, since
+      #      EvalSession#recordEvent keys real events on 'ts', not 'timestamp' --
+      #      app/frontend/app/utils/eval_session.js) -- so a guard like `if new_record?`
+      #      here is not enough: it would leave started_at/ended_at wiped to nil on every
+      #      LATER save (an admin toggling `highlighted`, attaching a note, any unrelated
+      #      edit), which is worse than the drift it was meant to prevent. And it would
+      #      still be a landmine against a future 'timestamp'-keyed ms event corrupting
+      #      the very first save with a bogus far-future date.
+      #   2. Deriving from Time.now directly (guarded or not) is inherently non-idempotent:
+      #      a historical eval's recorded time must not depend on when it happens to be
+      #      re-saved.
+      # Fix: anchor to a value that is itself stable across saves -- data['completed_at']
+      # (an epoch integer, persisted in the same JSON column,) set via ||= exactly once,
+      # at creation -- then always (re)derive started_at/ended_at from that anchor. This
+      # unconditionally overrides whatever the earlier events derivation produced (fixing
+      # #1) while producing the exact same result on every subsequent save (fixing #2).
       self.log_type = 'eval'
       mode_label = { 'targeted' => 'Targeted Feature-Match', 'comprehensive' => 'Comprehensive' }[self.data['eval_mode']] || 'Quick Screen'
       str = "#{mode_label} Evaluation by #{self.author ? self.author.user_name : 'user'}"
-      self.ended_at = Time.now
+      self.data['completed_at'] ||= Time.now.to_i
+      self.ended_at = Time.at(self.data['completed_at'])
       self.started_at = self.ended_at - self.data['duration_s'].to_i.seconds
     elsif self.data['profile']
       self.log_type = 'profile'

--- a/app/models/log_session.rb
+++ b/app/models/log_session.rb
@@ -279,6 +279,15 @@ class LogSession < ApplicationRecord
         self.data['prior_evals'] = existing_evals
       end
       self.data['duration'] = (self.ended_at - self.started_at).to_i rescue nil
+    elsif self.data['eval_mode']
+      # Tiered eval report (Quick Screen / Targeted / Comprehensive) -- distinct from the
+      # legacy singular data['eval'] shape above. started_at/ended_at/duration_s are already
+      # set by process_params, so only fill them here as a defensive fallback (||=).
+      self.log_type = 'eval'
+      mode_label = { 'targeted' => 'Targeted Feature-Match', 'comprehensive' => 'Comprehensive' }[self.data['eval_mode']] || 'Quick Screen'
+      str = "#{mode_label} Evaluation by #{self.author ? self.author.user_name : 'user'}"
+      self.ended_at   ||= Time.now
+      self.started_at ||= self.ended_at
     elsif self.data['profile']
       self.log_type = 'profile'
       str = "Profile: by #{self.author ? self.author.user_name : 'user'}: "
@@ -1244,6 +1253,14 @@ class LogSession < ApplicationRecord
     elsif params['type'] == 'journal'
       Rails.logger.warn('processing journal creation in client request')
       result = self.process_new(params, non_user_params)
+    elsif params['log_type'] == 'eval' && params['data'].is_a?(Hash) && params['data']['eval_mode']
+      # Tiered eval report (Quick Screen / Targeted / Comprehensive). This is a
+      # single client-authored save, not a stream of realtime button-press
+      # events, so it is processed synchronously like note/assessment rather
+      # than routed through the events-only background-job stash path below
+      # (which requires top-level params['events'] and would otherwise raise).
+      Rails.logger.warn('processing tiered eval creation in client request')
+      result = self.process_new(params, non_user_params)
     else
       stash_params = params
     end
@@ -1766,6 +1783,27 @@ class LogSession < ApplicationRecord
       self.data['assessment'] = params['assessment'] if params['assessment']
       self.data['eval'] = params['eval'] if params['eval']
       self.data['profile'] = params['profile'] if params['profile']
+      if params['log_type'] == 'eval' && params['data'].is_a?(Hash) && params['data']['eval_mode']
+        # Tiered eval report (Quick Screen / Targeted / Comprehensive). Distinct from the
+        # legacy singular data['eval'] shape above -- this carries the full SLP-facing
+        # payload (recommendation, intake, AI narrative, SETT form, ...) that
+        # EvalSession#toLogPayload (app/frontend/app/utils/eval_session.js) submits as a
+        # single client-authored save, not a stream of realtime button-press events.
+        eval_data = params['data']
+        self.log_type = 'eval'
+        self.data['eval_mode']         = eval_data['eval_mode']
+        self.data['protocol_version']  = eval_data['protocol_version']
+        self.data['intake']            = eval_data['intake']
+        self.data['item_bank_profile'] = eval_data['item_bank_profile']
+        self.data['events']            = eval_data['events'] || []
+        self.data['recommendation']    = eval_data['recommendation']
+        self.data['duration_s']        = eval_data['duration_s']
+        self.data['slp_notes']         = eval_data['slp_notes']
+        self.data['sett']              = eval_data['sett']
+        self.data['ai_narrative']      = eval_data['ai_narrative']
+        self.ended_at   ||= Time.now
+        self.started_at ||= self.ended_at - eval_data['duration_s'].to_i.seconds
+      end
       if self.data['assessment']
         if non_user_params[:automatic_assessment]
           self.data['assessment']['manual'] = false

--- a/app/models/log_session.rb
+++ b/app/models/log_session.rb
@@ -281,13 +281,20 @@ class LogSession < ApplicationRecord
       self.data['duration'] = (self.ended_at - self.started_at).to_i rescue nil
     elsif self.data['eval_mode']
       # Tiered eval report (Quick Screen / Targeted / Comprehensive) -- distinct from the
-      # legacy singular data['eval'] shape above. started_at/ended_at/duration_s are already
-      # set by process_params, so only fill them here as a defensive fallback (||=).
+      # legacy singular data['eval'] shape above. Override (not ||=) rather than trust
+      # started_at/ended_at from the events-timestamp derivation earlier in this method:
+      # that code is designed for realtime button-press 'session' logs keyed on
+      # event['timestamp'] in SECONDS, and would silently corrupt these fields with a
+      # bogus far-future date if a tiered-eval event ever carried a 'timestamp' key in JS
+      # milliseconds. EvalSession#recordEvent currently keys events on 'ts', not
+      # 'timestamp' (app/frontend/app/utils/eval_session.js), so that derivation is a
+      # no-op today -- but this branch must not depend on that key-naming accident for
+      # correctness, so it always derives from the authoritative duration_s instead.
       self.log_type = 'eval'
       mode_label = { 'targeted' => 'Targeted Feature-Match', 'comprehensive' => 'Comprehensive' }[self.data['eval_mode']] || 'Quick Screen'
       str = "#{mode_label} Evaluation by #{self.author ? self.author.user_name : 'user'}"
-      self.ended_at   ||= Time.now
-      self.started_at ||= self.ended_at
+      self.ended_at = Time.now
+      self.started_at = self.ended_at - self.data['duration_s'].to_i.seconds
     elsif self.data['profile']
       self.log_type = 'profile'
       str = "Profile: by #{self.author ? self.author.user_name : 'user'}: "
@@ -1801,8 +1808,9 @@ class LogSession < ApplicationRecord
         self.data['slp_notes']         = eval_data['slp_notes']
         self.data['sett']              = eval_data['sett']
         self.data['ai_narrative']      = eval_data['ai_narrative']
-        self.ended_at   ||= Time.now
-        self.started_at ||= self.ended_at - eval_data['duration_s'].to_i.seconds
+        # started_at/ended_at are derived authoritatively from duration_s in the
+        # data['eval_mode'] branch of generate_defaults (before_save), not here --
+        # see that branch's comment for why.
       end
       if self.data['assessment']
         if non_user_params[:automatic_assessment]

--- a/lib/json_api/log.rb
+++ b/lib/json_api/log.rb
@@ -141,7 +141,10 @@ module JsonApi::Log
     if json['log']['type'] == 'assessment'
       json['log']['assessment'] = {}.merge(log.data['assessment'] || {})
       json['log']['assessment']['stats'] = log.data['stats']
-    elsif json['log']['type'] == 'eval'
+    elsif json['log']['type'] == 'eval' && json['log']['evaluation']
+      # Legacy singular data['eval'] shape only -- the tiered eval report shape
+      # (data['eval_mode'], surfaced above as json['log']['tiered_eval']) has no
+      # 'evaluation' key and carries its own stats-equivalent fields already.
       json['log']['evaluation']['stats'] = log.data['stats']
     elsif json['log']['type'] == 'profile'
       history = []

--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -499,6 +499,39 @@ describe Api::LogsController, :type => :controller do
       expect(log.data['event_summary']).to eq('cool')
     end
 
+    it "should persist a tiered eval report's data through the real create path" do
+      token_user
+      post :create, params: {:log => {
+        :log_type => 'eval',
+        :data => {
+          :eval_mode => 'comprehensive',
+          :protocol_version => '1.0',
+          :intake => {'age_band' => 'adult'},
+          :recommendation => {'access_method' => 'direct'},
+          :events => [],
+          :duration_s => 42,
+          :slp_notes => 'looked good',
+          :sett => {'student' => 'Jane'},
+          :ai_narrative => 'AI-drafted narrative text'
+        },
+        :user_id => @user.global_id
+      }}
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+      log = LogSession.last
+      expect(log.log_type).to eq('eval')
+      expect(log.data['eval_mode']).to eq('comprehensive')
+      expect(log.data['recommendation']).to eq({'access_method' => 'direct'})
+      expect(log.data['slp_notes']).to eq('looked good')
+      expect(log.data['sett']).to eq({'student' => 'Jane'})
+      expect(log.data['ai_narrative']).to eq('AI-drafted narrative text')
+      expect(log.data['duration_s'].to_i).to eq(42)
+      # round-trips through JsonApi::Log's tiered_eval view, not just the raw column
+      expect(json['log']['tiered_eval']['eval_mode']).to eq('comprehensive')
+      expect(json['log']['tiered_eval']['ai_narrative']).to eq('AI-drafted narrative text')
+      expect(json['log']['tiered_eval']['slp_notes']).to eq('looked good')
+    end
+
     it "should try to extract and canonicalize the ip address" do
       token_user
       request.env['REMOTE_ADDR'] = '8.7.6.5'

--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -508,7 +508,16 @@ describe Api::LogsController, :type => :controller do
           :protocol_version => '1.0',
           :intake => {'age_band' => 'adult'},
           :recommendation => {'access_method' => 'direct'},
-          :events => [],
+          # EvalSession#recordEvent (app/frontend/app/utils/eval_session.js) stamps real
+          # events with a 'ts' key in JS milliseconds, NOT 'timestamp' in seconds -- this
+          # matters because LogSession#generate_defaults has an older events-timestamp
+          # derivation (for realtime button-press 'session' logs) keyed on 'timestamp' in
+          # seconds that runs before the eval_mode branch; a real-shape event here proves
+          # that derivation is a no-op for tiered eval and doesn't corrupt started_at/ended_at.
+          :events => [
+            {'ts' => (Time.now.to_i * 1000) - 120_000, 'subtest' => 'stage_probe', 'response' => 'correct'},
+            {'ts' => Time.now.to_i * 1000, 'subtest' => 'access_snapshot', 'response' => 'correct'}
+          ],
           :duration_s => 42,
           :slp_notes => 'looked good',
           :sett => {'student' => 'Jane'},
@@ -526,10 +535,16 @@ describe Api::LogsController, :type => :controller do
       expect(log.data['sett']).to eq({'student' => 'Jane'})
       expect(log.data['ai_narrative']).to eq('AI-drafted narrative text')
       expect(log.data['duration_s'].to_i).to eq(42)
+      # started_at/ended_at must be sane (current era), not derived from the ms-scale
+      # 'ts' event timestamps via the seconds-based legacy events derivation
+      expect(log.ended_at).to be_within(1.minute).of(Time.now)
+      expect(log.started_at).to be_within(1.minute).of(Time.now - 42.seconds)
+      expect(log.data['event_count']).to eq(2)
       # round-trips through JsonApi::Log's tiered_eval view, not just the raw column
       expect(json['log']['tiered_eval']['eval_mode']).to eq('comprehensive')
       expect(json['log']['tiered_eval']['ai_narrative']).to eq('AI-drafted narrative text')
       expect(json['log']['tiered_eval']['slp_notes']).to eq('looked good')
+      expect(json['log']['tiered_eval']['event_count']).to eq(2)
     end
 
     it "should try to extract and canonicalize the ip address" do

--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -547,6 +547,26 @@ describe Api::LogsController, :type => :controller do
       expect(json['log']['tiered_eval']['event_count']).to eq(2)
     end
 
+    it "should not mutate a tiered eval report's historical started_at/ended_at on a later, unrelated save" do
+      token_user
+      post :create, params: {:log => {
+        :log_type => 'eval',
+        :data => {:eval_mode => 'comprehensive', :events => [], :duration_s => 42, :ai_narrative => 'text'},
+        :user_id => @user.global_id
+      }}
+      log = LogSession.last
+      original_started_at = log.started_at
+      original_ended_at = log.ended_at
+
+      sleep 1 # no Timecop in this codebase; a real elapsed second is enough to detect drift
+      log.highlighted = true
+      log.save!
+      log.reload
+
+      expect(log.started_at).to eq(original_started_at)
+      expect(log.ended_at).to eq(original_ended_at)
+    end
+
     it "should try to extract and canonicalize the ip address" do
       token_user
       request.env['REMOTE_ADDR'] = '8.7.6.5'


### PR DESCRIPTION
## Summary
- `EvalSession#persist` posts `{log_type: 'eval', data: {eval_mode, ai_narrative, recommendation, sett, slp_notes, ...}}` to `/api/v1/logs`, but `LogSession#process_params` only ever handled the legacy flat `events`/`note`/`assessment`/singular-`eval` shape — the real create path fell into the events-only background-job branch and silently returned an empty, unpersisted log. Independent of any other work, this means the Comprehensive Eval "save report" feature has likely never actually persisted `eval_mode`/`recommendation`/`ai_narrative`/`sett`/`slp_notes` for any real user via the live API.
- Discovered while pre-flighting the EU AI Act Art.50(2) eval-narration content-marking work (separate branch), which depends on this data actually reaching the database.
- Fix is minimal and targeted:
  - `process_as_follow_on`: route the tiered-eval shape synchronously (mirrors the existing note/assessment/journal fast paths) instead of the events-required stash/background-job path.
  - `process_params`: actually copy `eval_mode`/`intake`/`recommendation`/`events`/`duration_s`/`slp_notes`/`sett`/`ai_narrative` into `self.data` and set `log_type`.
  - `generate_defaults`: its own `log_type` dispatch cascade only recognized the legacy `data['eval']` key and was silently overwriting `log_type` back to `'session'` for the new shape.
  - `json_api/log.rb#extra_includes`: guarded a legacy-only stats assignment that crashed (`NoMethodError` on nil) for the new shape's absent `'evaluation'` key — found via the new regression spec actually failing.

## Test plan
- [x] Reproduced the bug live pre-fix (real payload through `LogSession.process_as_follow_on` returned an empty, unpersisted log)
- [x] Confirmed live post-fix (full `data` hash round-trips through create -> reload, `log_type == 'eval'`)
- [x] New regression spec: `spec/controllers/api/logs_controller_spec.rb` — POSTs the real payload shape, asserts persistence AND round-trip through `JsonApi::Log`'s `tiered_eval` view
- [x] Full regression run: `log_session_spec.rb`, `log_session_board_spec.rb`, `logs_controller_spec.rb`, `json_api/log_spec.rb` — 283 examples, 0 failures, 5 pre-existing unrelated pending
- [x] `eval_narrator_spec.rb`, `eval_sessions_controller_spec.rb`, `eval_recommend_spec.rb` — 55 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeBiAwADoxVxc92QdcVtvZ