### PR TITLE
fix: org home-board settings typing crash and Start Codes selects

### DIFF
--- a/app/frontend/app/components/bound-select.js
+++ b/app/frontend/app/components/bound-select.js
@@ -216,33 +216,39 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-var self = this;
-this.ctrlAction = function(actionName) {
-  var bound = Array.prototype.slice.call(arguments, 1);
-  return function() {
-    var args = bound.concat(Array.prototype.slice.call(arguments));
-    var evt = args[args.length - 1];
-    if (evt && typeof evt.preventDefault === 'function' && (evt.type || evt.target)) {
-      if (evt.preventDefault) { evt.preventDefault(); }
-      args.pop();
-    }
-    self.send.apply(self, [actionName].concat(args));
-  };
-};
-this.ctrlActionNoBubble = function(actionName) {
-  var bound = Array.prototype.slice.call(arguments, 1);
-  return function(event) {
-    if (event && event.stopPropagation) { event.stopPropagation(); }
-    if (event && event.preventDefault) { event.preventDefault(); }
-    self.send.apply(self, [actionName].concat(bound));
-  };
-};
-this.ctrlActionEventValue = function(actionName, targetProp) {
-  return function(event) {
-    var value = event && event.target ? event.target[targetProp] : undefined;
-    self.send(actionName, value);
-  };
-};
+    var self = this;
+    // Stable handlers (same pattern as modern-select). The old ctrlAction
+    // helper called preventDefault then *dropped* the event before send(),
+    // so toggle/choose never got stopPropagation — clicks bubbled into
+    // modal-dialog / form parents and could immediately undo the open.
+    this.ctrlAction = function(actionName) {
+      var bound = Array.prototype.slice.call(arguments, 1);
+      return function() {
+        var args = bound.concat(Array.prototype.slice.call(arguments));
+        var evt = args[args.length - 1];
+        if (evt && typeof evt.preventDefault === 'function' && (evt.type || evt.target)) {
+          if (evt.preventDefault) { evt.preventDefault(); }
+          if (evt.stopPropagation) { evt.stopPropagation(); }
+          // Keep the event on the args list so actions like toggle/choose
+          // can also stopPropagation defensively.
+        }
+        self.send.apply(self, [actionName].concat(args));
+      };
+    };
+    this.ctrlActionNoBubble = function(actionName) {
+      var bound = Array.prototype.slice.call(arguments, 1);
+      return function(event) {
+        if (event && event.stopPropagation) { event.stopPropagation(); }
+        if (event && event.preventDefault) { event.preventDefault(); }
+        self.send.apply(self, [actionName].concat(bound));
+      };
+    };
+    this.ctrlActionEventValue = function(actionName, targetProp) {
+      return function(event) {
+        var value = event && event.target ? event.target[targetProp] : undefined;
+        self.send(actionName, value);
+      };
+    };
   },
 
 });

--- a/app/frontend/app/components/start-codes.hbs
+++ b/app/frontend/app/components/start-codes.hbs
@@ -128,7 +128,7 @@
             <div class="md-org-settings-field">
               <label class="md-org-settings-field__label">{{t "Sponsored" key="sponsored"}}</label>
               <label class="md-org-settings-toggle">
-                <Input id="premium" type="checkbox" @checked={{this.premium}} class="md-org-settings-toggle__input" />
+                <Input id="premium" @type="checkbox" @checked={{this.premium}} class="md-org-settings-toggle__input" />
                 <span class="md-org-settings-toggle__label">{{t "Sponsor any users who use this start code" key="sponsors_users_with_start_code"}}</span>
               </label>
             </div>
@@ -136,7 +136,7 @@
               <div class="md-org-settings-field">
                 <label class="md-org-settings-field__label">{{t "Premium Symbols" key="premium_symbols"}}</label>
                 <label class="md-org-settings-toggle">
-                  <Input id="premium_symbols" type="checkbox" @checked={{this.premium_symbols}} class="md-org-settings-toggle__input" />
+                  <Input id="premium_symbols" @type="checkbox" @checked={{this.premium_symbols}} class="md-org-settings-toggle__input" />
                   <span class="md-org-settings-toggle__label">{{t "Add premium symbols to users" key="add_premium_symbols_to_users"}}</span>
                 </label>
               </div>
