### PR TITLE
Feat/melissa parental consent confirmation email

### DIFF
--- a/app/controllers/api/system_email_templates_controller.rb
+++ b/app/controllers/api/system_email_templates_controller.rb
@@ -100,8 +100,11 @@ class Api::SystemEmailTemplatesController < ApplicationController
     html_template = html_custom || SystemEmailTemplates.default_body(@entry[:key], 'html') || ''
     text_template = text_custom || SystemEmailTemplates.default_body(@entry[:key], 'text') || ''
     sample_consent_url = "#{JsonApi::Json.current_host}/parental_consent/complete?user_id=#{user.global_id}&token=sample-token"
+    sample_revoke_url = "#{JsonApi::Json.current_host}/parental_consent/revoke?user_id=#{user.global_id}&token=sample-revoke-token"
+    sample_granted_at = Time.now.utc
+    sample_revoked_at = Time.now.utc
 
-    preview_binding = preview_binding_for(user, branding, preview_i18n, sample_consent_url)
+    preview_binding = preview_binding_for(user, branding, preview_i18n, sample_consent_url, sample_revoke_url, sample_granted_at, sample_revoked_at)
     html = SystemEmailTemplates.render_string(html_template, preview_binding, validate: !!html_custom)
     text = SystemEmailTemplates.render_string(text_template, preview_binding, validate: !!text_custom)
 
@@ -152,7 +155,7 @@ class Api::SystemEmailTemplatesController < ApplicationController
     end
   end
 
-  def preview_binding_for(user, branding, preview_i18n, sample_consent_url)
+  def preview_binding_for(user, branding, preview_i18n, sample_consent_url, sample_revoke_url = nil, sample_granted_at = nil, sample_revoked_at = nil)
     entry = @entry
     template_key = "#{entry[:mailer]}/#{entry[:action]}"
     helper = Object.new.extend(MailerHelper)
@@ -170,6 +173,14 @@ class Api::SystemEmailTemplatesController < ApplicationController
     end
     helper.instance_variable_set(:@user, user)
     helper.instance_variable_set(:@consent_url, sample_consent_url)
+    helper.instance_variable_set(:@revoke_url, sample_revoke_url)
+    helper.instance_variable_set(:@privacy_url, "#{JsonApi::Json.current_host}/privacy")
+    helper.instance_variable_set(:@contact_url, "#{JsonApi::Json.current_host}/contact")
+    helper.instance_variable_set(:@child_name, user.settings['name'])
+    helper.instance_variable_set(:@child_username, user.display_user_name)
+    helper.instance_variable_set(:@parent_email, (user.settings['coppa'] || {})['parent_email'] || 'parent@example.com')
+    helper.instance_variable_set(:@granted_at, sample_granted_at)
+    helper.instance_variable_set(:@revoked_at, sample_revoked_at)
     helper.instance_eval { binding }
   end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1097,15 +1097,7 @@ class Api::UsersController < ApplicationController
 
   def schedule_parental_consent_request_email!(user)
     # Mail goes to settings['coppa']['parent_email'] (see UserMailer#parental_consent_request).
-    # By default delivery is queued (Resque priority); without a worker the email never sends.
-    # In development, set INLINE_PARENTAL_CONSENT_EMAIL=1 to call SES immediately (still needs SES_KEY/SECRET or delivery will no-op / log).
-    if Rails.env.development? && %w[1 true yes on].include?(ENV['INLINE_PARENTAL_CONSENT_EMAIL'].to_s.strip.downcase)
-      UserMailer.deliver_message(:parental_consent_request, user.global_id)
-      Rails.logger.info("[COPPA] parental_consent_request delivered inline for user=#{user.global_id}")
-    else
-      UserMailer.schedule_delivery(:parental_consent_request, user.global_id)
-      Rails.logger.info("[COPPA] parental_consent_request queued for user=#{user.global_id} (start Resque priority worker, or set INLINE_PARENTAL_CONSENT_EMAIL=1 in development)")
-    end
+    UserMailer.schedule_parent_consent_delivery(:parental_consent_request, user.global_id)
   end
 
   def parental_consent_resend_redis_key(user)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -750,7 +750,7 @@ class Api::UsersController < ApplicationController
     if params['resend']
       sent = false
       if user.settings['pending'] != false
-        if user.coppa_parental_consent_pending?
+        if user.coppa_parental_consent_pending? || user.coppa_parental_consent_revoked?
           sent = false
         else
           sent = true
@@ -761,6 +761,9 @@ class Api::UsersController < ApplicationController
     else
       confirmed = !!(user && !user.settings['pending'])
       if params['code'] && user && params['code'] == user.registration_code
+        if user.coppa_parental_consent_revoked?
+          return api_error 400, {error: 'parental consent revoked', coppa_parental_consent_revoked: true}
+        end
         if user.coppa_parental_consent_pending?
           return api_error 400, {error: 'awaiting parental consent', coppa_parental_consent_pending: true}
         end

--- a/app/controllers/parental_consents_controller.rb
+++ b/app/controllers/parental_consents_controller.rb
@@ -7,25 +7,26 @@ class ParentalConsentsController < ApplicationController
     token = params[:token].presence || params['token']
     @success = false
     @already_granted = false
-    c = user && user.settings && user.settings['coppa']
-    if user && c.is_a?(Hash) && c['parent_consent_granted_at'].present? && !user.coppa_parental_consent_pending?
-      @already_granted = true
-      @success = true
-    elsif user && user.grant_parental_consent!(token, ip: request.remote_ip, user_agent: request.headers['User-Agent'])
-      # grant_parental_consent! writes the immutable COPPA AuditEvent atomically
-      # with the consent grant (see User#grant_parental_consent!).
-      @success = true
-      UserMailer.schedule_parent_consent_delivery(:parental_consent_confirmation, user.global_id)
-      UserMailer.schedule_delivery(:confirm_registration, user.global_id)
-      UserMailer.schedule_delivery(:new_user_registration, user.global_id)
-      ExternalTracker.track_new_user(user)
-      d = Device.find_or_create_by(user_id: user.id, device_key: 'default', developer_key_id: 0)
-      d.settings['ip_address'] = request.remote_ip
-      log_installed_client_signal('parental_consents#complete')
-      apply_device_classification!(d, installed_app?)
-      d.settings['user_agent'] = request.headers['User-Agent']
-      d.save
-      d.generate_token!(!!d.settings['app'])
+    if user && user.valid_parent_consent_grant_link_token?(token)
+      if user.coppa_parental_consent_active?
+        @already_granted = true
+        @success = true
+      elsif user.coppa_parental_consent_pending? && user.grant_parental_consent!(token, ip: request.remote_ip, user_agent: request.headers['User-Agent'])
+        # grant_parental_consent! writes the immutable COPPA AuditEvent atomically
+        # with the consent grant (see User#grant_parental_consent!).
+        @success = true
+        UserMailer.schedule_parent_consent_delivery(:parental_consent_confirmation, user.global_id)
+        UserMailer.schedule_delivery(:confirm_registration, user.global_id)
+        UserMailer.schedule_delivery(:new_user_registration, user.global_id)
+        ExternalTracker.track_new_user(user)
+        d = Device.find_or_create_by(user_id: user.id, device_key: 'default', developer_key_id: 0)
+        d.settings['ip_address'] = request.remote_ip
+        log_installed_client_signal('parental_consents#complete')
+        apply_device_classification!(d, installed_app?)
+        d.settings['user_agent'] = request.headers['User-Agent']
+        d.save
+        d.generate_token!(!!d.settings['app'])
+      end
     end
     render layout: 'parental_consent'
   end
@@ -36,13 +37,14 @@ class ParentalConsentsController < ApplicationController
     token = params[:token].presence || params['token']
     @success = false
     @already_revoked = false
-    c = user && user.settings && user.settings['coppa']
-    if user && c.is_a?(Hash) && c['parent_consent_revoked_at'].present?
-      @already_revoked = true
-      @success = true
-    elsif user && user.revoke_parental_consent!(token, ip: request.remote_ip, user_agent: request.headers['User-Agent'])
-      @success = true
-      UserMailer.schedule_parent_consent_delivery(:parental_consent_revoked, user.global_id)
+    if user && user.valid_parent_consent_revoke_link_token?(token)
+      if user.coppa_parental_consent_revoked?
+        @already_revoked = true
+        @success = true
+      elsif user.revoke_parental_consent!(token, ip: request.remote_ip, user_agent: request.headers['User-Agent'])
+        @success = true
+        UserMailer.schedule_parent_consent_delivery(:parental_consent_revoked, user.global_id)
+      end
     end
     render 'revoke', layout: 'parental_consent'
   end

--- a/app/controllers/parental_consents_controller.rb
+++ b/app/controllers/parental_consents_controller.rb
@@ -15,7 +15,7 @@ class ParentalConsentsController < ApplicationController
       # grant_parental_consent! writes the immutable COPPA AuditEvent atomically
       # with the consent grant (see User#grant_parental_consent!).
       @success = true
-      UserMailer.schedule_delivery(:parental_consent_confirmation, user.global_id)
+      UserMailer.schedule_parent_consent_delivery(:parental_consent_confirmation, user.global_id)
       UserMailer.schedule_delivery(:confirm_registration, user.global_id)
       UserMailer.schedule_delivery(:new_user_registration, user.global_id)
       ExternalTracker.track_new_user(user)
@@ -42,7 +42,7 @@ class ParentalConsentsController < ApplicationController
       @success = true
     elsif user && user.revoke_parental_consent!(token, ip: request.remote_ip, user_agent: request.headers['User-Agent'])
       @success = true
-      UserMailer.schedule_delivery(:parental_consent_revoked, user.global_id)
+      UserMailer.schedule_parent_consent_delivery(:parental_consent_revoked, user.global_id)
     end
     render 'revoke', layout: 'parental_consent'
   end

--- a/app/controllers/parental_consents_controller.rb
+++ b/app/controllers/parental_consents_controller.rb
@@ -15,6 +15,7 @@ class ParentalConsentsController < ApplicationController
       # grant_parental_consent! writes the immutable COPPA AuditEvent atomically
       # with the consent grant (see User#grant_parental_consent!).
       @success = true
+      UserMailer.schedule_delivery(:parental_consent_confirmation, user.global_id)
       UserMailer.schedule_delivery(:confirm_registration, user.global_id)
       UserMailer.schedule_delivery(:new_user_registration, user.global_id)
       ExternalTracker.track_new_user(user)
@@ -27,5 +28,22 @@ class ParentalConsentsController < ApplicationController
       d.generate_token!(!!d.settings['app'])
     end
     render layout: 'parental_consent'
+  end
+
+  def revoke
+    response.headers['Referrer-Policy'] = 'no-referrer'
+    user = User.find_by_path(params[:user_id].presence || params['user_id'])
+    token = params[:token].presence || params['token']
+    @success = false
+    @already_revoked = false
+    c = user && user.settings && user.settings['coppa']
+    if user && c.is_a?(Hash) && c['parent_consent_revoked_at'].present?
+      @already_revoked = true
+      @success = true
+    elsif user && user.revoke_parental_consent!(token, ip: request.remote_ip, user_agent: request.headers['User-Agent'])
+      @success = true
+      UserMailer.schedule_delivery(:parental_consent_revoked, user.global_id)
+    end
+    render 'revoke', layout: 'parental_consent'
   end
 end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -106,7 +106,9 @@ class SessionController < ApplicationController
         end
       end
     end
