### PR TITLE
chore(gcp): default seed-app-secrets OP_AWS_ITEM to AWS_IAM_ACCESSKEY

### DIFF
--- a/scripts/gcp/phase4-seed-app-secrets.sh
+++ b/scripts/gcp/phase4-seed-app-secrets.sh
@@ -20,8 +20,10 @@
 #
 # AWS_KEY / AWS_SECRET are the EXCEPTION: they are a NEW least-privilege IAM user minted for Cloud Run
 # (scripts/gcp/iam/), NOT Render's broad key. They are sourced from 1Password "LingoLinq Prod" /
-# "AWS Cloud Run" and are asserted to DIFFER from Render's AWS_KEY (so we never silently re-seed the
-# old key). Seed them only after the IAM user exists; see scripts/gcp/iam/README.md.
+# "AWS_IAM_ACCESSKEY" (fields AWS_KEY/AWS_SECRET) and are asserted to DIFFER from Render's AWS_KEY (so we
+# never silently re-seed the old key). Seed them only after the IAM user exists; see scripts/gcp/iam/README.md.
+# NOTE: the Prod-vault item "AWS Credentials" holds the OLD broad lingolinq-app key under the same
+# AWS_KEY/AWS_SECRET field labels -- do NOT point OP_AWS_ITEM at it (the differs-from-Render guard stops it).
 #
 # SMS_ENCRYPTION_KEY is preserve-exact: it salts persisted RemoteTarget.source_hash, so a changed
 # value orphans existing SMS rows. Reading it from live Render IS the preserve-exact source.
@@ -50,7 +52,7 @@ RENDER_PROD_SERVICE_ID="${RENDER_PROD_SERVICE_ID:-srv-d510bsemcj7s73966i60}"   #
 RUNTIME_SA_ID="${RUNTIME_SA_ID:-lingolinq-run}"
 RUNTIME_SA="${RUNTIME_SA_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
 OP_AWS_VAULT="${OP_AWS_VAULT:-LingoLinq Prod}"
-OP_AWS_ITEM="${OP_AWS_ITEM:-AWS Cloud Run}"
+OP_AWS_ITEM="${OP_AWS_ITEM:-AWS_IAM_ACCESSKEY}"
 
 # The 15 secrets sourced from live Render prod (exact running bytes).
 # NOTE: MAPS_KEY is intentionally NOT here. It is a CLIENT-PUBLIC key emitted into the browser via


### PR DESCRIPTION
## What

One-file change to the migration helper `scripts/gcp/phase4-seed-app-secrets.sh`: change the default `OP_AWS_ITEM` from `"AWS Cloud Run"` (a 1Password item that does not exist) to `"AWS_IAM_ACCESSKEY"` (the item that actually holds the least-priv Cloud Run IAM key), and add a comment warning about a same-named look-alike item.

## Why

The AWS branch of the seeder reads `op://LingoLinq Prod/$OP_AWS_ITEM/AWS_KEY` (and `AWS_SECRET`). The default pointed at `"AWS Cloud Run"`, which isn't a real item, so every AWS verify/seed run had to be invoked with an `OP_AWS_ITEM=AWS_IAM_ACCESSKEY` override or it would `STOP` with "empty/absent in 1Password". The correct least-priv key (IAM user `lingolinq-cloudrun-prod`) lives in the Prod-vault item **`AWS_IAM_ACCESSKEY`**, in fields `AWS_KEY`/`AWS_SECRET` that were confirmed byte-for-byte (sha256) equal to the values already seeded in GCP Secret Manager.

The comment also flags a footgun: a separate Prod-vault item named **`AWS Credentials`** carries the OLD broad `lingolinq-app` key under the *same* `AWS_KEY`/`AWS_SECRET` field labels. Pointing `OP_AWS_ITEM` at it would try to seed the old key — the script's existing "differs-from-Render" guard already stops that, and this comment documents it.

## Scope / safety

- **No change to seeding logic**, the differs-from-Render guard, or any write path. Default value + comments only.
- The seeder is operator-run tooling; it is **not** part of the Docker image or the `deploy-cloudrun.yml` build, so this does not affect the deploy.
- Verified read-only on live prod: `./scripts/gcp/phase4-seed-app-secrets.sh --verify --only AWS_KEY,AWS_SECRET` now passes with **no** `OP_AWS_ITEM` override (reads 1Password + Render, computes sha256, writes nothing).
- `bash -n` syntax check passes.

## Test

```
$ bash scripts/gcp/phase4-seed-app-secrets.sh --verify --only AWS_KEY,AWS_SECRET
==> 1Password-sourced AWS secrets (NEW least-priv IAM user) - asserted != Render's key
    AWS_KEY: from 1Password, differs from Render's key OK (sha256 821a9a5ef397...)
    AWS_SECRET: from 1Password, differs from Render's key OK (sha256 47477eb5d8d6...)
==> VERIFY complete. Nothing written.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)