### PR TITLE
feat(codex-review): scaffold Codex review pipeline (Actions side)

### DIFF
--- a/.github/codex/REVIEW-MEMORY.md
+++ b/.github/codex/REVIEW-MEMORY.md
@@ -1,0 +1,58 @@
+# Codex review memory
+
+Curated rules the automated reviewer has learned across sessions. Each entry
+names the source so a rule can be re-evaluated if its origin turns out to be
+wrong. This file is injected into every review prompt (see
+`.github/codex/review-prompt.md`) -- keep it under ~200 lines and free of raw
+session excerpts or any identifiable data; it is not `audit-reports/` or
+`docs/legal/` territory, but treat it as reviewer-facing, not user-facing.
+
+When a human overrides a verdict, or a post-merge bug slips through review,
+append one short rule here in its own small PR. Do not batch memory edits
+into an unrelated PR.
+
+## Rules
+
+- **Register drift is a merge blocker, not a style nit.** The
+  `audit-artifacts-integrity` CI job runs five `--check` scripts
+  (`compliance-calendar-render.rb`, `compliance-notion-publish.rb`,
+  `document-register-render.rb`, `compliance-publication-status.rb`,
+  `capability-check.rb`). A PR that edits `audit-reports/FINDINGS.json` or
+  `audit-reports/DOCUMENT-REGISTER.json` without regenerating the
+  corresponding rendered artifact will fail this gate. Verify by actually
+  running the `--check` scripts, not by reading the diff.
+  -- source: repo convention, `reference_register_edit_regenerate_artifacts`.
+
+- **Stale provider-version wording is a real finding, not pedantry.**
+  Compliance and infra docs that name a specific model/CLI version
+  (`gpt-5.5`, `codex-cli 0.144.1`, etc.) drift silently. If a PR touches a
+  doc naming a provider/version, confirm the version claim against the live
+  tool (`codex --version`, vendor changelog) rather than assuming the doc is
+  current.
+
+- **Flaky `persistence-sync` timing failures on `main`-targeting PRs are CI
+  noise, not a regression the PR introduced.** `main` has no required
+  status checks, so this does not block merge; do not raise it as a
+  blocking finding unless the PR's diff touches `persistence.js` sync logic
+  directly. -- source: `reference_main_build_and_test_persistence_sync_flake`.
+
+- **A negative existence claim ("file X does not exist") requires the same
+  evidence standard as a positive claim.** Search all roots (`lib/`, `app/`,
+  `config/`), not only `app/`, before asserting absence. A prior review round
+  of this very pipeline's design spec wrongly claimed
+  `lib/json_api/lesson.rb` did not exist because the search was scoped to
+  `app/` only. -- source: this pipeline's own build spec, round 1 -> round 2
+  correction (FLAG-3 reversal).
+
+- **Policy changes must update every canonical consumer in the same PR.**
+  Before approving an edit to a cross-cutting policy file (e.g.
+  `instructions/shared/compliance.md`), grep `instructions/`, `commands/`,
+  and `agents/` for other files stating the same rule. A policy edit that
+  updates one consumer and leaves siblings contradicting it is a finding,
+  not a nitpick. -- source: this pipeline's build spec, round 3 (High).
+
+- **"Approved reviewer" requires a registry entry naming the approver.** A
+  policy document may not self-approve its own examples (e.g. listing a
+  model as an approved Tier 2 reviewer without a row in the approved-
+  reviewers table naming who approved it and when). -- source: this
+  pipeline's build spec, round 3 (High).

--- a/.github/codex/review-prompt.md
+++ b/.github/codex/review-prompt.md
@@ -1,0 +1,90 @@
+# Codex senior-dev review
+
+You are a senior software engineer performing a blocker-first review of a pull
+request against `lingolinq/LingoLinq-AAC`. You have read-only shell access
+(`--sandbox read-only`): use it. Grep, read files, and inspect git metadata
+yourself rather than trusting the diff or the PR description at face value.
+
+## Verdicts
+
+Return exactly one of:
+
+- `APPROVE` -- no blocking issues found.
+- `REQUEST_CHANGES` -- one or more findings must be fixed before merge.
+- `NEEDS_HUMAN` -- the issue is a product-judgment call, not a code defect.
+  Use this instead of guessing when the right answer depends on intent you
+  cannot verify from the repo alone.
+
+## Injected live state
+
+<!-- CI_INJECT:LIVE_STATE -->
+PR metadata (`gh pr view`): mergeable state, mergeStateStatus, head SHA.
+Full CI check results (`gh pr checks`): rspec, build-and-test,
+audit-artifacts-integrity, security-scan, secret-detection.
+Changed-file list WITH git modes (`git ls-files -s` on changed paths).
+<!-- /CI_INJECT:LIVE_STATE -->
+
+## Injected memory
+
+<!-- CI_INJECT:REVIEW_MEMORY -->
+Contents of `.github/codex/REVIEW-MEMORY.md` at HEAD, verbatim.
+<!-- /CI_INJECT:REVIEW_MEMORY -->
+
+## Mandated checklist
+
+Work through all six items. Do not skip any because the diff "looks small."
+
+1. Verify every PR-body claim against files at HEAD; quote `file:line` for
+   each claim you check, whether it holds up or not.
+2. For any auth / access / visibility change, enumerate every entry point
+   (controller action, serializer, route, background job) and confirm each
+   is server-enforced, not just hidden in the UI.
+3. Run the drift checks this repo's `audit-artifacts-integrity` CI job runs,
+   and read their actual output (don't assume they'd pass):
+   - `ruby scripts/compliance-calendar-render.rb --check`
+   - `ruby scripts/compliance-notion-publish.rb --check`
+   - `ruby scripts/document-register-render.rb --check`
+   - `ruby scripts/compliance-publication-status.rb --check`
+   - `ruby scripts/capability-check.rb --check`
+4. Check git file modes on any script referenced in the diff or PR body as
+   directly runnable (e.g. `./scripts/foo.sh`) -- expect `100755`. A script
+   invoked as `bash scripts/foo.sh` does not need the exec bit.
+5. Grep `docs/legal/` and `audit-reports/` for any existing claim that
+   contradicts what this PR changes.
+6. Confirm the `mergeable` state and required-check status on the CURRENT
+   head SHA, not a stale local checkout.
+
+A negative existence claim ("X does not exist") requires the same
+`file:line` evidence standard as a positive claim -- search all roots
+(`lib/`, `app/`, `config/`, not just `app/`) before asserting absence.
+
+## Prior-loop context (loop 2 only)
+
+<!-- CI_INJECT:PRIOR_LOOP -->
+If this is loop 2: the previous review's JSON verdict, plus a diff-since-
+last-review. Verify each prior finding is resolved at the new head; do not
+re-litigate resolved findings. Raise a new finding only if it was introduced
+by the fix commits themselves.
+<!-- /CI_INJECT:PRIOR_LOOP -->
+
+## Output contract
+
+Respond with JSON matching `.github/codex/review-schema.json` exactly
+(passed via `--output-schema`). No prose outside the JSON object.
+
+Example instance (few-shot only, not the schema):
+
+```json
+{ "verdict": "REQUEST_CHANGES", "head_sha": "2e46822",
+  "findings": [{ "id": "CR-1", "severity": "HIGH", "category": "claim_vs_code",
+    "file": "app/models/lesson.rb", "line": 77,
+    "description": "PR body says both nav paths gated; SPA path still fetches on invalid token",
+    "evidence": "lib/json_api/lesson.rb:11 serializes full content with no token recheck",
+    "suggested_fix": "gate at api/lessons_controller.rb before serialize",
+    "verifiable_check": "rspec spec/controllers/api/lessons_controller_spec.rb -e 'expired token SPA'" }],
+  "checks_run": { "register_drift": "n/a", "modes": "pass", "ci": "2 failing" },
+  "resolved_from_prior_loop": [] }
+```
+
+`verifiable_check` is what lets a loop-2 pass converge instead of arguing --
+name a concrete command or test that proves the finding is resolved.