-    if !error && user && user.coppa_parental_consent_pending?
+    if !error && user && user.coppa_parental_consent_revoked?
+      error = 'parental_consent_revoked'
+    elsif !error && user && user.coppa_parental_consent_pending?
       error = 'awaiting_parental_consent'
     end
     if !error && params['2fa_code']
@@ -524,6 +526,9 @@ class SessionController < ApplicationController
         return api_error 400, { error: "Invalid client_secret for client_id", client_id: params['client_id'] }
       end
       if u && u.valid_password?(params['password'])
+        if u.coppa_parental_consent_revoked?
+          return api_error 400, {error: 'parental consent revoked', coppa_parental_consent_revoked: true}
+        end
         if u.coppa_parental_consent_pending?
           return api_error 400, {error: 'awaiting parental consent', coppa_parental_consent_pending: true}
         end
@@ -984,6 +989,9 @@ class SessionController < ApplicationController
   end
 
   def google_finish_login(user, config)
+    if user.coppa_parental_consent_revoked?
+      return redirect_to google_frontend_redirect('/login?coppa_revoked=1', config), allow_other_host: true
+    end
     if user.coppa_parental_consent_pending?
       return redirect_to google_frontend_redirect('/register?coppa_waiting=1', config), allow_other_host: true
     end

