### PR TITLE
Fix Ember onerror validation in CI

### DIFF
--- a/app/frontend/app/app.js
+++ b/app/frontend/app/app.js
@@ -28,6 +28,11 @@ setOnerror(function(err) {
     console.warn('[Ember Data] Suppressed duplicate record ID assertion:', err.message);
     return;
   }
+
+  if(isTesting() || LingoLinq.testing) {
+    throw err;
+  }
+
   // Enhanced debugging for unrecoverable render errors
   if(err && (err.message && err.message.indexOf('unrecoverable error') !== -1 || err.message && err.message.indexOf('Attempted to rerender') !== -1)) {
     console.error('[RENDER ERROR DEBUG] ========== UNRECOVERABLE RENDER ERROR ==========');
@@ -48,10 +53,6 @@ setOnerror(function(err) {
     } else {
       LingoLinq.track_error(JSON.stringify(err), false);
     }
-  }
-  // MUST rethrow when testing - required for test framework validation (after logging)
-  if(isTesting() || LingoLinq.testing) {
-    throw err;
   }
 });
 


### PR DESCRIPTION
## Summary
- Fixes the current main build-and-test failure in ember-qunit's Ember.onerror validation test.
- Preserves the existing duplicate-record-ID suppression.
- In test mode, rethrows Ember errors before production logging calls `LingoLinq.track_error`, avoiding the console.error that Testem counts as a failed run.

## Context
Current main (`5b3b355e`) and PR #594 both fail the same baseline CI check:
- `build-and-test` fails in `Run Ember tests (Chrome Headless)`
- failing test: `ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly`
- summary: `1713 tests, 1672 pass, 40 skip, 1 fail`

This PR is separate from PR #594. It does not touch Docker, Render, GCP, SES, DNS, Cloud Armor, ingress, or LL-42a24ee911.

## Validation
- `git diff --check` passed locally.
- Full Ember validation must run in GitHub Actions because the failure is in the CI browser/Testem path.