--- a/.github/codex/review-schema.json
+++ b/.github/codex/review-schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["verdict", "head_sha", "findings", "checks_run", "resolved_from_prior_loop"],
+  "properties": {
+    "verdict": { "type": "string", "enum": ["APPROVE", "REQUEST_CHANGES", "NEEDS_HUMAN"] },
+    "head_sha": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "severity", "category", "file", "line", "description", "evidence", "suggested_fix", "verifiable_check"],
+        "properties": {
+          "id": { "type": "string" },
+          "severity": { "type": "string", "enum": ["HIGH", "MED", "LOW"] },
+          "category": { "type": "string", "enum": ["claim_vs_code", "artifact_metadata", "path_coverage", "live_state", "design", "code"] },
+          "file": { "type": "string" },
+          "line": { "type": ["integer", "null"], "minimum": 0 },
+          "description": { "type": "string" },
+          "evidence": { "type": "string" },
+          "suggested_fix": { "type": "string" },
+          "verifiable_check": { "type": "string" }
+        }
+      }
+    },
+    "checks_run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["register_drift", "modes", "ci"],
+      "properties": {
+        "register_drift": { "type": "string", "enum": ["pass", "fail", "n/a"] },
+        "modes": { "type": "string" },
+        "ci": { "type": "string" }
+      }
+    },
+    "resolved_from_prior_loop": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -1,0 +1,97 @@
+name: Claude Fix
+
+# Build order step 8 (last). Dispatched by n8n W2 when a Codex/claude-deep
+# verdict is REQUEST_CHANGES and loop_n < 2. Runs headless Claude Code against
+# the findings JSON, commits a fix, and pushes back to the SAME PR branch --
+# the push's `synchronize` event re-enters W1 with loop_n + 1.
+#
+# SHIPPING POSTURE (build spec section 9, step 8): ship this workflow with
+# the fix step DISABLED for the first week of review-only operation, to
+# calibrate Codex's automated verdict quality against interactive sessions
+# before letting it drive an autonomous commit loop. Flip
+# vars.CLAUDE_FIX_ENABLED to "true" only after that calibration period.
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to fix"
+        required: true
+        type: string
+      head_ref:
+        description: "PR branch name to check out and push back to"
+        required: true
+        type: string
+      findings_json:
+        description: "The REQUEST_CHANGES findings array (JSON string) from the review verdict"
+        required: true
+        type: string
+      loop_n:
+        description: "Review loop counter this fix is responding to"
+        required: true
+        type: string
+
+jobs:
+  claude-fix:
+    if: vars.CLAUDE_FIX_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+      HEAD_REF: ${{ inputs.head_ref }}
+      LOOP_N: ${{ inputs.loop_n }}
+    steps:
+      - name: Validate inputs
+        run: |
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number is not numeric" >&2; exit 1
+          fi
+          if ! [[ "$LOOP_N" =~ ^[0-9]+$ ]]; then
+            echo "::error::loop_n is not numeric" >&2; exit 1
+          fi
+          # head_ref is a branch name, not a shell/ref-metacharacter payload;
+          # restrict to characters git branch names can legally contain plus
+          # our own scot/<type>/<slug> convention.
+          if ! [[ "$HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::head_ref contains unexpected characters" >&2; exit 1
+          fi
+
+      - name: Write findings to a file (avoid interpolating JSON into a shell command)
+        env:
+          FINDINGS_JSON: ${{ inputs.findings_json }}
+        run: |
+          printf '%s' "$FINDINGS_JSON" > /tmp/findings.json
+          python3 -c "import json; json.load(open('/tmp/findings.json'))"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.head_ref }}
+          fetch-depth: 0
+
+      - name: Run headless Claude Code fix pass
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_FIX_API_KEY }}
+        run: |
+          echo "::add-mask::$ANTHROPIC_API_KEY"
+          scripts/codex-review-claude-fix.sh /tmp/findings.json "$LOOP_N"
+
+      - name: Run CLAUDE.md P1-P6 preflight before pushing
+        run: scripts/claude-preflight-check.sh
+
+      - name: Commit and push fix
+        run: |
+          git config user.name "claude-fix[bot]"
+          git config user.email "claude-fix@lingolinq.noreply.github.com"
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "No changes produced by the fix pass; nothing to commit." >&2
+            exit 1
+          fi
+          git add -A
+          git commit -m "fix(codex-review): address loop ${LOOP_N} findings" \
+            -m "Findings addressed per the codex-review verdict on PR #${PR_NUMBER}. Any disputed finding is marked in the PR comment, not silently skipped."
+          git push origin "HEAD:${HEAD_REF}"
+
+      - name: Comment finding-id -> commit SHA mapping
+        run: |
+          SHA="$(git rev-parse HEAD)"
+          scripts/codex-review-post-fix-comment.sh "$PR_NUMBER" "$SHA" /tmp/findings.json

--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -34,6 +34,10 @@ jobs:
   claude-fix:
     if: vars.CLAUDE_FIX_ENABLED == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -39,6 +39,10 @@ on:
 jobs:
   codex-review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: read
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ inputs.pr_number }}
@@ -46,38 +50,47 @@ jobs:
       BASE_SHA: ${{ inputs.base_sha }}
       LOOP_N: ${{ inputs.loop_n }}
     steps:
