### PR TITLE
fix(codex-review): log Codex CLI in with API key

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -166,13 +166,22 @@ jobs:
         if: steps.classify.outputs.reviewer_route == 'codex'
         run: npm install -g @openai/codex
 
+      - name: Authenticate Codex CLI
+        if: steps.classify.outputs.reviewer_route == 'codex'
+        env:
+          OPENAI_API_KEY: ${{ secrets.CODEX_OPENAI_API_KEY }}
+          CODEX_HOME: ${{ runner.temp }}/codex-home
+        run: |
+          echo "::add-mask::$OPENAI_API_KEY"
+          mkdir -p "$CODEX_HOME"
+          printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key
+
       - name: Run reviewer (codex exec)
         id: review_codex
         if: steps.classify.outputs.reviewer_route == 'codex'
         env:
-          OPENAI_API_KEY: ${{ secrets.CODEX_OPENAI_API_KEY }}
+          CODEX_HOME: ${{ runner.temp }}/codex-home
         run: |
-          echo "::add-mask::$OPENAI_API_KEY"
           codex exec \
             --sandbox read-only \
             -m gpt-5.5 \


### PR DESCRIPTION
## Summary
- run `codex login --with-api-key` using `CODEX_OPENAI_API_KEY` before `codex exec`
- keep Codex credentials in `${{ runner.temp }}/codex-home` for the job
- fixes the smoke failure where Codex installed but called the Responses API without an auth header

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codex-review.yml'); puts 'yaml ok'"\n- official Codex auth docs say CI/API-key workflows should pipe `OPENAI_API_KEY` into `codex login --with-api-key`