### PR TITLE
compliance(ledger): Phase B -- capability-check.rb validator + CI + wrapper (canonical)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Verify compliance publication status report
         run: ruby scripts/compliance-publication-status.rb --check
 
+      - name: Verify capability ledger (currentEvidence resolves at HEAD; negativeEvidence scoping)
+        run: ruby scripts/capability-check.rb --check
+
   security-scan:
     runs-on: ubuntu-latest
 

--- a/audit-reports/CAPABILITY-LEDGER.json
+++ b/audit-reports/CAPABILITY-LEDGER.json
@@ -2,8 +2,8 @@
   "meta": {
     "title": "LingoLinq Capability Ledger",
     "purpose": "Code-cited, present-tense source of truth for what the product actually does today, so compliance docs (and reviewers) ground claims against verified capabilities instead of re-deriving them by hand. citation-check.rb is to findings as capability-check.rb (Phase B) is to this ledger.",
-    "status": "provisional-non-canonical",
-    "canonicalWhen": "Phase B (scripts/capability-check.rb) enforces currentEvidence resolution at HEAD and negativeEvidence grep scoping in CI. Until then, rows are code-verified best-effort and MUST NOT be treated as authoritative or mirrored to any external tool (e.g. Codex AGENTS.md).",
+    "status": "canonical",
+    "canonicalWhen": "Enforced as of Phase B: scripts/capability-check.rb validates every built/partial row's currentEvidence at HEAD and every deliberately-not-done row's negativeEvidence in CI (audit-artifacts-integrity). Mirroring to external tools (e.g. Codex AGENTS.md) is now permissible for these code-cited, identifier-free rows.",
     "schemaVersion": "0.1.0",
     "generatedDate": "2026-07-12",
     "verifiedAgainstBranch": "staging",
@@ -159,7 +159,7 @@
       "domain": "vendor-contracts",
       "claimLanguage": "A signed BAA is in place with AWS covering S3 storage.",
       "antiClaim": "The AWS BAA covers storage infrastructure; it does NOT cover the AI model-provider egress path (see cap no-model-provider-baa).",
-      "currentEvidence": { "file": "docs/legal/AWS_BAA_ACCEPTED.md", "line": 1, "snippet": "attestation" },
+      "currentEvidence": { "file": "docs/legal/AWS_BAA_ACCEPTED.md", "line": 1, "snippet": "AWS Business Associate Addendum (BAA) - ACCEPTED" },
       "evidenceType": "attestation",
       "frameworks": ["HIPAA"],
       "notes": "Signed 2026-02-07. Attestation-type evidence (document, not code).",
@@ -267,12 +267,10 @@
       "claimLanguage": null,
       "antiClaim": "No signed BAA currently covers the model-provider AI egress path (the AWS BAA is storage infrastructure only). HIPAA posture on the AI path is provisional pending CEO review.",
       "negativeEvidence": {
-        "grepScopes": ["docs/legal/**"],
-        "patterns": ["model.provider BAA", "Anthropic BAA", "Gemini BAA executed"],
-        "excludedPaths": [],
-        "reviewedSurfaces": ["docs/legal/ (no model-provider BAA artifact)", "docs/legal/AI_GOVERNANCE_MEMO.md (HIPAA conclusion marked provisional)"],
+        "absentFileGlobs": ["docs/legal/*anthropic*baa*", "docs/legal/*gemini*baa*", "docs/legal/*model*provider*baa*"],
+        "reviewedSurfaces": ["docs/legal/ (no model-provider BAA artifact; AWS_BAA is storage only)", "docs/legal/AI_GOVERNANCE_MEMO.md (HIPAA conclusion marked provisional)"],
         "expectedMatches": 0,
-        "reviewTriggers": "an executed model-provider BAA landing in docs/legal/"
+        "reviewTriggers": "an executed Anthropic/Google model-provider BAA file landing in docs/legal/"
       },
       "frameworks": ["HIPAA"],
       "notes": "Decision surface for Scot: pursue a model-provider BAA, keep PHI accounts off AI, or accept scrubber-only posture.",

--- a/docs/legal/CAPABILITY_LEDGER.md
+++ b/docs/legal/CAPABILITY_LEDGER.md
@@ -1,59 +1,53 @@
 # LingoLinq Capability Ledger
 
-> **PROVISIONAL -- NON-CANONICAL (Phase A).** Generated 2026-07-12, verified against `staging`.
-> This is the code-cited, present-tense record of what the product actually does today, so
-> compliance docs ground claims against verified capabilities instead of re-deriving them.
-> **Not yet authoritative:** it becomes canonical only when Phase B (`scripts/capability-check.rb`)
-> enforces `currentEvidence` resolution **at HEAD** and `negativeEvidence` grep scoping in CI. Until
-> then, do not treat rows as attested and do not mirror this file into any external tool (e.g. Codex
-> `AGENTS.md`). Source of truth is `audit-reports/CAPABILITY-LEDGER.json`; this render is
-> hand-maintained until the Phase B renderer lands.
+> Generated from `audit-reports/CAPABILITY-LEDGER.json` by `scripts/capability-check.rb --render`.
+> Do not hand-edit; edit the JSON (the source of truth) and re-render.
 >
-> Evidence semantics: `built`/`partial` rows carry `currentEvidence` (must resolve at HEAD, not a
-> pinned SHA -- this is the key difference from the findings register). `deliberately-not-done` rows
-> carry scoped `negativeEvidence` (grep scopes + expected zero matches). See the JSON for full fields.
+> **Status: canonical.** `built`/`partial` rows' `currentEvidence` is
+> validated to resolve at HEAD, and `deliberately-not-done` rows' `negativeEvidence` is
+> enforced, by `scripts/capability-check.rb --check` in CI (audit-artifacts-integrity). A
+> capability is a present-tense claim: if the backing code is removed, the check goes red.
+> Verified against `staging`; generated 2026-07-12.
 
 ## Built (11)
 
-| Capability | Evidence (HEAD) | Anti-claim it kills |
+| Capability | Evidence (HEAD) | Anti-claim / note |
 |---|---|---|
-| Password authentication (hashed) | `app/models/user.rb:98` | passwordless / device-JWT-only |
-| Server-side at-rest encryption | `app/models/concerns/secure_serialize.rb:1` | E2EE / zero-readable-keys |
-| PiiScrubber pseudonymization before AI egress | `lib/pii_scrubber.rb:215` | de-identified / anonymized |
-| COPPA under-13 AI hard-gate | `lib/ai_board_generator.rb:40` | (also note: not an EU under-16 gate) |
-| Jurisdiction primitive (EU vs non-EU) | `app/models/lingo_linq/jurisdiction.rb:58` | gates only the Art. 50(1) modal, nothing else yet |
-| AI board-gen + word-prediction (Anthropic Claude, **Anthropic-only**) | `lib/ai_word_predictor.rb:158` | Gemini fallback (disabled 2026-07-09) |
-| ZDR confirmed for the 2 active Anthropic models | `docs/legal/AI_DATA_SHARING_CONSENT.md:50` | ZDR for other/future models or non-Anthropic; a HIPAA BAA |
-| Hard-delete on request | `lib/flusher.rb:401` | automatic time-based wipe (there is none) |
-| AiApiLog audit trail + IP redaction | `app/models/ai_api_log.rb:30` | log anonymization (it's pseudonymization) |
-| Message banking retains user's OWN voice | `app/models/button_sound.rb:11` | voiceprint / speaker-ID |
-| AWS S3 BAA (storage) | `docs/legal/AWS_BAA_ACCEPTED.md` (attestation) | model-provider BAA (that's separate) |
+| Password authentication (bcrypt-hashed, via the passwords concern / GoSecure) | `app/models/user.rb:98` | NOT passwordless / device-JWT-only. |
+| Server-side at-rest encryption of sensitive fields (secure_serialize / SECURE_ENCRYPTION_KEY) | `app/models/concerns/secure_serialize.rb:1` | NOT end-to-end encryption; LingoLinq holds the keys. Do not claim 'zero readable keys' or E2EE. |
+| PiiScrubber pseudonymizes (scrubs direct identifiers from) payloads before AI egress | `lib/pii_scrubber.rb:215` | NOT de-identified or anonymized. Pseudonymized data is still personal data; does not meet HIPAA Safe Harbor. |
+| COPPA hard-gate blocks AI generation for under-13 users awaiting parental consent | `lib/ai_board_generator.rb:40` | This is an under-13 (COPPA) gate; it does NOT itself enforce an EU under-16 (GDPR Art. 8) block on the AI path (see cap eu-under16-ai-block). |
+| Jurisdiction detection primitive (EU vs non-EU) exists | `app/models/lingo_linq/jurisdiction.rb:58` | The EU jurisdiction primitive currently gates ONLY the (not-yet-built) Art. 50(1) disclosure modal; it does not by itself drive an under-16 AI block. |
+| Full hard-delete of a user on request (flush_user_completely) | `lib/flusher.rb:401` | There is no automatic time-based wipe (no 48h/180d purge); deletion is on request / policy-driven. |
+| AiApiLog audit trail with scrubbed summary columns / IP redaction | `app/models/ai_api_log.rb:30` | Redaction is pseudonymization of the log record, not anonymization. |
+| AI board generation + word prediction via Anthropic Claude (Anthropic-only runtime) | `lib/ai_word_predictor.rb:158` | The prior Google Gemini fallback was DISABLED 2026-07-09 (Gemini Developer/AI-Studio endpoint data-handling terms inadequate for child data); there is no runtime Gemini path today. A Vertex AI fallback may replace it later. Only pseudonymized data is sent (see cap pii-scrubber-pseudonymization). |
+| Message banking retains the user's OWN voice recordings for playback | `app/models/button_sound.rb:11` | These are the user's own communication recordings, NOT voiceprints/speaker-ID/biometrics (see cap no-voiceprints). |
+| Signed AWS S3 Business Associate Agreement (storage) | `docs/legal/AWS_BAA_ACCEPTED.md:1` | The AWS BAA covers storage infrastructure; it does NOT cover the AI model-provider egress path (see cap no-model-provider-baa). |
+| Zero-data-retention (ZDR) confirmed for the two active Anthropic models | `docs/legal/AI_DATA_SHARING_CONSENT.md:50` | ZDR is confirmed ONLY for these two specific models; it does NOT extend to any other/future Anthropic model outside the ZDR-eligible tier, and NOT to any non-Anthropic provider. ZDR is NOT a substitute for a HIPAA BAA (see cap no-model-provider-baa). Fable 5 / Mythos-class models are explicitly NOT ZDR-eligible and never receive identifiable payloads. |
 
 ## Partial (2)
 
-| Capability | Evidence (HEAD) | Scope / note |
+| Capability | Evidence (HEAD) | Anti-claim / note |
 |---|---|---|
-| TOTP 2FA (ROTP) | `app/models/concerns/passwords.rb:95` | exists but **optional**; admin/staff mandatory 2FA is an open item |
-| EU AI Act Art. 50(2) output marking | `lib/ai_board_generator.rb:123` | **board-generation output only**; other AI surfaces + durable marker persistence are follow-up. Obligation NOT closed |
+| TOTP two-factor authentication (ROTP), currently OPTIONAL | `app/models/concerns/passwords.rb:95` | NOT mandatory; do not claim enforced MFA for all users or admins. |
+| EU AI Act Article 50(2) machine-readable output marking -- board-generation slice only | `lib/ai_board_generator.rb:123` | The Art. 50(2) obligation is NOT closed: this slice marks board generation ONLY. Other AI-output surfaces (generate_focus_words, AiWordPredictor.predict, eval narration, AiPredictionGenerator) are not yet marked, and durable persistence of the marker (board.settings + relinking copy_for) is follow-up. Also distinct from the Art. 50(1) disclosure modal (see cap art50-1-disclosure-modal). |
 
 ## Planned (2)
 
-| Capability | Anchor | Status |
+| Capability | Evidence (HEAD) | Anti-claim / note |
 |---|---|---|
-| EU AI Act Art. 50(1) user disclosure modal | `lib/lingo_linq/ai_consent_disclosures.rb:5` | content merged (Phase 2); modal (Phase 3) + consent gate (Phase 4) not built. EU clock 2026-08-02 |
-| Under-16 (EU GDPR Art. 8) block on AI path | `lib/ai_board_generator.rb:40` | AI path still gates on under-13 only; gap-check pending |
+| EU AI Act Article 50(1) user-facing AI-interaction disclosure modal | `lib/lingo_linq/ai_consent_disclosures.rb:5` | The disclosure CONTENT exists (VPC Phase 2), but the user-facing modal (Phase 3) and consent enforcement (Phase 4) are NOT built. Do not claim a live Art. 50(1) disclosure. |
+| Jurisdiction-aware under-16 (EU GDPR Art. 8) block on the AI generation path | `lib/ai_board_generator.rb:40` | The AI generators enforce only the under-13 COPPA gate today; an EU under-16 block on the AI path is NOT confirmed built. Do not claim an under-16 gate is in place on AI features. |
 
-## Deliberately not done (4) -- out-of-scope by design
+## Deliberately not done -- out-of-scope by design (4)
 
 | Capability | Negative-evidence scope | Expected |
 |---|---|---|
-| End-to-end encryption | `app/**`,`lib/**` for `end_to_end`/`e2ee`/`zero_knowledge` | 0 matches |
-| Voiceprints / speaker-ID / voice-cloning | `app/**`,`lib/**` for `voiceprint`/`speaker_id`/`voice_clone` | 0 matches |
-| Diagnosis / disability / IEP / 504 fields | `db/schema.rb` for `disabilit`/`diagnos`/`iep`/`504`/`impair` | 0 matches |
-| Model-provider (Anthropic/Google) BAA | `docs/legal/**` for an executed model-provider BAA | 0 matches (HIPAA on AI path provisional) |
+| End-to-end encryption / zero-readable-keys | app/**/*.rb, lib/**/*.rb for end_to_end/e2ee/zero_knowledge/client_side_encrypt | 0 matches |
+| Voiceprints / speaker-identification / voice-cloning of training audio | app/**/*.rb, lib/**/*.rb for voiceprint/speaker_id/speaker_recognition/voice_clone | 0 matches |
+| Diagnosis / disability / IEP / 504 / medical-condition data fields | db/schema.rb for disabilit/diagnos/\biep\b/\b504\b/impair/medical_condition | 0 matches |
+| Signed BAA covering the AI model-provider (Anthropic/Google) egress path | absent files: docs/legal/*anthropic*baa*, docs/legal/*gemini*baa*, docs/legal/*model*provider*baa* | 0 matches |
 
 ---
 
-*Framing note: "deliberately not done" means out-of-scope by design, never a known gap shipped without. These rows exist to stop over-claims, mirroring the "Deliberately not claimed" section of `COMPLIANCE_PROGRAM_OVERVIEW.md`.*
-
-*Note on ZDR vs BAA: the two active Anthropic runtime models are ZDR-confirmed (a retention posture), but no signed BAA covers the model-provider egress path (a HIPAA contract). Those are different instruments; the ledger tracks both separately.*
+*Framing: "deliberately not done" means out-of-scope by design, never a known gap shipped without. These rows exist to stop over-claims, mirroring the "Deliberately not claimed" section of `COMPLIANCE_PROGRAM_OVERVIEW.md`.*

--- a/scripts/capability-check.rb
+++ b/scripts/capability-check.rb
@@ -1,0 +1,214 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# capability-check.rb - validator + renderer for the Capability Ledger.
+#
+# The Capability Ledger (audit-reports/CAPABILITY-LEDGER.json) is a code-cited,
+# PRESENT-TENSE record of what the product does today. This script is to that
+# ledger what citation-check.rb is to the findings register -- with ONE critical
+# difference:
+#
+#   citation-check pins finding evidence to a HISTORICAL sha (a finding is a
+#   point-in-time observation). capability-check validates evidence at HEAD (the
+#   current checkout), because a capability is a present-tense claim: if the code
+#   that backs a "built" row is removed, this check MUST go red.
+#
+# WHAT IT VALIDATES (at HEAD)
+#   - built / partial rows: currentEvidence {file,line,snippet} must resolve --
+#     the file exists and the snippet appears at that line (or anywhere in the
+#     file if no line is given). currentEvidence is REQUIRED for built/partial.
+#   - planned rows: currentEvidence is validated IF present (it points at partial
+#     / related code), but is not required.
+#   - deliberately-not-done rows: negativeEvidence must hold. Two forms:
+#       * content grep: grepScopes (globs) + patterns (regex, case-insensitive),
+#         minus excludedPaths, must yield exactly expectedMatches (usually 0).
+#         Use for code-absence (no E2EE identifier, no voiceprint path).
+#       * absentFileGlobs: none of the globs may match a file (case-insensitive).
+#         Use for artifact-absence (no executed model-provider BAA file), where a
+#         content grep would false-positive on prose that discusses the absence.
+#     negativeEvidence is REQUIRED for deliberately-not-done.
+#
+# MODES
+#   ruby scripts/capability-check.rb            # validate at HEAD, then WRITE the .md render
+#   ruby scripts/capability-check.rb --check    # validate at HEAD + assert .md matches; write nothing (CI)
+#   ruby scripts/capability-check.rb --render    # write the .md render only
+#
+# EXIT 0 = all rows validate (and, in --check, the render is in sync); 1 = a failure.
+#
+require 'json'
+require 'optparse'
+require 'set'
+
+LEDGER_JSON = 'audit-reports/CAPABILITY-LEDGER.json'
+RENDER_MD   = 'docs/legal/CAPABILITY_LEDGER.md'
+
+mode = :validate_and_write
+OptionParser.new do |o|
+  o.banner = 'Usage: ruby scripts/capability-check.rb [--check | --render]'
+  o.on('--check', 'Validate at HEAD and assert the .md render matches; write nothing') { mode = :check }
+  o.on('--render', 'Write the .md render (no drift assertion)') { mode = :render_only }
+end.parse!
+
+abort "capability-check: ledger not found: #{LEDGER_JSON}" unless File.file?(LEDGER_JSON)
+ledger = JSON.parse(File.read(LEDGER_JSON))
+caps = ledger['capabilities'] || []
+
+failures = []
+
+# --- currentEvidence: resolve file:line:snippet at HEAD -----------------------
+def resolve_current_evidence(ev)
+  return 'currentEvidence.file missing' unless ev && ev['file']
+  file = ev['file']
+  return "file not found at HEAD: #{file}" unless File.file?(file)
+  lines = File.readlines(file).map { |l| l.chomp }
+  line = ev['line']
+  snippet = ev['snippet']
+  if line
+    return "line #{line} out of range in #{file} (#{lines.size} lines)" if line < 1 || line > lines.size
+    actual = lines[line - 1]
+    if snippet && !actual.include?(snippet)
+      return "snippet not at #{file}:#{line}\n      expected line to contain: #{snippet.inspect}\n      actual line:              #{actual.strip.inspect}"
+    end
+  elsif snippet
+    return "snippet not found anywhere in #{file}: #{snippet.inspect}" unless lines.any? { |l| l.include?(snippet) }
+  end
+  nil
+end
+
+# --- negativeEvidence: content grep OR absent-file globs ----------------------
+def excluded?(path, excluded_globs)
+  excluded_globs.any? do |ex|
+    prefix = ex.sub(/\*+.*\z/, '').chomp('/')
+    prefix.empty? ? false : (path == prefix || path.start_with?("#{prefix}/"))
+  end
+end
+
+def check_negative_evidence(neg)
+  return 'negativeEvidence missing' unless neg
+  expected = neg['expectedMatches'] || 0
+
+  if neg['absentFileGlobs']
+    hits = neg['absentFileGlobs'].flat_map { |g| Dir.glob(g, File::FNM_CASEFOLD) }.uniq.select { |f| File.file?(f) }
+    return "absentFileGlobs expected #{expected} file(s), found #{hits.size}:\n      #{hits.join("\n      ")}" if hits.size != expected
+    return nil
+  end
+
+  scopes   = neg['grepScopes'] || []
+  patterns = neg['patterns'] || []
+  excluded = neg['excludedPaths'] || []
+  return 'negativeEvidence has neither grepScopes/patterns nor absentFileGlobs' if scopes.empty? || patterns.empty?
+
+  regexes = patterns.map { |p| Regexp.new(p, Regexp::IGNORECASE) }
+  files = scopes.flat_map { |g| Dir.glob(g) }.uniq.select { |f| File.file?(f) }
+  files.reject! { |f| excluded?(f, excluded) }
+
+  matches = []
+  files.each do |f|
+    File.foreach(f).with_index(1) do |text, ln|
+      if regexes.any? { |re| re.match?(text) }
+        matches << "#{f}:#{ln}: #{text.strip[0, 100]}"
+      end
+    end
+  end
+  return "negativeEvidence expected #{expected} match(es), found #{matches.size}:\n      #{matches.first(12).join("\n      ")}" if matches.size != expected
+  nil
+end
+
+# --- validate every row -------------------------------------------------------
+caps.each do |cap|
+  id = cap['id'] || '(no id)'
+  status = cap['status']
+  case status
+  when 'built', 'partial'
+    err = resolve_current_evidence(cap['currentEvidence'])
+    failures << "[#{id}] (#{status}) #{err}" if err
+  when 'planned'
+    if cap['currentEvidence']
+      err = resolve_current_evidence(cap['currentEvidence'])
+      failures << "[#{id}] (planned) #{err}" if err
+    end
+  when 'deliberately-not-done'
+    err = check_negative_evidence(cap['negativeEvidence'])
+    failures << "[#{id}] (deliberately-not-done) #{err}" if err
+  else
+    failures << "[#{id}] unknown status: #{status.inspect}"
+  end
+end
+
+# --- markdown render (deterministic; anchored to meta.generatedDate) ----------
+def render_markdown(ledger, caps)
+  meta = ledger['meta'] || {}
+  gen  = meta['generatedDate'] || 'unspecified'
+  by_status = ->(s) { caps.select { |c| c['status'] == s } }
+
+  out = +""
+  out << "# LingoLinq Capability Ledger\n\n"
+  out << "> Generated from `audit-reports/CAPABILITY-LEDGER.json` by `scripts/capability-check.rb --render`.\n"
+  out << "> Do not hand-edit; edit the JSON (the source of truth) and re-render.\n"
+  out << ">\n"
+  out << "> **Status: #{meta['status'] || 'unspecified'}.** `built`/`partial` rows' `currentEvidence` is\n"
+  out << "> validated to resolve at HEAD, and `deliberately-not-done` rows' `negativeEvidence` is\n"
+  out << "> enforced, by `scripts/capability-check.rb --check` in CI (audit-artifacts-integrity). A\n"
+  out << "> capability is a present-tense claim: if the backing code is removed, the check goes red.\n"
+  out << "> Verified against `#{meta['verifiedAgainstBranch'] || 'staging'}`; generated #{gen}.\n\n"
+
+  section = lambda do |title, status, kind|
+    rows = by_status.call(status)
+    return if rows.empty?
+    out << "## #{title} (#{rows.size})\n\n"
+    if kind == :negative
+      out << "| Capability | Negative-evidence scope | Expected |\n|---|---|---|\n"
+      rows.each do |c|
+        neg = c['negativeEvidence'] || {}
+        scope = if neg['absentFileGlobs']
+                  "absent files: #{neg['absentFileGlobs'].join(', ')}"
+                else
+                  "#{(neg['grepScopes'] || []).join(', ')} for #{(neg['patterns'] || []).join('/')}"
+                end
+        out << "| #{c['capability']} | #{scope} | #{neg['expectedMatches'] || 0} matches |\n"
+      end
+    else
+      out << "| Capability | Evidence (HEAD) | Anti-claim / note |\n|---|---|---|\n"
+      rows.each do |c|
+        ev = c['currentEvidence'] || {}
+        anchor = ev['file'] ? "`#{ev['file']}#{ev['line'] ? ":#{ev['line']}" : ''}`" : "(none)"
+        note = c['antiClaim'] || c['notes'] || ''
+        out << "| #{c['capability']} | #{anchor} | #{note} |\n"
+      end
+    end
+    out << "\n"
+  end
+
+  section.call('Built', 'built', :positive)
+  section.call('Partial', 'partial', :positive)
+  section.call('Planned', 'planned', :positive)
+  section.call('Deliberately not done -- out-of-scope by design', 'deliberately-not-done', :negative)
+
+  out << "---\n\n"
+  out << "*Framing: \"deliberately not done\" means out-of-scope by design, never a known gap shipped without. "
+  out << "These rows exist to stop over-claims, mirroring the \"Deliberately not claimed\" section of `COMPLIANCE_PROGRAM_OVERVIEW.md`.*\n"
+  out
+end
+
+rendered = render_markdown(ledger, caps)
+
+# --- report validation --------------------------------------------------------
+unless failures.empty?
+  warn "capability-check: #{failures.size} FAILURE(S)\n"
+  failures.each { |f| warn "  - #{f}" }
+  warn "\nFix the ledger row or the code it cites, then re-run. Do not commit a red ledger."
+  exit 1
+end
+
+case mode
+when :check
+  on_disk = File.file?(RENDER_MD) ? File.read(RENDER_MD) : nil
+  if on_disk != rendered
+    warn "capability-check: #{RENDER_MD} is out of sync with the JSON. Run `ruby scripts/capability-check.rb` to regenerate."
+    exit 1
+  end
+  puts "capability-check: OK (#{caps.size} capabilities validated at HEAD; render in sync)"
+when :render_only, :validate_and_write
+  File.write(RENDER_MD, rendered)
+  puts "capability-check: OK (#{caps.size} capabilities validated at HEAD; #{RENDER_MD} written)"
+end

--- a/scripts/regenerate-register.sh
+++ b/scripts/regenerate-register.sh
@@ -100,6 +100,8 @@ verify_all() {
     ruby scripts/document-register-render.rb --check
   step "verify: compliance publication status report" \
     ruby scripts/compliance-publication-status.rb --check
+  step "verify: capability ledger (currentEvidence at HEAD + negativeEvidence)" \
+    ruby scripts/capability-check.rb --check
 }
 
 if [ "$MODE" = "check" ]; then
@@ -139,6 +141,8 @@ step "render: Notion compliance page (local mirror only, no push)" \
   ruby scripts/compliance-notion-publish.rb
 step "render: compliance publication status report" \
   ruby scripts/compliance-publication-status.rb
+step "render: capability ledger (validate at HEAD + write .md)" \
+  ruby scripts/capability-check.rb
 
 # The Notion mirror embeds a wall-clock "Page generated:" line that --check
 # ignores by design. Rendering rewrites it every run, so a substantively


### PR DESCRIPTION
## What

Phase B makes the Capability Ledger **enforced and canonical**. Adds `scripts/capability-check.rb`, wires it into CI and the register wrapper, and flips `meta.status` to `canonical`.

## The validator (`scripts/capability-check.rb`)

- **built / partial rows:** `currentEvidence {file,line,snippet}` must resolve **at HEAD** (the current checkout), not a pinned SHA. This is the core difference from `citation-check.rb`: a capability is a present-tense claim, so if the backing code is removed the check **must go red**.
- **deliberately-not-done rows:** `negativeEvidence` must hold, in two forms:
  - **content grep** (`grepScopes` + `patterns` - `excludedPaths` == `expectedMatches`) for code-absence (no E2EE identifier, no voiceprint path, no health columns);
  - **absentFileGlobs** for artifact-absence (no executed model-provider BAA file). This replaced a content grep that would false-positive on prose discussing the missing BAA.
- **`--check`** (CI) validates + asserts the `.md` render is in sync; default validates + writes `docs/legal/CAPABILITY_LEDGER.md` (no longer hand-maintained).

**Proven with negative tests** (not just happy path): an out-of-range line, a wrong snippet at a valid line, and a planted banned pattern each correctly fail with a clear message; pristine passes.

## Wiring

- `ci.yml` `audit-artifacts-integrity`: added a `capability-check.rb --check` step.
- `scripts/regenerate-register.sh`: added ledger render + verify steps (its scope now covers the ledger too).

## Ledger JSON corrections (for enforceability)

- `meta.status`: `provisional-non-canonical` -> `canonical`.
- `aws-s3-baa` `currentEvidence` anchored to a real line (was a placeholder snippet).
- `no-model-provider-baa` `negativeEvidence` -> `absentFileGlobs` (file-absence), so a prose mention of the missing BAA can't false-positive.

## Explicitly NOT in this PR

Mirroring the ledger into Codex `AGENTS.md` -- that's the agreed follow-up **after this merges green**. The rows are code-cited, identifier-free, so they'll be safe to mirror then.

## Testing

- `capability-check.rb --check`: 19 capabilities validate at HEAD, render in sync, exit 0.
- Negative tests all fail correctly (see above).
- Full `regenerate-register.sh` run: green, idempotent, no churn beyond the ledger files.
- `bash -n` clean; script committed `100755`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)