### PR TITLE
docs(compliance): align program AI vendor summary

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -228,7 +228,7 @@
         "attestedBy": "Scot Wahlquist",
         "attestedDate": "2026-07-06"
       },
-      "contentHash": "bf8179b6fd45a426053e11a39dfb4195a881680eb9171dde712eb4ede3946af9",
+      "contentHash": "4a4cdfd19b7c1eb2ffe78c81af15eea6daa3f7f38f9ce564a28c485873c1bf8f",
       "bundles": [
         "compliance-records-set-2026-06"
       ],

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -40,7 +40,7 @@
 | Compliance & Security Program v1.0 (Attested) | Drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | published | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 | Compliance Posture Report | git | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-20 | 2026-09-20 | 2026-06-20 | `a81f72f13bef` | school-dpa-package |
 | Compliance Posture Report (branded) | Drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-07-06 | `bf8179b6fd45` | compliance-records-set-2026-06 |
+| Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-07-06 | `4a4cdfd19b7c` | compliance-records-set-2026-06 |
 | Records of Processing Activities (RoPA) and Data Map | Drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | published | GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 
 ### evidence (6)

--- a/docs/legal/COMPLIANCE_PROGRAM.md
+++ b/docs/legal/COMPLIANCE_PROGRAM.md
@@ -192,13 +192,15 @@ is **planned**, not yet built; it appears here so the consent architecture is on
   the 2025 COPPA Rule is satisfied by this document being embedded in (not merely linked from) the
   privacy notice; embedding is an open task.
 - **Subprocessors.** The Article 28 / 45 CFR 164.502(e) register is `docs/legal/SUBPROCESSORS.md`,
-  with a 30-day customer change-notice commitment. AWS BAA signed 2026-02-07. The active AI vendors (Anthropic,
-  Google) receive only pseudonymized (scrubbed) prompts via `lib/pii_scrubber.rb` and are
+  with a 30-day customer change-notice commitment. AWS BAA signed 2026-02-07. Anthropic is the
+  active AI vendor receiving pseudonymized (scrubbed) prompts via `lib/pii_scrubber.rb` and is
   classified as receiving pseudonymized personal data, not anonymous or de-identified data
   (direct identifiers removed by design, but still personal data under GDPR/UK-GDPR). OpenAI is
-  contracted but has no active data flow as of 2026-07-06 (see the register, row 3). Render BAA
-  is pending; no new hospital tenants requiring a hosting-provider BAA are onboarded until it
-  executes.
+  contracted but has no active data flow as of 2026-07-06 (see the register, row 3). Google Gemini
+  is retained in the register as a disabled historical row: the runtime path was disabled
+  2026-07-09, and no active code path sends data to Gemini as of the 2026-07-12 register
+  correction. Render BAA is pending; no new hospital tenants requiring a hosting-provider BAA are
+  onboarded until it executes.
 - **AI egress.** No directly identifying student or patient data is sent to external models by
   design; scrubbing removes known direct identifiers and is a strong safeguard, not an absolute
   guarantee (see the register's section 5.1). Zero data retention, where a vendor offers it, is


### PR DESCRIPTION
## Summary
- updates docs/legal/COMPLIANCE_PROGRAM.md so its AI-vendor summary matches docs/legal/SUBPROCESSORS.md
- changes the stale active "Anthropic, Google" wording to Anthropic active, OpenAI inactive, and Google Gemini retained as a disabled historical row
- regenerates DOCUMENT-REGISTER hashes/render for the changed git compliance document

## Validation
- ruby scripts/document-register-render.rb --check
- ruby scripts/citation-check.rb
- ruby scripts/compliance-publication-status.rb --check
- ruby scripts/compliance-calendar-render.rb --check
- ruby scripts/compliance-notion-publish.rb --check
- ruby scripts/capability-check.rb --check