### PR TITLE
docs: add PR Preflight gate (P1-P6) to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,72 @@ New user-facing features MUST be added behind a feature flag (`lib/feature_flags
 - Console access: use `bin/audit_console` (sets `USER_KEY` so console record-writes are attributed to you via PaperTrail, and works from the Render Shell tab, a Cloud Run exec shell, or locally), not a bare `rails console`. NOTE: `USER_KEY` is self-asserted free text, not derived from an authenticated principal, so the attributed actor is spoofable and the wrapper is opt-in (a bare `rails console` bypasses it with no attribution). The per-session `AuditEvent` logging this is meant to feed is also currently non-operative on the Ruby 3.4 / Reline stack (Readline hook bypassed; `ARGV_COMMAND` undefined at boot so the un-keyed-console refusal never fires). All three gaps are tracked as open finding LL-7f7372e3eb
 - Protected IDs require nonce to prevent snooping
 
+## PR Preflight (MANDATORY before opening a PR or pushing to an open PR)
+
+### P1. Claim Verification Gate
+Every factual claim in the PR title, PR body, or any touched doc must be verified
+against the CURRENT head, not against the plan, memory, or a prior session.
+- Before writing "X is fixed/built/supported": open the file and confirm at HEAD.
+- Any claim about a provider, integration, or capability (Anthropic, Gemini, SES,
+  ZDR, BAA, encryption, retention) requires a fresh grep of runtime code first:
+  git grep -n -i "gemini\|anthropic\|ses_\|zdr" -- lib/ app/ config/ ':!spec'
+- BANNED phrases in PR bodies unless backed by a per-path test or trace:
+  "both paths", "all call sites", "fully fixed", "no longer possible".
+- Plans are hypotheses. If executing a plan written in another session, re-verify
+  every file-level claim in the plan before implementing. This extends the
+  Plans B/D read-first rule to ALL plans.
+
+### P2. Entry-Point Enumeration (any auth/access/visibility change)
+Before coding, enumerate every path to the resource:
+  1. fresh server-rendered navigation
+  2. client-side SPA transition (Ember)
+  3. direct API call (verify with curl using raw params)
+  4. offline/cached content
+Enforcement lives at the server/API (Rails) layer. Client-side Ember flags are UX
+polish, never the security boundary. The PR body must include:
+  | Entry point | Enforced at | Test |
+Any path not covered is listed under "Not covered", not omitted.
+
+### P3. Generated Artifacts + Git Metadata (compliance/register PRs)
+Run before every push (these mirror the CI job `audit-artifacts-integrity`, so a
+green preflight means that job will not block the PR):
+  ruby scripts/compliance-notion-publish.rb            # regenerates the Notion page on disk
+  ruby scripts/compliance-notion-publish.rb --check     # exit 1 if the page drifts from FINDINGS
+  ruby scripts/document-register-render.rb --check       # exit 1 on register / hash / bundle drift
+  ruby scripts/compliance-calendar-render.rb --check     # exit 1 if calendar render drifts
+  ruby scripts/compliance-publication-status.rb --check  # exit 1 if publication-status report drifts
+  ruby scripts/capability-check.rb --check               # exit 1 if capability-ledger currentEvidence fails to resolve at HEAD / negativeEvidence scoping drifts
+  git diff --check                                       # whitespace / conflict markers
+  # exec-bit: only for CHANGED scripts that a doc/skill invokes DIRECTLY (./script),
+  # not every non-exec file in scripts/ (most .rb/.py run via `ruby`/`python` and are
+  # correctly 100644). List the directly-invoked ones explicitly, e.g.:
+  #   for s in scripts/regen-ledger.sh; do
+  #     git ls-files -s "$s" | awk '$1 !~ /^100755/ {print "NOT EXECUTABLE: " $4}'
+  #   done
+If a doc instructs running a script directly (./script, no interpreter prefix), the
+executable bit is part of the PR. If a check fails, fix it in THIS PR before pushing.
+
+### P4. Cross-Doc Consistency Sweep (touching docs/legal/** or audit-reports/**)
+When changing any claim in one compliance doc:
+  git grep -n -i "<subject>" -- docs/legal/ audit-reports/
+Reconcile every instance in the same PR, OR list the known-stale files in the PR
+body as explicit follow-ups. A register/ledger row marked "built" needs its
+evidence resolvable at HEAD, never only at a historical SHA.
+
+### P5. Honest Status Block (required in every PR body)
+## Fix status
+| Item | Status (Fixed / Partial: <scope> / Not fixed) | Evidence (file:line or spec) |
+## Not covered by this PR
+- <explicit list; "none" is acceptable only after P2>
+## Author-Model: <fable-5 | sonnet-x | opus-x | haiku-x>
+
+### P6. Behavioral Definition of Done (UI flows)
+Done = the full lifecycle works: action completes, modal closes/resolves, caller
+callback fires, list refreshes, success AND failure states are visible. A persisted
+record with a stuck UI is a High bug, not a partial success. If you cannot execute
+the flow, say so in the PR body and request a manual click-test of the SPECIFIC
+steps, listed.
+
 ## Environment Setup
 
 **Required services:**


### PR DESCRIPTION
Deliverable 1 of 2 from the 2026-07-12 "why Codex catches so many issues" thread. Adds a mandatory `## PR Preflight` section to `CLAUDE.md` that shifts the highest-frequency reviewer-caught miss classes left of CI and review: claim-vs-HEAD verification (P1), entry-point enumeration for auth/access changes (P2), generated-artifact + git-metadata checks that mirror the `audit-artifacts-integrity` CI job (P3), cross-doc consistency sweep (P4), an honest status block required in every PR body (P5), and a behavioral definition of done for UI flows (P6).

Docs-only change to an agent-instruction file. No feature flag, no i18n, no runtime code touched.

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| P1-P6 block inserted after `### Security` | Fixed | `CLAUDE.md` new `## PR Preflight` section |
| P3 lists every check the CI gate runs | Fixed | matches all 5 in `.github/workflows/ci.yml:115` audit-artifacts-integrity (calendar, notion, document-register, publication-status, capability-check) |
| All cited scripts exist and accept `--check` | Fixed | verified at HEAD for all 5 |
| exec-bit check scoped to directly-invoked changed scripts (not all of scripts/) | Fixed | P3 comment block |

## Not covered by this PR
- The Codex-review pipeline itself (Deliverable 2) is a separate build, tracked in `ai-company-brain outputs/docs/2026-07-12-codex-review-pipeline-build-spec.md`.
- P6 behavioral coverage is a documentation rule only; no automated UI smoke suite is added here.

## Author-Model: opus-4.8

## Review note
A Codex senior-dev pass on the first commit caught that P3 omitted the 5th CI check (`capability-check.rb --check`, ci.yml:139), which would have let a green preflight still fail the CI gate on capability-ledger drift. Verified against HEAD and amended before this PR was opened. That miss-then-catch is the exact pattern this gate exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)