### PR TITLE
fix(codex-review): install Codex CLI on runner

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -162,6 +162,10 @@ jobs:
           LIVE_STATE: ${{ steps.live_state.outputs.live_state }}
           LOOP_N: ${{ inputs.loop_n }}
 
+      - name: Install Codex CLI
+        if: steps.classify.outputs.reviewer_route == 'codex'
+        run: npm install -g @openai/codex
+
       - name: Run reviewer (codex exec)
         id: review_codex
         if: steps.classify.outputs.reviewer_route == 'codex'


### PR DESCRIPTION
## Summary
- install `@openai/codex` before invoking `codex exec` on GitHub-hosted runners
- fixes the smoke failure where the workflow reached prompt assembly but failed with `codex: command not found`

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codex-review.yml'); puts 'yaml ok'"\n- smoke run 29437537715 proved checkout/helper/classifier/prompt steps now pass before the missing Codex binary failure