### PR TITLE
compliance: assign Art. 50(1) modal to VPC as single owner + reconcile memo §7/§8

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -287,7 +287,7 @@
         "attestedBy": "Scot Wahlquist",
         "attestedDate": "2026-07-14"
       },
-      "contentHash": "0d3eb3fe73dad8b26b3e55f3e49a57afa5204758dd4d2d64327b282bb1ff863b",
+      "contentHash": "3bc97c8693637dea77183e6126e8443256c1a47abdc4279d9b58cb142b6f78fb",
       "bundles": [
         "compliance-records-set-2026-06"
       ],

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -34,7 +34,7 @@
 |---|---|---|---|---|---|---|---|---|---|---|
 | Accessibility Conformance Report (ACR / VPAT) | git | `docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md` | draft | WCAG | Scot Wahlquist | 2026-06-16 | 2026-09-16 | no | `e68ef80b2638` | school-dpa-package |
 | Accessibility Conformance Report (ACR / VPAT) (branded) | Drive | [open](https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit) | draft | WCAG | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| AI Governance Memo | git | `docs/legal/AI_GOVERNANCE_MEMO.md` | published | GDPR, COPPA | Scot Wahlquist | 2026-07-14 | 2026-10-14 | 2026-07-14 | `0d3eb3fe73da` | compliance-records-set-2026-06 |
+| AI Governance Memo | git | `docs/legal/AI_GOVERNANCE_MEMO.md` | published | GDPR, COPPA | Scot Wahlquist | 2026-07-14 | 2026-10-14 | 2026-07-14 | `3bc97c869363` | compliance-records-set-2026-06 |
 | AI Governance Memo (branded) | Drive | [open](https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit) | published | GDPR, COPPA | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 | AWS Business Associate Agreement (signed PDF) | git | `docs/legal/AWS_BAA_2026-02.pdf` | published | HIPAA | Scot Wahlquist | 2026-05-11 | 2027-05-11 | 2026-02 | `55f28e00168c` |  |
 | Compliance & Security Program v1.0 (Attested) | Drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | published | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |

--- a/docs/legal/AI_GOVERNANCE_MEMO.md
+++ b/docs/legal/AI_GOVERNANCE_MEMO.md
@@ -218,6 +218,21 @@ so no grace is needed for them.
   users** (internal/test accounts only). The deferral is withdrawn the instant a real EU customer
   onboards, at which point the modal moves to unconditional priority.
 
+**Ownership -- the 50(1) modal is VPC-owned (single owner).** Build and delivery of the Article
+50(1) disclosure modal belong to the **VPC (Verifiable Parental Consent) GSD project** as a phase
+on that track, not to any standalone Article 50 effort or compliance-doc thread. Rationale: the
+modal's linchpin dependency -- a shared call-context helper that stamps `jurisdiction:` at the
+three AI call sites (board generation, word prediction, eval narration) -- **is VPC Phase 4**, and
+that same helper un-inerts the currently-dormant EU log-retention purge
+(`AiApiLog.purge_old_eu_logs!`, which today matches zero rows because nothing stamps jurisdiction).
+Two efforts editing the same call sites would collide. Boundary rules: **(1)** only the VPC track
+edits the three AI call sites, the `article_50_disclosure_modal` flag, and the 50(1) paragraph of
+this section; **(2)** this section 5.2 is the shared contract -- any Article 50 thread reads it
+first and updates it last; **(3)** when the modal ships, the "not yet built / deferred" wording
+above is rewritten by the shipping thread and re-attested per section 6. Compliance-posture
+documentation (this memo, the calendar) remains a separate, non-code workstream and never edits
+the call sites.
+
 Tracked on the compliance calendar (`fix-euaiact-art50-2026-08-02`,
 `fix-euaiact-art50-2-2026-12-02`).
 
@@ -247,7 +262,9 @@ Tracked on the compliance calendar (`fix-euaiact-art50-2026-08-02`,
       stated in section 5.2 (board gen / focus words / eval narration in scope + marked + on
       prod; word prediction out of scope via the assistive-function carve-out; 50(3)/50(4) N/A;
       50(1) EU modal deferred-with-ratified-fallback on the COPPA VPC track). The section 5.2
-      restatement is **pending Scot's re-attestation** (see section 8, 2026-07-13 amendment).
+      restatement was **re-attested 2026-07-14** (see section 8, 2026-07-13/07-14 amendment). The
+      50(1) modal build is owned by the VPC GSD project as VPC Phase 4+ (see section 5.2 ownership
+      note).
 - [ ] Model inventory kept current as models are upgraded (the ids above are point-in-time).
 - [ ] Resolve the eval-narration consent-binding residual (LL-11db0dc848): bind the COPPA/consent
       gate subject to the eval content actually egressed, via server-side eval persistence


### PR DESCRIPTION
## What

Establishes **single ownership** of the one remaining EU AI Act Article 50 deliverable -- the 50(1) AI-interaction disclosure modal -- so parallel compliance/engineering threads stop colliding on the same files.

### `docs/legal/AI_GOVERNANCE_MEMO.md`
- **§5.2 -- Ownership note (new):** the Article 50(1) disclosure modal is a phase of the **VPC (Verifiable Parental Consent) GSD project**, not a standalone Art. 50 effort. The linchpin call-context helper that stamps `jurisdiction:` at the three AI call sites (board gen, word prediction, eval narration) **is VPC Phase 4**, and the same helper un-inerts the dormant EU log-retention purge (`AiApiLog.purge_old_eu_logs!`). Adds three boundary rules: only VPC edits the call sites / flag / 50(1) paragraph; §5.2 is the shared contract; the shipping thread rewrites the "deferred" wording and re-attests.
- **§7 -- reconcile:** the "Finalize Art. 50 applicability decision" item still read *pending Scot's re-attestation*; §8 now records the **2026-07-14 re-attestation**. Flipped to match and pointed at the ownership note.

### `audit-reports/DOCUMENT-REGISTER.{json,md}`
- Memo `contentHash` refreshed via `scripts/regenerate-register.sh`; every integrity check green (required for `audit-artifacts-integrity` CI).

## Why

The applicability position was finalized + attested (#605) while a separate thread scoped the modal *build*. Both were editing the same memo file (one already wrote a re-attestation line). This PR draws the boundary: **documentation stays here; the build is VPC-owned.**

## Not in scope
- The modal build itself (VPC GSD project).
- A mirror pointer in the VPC plan (follow-up once the plan path is confirmed).

## Review
Compliance surface, PII-free -- **Claude-only review** per the two-tier policy. No student/patient data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011t3WvH7KfsGu2sT3LiPzTh