### PR TITLE
fix(demo): stop Speak Mode buttons overlapping on short viewports

### DIFF
--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -73894,6 +73894,27 @@ span.md-board-detail-sentence-bar__modeling-badge--paused:hover {
     flex: 0 0 auto !important;
     align-content: start;
   }
+
+  /* Demo speak-only pins the page and re-caps the grid with max-height:100% +
+     overflow:hidden (see .demo-board-page--speak-only rules). That defeats
+     square-collapse: aspect-ratio cards stay column-tall while 1fr rows
+     compress, so buttons paint over the row above. Clear the fill trap and
+     let <main> scroll — same escape hatch as board-detail speak. */
+  .demo-board-page--speak-only:has(.md-board-detail-grid--shape-square) .demo-board-page__main {
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+  .demo-board-page--speak-only:has(.md-board-detail-grid--shape-square) .demo-board-page__board {
+    flex: 0 0 auto;
+    overflow: visible;
+  }
+  .demo-board-page--speak-only:has(.md-board-detail-grid--shape-square) .demo-board-page__board > .ember-view {
+    flex: 0 0 auto;
+    max-height: none;
+  }
+  .demo-board-page--speak-only .demo-board-page__board .md-board-detail-grid.md-board-detail-grid--shape-square {
+    max-height: none;
+  }
 }
 
 .md-board-detail-symbol-card {


### PR DESCRIPTION
## Summary
- On short/narrow viewports, demo Speak Mode square buttons were overlapping because speak-only layout kept `max-height: 100%` and `overflow: hidden` after square-collapse set `height: auto`.
- Clear that fill trap under the existing square-collapse media query so the grid can grow and `<main>` scrolls, matching board-detail speak behavior.

## Test plan
- [ ] Open `/demo/speak` (default square buttons) at a short viewport height (e.g. DevTools device mode or browser height under ~700px)
- [ ] Confirm buttons no longer overlap vertically and the board scrolls inside the main area
- [ ] Confirm tall/wide button shape prefs still fill without unexpected scroll on short screens
- [ ] Confirm taller viewports still fill as before (square-collapse scoped to max-width 1024 / max-height 700)


Made with [Cursor](https://cursor.com)