### PR TITLE
fix: pin Docker build npm to v10 major, not latest (main hotfix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,11 @@ RUN apt-get update -qq && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js (needed for Rails asset pipeline)
+# npm is pinned to the v10 major because newer npm releases can require a
+# Node major beyond 20, which would break this build without warning.
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g npm@latest
+    npm install -g npm@10
 
 # Set environment
 ENV RAILS_ENV="production" \


### PR DESCRIPTION
## Summary
- Targeted hotfix promotion of PR #592 to `main`, cherry-picking only the single Dockerfile-fix commit (`f49e7548d`) — not a full staging→main sync. `staging` is currently ~15 commits ahead of `main` with unrelated in-flight work that is intentionally NOT included here.
- Root cause (same as #592): `Dockerfile`'s `npm install -g npm@latest` pulled npm 12.0.1, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0` — incompatible with this stage's Node 20 install. This broke the GCP Cloud Run redeploy build (`deploy-cloudrun.yml --ref main`).
- Pins npm to the v10 major (matching Node 20's originally-bundled npm) instead of `latest`.
- No Node version, base image, build stage, package manager, Render config, GCP config, SES config, DNS, Cloud Armor, or ingress changes.

## Verification
- Diff against `origin/main` confirmed to be exactly 1 file, 3 insertions / 1 deletion — identical to the #592 diff, no other staging commits included.
- #592 merged to `staging` at `e6fb5bd12` after CI (rspec, build-and-test, audit-artifacts-integrity, secret-detection) all passed (build-and-test initially hit an unrelated pre-existing `persistence-sync` timing flake, confirmed also present on staging HEAD's own unrelated commit; cleared on rerun).

## Test plan
- [ ] CI on this PR (rspec / build-and-test / audit-artifacts-integrity / secret-detection)
- [ ] `deploy-cloudrun.yml` build (the only workflow that actually builds this Dockerfile) is `workflow_dispatch`-only, so it isn't exercised by this PR's CI — the real validation is the deferred GCP redeploy retry once this merges
- [ ] **Do not merge without explicit approval** — this targets `main` (Render prod's deploy branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)