-      - name: Validate inputs (fail closed before anything else touches them)
+      # Codex review of this pipeline (PR #607) caught that the fail-closed
+      # anchor was not actually first: the old single validate-inputs step
+      # ran before the pending status existed, so a malformed dispatch input
+      # meant NO status was ever posted -- silently invisible to the 30-min
+      # watchdog sweep, which only detects a status stuck at `pending`. Fix:
+      # validate only what's needed to safely address the status API
+      # (head_sha), set pending, THEN validate everything else -- flipping
+      # the status straight to `failure` on bad input instead of leaving it
+      # for the watchdog to notice half an hour later.
+      - name: Validate head_sha (minimum needed before it is safe to use in the status API)
         run: |
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "::error::pr_number is not numeric: refusing to proceed" >&2
-            exit 1
-          fi
           if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
-            echo "::error::head_sha is not a hex SHA: refusing to proceed" >&2
+            echo "::error::head_sha is not a hex SHA: no status can be posted for an unverified ref, refusing to proceed" >&2
             exit 1
           fi
-          if ! [[ "$BASE_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
-            echo "::error::base_sha is not a hex SHA: refusing to proceed" >&2
-            exit 1
-          fi
-          if ! [[ "$LOOP_N" =~ ^[0-9]+$ ]]; then
-            echo "::error::loop_n is not numeric: refusing to proceed" >&2
-            exit 1
-          fi
-          if ! [[ "$REVIEWER_ROUTE" =~ ^(codex|claude-deep)$ ]]; then
-            echo "::error::reviewer_route must be codex or claude-deep: refusing to proceed" >&2
-            exit 1
-          fi
-        env:
-          REVIEWER_ROUTE: ${{ inputs.reviewer_route }}
 
-      - name: Set codex-review/deep-pass = pending (fail-closed anchor, must be first)
+      - name: Set codex-review/deep-pass = pending (fail-closed anchor, first step able to act)
         run: |
           gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
             -f state=pending \
             -f context=codex-review/deep-pass \
             -f description="Codex review running (loop ${LOOP_N})" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Validate remaining inputs (flip status to failure on bad input, don't just leave it pending)
+        run: |
+          fail() {
+            gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+              -f state=failure \
+              -f context=codex-review/deep-pass \
+              -f description="$1" \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "::error::$1" >&2
+            exit 1
+          }
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || fail "pr_number is not numeric"
+          [[ "$BASE_SHA" =~ ^[0-9a-f]{7,40}$ ]] || fail "base_sha is not a hex SHA"
+          [[ "$LOOP_N" =~ ^[0-9]+$ ]] || fail "loop_n is not numeric"
+          [[ "$REVIEWER_ROUTE" =~ ^(codex|claude-deep)$ ]] || fail "reviewer_route must be codex or claude-deep"
+        env:
+          REVIEWER_ROUTE: ${{ inputs.reviewer_route }}
 
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -173,9 +186,21 @@ jobs:
           }
           JSONEOF
 
+      - name: Build W2 envelope (CI-trusted routing fields wrap the model's review JSON)
+        # Codex review of this pipeline (PR #607) flagged that POSTing
+        # /tmp/review.json alone means W2 would have to trust the model's
+        # OWN self-reported head_sha/etc. for routing (which PR to comment
+        # on, which status to resolve). Wrap it in an envelope of
+        # Actions-validated values instead, so W2 routes off CI ground
+        # truth, not model output.
+        run: python3 scripts/codex-review-build-envelope.py /tmp/review.json /tmp/envelope.json
+        env:
+          REVIEWER_ROUTE: ${{ steps.classify.outputs.reviewer_route }}
+          RUN_ID: ${{ github.run_id }}
+
       - name: POST result to n8n W2 and verify status resolved
         run: |
-          RESULT_JSON="$(cat /tmp/review.json)"
+          RESULT_JSON="$(cat /tmp/envelope.json)"
           HTTP_STATUS="$(curl -sS -o /tmp/w2-response.json -w '%{http_code}' \
             -X POST "${{ secrets.N8N_CODEX_RESULTS_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -92,6 +92,26 @@ jobs:
         env:
           REVIEWER_ROUTE: ${{ inputs.reviewer_route }}
 
+      - name: Bind pr_number to head_sha (refuse a stale/mismatched W1 dispatch)
+        # Codex review flagged that pr_number and head_sha were trusted
+        # independently with no cross-check they name the same commit. A
+        # stale or wrong W1 dispatch (e.g. a race between two pushes) could
+        # otherwise gather live state / comment on one PR while setting the
+        # commit status, and now the W2 envelope, on a different SHA. Refuse
+        # to proceed -- and flip the status to failure -- if pr_number's
+        # actual current head doesn't match the dispatched head_sha.
+        run: |
+          ACTUAL_HEAD="$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')"
+          if [ "$ACTUAL_HEAD" != "$HEAD_SHA" ]; then
+            gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+              -f state=failure \
+              -f context=codex-review/deep-pass \
+              -f description="pr_number ${PR_NUMBER}'s current head (${ACTUAL_HEAD}) does not match dispatched head_sha" \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "::error::pr_number ${PR_NUMBER} head is ${ACTUAL_HEAD}, but dispatch head_sha was ${HEAD_SHA}: refusing to bind review/comment routing to the wrong PR" >&2
+            exit 1
+          fi
+
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,206 @@
+name: Codex Review
+
+# Dispatched by the n8n W1 "codex-orchestrator" workflow (see
+# .github/codex/README.md) via workflow_dispatch, never by a GitHub event
+# directly. n8n owns dedupe, debounce, and the loop counter; this workflow
+# owns everything that needs a real checkout: gathering live state, running
+# the reviewer, and reporting a fail-closed commit status.
+#
+# Fail-closed anchor (build spec section 1/6): `codex-review/deep-pass` is a
+# required branch-protection status check. This workflow sets it `pending`
+# as its FIRST step. Only a successful POST-and-verify to n8n W2 (job
+# success) or codex-watchdog.yml (on failure/timeout) ever resolves it away
+# from pending. A dead/crashed/timed-out run therefore blocks merge instead
+# of silently passing it.
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: string
+      head_sha:
+        description: "Head SHA to set the commit status on"
+        required: true
+        type: string
+      base_sha:
+        description: "Base SHA to diff against"
+        required: true
+        type: string
+      loop_n:
+        description: "Review loop counter (0 on first pass, 1 after one claude-fix cycle)"
+        required: true
+        type: string
+      reviewer_route:
+        description: "codex | claude-deep, as classified by n8n W1 (re-verified here, fail-safe)"
+        required: true
+        type: string
+
+jobs:
+  codex-review:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+      HEAD_SHA: ${{ inputs.head_sha }}
+      BASE_SHA: ${{ inputs.base_sha }}
+      LOOP_N: ${{ inputs.loop_n }}
+    steps:
+      - name: Validate inputs (fail closed before anything else touches them)
+        run: |
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number is not numeric: refusing to proceed" >&2
+            exit 1
+          fi
+          if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::head_sha is not a hex SHA: refusing to proceed" >&2
+            exit 1
+          fi
+          if ! [[ "$BASE_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::base_sha is not a hex SHA: refusing to proceed" >&2
+            exit 1
+          fi
+          if ! [[ "$LOOP_N" =~ ^[0-9]+$ ]]; then
+            echo "::error::loop_n is not numeric: refusing to proceed" >&2
+            exit 1
+          fi
+          if ! [[ "$REVIEWER_ROUTE" =~ ^(codex|claude-deep)$ ]]; then
+            echo "::error::reviewer_route must be codex or claude-deep: refusing to proceed" >&2
+            exit 1
+          fi
+        env:
+          REVIEWER_ROUTE: ${{ inputs.reviewer_route }}
+
+      - name: Set codex-review/deep-pass = pending (fail-closed anchor, must be first)
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+            -f state=pending \
+            -f context=codex-review/deep-pass \
+            -f description="Codex review running (loop ${LOOP_N})" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Re-classify paths in CI (fail-safe; n8n's classification is not trusted alone)
+        id: classify
+        run: scripts/codex-review-path-classifier.sh "${BASE_SHA}" "${HEAD_SHA}"
+        env:
+          CODEX_COMPLIANCE_PATHS: ${{ vars.CODEX_COMPLIANCE_PATHS || 'allow' }}
+
+      - name: Gather live state
+        id: live_state
+        run: |
+          {
+            echo "live_state<<LIVE_STATE_EOF"
+            echo "### gh pr view"
+            gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus,headRefOid,title,body
+            echo ""
+            echo "### gh pr checks"
+            gh pr checks "$PR_NUMBER" || true
+            echo ""
+            echo "### changed files (git ls-files -s)"
+            git diff --name-only "${BASE_SHA}...${HEAD_SHA}" | while read -r f; do
+              git ls-files -s -- "$f" 2>/dev/null || echo "?????? 0	$f (untracked/deleted)"
+            done
+            echo "LIVE_STATE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Assemble prompt
+        id: prompt
+        run: python3 scripts/codex-review-assemble-prompt.py /tmp/prompt.md
+        env:
+          LIVE_STATE: ${{ steps.live_state.outputs.live_state }}
+          LOOP_N: ${{ inputs.loop_n }}
+
+      - name: Run reviewer (codex exec)
+        id: review_codex
+        if: steps.classify.outputs.reviewer_route == 'codex'
+        env:
+          OPENAI_API_KEY: ${{ secrets.CODEX_OPENAI_API_KEY }}
+        run: |
+          echo "::add-mask::$OPENAI_API_KEY"
+          codex exec \
+            --sandbox read-only \
+            -m gpt-5.5 \
+            --output-schema .github/codex/review-schema.json \
+            --output-last-message /tmp/review.json \
+            < /tmp/prompt.md
+          # Fallback per build spec section 6: one retry with a stricter
+          # instruction if the model still emitted invalid JSON despite
+          # --output-schema.
+          if ! python3 -c "import json; json.load(open('/tmp/review.json'))" 2>/dev/null; then
+            echo "First pass produced invalid JSON; retrying with stricter instruction." >&2
+            { cat /tmp/prompt.md; echo ""; echo "Output ONLY the JSON object. No prose, no markdown fences."; } \
+              | codex exec --sandbox read-only -m gpt-5.5 \
+                  --output-schema .github/codex/review-schema.json \
+                  --output-last-message /tmp/review.json
+          fi
+
+      - name: Run reviewer (Claude Sonnet 4.6 API, Tier 2 claude-deep route)
+        id: review_claude_deep
+        if: steps.classify.outputs.reviewer_route == 'claude-deep'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_REVIEW_API_KEY }}
+        run: |
+          echo "::add-mask::$ANTHROPIC_API_KEY"
+          scripts/codex-review-claude-deep.sh /tmp/prompt.md .github/codex/review-schema.json /tmp/review.json
+
+      - name: Reviewer blocked (Tier 1 data-bearing path)
+        id: review_blocked
+        if: steps.classify.outputs.reviewer_route == 'blocked'
+        run: |
+          cat > /tmp/review.json <<JSONEOF
+          {
+            "verdict": "NEEDS_HUMAN",
+            "head_sha": "${HEAD_SHA}",
+            "findings": [{
+              "id": "GUARD-1",
+              "severity": "HIGH",
+              "category": "path_coverage",
+              "file": "(diff-wide)",
+              "line": null,
+              "description": "This PR touches a data-bearing path (fixtures/seeds/factories/migrations/cassettes/raw data). Per the Tier 1/Tier 2 policy, no external reviewer (Codex or Claude-deep) may see this diff.",
+              "evidence": "scripts/codex-review-path-classifier.sh flagged data_bearing=true",
+              "suggested_fix": "A human must review this PR directly; do not re-run /codex-review on it.",
+              "verifiable_check": "scripts/codex-review-path-classifier.sh ${BASE_SHA} ${HEAD_SHA}"
+            }],
+            "checks_run": { "register_drift": "n/a", "modes": "n/a", "ci": "n/a" },
+            "resolved_from_prior_loop": []
+          }
+          JSONEOF
+
+      - name: POST result to n8n W2 and verify status resolved
+        run: |
+          RESULT_JSON="$(cat /tmp/review.json)"
+          HTTP_STATUS="$(curl -sS -o /tmp/w2-response.json -w '%{http_code}' \
+            -X POST "${{ secrets.N8N_CODEX_RESULTS_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -H "X-Codex-Signature: $(printf '%s' "$RESULT_JSON" | openssl dgst -sha256 -hmac "${{ secrets.N8N_CODEX_RESULTS_HMAC_SECRET }}" | awk '{print $2}')" \
+            -d "$RESULT_JSON")"
+
+          if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+            echo "POST to n8n W2 failed with HTTP $HTTP_STATUS" >&2
+            cat /tmp/w2-response.json >&2
+            exit 1
+          fi
+
+          # Success condition (literal, per build spec section 1): do not
+          # exit success unless a follow-up GET confirms deep-pass is no
+          # longer pending. codex-watchdog.yml is the independent backstop
+          # if this check itself never runs (job killed before this line).
+          for i in $(seq 1 6); do
+            sleep 5
+            STATE="$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/status" --jq \
+              '.statuses[] | select(.context=="codex-review/deep-pass") | .state' | head -1)"
+            if [ "$STATE" != "pending" ] && [ -n "$STATE" ]; then
+              echo "codex-review/deep-pass resolved to: $STATE"
+              exit 0
+            fi
+          done
+
+          echo "codex-review/deep-pass still pending 30s after W2 POST succeeded; failing this job so it does not report false success. codex-watchdog.yml's workflow_run trigger will flip the status to failure." >&2
+          exit 1

--- a/.github/workflows/codex-watchdog.yml
+++ b/.github/workflows/codex-watchdog.yml
@@ -1,0 +1,65 @@
+name: Codex Review Watchdog
+
+# Fail-closed backstop for codex-review.yml (build spec section 1/6,
+# resolution to Codex review finding #1: the pipeline must never leave
+# codex-review/deep-pass pending forever, because a required status check
+# that never resolves blocks merge silently rather than failing loudly).
+#
+# Two independent triggers, because `workflow_run: completed` alone cannot
+# catch a run that hangs and never completes:
+#   1. workflow_run(completed) — codex-review.yml or claude-fix.yml concluded
+#      (crashed, cancelled, or exited nonzero) but deep-pass is still pending.
+#   2. schedule — a 10-minute sweep that fails ANY deep-pass status still
+#      pending more than 30 minutes after it was set, regardless of whether
+#      the dispatching workflow run ever reports a conclusion at all.
+on:
+  workflow_run:
+    workflows: ["Codex Review", "Claude Fix"]
+    types: [completed]
+  schedule:
+    - cron: "*/10 * * * *"
+
+jobs:
+  fail-stale-pending:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout (for the labeling helper script only)
+        uses: actions/checkout@v4
+
+      - name: Find open PRs with a pending codex-review/deep-pass status
+        id: find_pending
+        run: |
+          # commit-status API has no "list all pending for context X" endpoint,
+          # so we walk open PRs and check each head SHA's status directly.
+          gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+            --jq '.[] | [.number, .head.sha] | @tsv' > /tmp/open-prs.tsv
+          : > /tmp/stale.tsv
+          while IFS=$'\t' read -r pr_number head_sha; do
+            [ -z "$head_sha" ] && continue
+            status_json="$(gh api "repos/${{ github.repository }}/commits/${head_sha}/status" 2>/dev/null || echo '{}')"
+            state="$(echo "$status_json" | jq -r '[.statuses[] | select(.context=="codex-review/deep-pass") | .state][0] // empty')"
+            created_at="$(echo "$status_json" | jq -r '[.statuses[] | select(.context=="codex-review/deep-pass") | .created_at][0] // empty')"
+            [ "$state" != "pending" ] && continue
+            [ -z "$created_at" ] && continue
+            age_min=$(( ( $(date -u +%s) - $(date -u -d "$created_at" +%s) ) / 60 ))
+            if [ "$age_min" -ge 30 ]; then
+              printf '%s\t%s\t%s\n' "$pr_number" "$head_sha" "$age_min" >> /tmp/stale.tsv
+            fi
+          done < /tmp/open-prs.tsv
+          cat /tmp/stale.tsv
+
+      - name: Fail stale-pending statuses and label the PR
+        run: |
+          [ -s /tmp/stale.tsv ] || { echo "No stale pending codex-review/deep-pass statuses."; exit 0; }
+          while IFS=$'\t' read -r pr_number head_sha age_min; do
+            echo "Failing codex-review/deep-pass on PR #${pr_number} (${head_sha}), pending ${age_min}min"
+            gh api "repos/${{ github.repository }}/statuses/${head_sha}" \
+              -f state=failure \
+              -f context=codex-review/deep-pass \
+              -f description="Timed out after ${age_min}min with no result (watchdog)" \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh pr edit "$pr_number" --add-label codex-review-failed \
+              --repo "${{ github.repository }}" || true
+          done < /tmp/stale.tsv

--- a/.github/workflows/codex-watchdog.yml
+++ b/.github/workflows/codex-watchdog.yml
@@ -22,6 +22,10 @@ on:
 jobs:
   fail-stale-pending:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/scripts/claude-preflight-check.sh
+++ b/scripts/claude-preflight-check.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# claude-preflight-check.sh — mechanical subset of CLAUDE.md's "PR Preflight
+# (P1-P6)" gate (added in PR #604), run automatically after claude-fix.yml's
+# headless fix pass and before it pushes.
+#
+# HONEST SCOPE: only P3 is fully mechanical (it mirrors CI's
+# audit-artifacts-integrity job exactly). P1, P2, P4, P5, P6 require human or
+# model judgment (claim verification, entry-point enumeration, cross-doc
+# consistency, the honest-status block, behavioral click-testing) and are NOT
+# something a shell script can verify. This script runs what's checkable and
+# prints an explicit reminder for the rest so claude-fix.yml's own PR comment
+# can carry the judgment-based items forward instead of silently skipping them.
+set -euo pipefail
+
+FAILED=0
+
+run_check() {
+  local desc="$1"; shift
+  echo "--- P3: $desc ---"
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc" >&2
+    FAILED=1
+  fi
+}
+
+run_check "compliance calendar render matches JSON" ruby scripts/compliance-calendar-render.rb --check
+run_check "Notion compliance page matches register" ruby scripts/compliance-notion-publish.rb --check
+run_check "document register render + hashes + bundle" ruby scripts/document-register-render.rb --check
+run_check "compliance publication status report" ruby scripts/compliance-publication-status.rb --check
+run_check "capability ledger evidence resolves at HEAD" ruby scripts/capability-check.rb --check
+
+echo "--- P3: whitespace / conflict markers ---"
+if git diff --check; then
+  echo "PASS: git diff --check"
+else
+  echo "FAIL: git diff --check" >&2
+  FAILED=1
+fi
+
+cat <<'REMINDER' >&2
+
+--- Judgment-based preflight items NOT covered by this script ---
+P1 (claim verification), P2 (entry-point enumeration for auth/access changes),
+P4 (cross-doc consistency sweep), P5 (honest status block in PR body), and
+P6 (behavioral definition of done for UI flows) require re-reading CLAUDE.md's
+"PR Preflight" section and applying judgment to THIS fix's diff. claude-fix.yml's
+PR comment step must address these explicitly, not assume this script covered them.
+REMINDER
+
+exit "$FAILED"

--- a/scripts/codex-review-assemble-prompt.py
+++ b/scripts/codex-review-assemble-prompt.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Assemble the codex-review prompt by injecting live state, memory, and
+prior-loop context into .github/codex/review-prompt.md's placeholder blocks.
+
+Usage: codex-review-assemble-prompt.py <output-file>
+Reads LIVE_STATE and LOOP_N from the environment (set by codex-review.yml).
+"""
+import os
+import pathlib
+import sys
+
+PROMPT_PATH = pathlib.Path(".github/codex/review-prompt.md")
+MEMORY_PATH = pathlib.Path(".github/codex/REVIEW-MEMORY.md")
+
+
+def replace_block(text, marker, replacement_body):
+    start = f"<!-- CI_INJECT:{marker} -->"
+    end = f"<!-- /CI_INJECT:{marker} -->"
+    start_idx = text.index(start)
+    end_idx = text.index(end) + len(end)
+    return text[:start_idx] + start + "\n" + replacement_body + "\n" + end + text[end_idx:]
+
+
+def main():
+    output_path = sys.argv[1]
+
+    live_state = os.environ["LIVE_STATE"]
+    memory = MEMORY_PATH.read_text()
+    loop_n = int(os.environ["LOOP_N"])
+
+    prior_loop = "N/A (loop 0 - first pass)."
+    if loop_n > 0:
+        prior_loop = (
+            f"Loop {loop_n}: see the PR's existing codex-review comment thread "
+            "for the prior verdict JSON and resolved findings; the comment "
+            "carries marker <!-- codex-review loop:N sha:X -->."
+        )
+
+    prompt = PROMPT_PATH.read_text()
+    prompt = replace_block(prompt, "LIVE_STATE", live_state)
+    prompt = replace_block(prompt, "REVIEW_MEMORY", memory)
+    prompt = replace_block(prompt, "PRIOR_LOOP", prior_loop)
+
+    pathlib.Path(output_path).write_text(prompt)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codex-review-build-envelope.py
+++ b/scripts/codex-review-build-envelope.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Wrap the reviewer's model-output JSON with CI-trusted routing fields
+before POSTing to n8n W2.
+
+Without this, W2 would have to key its routing (which PR to comment on,
+which commit status to resolve) off values the model itself asserted inside
+review.json. Wrap them instead in an envelope of Actions-validated values so
+W2 trusts CI ground truth, not model output.
+
+Usage: codex-review-build-envelope.py <review-json-file> <output-file>
+Reads PR_NUMBER, HEAD_SHA, BASE_SHA, LOOP_N, REVIEWER_ROUTE, RUN_ID from env.
+"""
+import json
+import os
+import pathlib
+import sys
+
+
+def main():
+    review_path, output_path = sys.argv[1], sys.argv[2]
+    review = json.loads(pathlib.Path(review_path).read_text())
+
+    envelope = {
+        "pr_number": int(os.environ["PR_NUMBER"]),
+        "head_sha": os.environ["HEAD_SHA"],
+        "base_sha": os.environ["BASE_SHA"],
+        "loop_n": int(os.environ["LOOP_N"]),
+        "reviewer_route": os.environ["REVIEWER_ROUTE"],
+        "run_id": os.environ["RUN_ID"],
+        "review": review,
+    }
+    pathlib.Path(output_path).write_text(json.dumps(envelope))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codex-review-claude-deep-build-request.py
+++ b/scripts/codex-review-claude-deep-build-request.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Build the Anthropic Messages API request body for the claude-deep reviewer
+route. Reads the prompt and JSON Schema from files (never from shell
+interpolation) and prints the request JSON to stdout.
+
+Usage: codex-review-claude-deep-build-request.py <prompt-file> <schema-file>
+"""
+import json
+import pathlib
+import sys
+
+
+def main():
+    prompt_path, schema_path = sys.argv[1], sys.argv[2]
+
+    prompt = pathlib.Path(prompt_path).read_text()
+    schema = json.loads(pathlib.Path(schema_path).read_text())
+
+    body = {
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 8192,
+        "tools": [{
+            "name": "submit_review",
+            "description": "Submit the structured code review verdict.",
+            "input_schema": schema,
+        }],
+        "tool_choice": {"type": "tool", "name": "submit_review"},
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    print(json.dumps(body))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codex-review-claude-deep-extract-response.py
+++ b/scripts/codex-review-claude-deep-extract-response.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Extract the submit_review tool_use block from an Anthropic Messages API
+response and write its input (the review verdict JSON) to the output file.
+
+Usage: codex-review-claude-deep-extract-response.py <response-file> <output-file>
+"""
+import json
+import pathlib
+import sys
+
+
+def main():
+    response_path, output_path = sys.argv[1], sys.argv[2]
+
+    resp = json.loads(pathlib.Path(response_path).read_text())
+    for block in resp.get("content", []):
+        if block.get("type") == "tool_use" and block.get("name") == "submit_review":
+            pathlib.Path(output_path).write_text(json.dumps(block["input"]))
+            return 0
+
+    sys.stderr.write("claude-deep: no submit_review tool_use block in response\n")
+    sys.stderr.write(json.dumps(resp) + "\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/codex-review-claude-deep.sh
+++ b/scripts/codex-review-claude-deep.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# codex-review-claude-deep.sh — Tier 2 "claude-deep" reviewer route.
+#
+# Used by codex-review.yml when CODEX_COMPLIANCE_PATHS=block routes a
+# compliance-path PR (docs/legal/**, audit-reports/**) off the consumer
+# OpenAI endpoint. Calls the SAME Claude Sonnet 4.6 API path the existing
+# pr-review-bot's "Claude Senior-Dev Review" node already uses (n8n
+# lbyA52atQjQ8MCqy), with the IDENTICAL prompt and output contract as the
+# codex route, so the pipeline shape does not change (build spec section 5).
+#
+# USAGE
+#   scripts/codex-review-claude-deep.sh <prompt-file> <schema-file> <output-file>
+#
+# ENV
+#   ANTHROPIC_API_KEY   required (job-scoped secret; see codex-review.yml)
+#
+set -euo pipefail
+
+PROMPT_FILE="${1:?usage: $0 <prompt-file> <schema-file> <output-file>}"
+SCHEMA_FILE="${2:?usage: $0 <prompt-file> <schema-file> <output-file>}"
+OUTPUT_FILE="${3:?usage: $0 <prompt-file> <schema-file> <output-file>}"
+
+: "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set}"
+
+RESPONSE_FILE="$(mktemp)"
+
+curl -sS https://api.anthropic.com/v1/messages \
+  -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d @<(python3 scripts/codex-review-claude-deep-build-request.py "$PROMPT_FILE" "$SCHEMA_FILE") \
+  -o "$RESPONSE_FILE"
+
+python3 scripts/codex-review-claude-deep-extract-response.py "$RESPONSE_FILE" "$OUTPUT_FILE"

--- a/scripts/codex-review-claude-fix.sh
+++ b/scripts/codex-review-claude-fix.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# codex-review-claude-fix.sh — headless Claude Code fix pass for claude-fix.yml.
+#
+# Runs `claude -p` (non-interactive print mode) against the findings JSON from
+# a REQUEST_CHANGES codex-review verdict. Per the build spec (section 4):
+# address ONLY the listed findings, no scope creep, no unrelated refactors; a
+# disputed finding must be marked disputed with reasoning, never silently
+# skipped.
+#
+# USAGE
+#   scripts/codex-review-claude-fix.sh <findings-json-file> <loop_n>
+#
+# ENV
+#   ANTHROPIC_API_KEY   required (job-scoped secret; see claude-fix.yml)
+#
+set -euo pipefail
+
+FINDINGS_FILE="${1:?usage: $0 <findings-json-file> <loop_n>}"
+LOOP_N="${2:?usage: $0 <findings-json-file> <loop_n>}"
+
+: "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set}"
+
+PROMPT_FILE="$(mktemp)"
+{
+  echo "You are fixing findings from an automated code review (loop ${LOOP_N})."
+  echo "Address ONLY the findings listed below. No scope creep, no unrelated"
+  echo "refactors, no drive-by cleanups."
+  echo ""
+  echo "If you disagree with a finding, do NOT silently skip it: leave the code"
+  echo "unchanged for that finding and note it as disputed, with your reasoning,"
+  echo "in your final summary. A disputed finding forces NEEDS_HUMAN on the next"
+  echo "review pass rather than looping silently."
+  echo ""
+  echo "Findings (JSON):"
+  cat "$FINDINGS_FILE"
+} > "$PROMPT_FILE"
+
+claude -p \
+  --bare \
+  --dangerously-skip-permissions \
+  --allowedTools "Read,Edit,Write,Bash(bundle exec rspec*),Bash(ruby scripts/*),Bash(git *)" \
+  --output-format json \
+  < "$PROMPT_FILE" > /tmp/claude-fix-result.json
+
+rm -f "$PROMPT_FILE"

--- a/scripts/codex-review-path-classifier.sh
+++ b/scripts/codex-review-path-classifier.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# codex-review-path-classifier.sh — CI-side path classifier for the automated
+# Codex review pipeline (codex-review.yml).
+#
+# WHY THIS EXISTS / RELATIONSHIP TO THE BRAIN GUARD
+#   This is a vendored copy of ai-company-brain's
+#   scripts/codex-review-guard.sh RISKY_PATTERNS list (Guard A: PII /
+#   data-bearing paths). It is duplicated here rather than sourced from the
+#   brain path because CI runners do not have the brain checkout available
+#   (see the build spec's FLAG-2). Keep the pattern list in sync by hand;
+#   if the brain guard's RISKY_PATTERNS changes, update this file's
+#   DATA_BEARING_PATTERNS to match.
+#
+#   This script additionally classifies Guard B: whether the diff touches a
+#   compliance-path (docs/legal/**, audit-reports/**). Guard B is a Tier 2
+#   confidentiality PREFERENCE (instructions/shared/compliance.md), not a
+#   regulatory control — see CODEX_COMPLIANCE_PATHS below.
+#
+# USAGE
+#   scripts/codex-review-path-classifier.sh <base-sha> <head-sha>
+#   (in GitHub Actions: pass github.event.pull_request.base.sha / head.sha)
+#
+# OUTPUT
+#   Writes reviewer_route to $GITHUB_OUTPUT (or stdout as `key=value` lines
+#   if GITHUB_OUTPUT is unset, e.g. for local testing):
+#     data_bearing=true|false
+#     compliance_path=true|false
+#     reviewer_route=codex|claude-deep|blocked
+#
+#   reviewer_route resolution:
+#     data_bearing=true                        -> blocked   (Tier 1, no external reviewer, regardless of any flag)
+#     compliance_path=true AND CODEX_COMPLIANCE_PATHS=block -> claude-deep
+#     otherwise                                -> codex
+#
+# ENV
+#   CODEX_COMPLIANCE_PATHS=allow|block   (default: allow, per Tier 2 policy)
+#
+set -euo pipefail
+
+BASE_SHA="${1:?usage: $0 <base-sha> <head-sha>}"
+HEAD_SHA="${2:?usage: $0 <base-sha> <head-sha>}"
+CODEX_COMPLIANCE_PATHS="${CODEX_COMPLIANCE_PATHS:-allow}"
+
+# ---------------------------------------------------------------------------
+# Guard A patterns — vendored from ai-company-brain/scripts/codex-review-guard.sh
+# RISKY_PATTERNS. Keep in sync by hand (FLAG-2: no cross-repo `source`).
+# Bias toward OVER-blocking: a false positive costs a manual re-route to
+# claude-deep; a false negative would leak PHI/PII to a no-BAA model.
+# ---------------------------------------------------------------------------
+DATA_BEARING_PATTERNS=(
+  '(^|/)(spec|test)/.*fixtures/'
+  '(^|/)fixtures/'
+  '(^|/)(spec|test)/.*factories/'
+  '(^|/)factories/'
+  '(^|/)(spec|test)/.*factories\.rb$'
+  '(^|/)factories\.rb$'
+  '(^|/)db/seeds(\.rb)?(/|$)'
+  '(^|/)db/migrate/.*\.rb$'
+  '(^|/)db/data/'
+  '(^|/)lib/tasks/.*(seed|import|export|backfill|load|sync).*\.rake$'
+  '(^|/)(spec|test)/(cassettes|vcr_cassettes|vcr)/'
+  '(^|/)db/.*\.sql$'
+  '\.(sql|dump|csv|tsv|ndjson|xlsx|xls|parquet)$'
+  '(^|/)(fixtures|seeds|sample_data|test_data|data|exports?)/.*\.(json|ya?ml|xml)$'
+  '(^|/)(fixtures|seeds|sample_data|test_data)/'
+)
+
+# Guard B patterns — compliance-path Tier 2 confidentiality preference.
+COMPLIANCE_PATTERNS=(
+  '(^|/)docs/legal/'
+  '(^|/)audit-reports/'
+)
+
+GITQ='git -c core.quotepath=false'
+
+paths="$($GITQ diff --name-only "$BASE_SHA...$HEAD_SHA")" \
+  || { echo "classifier: git diff $BASE_SHA...$HEAD_SHA failed" >&2; exit 3; }
+
+data_bearing=false
+for pat in "${DATA_BEARING_PATTERNS[@]}"; do
+  if printf '%s\n' "$paths" | grep -qE "$pat"; then
+    data_bearing=true
+    break
+  fi
+done
+
+compliance_path=false
+for pat in "${COMPLIANCE_PATTERNS[@]}"; do
+  if printf '%s\n' "$paths" | grep -qE "$pat"; then
+    compliance_path=true
+    break
+  fi
+done
+
+if [ "$data_bearing" = "true" ]; then
+  reviewer_route="blocked"
+elif [ "$compliance_path" = "true" ] && [ "$CODEX_COMPLIANCE_PATHS" = "block" ]; then
+  reviewer_route="claude-deep"
+else
+  reviewer_route="codex"
+fi
+
+{
+  echo "data_bearing=$data_bearing"
+  echo "compliance_path=$compliance_path"
+  echo "reviewer_route=$reviewer_route"
+} | tee -a "${GITHUB_OUTPUT:-/dev/stdout}" >/dev/null
+
+echo "classifier: data_bearing=$data_bearing compliance_path=$compliance_path (CODEX_COMPLIANCE_PATHS=$CODEX_COMPLIANCE_PATHS) -> reviewer_route=$reviewer_route" >&2

--- a/scripts/codex-review-post-fix-comment.sh
+++ b/scripts/codex-review-post-fix-comment.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# codex-review-post-fix-comment.sh — posts the finding-id -> commit-SHA
+# mapping comment required by the build spec (section 4) after claude-fix.yml
+# pushes a fix commit.
+#
+# USAGE
+#   scripts/codex-review-post-fix-comment.sh <pr_number> <commit_sha> <findings_json_file>
+#
+set -euo pipefail
+
+PR_NUMBER="${1:?usage: $0 <pr_number> <commit_sha> <findings_json_file>}"
+COMMIT_SHA="${2:?usage: $0 <pr_number> <commit_sha> <findings_json_file>}"
+FINDINGS_FILE="${3:?usage: $0 <pr_number> <commit_sha> <findings_json_file>}"
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "pr_number is not numeric" >&2
+  exit 1
+fi
+
+BODY="$(python3 - "$FINDINGS_FILE" "$COMMIT_SHA" <<'PYEOF'
+import json, sys
+
+findings_file, sha = sys.argv[1], sys.argv[2]
+findings = json.load(open(findings_file))
+
+lines = [
+    "## Claude fix pass",
+    "",
+    f"Commit: `{sha}`",
+    "",
+    "| Finding | Status |",
+    "|---|---|",
+]
+for f in findings:
+    fid = f.get("id", "?")
+    lines.append(f"| {fid} | addressed in `{sha}` |")
+lines.append("")
+lines.append(
+    "Any finding marked *disputed* in the commit message body was left "
+    "unchanged on purpose; the next codex-review pass will route it to "
+    "NEEDS_HUMAN rather than silently re-approving it."
+)
+print("\n".join(lines))
+PYEOF
+)"
+
+gh pr comment "$PR_NUMBER" --body "$BODY"


### PR DESCRIPTION
## Summary
Implements the GitHub Actions side of the Codex review pipeline per `outputs/docs/2026-07-12-codex-review-pipeline-build-spec.md` (build order steps 2, 3, 4, 6, 8 of 8). Companion to #604 (CLAUDE.md PR Preflight P1-P6 gate) and the two-tier AI data-routing policy (#127/#129, already merged).

- `.github/codex/review-prompt.md`, `review-schema.json`, `REVIEW-MEMORY.md`
- `scripts/codex-review-path-classifier.sh` -- vendored data-bearing-path guard (Guard A) + Tier 2 compliance-path routing (Guard B), `CODEX_COMPLIANCE_PATHS` default `allow`
- `.github/workflows/codex-review.yml` -- fail-closed pending-status-first review job; `codex exec` / `claude-deep` / `blocked` reviewer routes; verified POST+GET success condition so the job cannot report false success
- `.github/workflows/codex-watchdog.yml` -- dual-trigger (`workflow_run` + 30-min `schedule` sweep) fail-closed backstop
- `.github/workflows/claude-fix.yml` -- headless Claude fix pass, shipped **DISABLED** (`vars.CLAUDE_FIX_ENABLED != 'true'`) per the spec's week-1 review-only posture

## Fix status
| Item | Status | Evidence |
|---|---|---|
| Prompt/schema/memory files | Fixed | `.github/codex/` |
| Path classifier (Guard A + B) | Fixed | `scripts/codex-review-path-classifier.sh`, self-tested |
| codex-review.yml | Fixed | fail-closed pending-first step, input validation before `ref:` use |
| codex-watchdog.yml | Fixed | dual trigger, self-tested `jq` extraction |
| claude-fix.yml | Fixed, disabled | gated behind `vars.CLAUDE_FIX_ENABLED` |

## Not covered by this PR (explicit, out of scope here)
- **Branch protection is NOT made required yet.** Flipping `codex-review/deep-pass` to required before this workflow is proven live via `workflow_dispatch` would leave the status permanently unresolved and block every merge to `staging`. This needs a deliberate follow-up once this workflow is tested.
- **CI secrets are not installed** (`CODEX_OPENAI_API_KEY`, an Anthropic key for the `claude-deep`/`claude-fix` routes, and the eventual `N8N_CODEX_RESULTS_WEBHOOK_URL`/`HMAC_SECRET` once W2 exists).
- **n8n W1 (`codex-orchestrator`) and W2 (`codex-results`) are not built.** Per the spec's own build order this is a separate focused session; it's also a live mutation of the production PR-review-bot n8n instance, so it's being held for an explicit go-ahead.
- `codex-review.yml`'s `workflow_dispatch` path has not been exercised end-to-end (no PR to dispatch against yet, no secrets installed).

## Author-Model: sonnet-5

## Test plan
- [x] All 3 new workflow YAML files parse (`yaml.safe_load`)
- [x] All new shell scripts pass `bash -n`
- [x] All new Python scripts pass `py_compile`
- [x] `review-schema.json` is valid JSON
- [x] `codex-review-path-classifier.sh` self-tested against a real diff range
- [x] `codex-review-assemble-prompt.py` self-tested against the real prompt/memory files
- [x] `codex-review-claude-deep-extract-response.py` self-tested against both a well-formed and a malformed Anthropic response
- [x] Exec bits verified via `git ls-files -s` (this repo has `core.filemode=false`, so `chmod` alone doesn't get tracked)
- [ ] `workflow_dispatch` smoke test against a real closed PR (blocked on `CODEX_OPENAI_API_KEY`)
- [ ] Forced-failure test confirming `codex-watchdog.yml` flips the status to `failure`