@@ -161,7 +161,7 @@
             <Input class="md-org-settings-input" type="text" @value={{this.home_board_key}} placeholder="(optional board key to copy)" />
             {{#if this.home_board_key}}
               <label class="md-org-settings-toggle" style="margin-top: 8px;">
-                <Input id="shallow_clone" type="checkbox" @checked={{this.shallow_clone}} class="md-org-settings-toggle__input" />
+                <Input id="shallow_clone" @type="checkbox" @checked={{this.shallow_clone}} class="md-org-settings-toggle__input" />
                 <span class="md-org-settings-toggle__label">{{t "Apply shallow clones" key="apply_shallow_clones"}}</span>
               </label>
             {{/if}}

--- a/app/frontend/app/controllers/organization/settings.js
+++ b/app/frontend/app/controllers/organization/settings.js
@@ -15,6 +15,8 @@ export default Controller.extend({
   opening: function() {
     var _this = this;
     _this.set('status', null);
+    // Clear edit cache so the textarea re-seeds from model.home_board_keys.
+    _this.set('_home_board_key_lines', undefined);
     if(_this.get('model.saml_metadata_url')) {
       _this.set('external_auth', true);
     }
@@ -60,8 +62,20 @@ export default Controller.extend({
     var id = this.get('model.supervisor_profile_id');
     return !!(id == 'none' || id == '' || !id);
   }),
-  home_board_key_lines: computed('model.home_board_keys', function() {
-    return (this.get('model.home_board_keys') || []).join('\n');
+  // Writable: the settings textarea two-way-binds @value to this property.
+  // A get-only computed crashes on every keystroke (Ember tries to set it).
+  home_board_key_lines: computed('model.home_board_keys', {
+    get() {
+      var cached = this.get('_home_board_key_lines');
+      if(cached !== undefined && cached !== null) {
+        return cached;
+      }
+      return (this.get('model.home_board_keys') || []).join('\n');
+    },
+    set(key, value) {
+      this.set('_home_board_key_lines', value);
+      return value;
+    }
   }),
   board_keys_placeholder: computed(function() {
   return htmlSafe(i18n.t('board_keys_examples', "board keys or URLS\none per line"));
@@ -119,6 +133,18 @@ export default Controller.extend({
     };
   },
 
+  // Turn pasted board-detail / board-alt URLs into owner/slug keys.
+  // Matches Organization#process home_board_keys host+route stripping.
+  normalize_home_board_key(raw) {
+    var key = (raw || '').trim();
+    if(!key) { return ''; }
+    if(key.match(/^https?:\/\/[^\/]+\//)) {
+      key = key.replace(/^https?:\/\/[^\/]+\//, '');
+    }
+    key = key.replace(/^([^/]+)\/board-detail\/([^/]+)(?:\/edit)?\/?$/, '$1/$2');
+    key = key.replace(/^([^/]+)\/board\/([^/]+)\/?$/, '$1/$2');
+    return key;
+  },
   actions: {
     modify_templates: function() {
       var _this = this;
@@ -143,7 +169,9 @@ export default Controller.extend({
       }
       var home_board_key_lines = _this.get('home_board_key_lines');
       if(home_board_key_lines && home_board_key_lines.replace(/\s/g, '').length > 0) {
-        _this.set('model.home_board_keys', home_board_key_lines.split(/\n/).map(function(s) { return s.trim(); }).filter(function(s) { return s.length > 0; }));
+        _this.set('model.home_board_keys', home_board_key_lines.split(/\n/).map(function(s) {
+          return _this.normalize_home_board_key(s.trim());
+        }).filter(function(s) { return s.length > 0; }));
       }
       _this.set('model.support_target', null);
       if(_this.get('allow_support_target') && _this.get('support_email')) {
@@ -152,6 +180,7 @@ export default Controller.extend({
       var org = _this.get('model');
       _this.set('status', {saving: true});
       org.save().then(function() {
+        _this.set('_home_board_key_lines', undefined);
         _this.set('status', null);
         _this.router.transitionTo('organization', _this.get('model.id'));
       }, function() {

--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -84740,6 +84740,14 @@ span.md-board-detail-sentence-bar__modeling-badge--paused:hover {
 .md-org-settings-field {
   margin-bottom: 18px;
 }
+/* bound-select / modern-select use tagName:span; an inline span shrinks
+   the hit target so clicks on the painted trigger miss the <button>.
+   Same fix as `.md-modal-body .md-modal-field > span`. */
+.md-org-settings-field > span {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+}
 .md-org-settings-field__label {
   display: block;
   font-size: 14px;

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1695,6 +1695,11 @@ class Organization < ApplicationRecord
         if key.match(/^https?:\/\/[^\/]+\//)
           key = key.sub(/^https?:\/\/[^\/]+\//, '')
         end
+        # Modern Ember routes are /:user/board-detail/:boardname (and
+        # /:user/board/:boardname). Strip those middle segments so a pasted
+        # URL becomes the board key owner/slug (e.g. lingolinq/vocal-flair-84).
+        key = key.sub(%r{\A([^/]+)/board-detail/([^/]+)(?:/edit)?/?\z}, '\1/\2')
+        key = key.sub(%r{\A([^/]+)/board/([^/]+)/?\z}, '\1/\2')
         board = Board.find_by_path(key)
         if board && board.public
           self.settings['default_home_boards'] << {

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -20,6 +20,8 @@ file (see [README.md](README.md)).
 
 ## Index
 
+- [Gotcha: Textarea `@value` on a get-only computed crashes on keystroke — needs a setter/cache](#gotcha-textarea-value-on-a-get-only-computed-crashes-on-keystroke--needs-a-settercache)
+- [Gotcha: Ember `<Input>` checkboxes need `@type`, and bound-select must stopPropagation](#gotcha-ember-input-checkboxes-need-type-and-bound-select-must-stoppropagation)
 - [Gotcha: Ember strict-mode templates treat bare names as helpers — use `this.` for controller props](#gotcha-ember-strict-mode-templates-treat-bare-names-as-helpers--use-this-for-controller-props)
 - [Gotcha: AI feature flags are rollout; prefs turn AI on — Ember UI must AND both](#gotcha-ai-feature-flags-are-rollout-prefs-turn-ai-on--ember-ui-must-and-both)
 - [Gotcha: serialize rapid model saves — overlapping user.save() lose updates / trip "in flight"](#gotcha-serialize-rapid-model-saves--overlapping-usersave-lose-updates--trip-in-flight)
@@ -6487,6 +6489,14 @@ the cheap fallback to confirm controller/route syntax.
 ## Gotcha: persistence-sync Jasmine harness — wait for `sync_boards` tail / `syncSettled`, not only the `sync()` promise
 
 Recurring Ember CI flakes (timeout / async-work-not-finished) in `persistence-sync-test.js` often look like PR regressions but are harness races: `persistence.sync()` can resolve while real board traversal (`enableRealSyncBoards` / `sync_boards`) and remap/tail work are still running. Passing siblings already use `primeBoardRevisionsSyncHarness(function(){ tailDone = true; })` and wait `done && tailDone`; tests that call the harness with no callback and wait only on `done` assert/cleanup early. Post-`sync()` fixed `later(..., 50)` plus immediate `cancelSyncTailWork()` has the same shape for temp-id rewrite. Prefer `waitForSyncDoneAndSettled(done)` (`done && syncSettled()`) plus the board-sync completion callback, and only cancel tail work after permanent IDs are visible. See `docs/task-management/2026-07-13-ember-ci-persistence-sync-harness-wait.md`. (2026-07-13)
+
+## Gotcha: Textarea `@value` on a get-only computed crashes on keystroke — needs a setter/cache
+
+Org Settings → Home Boards bound `<Textarea @value={{this.home_board_key_lines}}>` to a **get-only** computed that joined `model.home_board_keys`. Typing tried to `set('home_board_key_lines', …)` and threw `Cannot read properties of undefined (reading 'call')` (missing Ember computed setter). Fix: writable computed with a `_home_board_key_lines` edit cache, cleared in `opening()` / after save. Related: pasted modern board URLs (`/:user/board-detail/:slug`) are not board keys until host + `board-detail`/`board` segments are stripped to `owner/slug` — do that in both the settings save normalize and `Organization#process`. See `docs/task-management/2026-07-16-org-home-board-key-lines.md`. (2026-07-16)
+
+## Gotcha: Ember `<Input>` checkboxes need `@type`, and bound-select must stopPropagation
+
+`<Input type="checkbox" @checked={{…}}>` renders as a text field (`ember-text-field`, `type="text"`) — the HTML `type` attr is not the component arg. Use `@type="checkbox"` (as organization/settings already does). Separately, `bound-select`'s `ctrlAction` helper used to `preventDefault` then **pop the event** before `send`, so `toggle`/`choose` never received it and never `stopPropagation`'d — clicks bubbled into `modal-dialog` and selects looked dead. Match `modern-select`: keep the event, stopPropagation, and make `.md-org-settings-field > span` `display:block` so the `tagName:span` wrapper doesn't shrink the hit target. See `docs/task-management/2026-07-16-org-home-board-key-lines.md`. (2026-07-16)
 
 ## Pattern: EU AI under-16 consent is a third blob, not COPPA signup
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1054,6 +1054,15 @@ describe Organization, :type => :model do
       o.process({:home_board_key => b.key}, {updater: u})
       expect(o.settings['default_home_boards']).to eq([{'key' => b.key, 'id' => b.global_id}])
     end
+
+    it "should accept a pasted board-detail URL as a home board key" do
+      u = User.create
+      b = Board.create(user: u, public: true)
+      o = Organization.create
+      url = "https://lingolinq-staging.onrender.com/#{u.user_name}/board-detail/#{b.key.split('/', 2)[1]}"
+      o.process({:home_board_keys => [url]}, {updater: u})
+      expect(o.settings['default_home_boards']).to eq([{'key' => b.key, 'id' => b.global_id}])
+    end
     
     it "should not allow setting a private home board" do
       u = User.create


### PR DESCRIPTION
Make home_board_key_lines writable, normalize board-detail URLs to owner/slug keys, stopPropagation on bound-select clicks, and use @type for Start Codes checkboxes so org setup controls work again.