### PR TITLE
compliance(register): enforce + green citation-check (re-anchor LL-5d7197fa7d, fix --check masking)

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -605,7 +605,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "a57c113200a45587de23fb2cdedeebcac544a4eda8ac4ca88010d0677b5890dc",
+      "contentHash": "fd26a3f5604caefb3c9f68ba1668d4fd40dfb3ba690f71dd915f415b0118f9a2",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -69,7 +69,7 @@
 | Compliance Status Snapshot (2026-06-18) | git | `docs/legal/COMPLIANCE_STATUS_2026-06-18.md` | superseded |  | Scot Wahlquist | 2026-06-18 |  | no | `94b8288187ea` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `a57c113200a4` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `fd26a3f5604c` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -3111,9 +3111,9 @@
       "evidence": {
         "type": "code",
         "file": "lib/flusher.rb",
-        "line": 116,
-        "snippet": "docs/legal/DATA_RETENTION.md:30, authentication/audit-trail paper_trail",
-        "sha": "84f573b34cba5c4212f4e0948abf92a20335609c"
+        "line": 135,
+        "snippet": "stale_version_count = stale_types.any? ? PaperTrail::Version.where(item_type: stale_types).count",
+        "sha": "7419c7368eb154707e322e71bdd8bfad893318d7"
       },
       "firstSeen": "2026-07-02",
       "lastSeen": "2026-07-02",

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -57,7 +57,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-2695434541 |  | low | SOC2 | **accepted** | audit-run | Puma Gemfile constraint permits 7.2.0 which predates the CVE-2026-47736/47737 fix; floor unset | `Gemfile`:62 |
 | LL-b0bc6880e6 |  | low | SOC2 | **accepted** | audit-run | sync-render-secrets.yml (holds RENDER_API_KEY + 1Password token) declares no permissions: block, inheriting default write GITHUB_TOKEN | `.github/workflows/sync-render-secrets.yml`:14 |
 | LL-e76d6378b5 |  | low |  | **accepted** | audit-run | Webhook model declares notifications and content_type attrs that Rails never serializes | `app/frontend/app/models/webhook.js`:12 |
-| LL-5d7197fa7d |  | low | HIPAA, FERPA | untriaged | audit-run | PaperTrail versions with unconstantizable item_type are detected but retention disposition is undecided | `lib/flusher.rb`:116 |
+| LL-5d7197fa7d |  | low | HIPAA, FERPA | untriaged | audit-run | PaperTrail versions with unconstantizable item_type are detected but retention disposition is undecided | `lib/flusher.rb`:135 |
 | LL-de9c94bf36 |  | low | GDPR | untriaged | audit-run | Org retention policy purges a sponsored user's entire log history, including logs outside that org's context | `lib/data_policy_enforcer.rb`:31 |
 | LL-d8072299bf |  | low | GDPR, COPPA | untriaged | audit-run | Automated retention only runs for org-sponsored users; standalone accounts keep communication logs indefinitely | `lib/data_policy_enforcer.rb`:22 |
 | LL-c226391436 |  | low | SOC2 | untriaged | audit-run | Content-Security-Policy is report-only (nothing blocked) and script-src permits unsafe-inline + unsafe-eval | `config/initializers/content_security_policy.rb`:114 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,7 +11,7 @@
 **Audited commit:** `20953ab3d5a80c3a9cbb249f37a79357b7f1baf1`  
 **Audited ref:** `scot/compliance/audit-refresh-2026-07-07`  
 **Run date:** 2026-07-08  
-**Page generated:** 2026-07-13T07:30:51Z
+**Page generated:** 2026-07-13T08:04:43Z
 
 ## Headline - open findings
 
@@ -66,7 +66,7 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 | LL-57e9beb87f |  | low | GDPR, FERPA | Flusher.flush_leftovers has no usage-based orphan check for orphaned ButtonImage/ButtonSound media records (item 1) | `lib/flusher.rb`:57 |
 | LL-5a173ce87f |  | low |  | Utterance Rails builder emits created_at but Ember model declares timestamp instead | `app/frontend/app/models/utterance.js`:15 |
 | LL-5ae3d7ca2c |  | low | SOC2 | ci.yml declares no top-level permissions block; GITHUB_TOKEN inherits repo-default scope for all jobs (incl. one running downloaded gitleaks) | `.github/workflows/ci.yml`:1 |
