### PR TITLE
fix(codex-review): pass -R explicitly to gh pr calls run before checkout

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -101,7 +101,7 @@ jobs:
         # to proceed -- and flip the status to failure -- if pr_number's
         # actual current head doesn't match the dispatched head_sha.
         run: |
-          ACTUAL_HEAD="$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')"
+          ACTUAL_HEAD="$(gh pr view "$PR_NUMBER" -R "${{ github.repository }}" --json headRefOid --jq '.headRefOid')"
           if [ "$ACTUAL_HEAD" != "$HEAD_SHA" ]; then
             gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
               -f state=failure \
@@ -130,10 +130,10 @@ jobs:
           {
             echo "live_state<<LIVE_STATE_EOF"
             echo "### gh pr view"
-            gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus,headRefOid,title,body
+            gh pr view "$PR_NUMBER" -R "${{ github.repository }}" --json mergeable,mergeStateStatus,headRefOid,title,body
             echo ""
             echo "### gh pr checks"
-            gh pr checks "$PR_NUMBER" || true
+            gh pr checks "$PR_NUMBER" -R "${{ github.repository }}" || true
             echo ""
             echo "### changed files (git ls-files -s)"
             git diff --name-only "${BASE_SHA}...${HEAD_SHA}" | while read -r f; do


### PR DESCRIPTION
## Summary
The first live workflow_dispatch smoke test of `codex-review.yml` (#607, run 29424797637) failed at the "Bind pr_number to head_sha" step with `fatal: not a git repository`. Root cause: `gh pr view` without `-R` auto-detects owner/repo from the local git remote, but that step deliberately runs before "Checkout PR head" (we don't want to trust an unverified `head_sha` enough to check it out first). With no checkout yet, `gh` had nothing to auto-detect against.

Fix: pass `-R "${{ github.repository }}"` explicitly on every `gh pr` call in the job, including the two in "Gather live state" that happened to work only because they run after checkout — an implicit ordering dependency that shouldn't have been load-bearing.

## Test plan
- [x] YAML parses (`yaml.safe_load`)
- [x] Every `run:` block passes `bash -n`
- [ ] Re-dispatch the smoke test once merged and confirm the bind-check step passes