### PR TITLE
compliance(register): close LL-9a09771121 verified-closed (Render prod SigV2 -> SigV4)

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "29edde7e3b5500df6491b77d9279237484f6581cd305add22f00d040bfda4395",
+      "contentHash": "a57c113200a45587de23fb2cdedeebcac544a4eda8ac4ca88010d0677b5890dc",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `29edde7e3b55` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `a57c113200a4` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -3380,12 +3380,12 @@
       "frameworks": [
         "SOC2"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "disposition": {
-        "state": "untriaged",
-        "decidedBy": "",
-        "decidedDate": "",
-        "rationale": ""
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-07-13",
+        "rationale": "SigV4 PresignedPost signing backported to Render production (branch main) in #538; prod uploads verified working and all degraded data-URI records repaired. See closureEvidence."
       },
       "evidence": {
         "type": "code",
@@ -3403,9 +3403,9 @@
         "timeframe": "7-15d"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "b03fb7cf1c4812cb5430c0dfc282e4c86b56a874",
+        "verifierNote": "Verified 2026-07-05..06: the SigV2 (HMAC-SHA1) POST policy that SSE-KMS S3 rejects was remediated by backporting the SigV4 PresignedPost signer to main in #538 (fix commit 4d28166ea; merge b03fb7cf1), after the KMS/NO_ACL/CDN env prerequisites were applied 2026-07-05. Render prod web+worker deployed b03fb7cf1. All 51 degraded records (49 button_images + 2 button_sounds) re-driven via Render one-off jobs with 0 failures; prod DB now has 0 data-URI fallbacks and 51 bucket URLs. End-to-end confirmed: a repaired object serves 200 image/png via CloudFront (d34sa6lc5jfe66.cloudfront.net) while the raw bucket URL still 403s. Companion finding LL-705b10bcd7 (GCP stack, same root defect) was independently live-verified.",
+        "attestation": "Scot Wahlquist 2026-07-13: attested verified-closed; SigV4 remediation backported to Render prod main in #538, prod-verified 2026-07-06."
       },
       "notes": "Split out of LL-705b10bcd7 (which tracks the GCP rehearsal stack, now live-verified): same root defect, different deploy target and IAM principal. The data-URI fallback keeps prod images rendering (served inline from the DB), so user impact is degraded-not-broken for images; sounds/videos over the size cap are lost (errored_pending_url). Scope details and consumer inventory: ai-company-brain outputs/plans/2026-07-05-s3-private-bucket-read-path-scope.md."
     },

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,17 +5,16 @@
 
 **Audited:** `scot/compliance/audit-refresh-2026-07-07` @ `20953ab3d5a80c3a9cbb249f37a79357b7f1baf1` on 2026-07-08  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 8 High
+**Headline (open + remediated-unverified):** 0 Critical / 7 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (56)
+## Open (55)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
 | LL-90045bb29c |  | high | FERPA | **accepted** | audit-run | User#user_token is a permanent, non-expiring credential serialized on login and embedded in navigable lesson/board share URLs | `lib/json_api/user.rb`:41 |
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | **accepted** | audit-review | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
-| LL-9a09771121 |  | high | SOC2 | untriaged | audit-run | Render production (branch main) still hand-signs S3 POST policies with SigV2; every upload to the SSE-KMS uploads bucket fails and silently degrades to DB-stored data URIs | `lib/uploader.rb`:291 |
 | LL-f150e0e828 |  | high | COPPA, GDPR | **accepted** | pr-review | District seat reclaim converts an under-13's account to a consumer trial with no parental re-consent or notice (COPPA) | `app/models/license.rb`:76 |
 | LL-854b1d3853 |  | high | GDPR, FERPA, COPPA | **accepted** | pr-review | Hard delete leaves UserVideo records and off-board voice recordings (ButtonSound) undeleted (GDPR right-to-erasure) | `lib/flusher.rb`:363 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
@@ -78,7 +77,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-705b10bcd7 |  | high | SOC2 | untriaged | audit-run | BoardDownstreamButtonSet S3 writes fail against KMS-encrypted bucket: 'Requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4' | (attestation) |
 | LL-5954bcbbe6 |  | medium | SOC2 | untriaged | audit-run | Pre-existing Resque background-job failures: ImageMagick identify missing in Cloud Run image, stale job_stash lookups, and a call to a removed Board method | (attestation) |
 
-## Verified closed (43)
+## Verified closed (44)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -98,6 +97,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-080a21089f |  | high | FERPA, HIPAA, GDPR | untriaged | audit-run | Account deletion / right-to-erasure path writes no AuditEvent | `app/controllers/api/users_controller.rb`:388 |
 | LL-7acd0e7416 |  | high | FERPA, HIPAA | untriaged | audit-run | Admin-support reads of individual student records (version history, daily usage) write no AuditEvent | `app/controllers/api/users_controller.rb`:485 |
 | LL-9b5d0f1381 |  | high | WCAG | **fixed** | audit-run | Find-a-button search input has no accessible name (placeholder-only, non-i18n) | `app/frontend/app/templates/find-button.hbs`:8 |