-| LL-5d7197fa7d |  | low | HIPAA, FERPA | PaperTrail versions with unconstantizable item_type are detected but retention disposition is undecided | `lib/flusher.rb`:116 |
+| LL-5d7197fa7d |  | low | HIPAA, FERPA | PaperTrail versions with unconstantizable item_type are detected but retention disposition is undecided | `lib/flusher.rb`:135 |
 | LL-5e7676187f |  | low |  | indexeddbshim is pinned to a stale major (^6.1.0, ~10 majors behind latest 16.1.0) in the production bundle | `app/frontend/package.json`:70 |
 | LL-5f0f4f52f8 |  | low | SOC2 | Audit system files (.claude/) are not in any finder scan scope (no self-audit) | `.claude/agents/infra-auditor.md`:62 |
 | LL-6447a21503 |  | low |  | Organization model declares total_extras attribute but Rails builder never emits it | `app/frontend/app/models/organization.js`:42 |

--- a/scripts/regenerate-register.sh
+++ b/scripts/regenerate-register.sh
@@ -90,18 +90,27 @@ step() {  # step "label" cmd args...
 # is intentionally NOT part of the CI integrity job (ci.yml); gating on it locally
 # is a stricter, correct pre-render safeguard. ---------------------------------
 verify_all() {
+  # Run EVERY check and remember if ANY failed. verify_all is always called in a
+  # condition context (`if verify_all` / `if ! verify_all`), which disables set -e
+  # inside it, so a bare `step` list would (a) keep going past a failure anyway and
+  # (b) return only the LAST step's status -- masking an early failure (e.g. a red
+  # citation-check) behind a later green step. Accumulate into rc so the caller
+  # sees a non-zero result whenever any single check failed, while still running
+  # all of them so every failure is reported in one pass.
+  local rc=0
   step "verify: citation-check (evidence resolves; stricter-than-CI local gate)" \
-    ruby scripts/citation-check.rb "$FINDINGS"
+    ruby scripts/citation-check.rb "$FINDINGS" || rc=1
   step "verify: compliance calendar render matches JSON" \
-    ruby scripts/compliance-calendar-render.rb --check
+    ruby scripts/compliance-calendar-render.rb --check || rc=1
   step "verify: Notion compliance page matches register" \
-    ruby scripts/compliance-notion-publish.rb --check
+    ruby scripts/compliance-notion-publish.rb --check || rc=1
   step "verify: document register render + git hashes + bundle completeness" \
-    ruby scripts/document-register-render.rb --check
+    ruby scripts/document-register-render.rb --check || rc=1
   step "verify: compliance publication status report" \
-    ruby scripts/compliance-publication-status.rb --check
+    ruby scripts/compliance-publication-status.rb --check || rc=1
   step "verify: capability ledger (currentEvidence at HEAD + negativeEvidence)" \
-    ruby scripts/capability-check.rb --check
+    ruby scripts/capability-check.rb --check || rc=1
+  return $rc
 }
 
 if [ "$MODE" = "check" ]; then


### PR DESCRIPTION
## Summary

Two coupled register-integrity follow-ups from #595. Together they make `regenerate-register.sh --check` both **enforced** (it can no longer mask a failure) and **green** (the one failure it was masking is fixed).

## 1. `fix(compliance-tooling)`: `--check` must fail on any failed step

`verify_all()` is always called in a condition (`if verify_all` / `if ! verify_all`), which disables `set -e` inside it. The old bare list of `step` calls therefore returned only the **last** step's status, so an early failure (e.g. a red `citation-check`) was masked whenever a later step passed, and `--check` could exit `0` despite a real integrity failure.

Fix: accumulate each step into a local `rc` (`|| rc=1`) and `return $rc`. Every step still runs (so all failures surface in one pass), but the check fails if any step fails.

Verified: on a register with an unresolved citation, `--check` now exits `1` (was masked to `0`) and still runs the remaining checks.

## 2. `compliance(register)`: re-anchor `LL-5d7197fa7d` evidence

That finding's evidence pointed at `lib/flusher.rb@84f573b34c`, a commit **squashed out of history**, so `citation-check` failed to resolve it (`file not found at sha`) on pristine `staging` (surfaced as the pre-existing failure noted in #595). The referenced code still exists (the report-only stale-`item_type` PaperTrail block). Re-anchored to the stable detection line (`stale_version_count`, line 135) at current `staging` HEAD `7419c7368e`, with the actual detection statement as the snippet (the old snippet was a drift-prone comment line).

**Evidence pointer only** -- `status` (open), `disposition` (none), and `severity` (low) are unchanged. This is not a triage or closure.

## Verification

- `citation-check`: **PASS 97 / FAIL 0 / SKIP 10** (was FAIL 1).
- `regenerate-register.sh --check`: **exit 0, all checks pass** (CI `audit-artifacts-integrity` plus the stricter local citation gate).
- `FINDINGS.json` diff is exactly three evidence fields on one finding; the `FINDINGS.md` / `DOCUMENT-REGISTER.*` / Notion-mirror changes are the deterministic downstream re-render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169vEDQV8fiA2NqDrj4M7GJ
