### PR TITLE
fix: avoid test-mode Ember onerror logging

### DIFF
--- a/app/frontend/app/app.js
+++ b/app/frontend/app/app.js
@@ -28,6 +28,11 @@ setOnerror(function(err) {
     console.warn('[Ember Data] Suppressed duplicate record ID assertion:', err.message);
     return;
   }
+
+  if(isTesting() || LingoLinq.testing) {
+    throw err;
+  }
+
   // Enhanced debugging for unrecoverable render errors
   if(err && (err.message && err.message.indexOf('unrecoverable error') !== -1 || err.message && err.message.indexOf('Attempted to rerender') !== -1)) {
     console.error('[RENDER ERROR DEBUG] ========== UNRECOVERABLE RENDER ERROR ==========');
@@ -48,10 +53,6 @@ setOnerror(function(err) {
     } else {
       LingoLinq.track_error(JSON.stringify(err), false);
     }
-  }
-  // MUST rethrow when testing - required for test framework validation (after logging)
-  if(isTesting() || LingoLinq.testing) {
-    throw err;
   }
 });
 


### PR DESCRIPTION
## Summary
- Moves the test-mode Ember.onerror rethrow before production error logging.
- Preserves the existing duplicate-record-ID suppression.
- Keeps the fix scoped to app/frontend/app/app.js so staging CI can pass again.

## Context
PR #601 is blocked by the same Ember CI baseline failure that PR #598 already fixed against main. Directly retargeting #598 to staging is unsafe because that branch carries a large main-vs-staging diff. This PR cherry-picks only the one-file fix onto staging.

## Validation
- git diff --check passed locally.
- Existing PR #598 has the same one-file fix and green build-and-test.
- Full Ember validation must run in GitHub Actions because the failure is in the CI browser/Testem path.