+| LL-9a09771121 |  | high | SOC2 | **fixed** | audit-run | Render production (branch main) still hand-signs S3 POST policies with SigV2; every upload to the SSE-KMS uploads bucket fails and silently degrades to DB-stored data URIs | `lib/uploader.rb`:291 |
 | LL-47117a3443 |  | high | COPPA, GDPR, FERPA | untriaged | audit-run | COPPA verifiable parental consent is granted with no immutable AuditEvent | `app/controllers/parental_consents_controller.rb`:14 |
 | LL-85038c0a7b |  | high |  | untriaged | audit-run | buttonsets#generate debug_sync=1 path returns raw exception message and full Ruby backtrace as JSON error body | `app/controllers/api/button_sets_controller.rb`:83 |
 | LL-efef111d59 | Dep-nokogiri-1194 | high | SOC2 | untriaged | audit-run | nokogiri 1.19.3 vulnerable to six published advisories (fixed in 1.19.4) | `Gemfile.lock`:281 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `20953ab3d5a80c3a9cbb249f37a79357b7f1baf1`  
 **Audited ref:** `scot/compliance/audit-refresh-2026-07-07`  
 **Run date:** 2026-07-08  
-**Page generated:** 2026-07-11T21:28:00Z
+**Page generated:** 2026-07-13T07:30:51Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **8** | 26 | 25 |
+| **0** | **7** | 26 | 25 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -29,7 +29,6 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-7f7372e3eb |  | high | SOC2, HIPAA | Audited-console wrapper still shells to Heroku CLI; not operative on Render so console access is unaudited | `bin/audit_console`:7 |
 | LL-854b1d3853 |  | high | GDPR, FERPA, COPPA | Hard delete leaves UserVideo records and off-board voice recordings (ButtonSound) undeleted (GDPR right-to-erasure) | `lib/flusher.rb`:363 |
 | LL-90045bb29c |  | high | FERPA | User#user_token is a permanent, non-expiring credential serialized on login and embedded in navigable lesson/board share URLs | `lib/json_api/user.rb`:41 |
-| LL-9a09771121 |  | high | SOC2 | Render production (branch main) still hand-signs S3 POST policies with SigV2; every upload to the SSE-KMS uploads bucket fails and silently degrades to DB-stored data URIs | `lib/uploader.rb`:291 |
 | LL-a95e9c5f7c |  | high | SOC2 | lingolinq-worker's 512Mi memory limit is too small for ButtonImage/BoardDownstreamButtonSet jobs, causing continuous OOM kills that land as Resque::Failure instead of being requeued | (attestation) |
 | LL-f150e0e828 |  | high | COPPA, GDPR | District seat reclaim converts an under-13's account to a consumer trial with no parental re-consent or notice (COPPA) | `app/models/license.rb`:76 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |


### PR DESCRIPTION
## Summary

Closes the register's only untriaged open High, **LL-9a09771121** (Render production still hand-signed S3 POST policies with SigV2, so every upload to the SSE-KMS uploads bucket failed and silently degraded to DB-stored data URIs).

The root defect was remediated on Render prod by backporting the SigV4 PresignedPost signer to `main` in **#538** (fix commit `4d28166ea`, merge `b03fb7cf1`), after the KMS / `UPLOADS_S3_NO_ACL` / `UPLOADS_S3_CDN` prerequisites were applied 2026-07-05. Prod web+worker deployed `b03fb7cf1`; all 51 degraded records (49 `button_images` + 2 `button_sounds`) were re-driven via Render one-off jobs with 0 failures; prod DB now has 0 data-URI fallbacks and 51 bucket URLs. End-to-end confirmed: a repaired object serves `200 image/png` via CloudFront while the raw bucket URL still `403`s. Companion finding `LL-705b10bcd7` (GCP stack, same root defect) was independently live-verified.

## Register change

- `status`: `open` -> `verified-closed`
- `disposition.state`: `untriaged` -> `fixed` (decidedBy Scot Wahlquist, 2026-07-13)
- `closureEvidence`: sha `b03fb7cf1...`, verifierNote, and CEO attestation populated
- Derived artifacts regenerated (`FINDINGS.md`, `DOCUMENT-REGISTER.*`, Notion mirror)
- Headline: **0C/8H -> 0C/7H**

Only Scot sets `verified-closed` and the attestation; merging this PR is the CEO sign-off.

## Verification

- **CI `audit-artifacts-integrity` checks: all pass** (`compliance-calendar-render`, `compliance-notion-publish`, `document-register-render`, `compliance-publication-status`, `capability-check`, each `--check` exit 0).
- The stricter, local-only `citation-check` (intentionally **not** a CI job, per `ci.yml` and the `regenerate-register.sh` header) still reports **one pre-existing, unrelated FAILURE**: `LL-5d7197fa7d` (open/low, `lib/flusher.rb`) is anchored to commit `84f573b34c`, which was squashed out of history, so its evidence snippet can no longer resolve. This **reproduces on pristine `staging`** (control run: `PASS: 96 FAIL: 1 SKIP: 10`), is not introduced by this PR, and is not a merge gate. Tracked for a separate re-anchor follow-up.

## Follow-ups (out of scope here)

1. **Re-anchor `LL-5d7197fa7d`** evidence to a live commit so `citation-check` goes fully green.
2. **Fix `scripts/regenerate-register.sh` `--check`**: `verify_all` runs inside an `if` condition, which suppresses `set -e`, and it returns only the last `step`'s status. An early `citation-check` failure is therefore masked and `--check` can exit 0 despite it. `--check` should fail (exit non-zero) if any step, including an early `citation-check`, fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169vEDQV8fiA2NqDrj4M7GJ
