### PR TITLE
security(deps): bump loofah >= 2.25.2 and rails-html-sanitizer >= 1.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,11 @@ gem 'json', '>= 2.19.2'
 # replace the JSON module across the app, including Rails internals.
 # CVE-2026-54500/54502/54592; bundler-audit minimum
 gem 'oj', '>= 3.17.3'
-# GHSA-46fp-8f5p-pf2m (allowed_uri?); rails-html-sanitizer 1.7.0 depends on loofah ~> 2.25; ensure >= 2.25.1
-gem 'loofah', '>= 2.25.1'
+# GHSA-46fp-8f5p-pf2m + GHSA-5qhf-9phg-95m2 + GHSA-8whx-365g-h9vv + GHSA-9wjq-cp2p-hrgf
+# (allowed_uri? javascript: bypasses via char refs; SVG href local-reference bypass); ensure >= 2.25.2
+gem 'loofah', '>= 2.25.2'
+# GHSA-cj75-f6xr-r4g7 (possible XSS with certain configs); transitive via actionview/actiontext, pin patched
+gem 'rails-html-sanitizer', '>= 1.7.1'
 # GHSA-6jxj-px6v-747w et al.; bundler-audit minimum (transitive via loofah, rails-dom-testing)
 gem 'crass', '>= 1.0.7'
 # ERB @_init deserialization guard bypass (def_module/def_method/def_class); pulled transitively, pin patched 6.x

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lumberjack (1.4.2)
@@ -388,8 +388,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (7.2.3.1)
       actionpack (= 7.2.3.1)
@@ -606,7 +606,7 @@ DEPENDENCIES
   http-2
   irb
   json (>= 2.19.2)
-  loofah (>= 2.25.1)
+  loofah (>= 2.25.2)
   matrix
   mutex_m
   obf
@@ -623,6 +623,7 @@ DEPENDENCIES
   rack-timeout
   rails (>= 7.2.3.1, < 7.3)
   rails-controller-testing
+  rails-html-sanitizer (>= 1.7.1)
   resque (~> 3.0)
   rotp
   rspec-rails


### PR DESCRIPTION
## Why
`bundle-audit check --update` (the CI `security-scan` job) flags 4 advisories against staging's current `Gemfile.lock`. This is **repo-wide** — every open PR off staging is red on `security-scan`, including #627. Fixing it here unblocks all of them.

| Gem | Locked | Advisories | Fix |
| --- | --- | --- | --- |
| loofah | 2.25.1 | GHSA-5qhf-9phg-95m2, GHSA-8whx-365g-h9vv (`allowed_uri?` javascript: bypasses via char refs), GHSA-9wjq-cp2p-hrgf (Medium; SVG `href` local-reference bypass) | `>= 2.25.2` |
| rails-html-sanitizer | 1.7.0 | GHSA-cj75-f6xr-r4g7 (possible XSS with certain configs) | `>= 1.7.1` |

## Change
- Bumped the existing `loofah` security-floor pin `>= 2.25.1` -> `>= 2.25.2` (updated GHSA comment).
- Added a `rails-html-sanitizer >= 1.7.1` floor (transitive via actionview/actiontext), matching the repo's existing security-floor-pin pattern.
- `bundle lock --update loofah rails-html-sanitizer` (conservative): **only these two gems** and their constraint edges change in `Gemfile.lock` — no other gems touched.

## Verification
`bundle-audit check` -> **No vulnerabilities found** (was 4). No app code changes; patch-level dependency bumps only.

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| loofah advisories | Fixed | Gemfile.lock loofah 2.25.2; bundle-audit clean |
| rails-html-sanitizer advisory | Fixed | Gemfile.lock rails-html-sanitizer 1.7.1; bundle-audit clean |

## Not covered by this PR
- None. Scoped to the two flagged gems.

## Author-Model: opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6YbRBEdeRmcjFMcYiwVFH