### PR TITLE
fix: pin Docker build npm to v10 major, not latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,11 @@ RUN apt-get update -qq && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js (needed for Rails asset pipeline)
+# npm is pinned to the v10 major because newer npm releases can require a
+# Node major beyond 20, which would break this build without warning.
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g npm@latest
+    npm install -g npm@10
 
 # Set environment
 ENV RAILS_ENV="production" \


### PR DESCRIPTION
## Summary
- The GCP Cloud Run redeploy (`gh workflow run deploy-cloudrun.yml --ref main`) failed at the Docker build step: `RUN ... npm install -g npm@latest` pulled npm 12.0.1, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0` — incompatible with this stage's `node:20-bullseye`/nodesource Node 20 install.
- Pins npm to the v10 major (matching Node 20's originally-bundled npm, `10.8.2`) instead of chasing `latest`, so the build stays reproducible regardless of future npm releases.
- Same unpinned line exists on `staging` (verified via `git show origin/staging:Dockerfile`), so this is a real reproducibility gap independent of the GCP migration — a future Render rebuild from a clean image cache would hit the identical failure.
- No Node version, base image, build stage, package manager, Render config, GCP config, SES config, DNS, Cloud Armor, or ingress changes.

## Test plan
- [ ] CI (rspec / build-and-test / audit-artifacts-integrity / secret-detection) — none of these exercise the Dockerfile; confirmed `deploy-cloudrun.yml` is the only workflow that builds it, and it is `workflow_dispatch`-only (never runs on push/PR).
- [ ] No Docker CLI available in this environment to build-test locally — real validation is the next `deploy-cloudrun.yml` run once this reaches `main`.
- [ ] Awaiting Scot's approval before merge, per the dual-reviewer approval on this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)