### PR TITLE
fix: address Codex PR review for dashboard prefs and bundle fetch

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1244,7 +1244,7 @@ class User < ApplicationRecord
   # the 'hero' non-grid toggle). Duplicated here so the server can validate the
   # user-supplied dashboard_* preferences on write (Ruby can't import the JS).
   # Keep in sync if a section key is added/removed there.
-  DASHBOARD_SECTION_KEYS = ['boards', 'speak', 'extras', 'caseload', 'org',
+  DASHBOARD_SECTION_KEYS = ['boards', 'speak', 'extras', 'caseload', 'rooms', 'attention', 'org',
       'account', 'createboard', 'reports', 'editdashboard', 'hero']
   CONFIRMATION_PREFERENCE_PARAMS = ['logging', 'private_logging', 'geo_logging', 'allow_log_reports',
       'allow_log_publishing', 'cookies', 'never_delete', 'logging_cutoff', 'logging_permissions', 'logging_code']

--- a/lib/converters/api_json_bundle.rb
+++ b/lib/converters/api_json_bundle.rb
@@ -44,7 +44,9 @@ module Converters::ApiJsonBundle
       end
     end
 
-    head = SafeHttp.head(sanitized)
+    fetch_url = Uploader.signed_internal_url(sanitized)
+
+    head = SafeHttp.head(fetch_url)
     if head.success?
       len = response_content_length(head)
       if len && len > MAX_BUNDLE_BYTES
@@ -52,7 +54,7 @@ module Converters::ApiJsonBundle
       end
     end
 
-    response = SafeHttp.get(sanitized)
+    response = SafeHttp.get(fetch_url)
     raise Progress::ProgressError, "failed to download bundle (#{response.code})" unless response.success?
 
     body = response.body.to_s

--- a/lib/converters/api_json_bundle.rb
+++ b/lib/converters/api_json_bundle.rb
@@ -44,7 +44,8 @@ module Converters::ApiJsonBundle
       end
     end
 
-    fetch_url = Uploader.signed_internal_url(sanitized)
+    fetch_url = Uploader.signed_internal_url(sanitized).presence || sanitized
+    raise Progress::ProgressError, "invalid bundle URL" unless fetch_url.present?
 
     head = SafeHttp.head(fetch_url)
     if head.success?

--- a/lib/safe_http.rb
+++ b/lib/safe_http.rb
@@ -279,12 +279,13 @@ module SafeHttp
     end
 
     def failed_response(message = 'blocked or invalid URL')
+      msg = message.to_s
       OpenStruct.new(
         success?: false,
         code: 0,
-        body: message,
+        body: msg,
         headers: {},
-        return_message: message
+        return_message: msg
       )
     end
 

--- a/lib/safe_http.rb
+++ b/lib/safe_http.rb
@@ -1,5 +1,6 @@
 require 'ffi'
 require 'ipaddr'
+require 'ostruct'
 require 'socket'
 require 'timeout'
 require 'ethon'

--- a/spec/lib/converters/api_json_bundle_spec.rb
+++ b/spec/lib/converters/api_json_bundle_spec.rb
@@ -115,12 +115,28 @@ describe Converters::ApiJsonBundle do
       }.to raise_error(Progress::ProgressError, /invalid import bundle URL/)
     end
 
+    it 'presigns uploads-bucket bundle URLs before downloading' do
+      importer = User.create
+      uploads_bucket = ENV['UPLOADS_S3_BUCKET'] || 'lingolinq-dev-uploads'
+      url = "https://#{uploads_bucket}.s3.amazonaws.com/imports/boards/#{importer.global_id}/bundle-abc.json"
+      signed = 'https://signed.example.com/bundle?X-Amz-Signature=abc'
+      allow(Uploader).to receive(:valid_import_bundle_url?).with(url, importer.global_id).and_return(true)
+      allow(Uploader).to receive(:sanitize_url).with(url).and_return(url)
+      expect(Uploader).to receive(:signed_internal_url).with(url).and_return(signed)
+      allow(SafeHttp).to receive(:head).with(signed).and_return(double('head', success?: true, headers: {}))
+      allow(SafeHttp).to receive(:get).with(signed).and_return(double('get', success?: true, body: '{"boards":[]}', code: 200))
+
+      result = described_class.load_bundle(url, allowed_importer_global_id: importer.global_id)
+      expect(result['boards']).to eq([])
+    end
+
     it 'rejects bundles larger than MAX_BUNDLE_BYTES' do
       importer = User.create
       uploads_bucket = ENV['UPLOADS_S3_BUCKET'] || 'lingolinq-dev-uploads'
       url = "https://#{uploads_bucket}.s3.amazonaws.com/imports/boards/#{importer.global_id}/bundle-abc.json"
       allow(Uploader).to receive(:valid_import_bundle_url?).with(url, importer.global_id).and_return(true)
       allow(Uploader).to receive(:sanitize_url).with(url).and_return(url)