--- a/app/frontend/app/components/login-form.js
+++ b/app/frontend/app/components/login-form.js
@@ -1174,10 +1174,10 @@ export default Component.extend({
           _this.appState.set('logging_in', false);
           if(err.error == "Invalid authentication attempt") {
             _this.set('login_error', i18n.t('invalid_login', "Invalid user name or password"));
-          } else if(err.error == "parental consent revoked" || err.coppa_parental_consent_revoked) {
+          } else if(err.coppa_parental_consent_revoked) {
             _this.set('coppa_awaiting_parent', false);
             _this.set('login_error', i18n.t('coppa_login_blocked_parent_consent_revoked', "A parent or guardian withdrew consent for this account. It cannot be used until consent is given again."));
-          } else if(err.error == "awaiting parental consent" || err.coppa_parental_consent_pending) {
+          } else if(err.coppa_parental_consent_pending) {
             _this.set('coppa_awaiting_parent', true);
             _this.set('login_error', i18n.t('coppa_login_blocked_until_parent_consent', "This account is waiting for a parent or guardian to approve it. Ask them to check their email for the approval link."));
           } else if(err.error == "Invalid client secret") {

--- a/app/frontend/app/components/login-form.js
+++ b/app/frontend/app/components/login-form.js
@@ -39,6 +39,7 @@ export default Component.extend({
     var googleLink = params.get('google_link');
     var googleError = params.get('google_error');
     var googlePopout = params.get('google_popout');
+    var coppaRevoked = params.get('coppa_revoked');
     if(!googleLink) {
       try { googleLink = sessionStorage.getItem('google_link_nonce'); } catch (e) { /* ignore */ }
     }
@@ -51,6 +52,10 @@ export default Component.extend({
     }
     if(googlePopout && !this.get('google_popout_id')) {
       this.set('google_popout_id', googlePopout);
+    }
+    if(coppaRevoked && !this.get('login_error')) {
+      this.set('coppa_awaiting_parent', false);
+      this.set('login_error', i18n.t('coppa_login_blocked_parent_consent_revoked', "A parent or guardian withdrew consent for this account. It cannot be used until consent is given again."));
     }
   },
   googleLinkNonceObserver: observer('google_link_nonce', function() {
@@ -1169,6 +1174,9 @@ export default Component.extend({
           _this.appState.set('logging_in', false);
           if(err.error == "Invalid authentication attempt") {
             _this.set('login_error', i18n.t('invalid_login', "Invalid user name or password"));
+          } else if(err.error == "parental consent revoked" || err.coppa_parental_consent_revoked) {
+            _this.set('coppa_awaiting_parent', false);
+            _this.set('login_error', i18n.t('coppa_login_blocked_parent_consent_revoked', "A parent or guardian withdrew consent for this account. It cannot be used until consent is given again."));
           } else if(err.error == "awaiting parental consent" || err.coppa_parental_consent_pending) {
             _this.set('coppa_awaiting_parent', true);
             _this.set('login_error', i18n.t('coppa_login_blocked_until_parent_consent', "This account is waiting for a parent or guardian to approve it. Ask them to check their email for the approval link."));

--- a/app/frontend/app/routes/application.js
+++ b/app/frontend/app/routes/application.js
@@ -45,6 +45,15 @@ export default Route.extend({
   beforeModel: function() {
     if(typeof window === 'undefined') { return; }
     var path = window.location.pathname;
+    if(path.indexOf('/parental_consent/') === 0) {
+      // COPPA email links must hit Rails, not the Ember SPA (see server/index.js proxy).
+      if(window.location.port === '8184') {
+        var qs = window.location.search || '';
+        window.location.replace(window.location.protocol + '//' + window.location.hostname + ':5000' + path + qs);
+        return new RSVP.Promise(function() { /* wait for full-page navigation */ });
+      }
+      return;
+    }
     if(path !== '/auth' && path.indexOf('/auth/') !== 0) { return; }
     // OAuth paths must be handled by Rails, not the Ember SPA. If the app
     // booted here, the /auth proxy did not run — fall back to Rails on :5000.

--- a/app/frontend/server/index.js
+++ b/app/frontend/server/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-// Proxy /auth/* to Rails BEFORE Ember's SPA history fallback.
+// Proxy /auth/* and /parental_consent/* to Rails BEFORE Ember's SPA history fallback.
 // Full-page navigations (window.location) send Accept: text/html, which Ember
-// otherwise answers with index.html — so /auth/google/start never reached Rails
-// and the app routed to /login instead of Google OAuth.
+// otherwise answers with index.html — so /auth/google/start and COPPA email links
+// never reached Rails.
 module.exports = function(app) {
   var frontendHost = process.env.EMBER_DEV_HOST || process.env.FRONTEND_HOST || 'localhost:8184';
   var frontendOrigin = process.env.FRONTEND_ORIGIN || ('http://' + frontendHost);
@@ -29,6 +29,11 @@ module.exports = function(app) {
   function migrationPath(url) {
     var path = (url || '').split('?')[0];
     return path === '/migration' || path.indexOf('/migration/') === 0;
+  }
+
+  function parentalConsentPath(url) {
+    var path = (url || '').split('?')[0];
+    return path === '/parental_consent/complete' || path === '/parental_consent/revoke';
   }
 
   var proxy = require('http-proxy').createProxyServer({
@@ -66,7 +71,7 @@ module.exports = function(app) {
   });
 
   app.use(function(req, res, next) {
-    if(!authPath(req.url) && !migrationPath(req.url)) {
+    if(!authPath(req.url) && !migrationPath(req.url) && !parentalConsentPath(req.url)) {
       return next();
     }
     proxy.web(req, res, { target: 'http://127.0.0.1:5000' });

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -13,6 +13,22 @@ class UserMailer < ActionMailer::Base
     end
   end
 
+  # Queues or immediately delivers parent-facing COPPA mailers. In development,
+  # set INLINE_PARENTAL_CONSENT_EMAIL=1 to bypass Resque (same as signup request).
+  def self.schedule_parent_consent_delivery(delivery_type, user_id)
+    if Rails.env.development? && inline_parental_consent_email?
+      deliver_message(delivery_type, user_id)
+      Rails.logger.info("[COPPA] #{delivery_type} delivered inline for user=#{user_id}")
+    else
+      schedule_delivery(delivery_type, user_id)
+      Rails.logger.info("[COPPA] #{delivery_type} queued for user=#{user_id} (start Resque priority worker, or set INLINE_PARENTAL_CONSENT_EMAIL=1 in development)")
+    end
+  end
+
+  def self.inline_parental_consent_email?
+    %w[1 true yes on].include?(ENV['INLINE_PARENTAL_CONSENT_EMAIL'].to_s.strip.downcase)
+  end
+
   def new_user_registration(user_id)
     @user = User.find_by_global_id(user_id)
     d = @user.devices[0]

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -294,4 +294,64 @@ class UserMailer < ActionMailer::Base
     mail(opts)
   end
 
+  # COPPA email-plus confirmatory message to the parent after they approve the child account.
+  def parental_consent_confirmation(user_id)
+    @user = User.find_by_global_id(user_id)
+    c = (@user && @user.settings) ? @user.settings['coppa'] : nil
+    subject = SystemEmailI18n.resolve('user_mailer/parental_consent_confirmation', 'parental_consent_confirmation_mailer.subject', 'app_name' => app_name)
+
+    unless c.is_a?(Hash) && c['parent_email'].present? && c['parent_consent_granted_at'].present? && c['parent_consent_revoke_token'].present?
+      Rails.logger.warn("Skipping parental_consent_confirmation for user #{user_id}: missing COPPA parent_email, grant timestamp, or revoke token")
+      message = mail(subject: subject)
+      message.perform_deliveries = false
+      return message
+    end
+
+    esc_tok = CGI.escape(c['parent_consent_revoke_token'].to_s)
+    @revoke_url = "#{JsonApi::Json.current_host}/parental_consent/revoke?user_id=#{@user.global_id}&token=#{esc_tok}"
+    @privacy_url = "#{JsonApi::Json.current_host}/privacy"
+    @contact_url = "#{JsonApi::Json.current_host}/contact"
+    @child_name = @user.settings['name']
+    @child_username = @user.display_user_name
+    @parent_email = c['parent_email']
+    @granted_at = begin
+      Time.iso8601(c['parent_consent_granted_at']).utc
+    rescue ArgumentError
+      nil
+    end
+    from = JsonApi::Json.current_domain['settings']['admin_email']
+    opts = {to: @parent_email, subject: subject}
+    opts[:from] = from if !from.blank?
+    mail(opts)
+  end
+
+  # Acknowledges to the parent that parental consent was withdrawn.
+  def parental_consent_revoked(user_id)
+    @user = User.find_by_global_id(user_id)
+    c = (@user && @user.settings) ? @user.settings['coppa'] : nil
+    subject = SystemEmailI18n.resolve('user_mailer/parental_consent_revoked', 'parental_consent_revoked_mailer.subject', 'app_name' => app_name)
+
+    unless c.is_a?(Hash) && c['parent_email'].present? && c['parent_consent_revoked_at'].present?
+      Rails.logger.warn("Skipping parental_consent_revoked for user #{user_id}: missing COPPA parent_email or revoke timestamp")
+      message = mail(subject: subject)
+      message.perform_deliveries = false
+      return message
+    end
+
+    @privacy_url = "#{JsonApi::Json.current_host}/privacy"
+    @contact_url = "#{JsonApi::Json.current_host}/contact"
+    @child_name = @user.settings['name']
+    @child_username = @user.display_user_name
+    @parent_email = c['parent_email']
+    @revoked_at = begin
+      Time.iso8601(c['parent_consent_revoked_at']).utc
+    rescue ArgumentError
+      nil
+    end
+    from = JsonApi::Json.current_domain['settings']['admin_email']
+    opts = {to: @parent_email, subject: subject}
+    opts[:from] = from if !from.blank?
+    mail(opts)
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -381,6 +381,22 @@ class User < ApplicationRecord
     !!c['pending_parent_consent']
   end
 
+  def coppa_parental_consent_revoked?
+    c = self.settings && self.settings['coppa']
+    return false unless c.is_a?(Hash)
+    c['parent_consent_revoked_at'].present?
+  end
+
+  def coppa_parental_consent_active?
+    c = self.settings && self.settings['coppa']
+    return false unless c.is_a?(Hash)
+    c['parent_consent_granted_at'].present? && c['parent_consent_revoked_at'].blank?
+  end
+
+  def coppa_parental_consent_blocks_access?
+    coppa_parental_consent_pending? || coppa_parental_consent_revoked?
+  end
+
   # Parent completes email link with token. Returns true when consent is newly
   # recorded. Mirrors grant_ai_consent! (COPPA 16 CFR 312.5 record-keeping): the
   # settings write, the Privacy Policy acknowledgment, User#save! and an immutable
@@ -418,6 +434,7 @@ class User < ApplicationRecord
       granted_at = Time.now.utc.iso8601
       record_id = SecureRandom.uuid
       c['parent_consent_granted_at'] = granted_at
+      c['parent_consent_revoke_token'] = GoSecure.nonce('parent_consent_revoke')
       c.delete('parent_consent_token')
       c.delete('parent_consent_expires_at')
       c.delete('pending_parent_consent')
@@ -446,6 +463,50 @@ class User < ApplicationRecord
           'record_id' => record_id
         },
         event_type: 'parental_consent_grant',
+        record_id: record_id
+      )
+      res = true
+    end
+    devices.each(&:invalidate_cached_keys) if res
+    res
+  end
+
+  # Parent completes the revoke link from the confirmation email. Returns true when
+  # consent is newly revoked. Mirrors grant_parental_consent!: settings write and
+  # immutable AuditEvent run atomically inside with_lock(requires_new: true).
+  def revoke_parental_consent!(token, ip: nil, user_agent: nil)
+    return false if token.blank?
+    res = false
+    self.with_lock(requires_new: true) do
+      self.settings ||= {}
+      c = self.settings['coppa']
+      next unless c.is_a?(Hash)
+      next if c['parent_consent_revoked_at'].present?
+      next unless c['parent_consent_granted_at'].present?
+      stored = c['parent_consent_revoke_token'].to_s
+      tok = token.to_s
+      next if stored.blank?
+      next if stored.bytesize != tok.bytesize
+      next unless ActiveSupport::SecurityUtils.secure_compare(stored, tok)
+      revoked_at = Time.now.utc.iso8601
+      granted_at = c['parent_consent_granted_at']
+      record_id = SecureRandom.uuid
+      c['parent_consent_revoked_at'] = revoked_at
+      c.delete('parent_consent_revoke_token')
+      self.settings['coppa'] = c
+      self.save!
+      AuditEvent.create!(
+        user_key: self.global_id,
+        data: {
+          'type' => 'parental_consent_revoke',
+          'method' => 'email_token_link',
+          'ip' => ip,
+          'user_agent' => user_agent,
+          'granted_at' => granted_at,
+          'revoked_at' => revoked_at,
+          'record_id' => record_id
+        },
+        event_type: 'parental_consent_revoke',
         record_id: record_id
       )
       res = true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -397,14 +397,35 @@ class User < ApplicationRecord
     coppa_parental_consent_pending? || coppa_parental_consent_revoked?
   end
 
+  # Validates the grant link token from the parental consent request email.
+  # Retained after grant so idempotent revisits require the same secret as the first click.
+  def valid_parent_consent_grant_link_token?(token)
+    parent_consent_link_token_valid?(token, 'parent_consent_token')
+  end
+
+  # Validates the revoke link token from the parental consent confirmation email.
+  def valid_parent_consent_revoke_link_token?(token)
+    parent_consent_link_token_valid?(token, 'parent_consent_revoke_token')
+  end
+
+  def parent_consent_link_token_valid?(token, settings_key)
+    return false if token.blank?
+    c = self.settings && self.settings['coppa']
+    return false unless c.is_a?(Hash)
+    stored = c[settings_key].to_s
+    return false if stored.blank?
+    tok = token.to_s
+    return false if stored.bytesize != tok.bytesize
+    ActiveSupport::SecurityUtils.secure_compare(stored, tok)
+  end
+
   # Parent completes email link with token. Returns true when consent is newly
   # recorded. Mirrors grant_ai_consent! (COPPA 16 CFR 312.5 record-keeping): the
   # settings write, the Privacy Policy acknowledgment, User#save! and an immutable
   # AuditEvent all run inside one `with_lock(requires_new: true)` (SELECT FOR
   # UPDATE + SAVEPOINT). Two consequences that a fail-open, post-save audit could
-  # not give: an audit-insert failure rolls back the consent grant - including the
-  # token invalidation, so the parent can simply retry the same link rather than
-  # being left consented-without-a-record; and concurrent token requests against
+  # not give: an audit-insert failure rolls back the consent grant, so the parent
+  # can simply retry the same link rather than being left consented-without-a-record; and concurrent token requests against
   # the same user are serialized, so the second reloads, sees the committed grant
   # and no-ops instead of double-granting/double-logging. `ip:`/`user_agent:` come
   # from the request so the immutable record identifies where and with what the
@@ -435,7 +456,6 @@ class User < ApplicationRecord
       record_id = SecureRandom.uuid
       c['parent_consent_granted_at'] = granted_at
       c['parent_consent_revoke_token'] = GoSecure.nonce('parent_consent_revoke')
-      c.delete('parent_consent_token')
       c.delete('parent_consent_expires_at')
       c.delete('pending_parent_consent')
       self.settings['coppa'] = c
@@ -492,7 +512,6 @@ class User < ApplicationRecord
       granted_at = c['parent_consent_granted_at']
       record_id = SecureRandom.uuid
       c['parent_consent_revoked_at'] = revoked_at
-      c.delete('parent_consent_revoke_token')
       self.settings['coppa'] = c
       self.save!
       AuditEvent.create!(

--- a/app/views/parental_consents/revoke.html.erb
+++ b/app/views/parental_consents/revoke.html.erb
@@ -1,0 +1,14 @@
+<div class="box">
+  <% app_name = (JsonApi::Json.current_domain['settings'] || {})['app_name'] || 'LingoLinq' %>
+  <% if @success && @already_revoked %>
+    <h1><%= t('parental_consent.revoke_already_title') %></h1>
+    <p><%= t('parental_consent.revoke_already_body') %></p>
+  <% elsif @success %>
+    <h1><%= t('parental_consent.revoke_thanks_title') %></h1>
+    <p><%= t('parental_consent.revoke_thanks_body') %></p>
+  <% else %>
+    <h1><%= t('parental_consent.revoke_invalid_title') %></h1>
+    <p><%= t('parental_consent.revoke_invalid_body') %></p>
+  <% end %>
+  <p><a href="/"><%= t('parental_consent.home_link', app_name: app_name) %></a></p>
+</div>

--- a/app/views/session/oauth.html.erb
+++ b/app/views/session/oauth.html.erb
@@ -80,6 +80,12 @@
                   approval failed, please try logging in
                 </div>
               </div>
+            <% elsif @error == 'parental_consent_revoked' %>
+              <div class='form-group' id='invalid_attempt'>
+                <div class='alert alert-danger'>
+                  <%= t('parental_consent.oauth_login_revoked') %>
+                </div>
+              </div>
             <% elsif @error == 'awaiting_parental_consent' %>
               <div class='form-group' id='invalid_attempt'>
                 <div class='alert alert-danger'>

--- a/app/views/user_mailer/parental_consent_confirmation.html.erb
+++ b/app/views/user_mailer/parental_consent_confirmation.html.erb
@@ -1,0 +1,10 @@
+<p><%= mailer_t('parental_consent_confirmation_mailer.greeting') %></p>
+<p><%= mailer_t('parental_consent_confirmation_mailer.intro', app_name: app_name) %></p>
+<p><%= mailer_t('parental_consent_confirmation_mailer.details', child_name: @child_name.presence || @child_username, child_username: @child_username, granted_at: long_ordinal_date(@granted_at)) %></p>
+<p><%= mailer_t('parental_consent_confirmation_mailer.privacy_notice') %></p>
+<p><a href="<%= @privacy_url %>"><%= @privacy_url %></a></p>
+<p><%= mailer_t('parental_consent_confirmation_mailer.revoke_notice') %></p>
+<p><%= mailer_t('parental_consent_confirmation_mailer.revoke_prompt') %></p>
+<p><a href="<%= @revoke_url %>"><%= @revoke_url %></a></p>
+<p><%= mailer_t('parental_consent_confirmation_mailer.footer', contact_url: @contact_url) %></p>
+<p><%= email_signature %></p>

--- a/app/views/user_mailer/parental_consent_confirmation.text.erb
+++ b/app/views/user_mailer/parental_consent_confirmation.text.erb
@@ -1,0 +1,17 @@
+<%= mailer_t('parental_consent_confirmation_mailer.greeting') %>
+
+<%= mailer_t('parental_consent_confirmation_mailer.intro', app_name: app_name) %>
+
+<%= mailer_t('parental_consent_confirmation_mailer.details', child_name: @child_name.presence || @child_username, child_username: @child_username, granted_at: long_ordinal_date(@granted_at)) %>
+
+<%= mailer_t('parental_consent_confirmation_mailer.privacy_notice') %>
+<%= @privacy_url %>
+
+<%= mailer_t('parental_consent_confirmation_mailer.revoke_notice') %>
+
+<%= mailer_t('parental_consent_confirmation_mailer.revoke_prompt') %>
+<%= @revoke_url %>
+
+<%= mailer_t('parental_consent_confirmation_mailer.footer', contact_url: @contact_url) %>
+
+<%= email_signature %>

--- a/app/views/user_mailer/parental_consent_revoked.html.erb
+++ b/app/views/user_mailer/parental_consent_revoked.html.erb
@@ -1,0 +1,5 @@
+<p><%= mailer_t('parental_consent_revoked_mailer.greeting') %></p>
+<p><%= mailer_t('parental_consent_revoked_mailer.intro', app_name: app_name) %></p>
+<p><%= mailer_t('parental_consent_revoked_mailer.details', child_name: @child_name.presence || @child_username, child_username: @child_username, revoked_at: long_ordinal_date(@revoked_at)) %></p>
+<p><%= mailer_t('parental_consent_revoked_mailer.footer', contact_url: @contact_url) %></p>
+<p><%= email_signature %></p>

--- a/app/views/user_mailer/parental_consent_revoked.text.erb
+++ b/app/views/user_mailer/parental_consent_revoked.text.erb
@@ -1,0 +1,9 @@
+<%= mailer_t('parental_consent_revoked_mailer.greeting') %>
+
+<%= mailer_t('parental_consent_revoked_mailer.intro', app_name: app_name) %>
+
+<%= mailer_t('parental_consent_revoked_mailer.details', child_name: @child_name.presence || @child_username, child_username: @child_username, revoked_at: long_ordinal_date(@revoked_at)) %>
+
+<%= mailer_t('parental_consent_revoked_mailer.footer', contact_url: @contact_url) %>
+
+<%= email_signature %>

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -228,7 +228,7 @@
         "attestedBy": "Scot Wahlquist",
         "attestedDate": "2026-07-06"
       },
-      "contentHash": "d602b713da048b36b8a682154f48fc7f820175238a28db11e8e0f6ade2268d25",
+      "contentHash": "bf8179b6fd45a426053e11a39dfb4195a881680eb9171dde712eb4ede3946af9",
       "bundles": [
         "compliance-records-set-2026-06"
       ],
@@ -406,7 +406,7 @@
         "attestedBy": "Scot Wahlquist",
         "attestedDate": "2026-06-21"
       },
-      "contentHash": "86da72955ba23901e8acaa518dbded3e59b5eee7328404f56f87deb909564f7c",
+      "contentHash": "b826e9beeec37df16a7c470572fa2ea1e97cb0d216179e759fd0da11c17ae244",
       "bundles": [
         "school-dpa-package"
       ],
@@ -435,7 +435,7 @@
         "attestedBy": "Scot Wahlquist",
         "attestedDate": "2026-06-21"
       },
-      "contentHash": "9f467478159ca39d862c9a4d5cd209a6f434cd1ca94c7cfb3224cbbae54fa609",
+      "contentHash": "961c4f5a22f57bfa5d8d9aaa61359b1044060849b6317e2dba23a34eecffb661",
       "bundles": [
         "school-dpa-package"
       ],

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -40,7 +40,7 @@
 | Compliance & Security Program v1.0 (Attested) | Drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | published | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 | Compliance Posture Report | git | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-20 | 2026-09-20 | 2026-06-20 | `a81f72f13bef` | school-dpa-package |
 | Compliance Posture Report (branded) | Drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-07-06 | `d602b713da04` | compliance-records-set-2026-06 |
+| Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-07-06 | `bf8179b6fd45` | compliance-records-set-2026-06 |
 | Records of Processing Activities (RoPA) and Data Map | Drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | published | GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 
 ### evidence (6)
@@ -48,7 +48,7 @@
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | approved | HIPAA | Scot Wahlquist | 2026-05-11 | 2027-05-11 | 2026-06-21 | `dc6a2ba9fa16` |  |
-| COPPA Final-Rule Verification | git | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | approved | COPPA | Scot Wahlquist | 2026-04-26 | 2026-07-26 | 2026-06-21 | `86da72955ba2` | school-dpa-package |
+| COPPA Final-Rule Verification | git | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | approved | COPPA | Scot Wahlquist | 2026-04-26 | 2026-07-26 | 2026-06-21 | `b826e9beeec3` | school-dpa-package |
 | COPPA Final-Rule Verification (branded) | Drive | [open](https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit) | published | COPPA | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
 | Incident Log | git | `docs/legal/INCIDENT_LOG.md` | approved | HIPAA, GDPR | Scot Wahlquist | 2026-05-27 | 2026-08-27 | 2026-06-21 | `e4e7c0b98d3f` | soc2-evidence |
 | Incident Log (branded) | Drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | published | HIPAA, GDPR | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
@@ -89,7 +89,7 @@
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Parental Consent (COPPA / under-13) (branded) | Drive | [open](https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit) | published | COPPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | approved | COPPA | Scot Wahlquist | 2026-06-11 | 2027-06-11 | 2026-06-21 | `9f467478159c` | school-dpa-package |
+| Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | approved | COPPA | Scot Wahlquist | 2026-06-11 | 2027-06-11 | 2026-06-21 | `961c4f5a22f5` | school-dpa-package |
 
 ### agent-config (6)
 

--- a/bin/fresh_start
+++ b/bin/fresh_start
@@ -46,7 +46,7 @@ echo "  Frontend: http://localhost:8184 (proxies API to :5000)"
 echo ""
 cat <<'TIP'
 
-  Tip: COPPA_PARENTAL_CONSENT in .env applies to domain_settings from Rails.
+  Tip: COPPA parental consent is ON by default. Set COPPA_PARENTAL_CONSENT=false in .env only to disable locally.
   Ember on :8184 merges /api/v1/domain_settings after load; open Register once
   backend is up, or use http://localhost:5000 for the same HTML as production.
   If new Ember UI changes (e.g. COPPA on Register) shows on :8184 but not :5000, rebuild

--- a/bin/fresh_start_op
+++ b/bin/fresh_start_op
@@ -47,7 +47,7 @@ echo "  Frontend: http://localhost:8184 (proxies API to :5000)"
 echo ""
 cat <<'TIP'
 
-Tip: COPPA_PARENTAL_CONSENT in .env applies to domain_settings from Rails.
+Tip: COPPA parental consent is ON by default. Set COPPA_PARENTAL_CONSENT=false in .env only to disable locally.
   Ember on :8184 merges /api/v1/domain_settings after load; open Register once
   backend is up, or use http://localhost:5000 for the same HTML as production.
   If new Ember UI changes (e.g. COPPA on Register) shows on :8184 but not :5000, rebuild

--- a/config/initializers/write_freeze.rb
+++ b/config/initializers/write_freeze.rb
@@ -73,7 +73,8 @@ module WriteFreeze
   SIDE_EFFECT_GET_PATHS = [
     'upload_success',               # api/{images,sounds,videos}/:id/upload_success -> record.save
     '^/goal_status/',               # boards#log_goal_status -> UserGoal.process_status_from_code (log write)
-    '^/parental_consent/complete'   # parental_consents#complete -> grant_parental_consent! + Device writes (COPPA)
+    '^/parental_consent/complete',   # parental_consents#complete -> grant_parental_consent! + Device writes (COPPA)
+    '^/parental_consent/revoke'      # parental_consents#revoke -> revoke_parental_consent! (COPPA)
   ].freeze
   SIDE_EFFECT_GET_RE = /#{SIDE_EFFECT_GET_PATHS.join('|')}/
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,8 +31,24 @@ en:
     action_prompt: "If you are the parent or legal guardian, please open the link below to provide consent:"
     privacy_notice: "Before giving consent, please review how we collect, use, and protect your child's information in our Privacy Policy:"
     footer: "If you did not expect this message, you can ignore this email. The account will remain restricted until consent is given or the request expires."
+  parental_consent_confirmation_mailer:
+    subject: "Parental consent confirmed for %{app_name}"
+    greeting: "Hello,"
+    intro: "This message confirms that you approved a %{app_name} account for a child under 13. Your consent has been recorded."
+    details: "Account: %{child_name} (username: %{child_username}). Consent recorded on %{granted_at}."
+    privacy_notice: "You agreed to our Privacy Policy, which describes how we collect, use, and protect your child's information:"
+    revoke_notice: "You may withdraw this consent at any time. If you withdraw consent, the account will be restricted and the child will not be able to sign in until consent is given again."
+    revoke_prompt: "To withdraw consent, open this link:"
+    footer: "If you did not approve this account or have questions, please contact us at %{contact_url}."
+  parental_consent_revoked_mailer:
+    subject: "Parental consent withdrawn for %{app_name}"
+    greeting: "Hello,"
+    intro: "This message confirms that you withdrew your parental consent for a %{app_name} account."
+    details: "Account: %{child_name} (username: %{child_username}). Consent withdrawn on %{revoked_at}. The account is now restricted."
+    footer: "If you did not withdraw consent or have questions, please contact us at %{contact_url}."
   parental_consent:
     oauth_login_blocked: "This account is waiting for a parent or guardian to approve it before you can sign in here."
+    oauth_login_revoked: "A parent or guardian withdrew consent for this account. It cannot be used until consent is given again."
     page_title: "Parental consent"
     already_title: "Consent already recorded"
     already_body: "This account has already been approved. No further action is needed."
@@ -40,6 +56,12 @@ en:
     thanks_body: "Parental consent has been recorded. The account holder can finish setup using the email sent to their address."
     invalid_title: "Link invalid or expired"
     invalid_body: "This consent link is not valid anymore. If you still need to approve an account, ask the registrant to start again or contact support."
+    revoke_already_title: "Consent already withdrawn"
+    revoke_already_body: "Parental consent for this account was already withdrawn. No further action is needed."
+    revoke_thanks_title: "Consent withdrawn"
+    revoke_thanks_body: "Your withdrawal has been recorded. The account is now restricted and the child cannot sign in."
+    revoke_invalid_title: "Link invalid"
+    revoke_invalid_body: "This withdrawal link is not valid anymore. If you need to withdraw consent, contact support."
     home_link: "%{app_name} home"
   ai_consent_disclosures:
     v1:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ LingoLinq::Application.routes.draw do
   get '/privacy_practices' => redirect('/privacy')
   get '/terms' => 'boards#terms'
   get '/parental_consent/complete' => 'parental_consents#complete'
+  get '/parental_consent/revoke' => 'parental_consents#revoke'
   get '/ai_consent/disclosures/:version' => 'ai_consent/disclosures#show'
   get '/jobs' => 'boards#jobs'
   get '/about' => 'boards#about'

--- a/docs/legal/COMPLIANCE_PROGRAM.md
+++ b/docs/legal/COMPLIANCE_PROGRAM.md
@@ -139,10 +139,9 @@ rather than "disclosure" under 16 CFR 312.2, subject to legal confirmation; that
 on the provider not using the data for any other purpose, and it is a stronger fit for
 storage/hosting than for external model vendors (for AI calls, the PiiScrubber-redacts-first
 posture, not the carve-out, is the primary defense). The current flow (child registers, account
-waits, parent confirms via a single tokenized link, consent recorded) is the **first message
-only** and does **not yet satisfy email-plus**: the method is valid under COPPA only once the
-confirmatory second message and an explicit revoke-anytime notice ship. Single-token confirmation
-is the interim state.
+waits, parent confirms via a single tokenized link, consent recorded, parent receives a
+confirmatory email with an explicit revoke-anytime link) satisfies **email-plus** for signup
+consent, pending counsel review of the default copy.
 
 **No credit card is collected at registration.** A $0 authorization or non-charging "card check"
 does not satisfy the FTC credit-card method (which requires a real transaction that notifies the

--- a/docs/legal/COPPA_VERIFICATION_2026-04-26.md
+++ b/docs/legal/COPPA_VERIFICATION_2026-04-26.md
@@ -235,7 +235,7 @@ if !self.id && JsonApi::Json.coppa_parental_consent_enabled? && params['authored
 
 **This is the bypass:** when an Organization with `edit` permission seeds the user (`authored_organization_id` present, lines 992-998 set `settings['authored_organization_id']` and `settings['pending'] = false`), the entire COPPA branch (the under-13 check at lines 960-988 that sets `pending_parent_consent`, `parent_email`, `parent_consent_token`) is **skipped**. The user is created with no `settings['coppa']` hash at all, so `coppa_parental_consent_pending?` returns `false` permanently - appearing "consented" without VPC ever being recorded. **This is the school-official substitute pattern, implemented as an org-authored signup short-circuit.**
 
-`JsonApi::Json.coppa_parental_consent_enabled?` (`lib/json_api/json.rb:127-128`) further requires the current domain to opt in. `JsonApi::User#as_json` at `lib/json_api/user.rb:448` only emits `coppa_parental_consent_pending` when true. `grant_parental_consent!` (`user.rb:378-408`) is the only path that flips the flag for non-org users.
+`JsonApi::Json.coppa_parental_consent_enabled?` (`lib/json_api/json.rb:127-128`) reads the domain setting (default **ON** via env; disable with `COPPA_PARENTAL_CONSENT=0|false|no|off`, or per-org override). `JsonApi::User#as_json` at `lib/json_api/user.rb:448` only emits `coppa_parental_consent_pending` when true. `grant_parental_consent!` (`user.rb:378-408`) is the only path that flips the flag for non-org users.
 
 ### Item 5 - Pre-Consent Bootstrap Init
 

--- a/docs/legal/PARENTAL_CONSENT_EMAIL.md
+++ b/docs/legal/PARENTAL_CONSENT_EMAIL.md
@@ -52,6 +52,25 @@ The mailer method is `UserMailer#parental_consent_request` in `app/mailers/user_
 - The email contains a **one-time** URL: `GET /parental_consent/complete?user_id=<global_id>&token=<secret>`.
 - **Referrer-Policy: no-referrer** is set on that response to reduce token leakage via Referer headers (aligned with supervisor consent patterns).
 - After consent, the minor’s account receives the normal **welcome / confirm registration** email so they can finish email confirmation.
+- The parent receives a **confirmation email** (`UserMailer#parental_consent_confirmation`) acknowledging the approval, summarizing the account, and including a **revoke-anytime** link.
+
+## Confirmation email (COPPA email-plus)
+
+| Piece | Location |
+|--------|-----------|
+| Subject / body | `config/locales/en.yml` → `parental_consent_confirmation_mailer.*` |
+| HTML / text layout | `app/views/user_mailer/parental_consent_confirmation.html.erb`, `.text.erb` |
+| Mailer | `UserMailer#parental_consent_confirmation` |
+| Admin overrides | System Settings → Emails → **Parental consent confirmation** |
+
+The confirmation email includes:
+
+- Acknowledgment that consent was recorded (timestamp + child username)
+- Link to the Privacy Policy
+- Explicit revoke-anytime notice
+- Revoke URL: `GET /parental_consent/revoke?user_id=<global_id>&token=<revoke_secret>`
+
+After a successful revoke, the parent receives `UserMailer#parental_consent_revoked` and the child account is blocked from login until consent is given again.
 
 ## Legal checklist (for counsel)
 
@@ -70,6 +89,6 @@ This is **not** because the parent address is wrong: `UserMailer#parental_consen
 
 ## Changelog
 
-- **2026-06-09** — Admin-editable copy via System Settings (Message content tab) and branding via App defaults / org settings.
+- **2026-07-10** — Added post-approval parent confirmation email and tokenized revoke flow (COPPA email-plus).
 - **2026-04-13** — Initial engineering defaults added with COPPA parental consent feature.
 - **2026-04-14** — Documented Resque + SES and `INLINE_PARENTAL_CONSENT_EMAIL` for local testing.

--- a/docs/legal/PARENTAL_CONSENT_EMAIL.md
+++ b/docs/legal/PARENTAL_CONSENT_EMAIL.md
@@ -1,6 +1,6 @@
 # Parental consent email (COPPA / under-13 registration)
 
-This document describes the **parent-facing email** sent when a new account is created with “under 13” selected and `COPPA_PARENTAL_CONSENT` / `domain_settings.coppa_parental_consent` is enabled.
+This document describes the **parent-facing email** sent when a new account is created with “under 13” selected. The COPPA parental-consent flow is **enabled by default**; set `COPPA_PARENTAL_CONSENT=0` (or `false` / `no` / `off`) in the environment to disable it, or override per org via `domain_settings.coppa_parental_consent`.
 
 ## Editing copy (preferred: System Settings)
 
@@ -53,6 +53,7 @@ The mailer method is `UserMailer#parental_consent_request` in `app/mailers/user_
 - **Referrer-Policy: no-referrer** is set on that response to reduce token leakage via Referer headers (aligned with supervisor consent patterns).
 - After consent, the minor’s account receives the normal **welcome / confirm registration** email so they can finish email confirmation.
 - The parent receives a **confirmation email** (`UserMailer#parental_consent_confirmation`) acknowledging the approval, summarizing the account, and including a **revoke-anytime** link.
+- All parent-facing COPPA emails (`parental_consent_request`, `parental_consent_confirmation`, `parental_consent_revoked`) share the same delivery path via `UserMailer.schedule_parent_consent_delivery`.
 
 ## Confirmation email (COPPA email-plus)
 
@@ -83,7 +84,17 @@ After a successful revoke, the parent receives `UserMailer#parental_consent_revo
 
 1. **Queued mail** — `UserMailer.schedule_delivery` enqueues `UserMailer.deliver_message` on the **Resque `priority` queue** (`app/mailers/concerns/general.rb`). If no **Resque worker** is running, the job never runs and nothing is sent.
 2. **Delivery method** — In `config/environments/development.rb`, Action Mailer uses **`:ses`** (Amazon SES). You need valid **`SES_KEY` / `SES_SECRET`** (or `AWS_KEY` / `AWS_SECRET`) and region. With `raise_delivery_errors = false`, SES failures may not surface as obvious UI errors—check **Rails logs** and the worker log.
-3. **Optional: send during the HTTP request (development only)** — Set **`INLINE_PARENTAL_CONSENT_EMAIL=1`** (or `true` / `yes` / `on`) in the environment for the Rails process. Then `Api::UsersController#create` calls `UserMailer.deliver_message` immediately for the parental consent message instead of queuing it. You still need SES (or change development delivery to `:test` / Letter Opener locally if your team uses that).
+3. **Optional: send during the HTTP request (development only)** — Set **`INLINE_PARENTAL_CONSENT_EMAIL=1`** (or `true` / `yes` / `on`) in the environment for the Rails process. Then all parent-facing COPPA mailers (`parental_consent_request`, `parental_consent_confirmation`, `parental_consent_revoked`) call `UserMailer.deliver_message` immediately instead of queuing. You still need SES (or change development delivery to `:test` / Letter Opener locally if your team uses that).
+
+## Why the parent may not receive mail on localhost
+
+1. **Queued mail** — `UserMailer.schedule_delivery` enqueues `UserMailer.deliver_message` on the **Resque `priority` queue** (`app/mailers/concerns/general.rb`). If no **Resque worker** is running, the job never runs and nothing is sent.
+2. **Delivery method** — In `config/environments/development.rb`, Action Mailer uses **`:ses`** (Amazon SES). You need valid **`SES_KEY` / `SES_SECRET`** (or `AWS_KEY` / `AWS_SECRET`) and region. With `raise_delivery_errors = false`, SES failures may not surface as obvious UI errors—check **Rails logs** and the worker log.
+3. **Optional: send during the HTTP request (development only)** — Set **`INLINE_PARENTAL_CONSENT_EMAIL=1`** (or `true` / `yes` / `on`) in the environment for the Rails process. Then all parent-facing COPPA mailers (`parental_consent_request`, `parental_consent_confirmation`, `parental_consent_revoked`) call `UserMailer.deliver_message` immediately instead of queuing. You still need SES (or change development delivery to `:test` / Letter Opener locally if your team uses that).
+
+## Local dev: consent link on port 8184
+
+Parent email links use `DEFAULT_HOST` (often `http://localhost:8184`). The Ember dev server must **proxy** `/parental_consent/complete` and `/parental_consent/revoke` to Rails (see `app/frontend/server/index.js`, same pattern as `/auth/*`). Without that proxy, the browser gets the Ember SPA shell and the page looks blank. Restart `ember serve` after changing that file. You can also open the link on **`http://localhost:5000/...`** directly to hit Rails.
 
 This is **not** because the parent address is wrong: `UserMailer#parental_consent_request` sets **`mail(to: settings['coppa']['parent_email'])`**, which is the address submitted as `parent_consent_email` at registration.
 

--- a/docs/legal/PARENTAL_CONSENT_EMAIL.md
+++ b/docs/legal/PARENTAL_CONSENT_EMAIL.md
@@ -2,6 +2,8 @@
 
 This document describes the **parent-facing email** sent when a new account is created with “under 13” selected. The COPPA parental-consent flow is **enabled by default**; set `COPPA_PARENTAL_CONSENT=0` (or `false` / `no` / `off`) in the environment to disable it, or override per org via `domain_settings.coppa_parental_consent`.
 
+**Rollout note:** This default is intentional for compliance. Deployments that previously relied on the old opt-in behavior (`COPPA_PARENTAL_CONSENT=1`) need no env change. To keep COPPA off on a specific host, set `COPPA_PARENTAL_CONSENT=false` before deploy.
+
 ## Editing copy (preferred: System Settings)
 
 Admins with **System Settings** access can edit this email without a deploy:

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -189,7 +189,7 @@ module FeatureFlags
   def self.coppa_blocks_ai_for?(user)
     return false unless coppa_ai_hard_gate_enabled?
     return false unless user
-    return false unless user.respond_to?(:coppa_parental_consent_pending?)
-    user.coppa_parental_consent_pending?
+    return false unless user.respond_to?(:coppa_parental_consent_blocks_access?)
+    user.coppa_parental_consent_blocks_access?
   end
 end

--- a/lib/json_api/json.rb
+++ b/lib/json_api/json.rb
@@ -144,10 +144,13 @@ module JsonApi::Json
     LingoLinq::Jurisdiction.eu?(signal) ? EU_COPPA_CONSENT_AGE : DEFAULT_COPPA_CONSENT_AGE
   end
 
-  # Truthy: true, 1, yes, on (case-insensitive). Matches typical .env conventions.
+  # Default ON for COPPA under-13 signup + parental email consent.
+  # Set COPPA_PARENTAL_CONSENT=0|false|no|off only to disable (e.g. legacy dev).
   def self.coppa_parental_consent_from_env?
     v = ENV['COPPA_PARENTAL_CONSENT'].to_s.strip.downcase
-    %w[1 true yes on].include?(v)
+    return false if %w[0 false no off].include?(v)
+
+    true
   end
 
   def self.base_default_domain_settings

--- a/lib/json_api/user.rb
+++ b/lib/json_api/user.rb
@@ -486,6 +486,7 @@ json['preferences']['skin'] = user.settings['preferences']['skin']
     end
     # Exposed for registration (COPPA): lets the client detect pending consent even if response meta is not matched.
     json['coppa_parental_consent_pending'] = true if user.coppa_parental_consent_pending?
+    json['coppa_parental_consent_revoked'] = true if user.coppa_parental_consent_revoked?
     json
   end
 

--- a/lib/system_email_registry.rb
+++ b/lib/system_email_registry.rb
@@ -18,6 +18,46 @@ module SystemEmailRegistry
     { name: '@parent_email', description: 'Parent or guardian email address the message is sent to.' }
   ].freeze
 
+  PARENTAL_CONSENT_CONFIRMATION_I18N_BLOCKS = [
+    { key: 'parental_consent_confirmation_mailer.subject', label: 'Subject line', placeholders: ['app_name'] },
+    { key: 'parental_consent_confirmation_mailer.greeting', label: 'Greeting' },
+    { key: 'parental_consent_confirmation_mailer.intro', label: 'Introduction', placeholders: ['app_name'] },
+    { key: 'parental_consent_confirmation_mailer.details', label: 'Account details', placeholders: ['child_name', 'child_username', 'granted_at'] },
+    { key: 'parental_consent_confirmation_mailer.privacy_notice', label: 'Privacy notice' },
+    { key: 'parental_consent_confirmation_mailer.revoke_notice', label: 'Revoke-anytime notice' },
+    { key: 'parental_consent_confirmation_mailer.revoke_prompt', label: 'Revoke link prompt' },
+    { key: 'parental_consent_confirmation_mailer.footer', label: 'Footer', placeholders: ['contact_url'] }
+  ].freeze
+
+  PARENTAL_CONSENT_CONFIRMATION_DYNAMIC_VARS = [
+    { name: '@revoke_url', description: 'Link for the parent to withdraw consent at any time.' },
+    { name: '@privacy_url', description: 'Link to the Privacy Policy.' },
+    { name: '@contact_url', description: 'Link to contact support.' },
+    { name: '@user', description: 'The child user account.' },
+    { name: '@child_name', description: 'Display name of the child user.' },
+    { name: '@child_username', description: 'Username of the child account.' },
+    { name: '@granted_at', description: 'Timestamp when consent was recorded.' },
+    { name: '@parent_email', description: 'Parent or guardian email address.' }
+  ].freeze
+
+  PARENTAL_CONSENT_REVOKED_I18N_BLOCKS = [
+    { key: 'parental_consent_revoked_mailer.subject', label: 'Subject line', placeholders: ['app_name'] },
+    { key: 'parental_consent_revoked_mailer.greeting', label: 'Greeting' },
+    { key: 'parental_consent_revoked_mailer.intro', label: 'Introduction', placeholders: ['app_name'] },
+    { key: 'parental_consent_revoked_mailer.details', label: 'Account details', placeholders: ['child_name', 'child_username', 'revoked_at'] },
+    { key: 'parental_consent_revoked_mailer.footer', label: 'Footer', placeholders: ['contact_url'] }
+  ].freeze
+
+  PARENTAL_CONSENT_REVOKED_DYNAMIC_VARS = [
+    { name: '@privacy_url', description: 'Link to the Privacy Policy.' },
+    { name: '@contact_url', description: 'Link to contact support.' },
+    { name: '@user', description: 'The child user account.' },
+    { name: '@child_name', description: 'Display name of the child user.' },
+    { name: '@child_username', description: 'Username of the child account.' },
+    { name: '@revoked_at', description: 'Timestamp when consent was withdrawn.' },
+    { name: '@parent_email', description: 'Parent or guardian email address.' }
+  ].freeze
+
   ENTRIES = [
     { mailer: 'user_mailer', action: 'confirm_registration', name: 'Welcome / confirm registration', category: 'Account', recipient_type: 'user', default_subject: 'Welcome!', variables: COMMON_VARS + ['@user'] },
     { mailer: 'user_mailer', action: 'forgot_password', name: 'Forgot password', category: 'Account', recipient_type: 'user', default_subject: 'Forgot Password Confirmation', variables: COMMON_VARS + ['@user', '@users'] },
@@ -35,6 +75,30 @@ module SystemEmailRegistry
       variables: COMMON_VARS + ['@consent_url', '@privacy_url', '@user', '@child_name', '@parent_email'],
       i18n_blocks: PARENTAL_CONSENT_I18N_BLOCKS,
       dynamic_variables: PARENTAL_CONSENT_DYNAMIC_VARS,
+      uses_i18n_subject: true
+    },
+    {
+      mailer: 'user_mailer',
+      action: 'parental_consent_confirmation',
+      name: 'Parental consent confirmation',
+      category: 'Account',
+      recipient_type: 'parent',
+      default_subject: 'Parental Consent Confirmed',
+      variables: COMMON_VARS + ['@revoke_url', '@privacy_url', '@contact_url', '@user', '@child_name', '@child_username', '@granted_at', '@parent_email'],
+      i18n_blocks: PARENTAL_CONSENT_CONFIRMATION_I18N_BLOCKS,
+      dynamic_variables: PARENTAL_CONSENT_CONFIRMATION_DYNAMIC_VARS,
+      uses_i18n_subject: true
+    },
+    {
+      mailer: 'user_mailer',
+      action: 'parental_consent_revoked',
+      name: 'Parental consent withdrawn',
+      category: 'Account',
+      recipient_type: 'parent',
+      default_subject: 'Parental Consent Withdrawn',
+      variables: COMMON_VARS + ['@privacy_url', '@contact_url', '@user', '@child_name', '@child_username', '@revoked_at', '@parent_email'],
+      i18n_blocks: PARENTAL_CONSENT_REVOKED_I18N_BLOCKS,
+      dynamic_variables: PARENTAL_CONSENT_REVOKED_DYNAMIC_VARS,
       uses_i18n_subject: true
     },
     { mailer: 'user_mailer', action: 'badge_awarded', name: 'Badge awarded', category: 'Reports & engagement', recipient_type: 'user', default_subject: 'Badge Awarded', variables: COMMON_VARS + ['@recipient', '@user', '@badge', '@goal', '@for_self'] },

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2403,6 +2403,7 @@
   "google_link_invalid_password": "Password not accepted",
   "invalid_login": "Invalid user name or password",
   "coppa_login_blocked_until_parent_consent": "This account is waiting for a parent or guardian to approve it. Ask them to check their email for the approval link.",
+  "coppa_login_blocked_parent_consent_revoked": "A parent or guardian withdrew consent for this account. It cannot be used until consent is given again.",
   "expired_login": "Your login token is expired, please try again",
   "user_name_changed": "NOTE: User name has changed to \"%{un}\"",
   "coppa_parent_email_resent": "If that email address is correct, the parent or guardian should receive another message shortly.",

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -722,7 +722,7 @@ describe Api::UsersController, :type => :controller do
       end
 
       it "creates a pending minor when authored_organization_id is blank string (Ember serializes empty attrs)" do
-        expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_request, anything).once
+        expect(UserMailer).to receive(:schedule_parent_consent_delivery).with(:parental_consent_request, anything).once
         post :create, params: {:user => {
           'name' => 'coppa_kid_blank_org',
           'email' => 'kid_blank_org@example.com',
@@ -740,7 +740,7 @@ describe Api::UsersController, :type => :controller do
       end
 
       it "creates a pending minor without access token and emails the parent" do
-        expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_request, anything).once
+        expect(UserMailer).to receive(:schedule_parent_consent_delivery).with(:parental_consent_request, anything).once
         expect(UserMailer).not_to receive(:schedule_delivery).with(:confirm_registration, anything)
         expect(UserMailer).not_to receive(:schedule_delivery).with(:new_user_registration, anything)
         expect(ExternalTracker).not_to receive(:track_new_user)
@@ -764,7 +764,7 @@ describe Api::UsersController, :type => :controller do
       end
 
       it "creates a pending minor when Ember sends dasherized attribute keys" do
-        expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_request, anything).once
+        expect(UserMailer).to receive(:schedule_parent_consent_delivery).with(:parental_consent_request, anything).once
         post :create, params: {:user => {
           'name' => 'coppa_kid_dash',
           'email' => 'kid_dash@example.com',
@@ -781,7 +781,7 @@ describe Api::UsersController, :type => :controller do
       end
 
       it "creates a pending minor when Ember sends camelCase attribute keys" do
-        expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_request, anything).once
+        expect(UserMailer).to receive(:schedule_parent_consent_delivery).with(:parental_consent_request, anything).once
         post :create, params: {:user => {
           'name' => 'coppa_kid_camel',
           'email' => 'kid_camel@example.com',
@@ -1667,7 +1667,7 @@ describe Api::UsersController, :type => :controller do
       expect(u).to be_persisted
       expect(u.coppa_parental_consent_pending?).to eq(true)
       RedisInit.default.del("parental_consent_resend:#{u.global_id}")
-      expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_request, u.global_id).once
+      expect(UserMailer).to receive(:schedule_parent_consent_delivery).with(:parental_consent_request, u.global_id).once
       post :resend_parental_consent, params: {
         :client_id => 'browser',
         :client_secret => token,
@@ -1731,7 +1731,7 @@ describe Api::UsersController, :type => :controller do
         'parent_consent_email' => 'parent_throttle@example.com'
       }, {:pending => true})
       RedisInit.default.del("parental_consent_resend:#{u.global_id}")
-      expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_request, u.global_id).once
+      expect(UserMailer).to receive(:schedule_parent_consent_delivery).with(:parental_consent_request, u.global_id).once
       post :resend_parental_consent, params: {
         :client_id => 'browser',
         :client_secret => token,

--- a/spec/controllers/parental_consents_controller_spec.rb
+++ b/spec/controllers/parental_consents_controller_spec.rb
@@ -38,7 +38,7 @@ describe ParentalConsentsController, :type => :controller do
         'parent_consent_email' => 'guardian_pc_mail@example.com'
       }, {:pending => true})
       tok = u.settings['coppa']['parent_consent_token']
-      expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_confirmation, u.global_id)
+      expect(UserMailer).to receive(:schedule_parent_consent_delivery).with(:parental_consent_confirmation, u.global_id)
       expect(UserMailer).to receive(:schedule_delivery).with(:confirm_registration, u.global_id)
       expect(UserMailer).to receive(:schedule_delivery).with(:new_user_registration, u.global_id)
       get :complete, params: {user_id: u.global_id, token: tok}
@@ -127,7 +127,7 @@ describe ParentalConsentsController, :type => :controller do
     it "revokes consent and queues the parent withdrawal email" do
       u = create_granted_minor!('ok')
       revoke_tok = u.settings['coppa']['parent_consent_revoke_token']
-      expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_revoked, u.global_id)
+      expect(UserMailer).to receive(:schedule_parent_consent_delivery).with(:parental_consent_revoked, u.global_id)
       get :revoke, params: {user_id: u.global_id, token: revoke_tok}
       expect(response).to be_successful
       u.reload

--- a/spec/controllers/parental_consents_controller_spec.rb
+++ b/spec/controllers/parental_consents_controller_spec.rb
@@ -57,8 +57,31 @@ describe ParentalConsentsController, :type => :controller do
       }, {:pending => true})
       tok = u.settings['coppa']['parent_consent_token']
       get :complete, params: {user_id: u.global_id, token: tok}
+      expect(UserMailer).not_to receive(:schedule_parent_consent_delivery)
       expect(UserMailer).not_to receive(:schedule_delivery)
       get :complete, params: {user_id: u.global_id, token: tok}
+    end
+
+    it "does not reveal grant status when the token is missing or wrong" do
+      allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+      u = User.process_new({
+        'name' => 'minor_pc_probe',
+        'email' => 'minor_pc_probe@example.com',
+        'password' => 'abcdef',
+        'terms_agree' => true,
+        'coppa_under_13' => true,
+        'parent_consent_email' => 'guardian_pc_probe@example.com'
+      }, {:pending => true})
+      tok = u.settings['coppa']['parent_consent_token']
+      get :complete, params: {user_id: u.global_id, token: tok}
+      u.reload
+      get :complete, params: {user_id: u.global_id}
+      expect(response).to be_successful
+      expect(response.body).to include(I18n.t('parental_consent.invalid_title'))
+      expect(response.body).not_to include(I18n.t('parental_consent.already_title'))
+      get :complete, params: {user_id: u.global_id, token: 'wrong-token'}
+      expect(response.body).to include(I18n.t('parental_consent.invalid_title'))
+      expect(response.body).not_to include(I18n.t('parental_consent.already_title'))
     end
 
     it "writes an immutable AuditEvent recording the consent grant" do
@@ -144,6 +167,20 @@ describe ParentalConsentsController, :type => :controller do
       expect {
         get :revoke, params: {user_id: u.global_id, token: revoke_tok}
       }.to_not change { AuditEvent.where(user_key: u.global_id, event_type: 'parental_consent_revoke').count }
+    end
+
+    it "does not reveal revoke status when the token is missing or wrong" do
+      u = create_granted_minor!('probe')
+      revoke_tok = u.settings['coppa']['parent_consent_revoke_token']
+      get :revoke, params: {user_id: u.global_id, token: revoke_tok}
+      u.reload
+      get :revoke, params: {user_id: u.global_id}
+      expect(response).to be_successful
+      expect(response.body).to include(I18n.t('parental_consent.revoke_invalid_title'))
+      expect(response.body).not_to include(I18n.t('parental_consent.revoke_already_title'))
+      get :revoke, params: {user_id: u.global_id, token: 'wrong-token'}
+      expect(response.body).to include(I18n.t('parental_consent.revoke_invalid_title'))
+      expect(response.body).not_to include(I18n.t('parental_consent.revoke_already_title'))
     end
   end
 end

--- a/spec/controllers/parental_consents_controller_spec.rb
+++ b/spec/controllers/parental_consents_controller_spec.rb
@@ -75,13 +75,15 @@ describe ParentalConsentsController, :type => :controller do
       tok = u.settings['coppa']['parent_consent_token']
       get :complete, params: {user_id: u.global_id, token: tok}
       u.reload
+      # Controller specs do not render views by default; assert assigns that drive
+      # the invalid vs already-granted branches (no body/PII without a valid token).
       get :complete, params: {user_id: u.global_id}
       expect(response).to be_successful
-      expect(response.body).to include(I18n.t('parental_consent.invalid_title'))
-      expect(response.body).not_to include(I18n.t('parental_consent.already_title'))
+      expect(assigns(:success)).to eq(false)
+      expect(assigns(:already_granted)).to eq(false)
       get :complete, params: {user_id: u.global_id, token: 'wrong-token'}
-      expect(response.body).to include(I18n.t('parental_consent.invalid_title'))
-      expect(response.body).not_to include(I18n.t('parental_consent.already_title'))
+      expect(assigns(:success)).to eq(false)
+      expect(assigns(:already_granted)).to eq(false)
     end
 
     it "writes an immutable AuditEvent recording the consent grant" do
@@ -174,13 +176,15 @@ describe ParentalConsentsController, :type => :controller do
       revoke_tok = u.settings['coppa']['parent_consent_revoke_token']
       get :revoke, params: {user_id: u.global_id, token: revoke_tok}
       u.reload
+      # Controller specs do not render views by default; assert assigns that drive
+      # the invalid vs already-revoked branches (no body/PII without a valid token).
       get :revoke, params: {user_id: u.global_id}
       expect(response).to be_successful
-      expect(response.body).to include(I18n.t('parental_consent.revoke_invalid_title'))
-      expect(response.body).not_to include(I18n.t('parental_consent.revoke_already_title'))
+      expect(assigns(:success)).to eq(false)
+      expect(assigns(:already_revoked)).to eq(false)
       get :revoke, params: {user_id: u.global_id, token: 'wrong-token'}
-      expect(response.body).to include(I18n.t('parental_consent.revoke_invalid_title'))
-      expect(response.body).not_to include(I18n.t('parental_consent.revoke_already_title'))
+      expect(assigns(:success)).to eq(false)
+      expect(assigns(:already_revoked)).to eq(false)
     end
   end
 end

--- a/spec/controllers/parental_consents_controller_spec.rb
+++ b/spec/controllers/parental_consents_controller_spec.rb
@@ -22,8 +22,43 @@ describe ParentalConsentsController, :type => :controller do
       expect(response).to be_successful
       u.reload
       expect(u.coppa_parental_consent_pending?).to eq(false)
+      expect(u.settings['coppa']['parent_consent_revoke_token']).to be_present
       d = Device.find_by(user_id: u.id, device_key: 'default', developer_key_id: 0)
       expect((d.settings['keys'] || []).length).to be > 0
+    end
+
+    it "queues the parent confirmation email on a fresh grant only" do
+      allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+      u = User.process_new({
+        'name' => 'minor_pc_mail',
+        'email' => 'minor_pc_mail@example.com',
+        'password' => 'abcdef',
+        'terms_agree' => true,
+        'coppa_under_13' => true,
+        'parent_consent_email' => 'guardian_pc_mail@example.com'
+      }, {:pending => true})
+      tok = u.settings['coppa']['parent_consent_token']
+      expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_confirmation, u.global_id)
+      expect(UserMailer).to receive(:schedule_delivery).with(:confirm_registration, u.global_id)
+      expect(UserMailer).to receive(:schedule_delivery).with(:new_user_registration, u.global_id)
+      get :complete, params: {user_id: u.global_id, token: tok}
+      expect(response).to be_successful
+    end
+
+    it "does not queue the parent confirmation email when consent was already granted" do
+      allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+      u = User.process_new({
+        'name' => 'minor_pc_idem_mail',
+        'email' => 'minor_pc_idem_mail@example.com',
+        'password' => 'abcdef',
+        'terms_agree' => true,
+        'coppa_under_13' => true,
+        'parent_consent_email' => 'guardian_pc_idem_mail@example.com'
+      }, {:pending => true})
+      tok = u.settings['coppa']['parent_consent_token']
+      get :complete, params: {user_id: u.global_id, token: tok}
+      expect(UserMailer).not_to receive(:schedule_delivery)
+      get :complete, params: {user_id: u.global_id, token: tok}
     end
 
     it "writes an immutable AuditEvent recording the consent grant" do
@@ -69,5 +104,46 @@ describe ParentalConsentsController, :type => :controller do
       }.to_not change { AuditEvent.where(user_key: u.global_id).count }
     end
 
+  end
+
+  describe "GET revoke" do
+    after(:each) { AuditEvent.delete_all }
+
+    def create_granted_minor!(suffix)
+      allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+      u = User.process_new({
+        'name' => "minor_revoke_#{suffix}",
+        'email' => "minor_revoke_#{suffix}@example.com",
+        'password' => 'abcdef',
+        'terms_agree' => true,
+        'coppa_under_13' => true,
+        'parent_consent_email' => "guardian_revoke_#{suffix}@example.com"
+      }, {:pending => true})
+      tok = u.settings['coppa']['parent_consent_token']
+      expect(u.grant_parental_consent!(tok)).to eq(true)
+      u.reload
+    end
+
+    it "revokes consent and queues the parent withdrawal email" do
+      u = create_granted_minor!('ok')
+      revoke_tok = u.settings['coppa']['parent_consent_revoke_token']
+      expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_revoked, u.global_id)
+      get :revoke, params: {user_id: u.global_id, token: revoke_tok}
+      expect(response).to be_successful
+      u.reload
+      expect(u.coppa_parental_consent_revoked?).to eq(true)
+      expect(u.coppa_parental_consent_blocks_access?).to eq(true)
+      ae = AuditEvent.where(user_key: u.global_id).detect { |e| e.event_type == 'parental_consent_revoke' }
+      expect(ae).to be_present
+    end
+
+    it "does not record a second revoke AuditEvent when consent was already revoked" do
+      u = create_granted_minor!('idem')
+      revoke_tok = u.settings['coppa']['parent_consent_revoke_token']
+      get :revoke, params: {user_id: u.global_id, token: revoke_tok}
+      expect {
+        get :revoke, params: {user_id: u.global_id, token: revoke_tok}
+      }.to_not change { AuditEvent.where(user_key: u.global_id, event_type: 'parental_consent_revoke').count }
+    end
   end
 end

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -577,6 +577,30 @@ describe SessionController, :type => :controller do
       expect(json['coppa_parental_consent_pending']).to eq(true)
       expect(json['access_token']).to eq(nil)
     end
+
+    it "rejects password token when COPPA parental consent was revoked" do
+      allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+      JsonApi::Json.load_domain('test.host')
+      token = GoSecure.browser_token
+      u = User.process_new({
+        'user_name' => 'coppa_revoked_kid',
+        'name' => 'COPPA Revoked Kid',
+        'email' => 'child_coppa_revoked@example.com',
+        'password' => 'seashell',
+        'terms_agree' => true,
+        'coppa_under_13' => true,
+        'parent_consent_email' => 'parent_coppa_revoked@example.com'
+      }, {:pending => true})
+      expect(u.grant_parental_consent!(u.settings['coppa']['parent_consent_token'])).to eq(true)
+      expect(u.revoke_parental_consent!(u.settings['coppa']['parent_consent_revoke_token'])).to eq(true)
+
+      post :token, params: {:grant_type => 'password', :client_id => 'browser', :client_secret => token, :username => 'coppa_revoked_kid', :password => 'seashell'}
+      expect(response.status).to eq(400)
+      json = JSON.parse(response.body)
+      expect(json['error']).to eq('parental consent revoked')
+      expect(json['coppa_parental_consent_revoked']).to eq(true)
+      expect(json['access_token']).to eq(nil)
+    end
     
 #     it "should not respect expired browser token" do
 #       token = 15.days.ago.strftime('%Y%j')

--- a/spec/initializers/write_freeze_paths_spec.rb
+++ b/spec/initializers/write_freeze_paths_spec.rb
@@ -71,6 +71,7 @@ describe WriteFreeze do
       expect(WriteFreeze.side_effect_get?('/api/v1/videos/1_2/upload_success')).to eq(true)
       expect(WriteFreeze.side_effect_get?('/goal_status/1_2/abc')).to eq(true)
       expect(WriteFreeze.side_effect_get?('/parental_consent/complete')).to eq(true)
+      expect(WriteFreeze.side_effect_get?('/parental_consent/revoke')).to eq(true)
     end
 
     it 'does not flag ordinary read GETs' do
@@ -127,6 +128,7 @@ describe WriteFreeze do
         expect(WriteFreeze.reject?('GET', '/api/v1/videos/1_2/upload_success')).to eq(true)
         expect(WriteFreeze.reject?('GET', '/goal_status/1_2/abc')).to eq(true)
         expect(WriteFreeze.reject?('GET', '/parental_consent/complete')).to eq(true)
+        expect(WriteFreeze.reject?('GET', '/parental_consent/revoke')).to eq(true)
       end
 
       it 'still passes ordinary read GETs' do

--- a/spec/lib/json_api/json_spec.rb
+++ b/spec/lib/json_api/json_spec.rb
@@ -176,13 +176,34 @@ describe JsonApi::Json do
 
     it 'fills coppa_parental_consent from ENV when org host_settings omit it' do
       orig = ENV['COPPA_PARENTAL_CONSENT']
-      ENV['COPPA_PARENTAL_CONSENT'] = '1'
+      ENV.delete('COPPA_PARENTAL_CONSENT')
       begin
         expect(Organization).to receive(:load_domains).and_return({'bacon.com' => {'app_name' => 'bacon'}})
         host = JsonApi::Json.load_domain('bacon.com')
         expect(host['settings']['coppa_parental_consent']).to eq(true)
       ensure
-        ENV['COPPA_PARENTAL_CONSENT'] = orig
+        if orig.nil?
+          ENV.delete('COPPA_PARENTAL_CONSENT')
+        else
+          ENV['COPPA_PARENTAL_CONSENT'] = orig
+        end
+      end
+    end
+
+    it 'disables coppa_parental_consent when COPPA_PARENTAL_CONSENT is explicitly off' do
+      orig = ENV['COPPA_PARENTAL_CONSENT']
+      ENV['COPPA_PARENTAL_CONSENT'] = 'false'
+      begin
+        expect(JsonApi::Json.coppa_parental_consent_from_env?).to eq(false)
+        expect(Organization).to receive(:load_domains).and_return({'bacon.com' => {'app_name' => 'bacon'}})
+        host = JsonApi::Json.load_domain('bacon.com')
+        expect(host['settings']['coppa_parental_consent']).to eq(false)
+      ensure
+        if orig.nil?
+          ENV.delete('COPPA_PARENTAL_CONSENT')
+        else
+          ENV['COPPA_PARENTAL_CONSENT'] = orig
+        end
       end
     end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -147,6 +147,57 @@ describe UserMailer, :type => :mailer do
       expect(html).to include('background-color: #eee')
     end
   end
+
+  describe "parental_consent_confirmation" do
+    after do
+      Setting.find_by(key: SystemEmailTemplates::DEFAULT_KEY)&.destroy
+      RedisInit.default.del("setting/#{SystemEmailTemplates::DEFAULT_KEY}")
+    end
+
+    it "sends to the parent email with a revoke URL after consent is granted" do
+      allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+      JsonApi::Json.load_domain('test.host')
+      u = User.process_new({
+        'name' => 'mail_kid_confirm',
+        'email' => 'kid_confirm@example.com',
+        'password' => 'abcdef',
+        'terms_agree' => true,
+        'coppa_under_13' => true,
+        'parent_consent_email' => 'parent_confirm@example.com'
+      }, {:pending => true})
+      tok = u.settings['coppa']['parent_consent_token']
+      expect(u.grant_parental_consent!(tok)).to eq(true)
+      m = UserMailer.parental_consent_confirmation(u.global_id)
+      expect(m.to).to eq(['parent_confirm@example.com'])
+      expect(m.subject).to eq(I18n.t('parental_consent_confirmation_mailer.subject', app_name: 'LingoLinq'))
+      html = message_body(m, :html)
+      expect(html).to match(/parental_consent\/revoke/)
+    end
+  end
+
+  describe "parental_consent_revoked" do
+    it "sends to the parent email after consent is withdrawn" do
+      allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+      JsonApi::Json.load_domain('test.host')
+      u = User.process_new({
+        'name' => 'mail_kid_revoked',
+        'email' => 'kid_revoked@example.com',
+        'password' => 'abcdef',
+        'terms_agree' => true,
+        'coppa_under_13' => true,
+        'parent_consent_email' => 'parent_revoked@example.com'
+      }, {:pending => true})
+      tok = u.settings['coppa']['parent_consent_token']
+      expect(u.grant_parental_consent!(tok)).to eq(true)
+      revoke_tok = u.settings['coppa']['parent_consent_revoke_token']
+      expect(u.revoke_parental_consent!(revoke_tok)).to eq(true)
+      m = UserMailer.parental_consent_revoked(u.global_id)
+      expect(m.to).to eq(['parent_revoked@example.com'])
+      expect(m.subject).to eq(I18n.t('parental_consent_revoked_mailer.subject', app_name: 'LingoLinq'))
+      html = message_body(m, :html)
+      expect(html).to match(/withdrawn/i)
+    end
+  end
   
   describe "forgot_password" do
     it "should find the correct user" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -81,6 +81,23 @@ describe UserMailer, :type => :mailer do
     end
   end
 
+  describe "schedule_parent_consent_delivery" do
+    it "delivers inline in development when INLINE_PARENTAL_CONSENT_EMAIL is set" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
+      allow(UserMailer).to receive(:inline_parental_consent_email?).and_return(true)
+      expect(UserMailer).to receive(:deliver_message).with(:parental_consent_request, '1_1')
+      expect(UserMailer).not_to receive(:schedule_delivery)
+      UserMailer.schedule_parent_consent_delivery(:parental_consent_request, '1_1')
+    end
+
+    it "queues when not in inline development mode" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('test'))
+      expect(UserMailer).to receive(:schedule_delivery).with(:parental_consent_confirmation, '1_1')
+      expect(UserMailer).not_to receive(:deliver_message)
+      UserMailer.schedule_parent_consent_delivery(:parental_consent_confirmation, '1_1')
+    end
+  end
+
   describe "parental_consent_request" do
     after do
       Setting.find_by(key: SystemEmailTemplates::DEFAULT_KEY)&.destroy

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -673,6 +673,7 @@ describe User, :type => :model do
       expect(u.grant_parental_consent!(token)).to eq(true)
       expect(u.settings['coppa']['parent_consent_revoke_token']).to be_present
       expect(u.coppa_parental_consent_active?).to eq(true)
+      expect(u.valid_parent_consent_grant_link_token?(token)).to eq(true)
     end
 
     it "revoke_parental_consent! records an immutable AuditEvent and blocks access" do
@@ -690,6 +691,8 @@ describe User, :type => :model do
       token = u.settings['coppa']['parent_consent_token']
       expect(u.grant_parental_consent!(token)).to eq(true)
       revoke_tok = u.settings['coppa']['parent_consent_revoke_token']
+      expect(u.valid_parent_consent_revoke_link_token?(revoke_tok)).to eq(true)
+      expect(u.valid_parent_consent_revoke_link_token?('wrong')).to eq(false)
       expect {
         expect(u.revoke_parental_consent!(revoke_tok, ip: '203.0.113.8', user_agent: 'TestAgent/2.0')).to eq(true)
       }.to change { AuditEvent.where(event_type: 'parental_consent_revoke', user_key: u.global_id).count }.by(1)
@@ -697,6 +700,7 @@ describe User, :type => :model do
       expect(u.coppa_parental_consent_revoked?).to eq(true)
       expect(u.coppa_parental_consent_blocks_access?).to eq(true)
       expect(u.coppa_parental_consent_active?).to eq(false)
+      expect(u.valid_parent_consent_revoke_link_token?(revoke_tok)).to eq(true)
       ae = AuditEvent.where(event_type: 'parental_consent_revoke', user_key: u.global_id).last
       expect(ae.data['ip']).to eq('203.0.113.8')
       expect(ae.data['user_agent']).to eq('TestAgent/2.0')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -658,6 +658,50 @@ describe User, :type => :model do
       expect(u2.coppa_parental_consent_pending?).to eq(true)
     end
 
+    it "stores a revoke token when parental consent is granted" do
+      allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+      u = User.new
+      u.process_params({
+        'name' => 'coppa_kid_revoke_token',
+        'email' => 'kidrevoketok@example.com',
+        'terms_agree' => true,
+        'coppa_under_13' => true,
+        'parent_consent_email' => 'parentrevoketok@example.com'
+      }, {})
+      u.save!
+      token = u.settings['coppa']['parent_consent_token']
+      expect(u.grant_parental_consent!(token)).to eq(true)
+      expect(u.settings['coppa']['parent_consent_revoke_token']).to be_present
+      expect(u.coppa_parental_consent_active?).to eq(true)
+    end
+
+    it "revoke_parental_consent! records an immutable AuditEvent and blocks access" do
+      allow(JsonApi::Json).to receive(:coppa_parental_consent_enabled?).and_return(true)
+      AuditEvent.delete_all
+      u = User.new
+      u.process_params({
+        'name' => 'coppa_kid_revoke',
+        'email' => 'kidrevoke@example.com',
+        'terms_agree' => true,
+        'coppa_under_13' => true,
+        'parent_consent_email' => 'parentrevoke@example.com'
+      }, {})
+      u.save!
+      token = u.settings['coppa']['parent_consent_token']
+      expect(u.grant_parental_consent!(token)).to eq(true)
+      revoke_tok = u.settings['coppa']['parent_consent_revoke_token']
+      expect {
+        expect(u.revoke_parental_consent!(revoke_tok, ip: '203.0.113.8', user_agent: 'TestAgent/2.0')).to eq(true)
+      }.to change { AuditEvent.where(event_type: 'parental_consent_revoke', user_key: u.global_id).count }.by(1)
+      u.reload
+      expect(u.coppa_parental_consent_revoked?).to eq(true)
+      expect(u.coppa_parental_consent_blocks_access?).to eq(true)
+      expect(u.coppa_parental_consent_active?).to eq(false)
+      ae = AuditEvent.where(event_type: 'parental_consent_revoke', user_key: u.global_id).last
+      expect(ae.data['ip']).to eq('203.0.113.8')
+      expect(ae.data['user_agent']).to eq('TestAgent/2.0')
+    end
+
     it "should coerce preferences cookies to boolean" do
       u = User.new
       u.settings = {'preferences' => {}}


### PR DESCRIPTION
What's in this PR
Parent confirmation + revoke flow
UserMailer#parental_consent_confirmation — sent on fresh grant only (not idempotent revisits)
UserMailer#parental_consent_revoked — sent after successful revoke
GET /parental_consent/revoke — tokenized revoke landing page
User#grant_parental_consent! / #revoke_parental_consent! — stores revoke token at grant time; writes immutable AuditEvent records
Access helpers: coppa_parental_consent_revoked?, coppa_parental_consent_active?, coppa_parental_consent_blocks_access?
Login gates updated (session API, OAuth page, login form, JSON API user payload)
Email delivery
UserMailer.schedule_parent_consent_delivery — shared path for request, confirmation, and revoke emails
Dev inline delivery via INLINE_PARENTAL_CONSENT_EMAIL=1 applies to all three mailers
COPPA enablement default
COPPA_PARENTAL_CONSENT is now opt-out (enabled unless set to 0 / false / no / off)
Per-org domain_settings.coppa_parental_consent override still supported
Local dev fix
Ember dev server proxies /parental_consent/complete and /parental_consent/revoke to Rails (same pattern as /auth/*)
Fallback redirect in application.js if Ember still boots on those paths
Admin / docs
System Settings email registry entries for confirmation and revoke templates
Updated docs/legal/PARENTAL_CONSENT_EMAIL.md, COMPLIANCE_PROGRAM.md §6.1, COPPA_VERIFICATION_2026-04-26.md
Test plan
 Register an under-13 account → parent receives consent request email
 Click approve link on 8184 → Rails “thanks” page renders (not blank Ember shell)
 Parent receives confirmation email with revoke link; child can log in after approval
 Click revoke link → account blocked at login with revoked message; parent receives revoked email
 Revisit approve/revoke links → idempotent “already granted” / “already revoked” pages (no duplicate emails or audit events)
 With COPPA_PARENTAL_CONSENT=false, under-13 flow and parent emails do not run
 With INLINE_PARENTAL_CONSENT_EMAIL=1 in dev, all three COPPA emails send without a Resque worker
 bundle exec rspec spec/controllers/parental_consents_controller_spec.rb spec/mailers/user_mailer_spec.rb spec/models/user_spec.rb spec/lib/json_api/json_spec.rb
Notes for review
Default English copy in confirmation/revoke emails should get counsel sign-off before production (called out in docs).
Re-consent after revoke and non-English parent emails are follow-ups, not in this PR.