+      allow(Uploader).to receive(:signed_internal_url).with(url).and_return(url)
       head = double('head', success?: true, headers: { 'Content-Length' => (described_class::MAX_BUNDLE_BYTES + 1).to_s })
       allow(SafeHttp).to receive(:head).with(url).and_return(head)
 
@@ -135,6 +151,7 @@ describe Converters::ApiJsonBundle do
       url = "https://#{uploads_bucket}.s3.amazonaws.com/imports/boards/#{importer.global_id}/bundle-abc.json"
       allow(Uploader).to receive(:valid_import_bundle_url?).with(url, importer.global_id).and_return(true)
       allow(Uploader).to receive(:sanitize_url).with(url).and_return(url)
+      allow(Uploader).to receive(:signed_internal_url).with(url).and_return(url)
       allow(SafeHttp).to receive(:head).with(url).and_return(double('head', success?: true, headers: {}))
       allow(SafeHttp).to receive(:get).with(url).and_return(double('get', success?: true, body: '<html></html>', code: 200))
 

--- a/spec/lib/converters/api_json_bundle_spec.rb
+++ b/spec/lib/converters/api_json_bundle_spec.rb
@@ -130,6 +130,20 @@ describe Converters::ApiJsonBundle do
       expect(result['boards']).to eq([])
     end
 
+    it 'falls back to the canonical bundle URL when presigning returns blank' do
+      importer = User.create
+      uploads_bucket = ENV['UPLOADS_S3_BUCKET'] || 'lingolinq-dev-uploads'
+      url = "https://#{uploads_bucket}.s3.amazonaws.com/imports/boards/#{importer.global_id}/bundle-abc.json"
+      allow(Uploader).to receive(:valid_import_bundle_url?).with(url, importer.global_id).and_return(true)
+      allow(Uploader).to receive(:sanitize_url).with(url).and_return(url)
+      allow(Uploader).to receive(:signed_internal_url).with(url).and_return('')
+      allow(SafeHttp).to receive(:head).with(url).and_return(double('head', success?: true, headers: {}))
+      allow(SafeHttp).to receive(:get).with(url).and_return(double('get', success?: true, body: '{"boards":[]}', code: 200))
+
+      result = described_class.load_bundle(url, allowed_importer_global_id: importer.global_id)
+      expect(result['boards']).to eq([])
+    end
+
     it 'rejects bundles larger than MAX_BUNDLE_BYTES' do
       importer = User.create
       uploads_bucket = ENV['UPLOADS_S3_BUCKET'] || 'lingolinq-dev-uploads'

--- a/spec/lib/safe_http_spec.rb
+++ b/spec/lib/safe_http_spec.rb
@@ -142,6 +142,14 @@ describe SafeHttp do
       expect(res.effective_url).to eq(nil)
     end
 
+    it 'coerces non-string failed_response messages to strings' do
+      expect(Typhoeus).not_to receive(:get)
+
+      res = SafeHttp.get('http://127.0.0.1/internal')
+      expect(res.body).to be_a(String)
+      expect(res.return_message).to be_a(String)
+    end
+
     it 'returns a failed response for IPv4-compatible IPv6 literals without calling Typhoeus' do
       expect(Typhoeus).not_to receive(:get)
 

--- a/spec/lib/safe_http_spec.rb
+++ b/spec/lib/safe_http_spec.rb
@@ -138,6 +138,7 @@ describe SafeHttp do
       res = SafeHttp.get('http://169.254.169.254/latest/meta-data/')
       expect(res.success?).to eq(false)
       expect(res.code).to eq(0)
+      expect(res.body).to eq('blocked or invalid URL')
       expect(res.effective_url).to eq(nil)
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -667,6 +667,26 @@ describe User, :type => :model do
       expect(u.settings['preferences']['cookies']).to eq(true)
     end
 
+    it "preserves supporter dashboard sections rooms and attention on write" do
+      u = User.new
+      u.settings = {'preferences' => {}}
+      u.process_params({'preferences' => {
+        'dashboard_sections' => {
+          'boards' => true,
+          'rooms' => true,
+          'attention' => false,
+          'not_a_section' => true
+        },
+        'dashboard_order' => ['boards', 'rooms', 'attention', 'bogus']
+      }}, {})
+      expect(u.settings['preferences']['dashboard_sections']).to eq({
+        'boards' => true,
+        'rooms' => true,
+        'attention' => false
+      })
+      expect(u.settings['preferences']['dashboard_order']).to eq(['boards', 'rooms', 'attention'])
+    end
+
     it "should persist require_sidebar_edit_pin (whitelisted) and coerce to boolean" do
       # Guards the silent-drop failure mode: a preference not in PREFERENCE_PARAMS
       # is dropped by process_params and never persists. require_sidebar_edit_pin


### PR DESCRIPTION
Preserve rooms/attention dashboard section keys on save, presign private-bucket JSON bundle URLs before worker download, and require ostruct for SafeHttp blocked-URL fallback responses.