### PR TITLE
fix(codex-review): classify tool-call runner failures

### DIFF
--- a/scripts/codex-review-build-envelope.py
+++ b/scripts/codex-review-build-envelope.py
@@ -24,6 +24,10 @@ INFRASTRUCTURE_MARKERS = (
     "operation not permitted",
     "every shell invocation failed",
     "unable to complete the mandated read-only repository inspection",
+    "tool calls are failing",
+    "before any shell command can run",
+    "command channel rejected",
+    "output-schema validation error",
     "sandbox",
 )
 

--- a/scripts/codex-review-build-envelope.test.py
+++ b/scripts/codex-review-build-envelope.test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Regression tests for codex-review-build-envelope.py status mapping."""
+import importlib.util
+import pathlib
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("codex-review-build-envelope.py")
+SPEC = importlib.util.spec_from_file_location("codex_review_build_envelope", MODULE_PATH)
+build_envelope = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(build_envelope)
+
+
+class ReviewOutcomeTest(unittest.TestCase):
+    def test_current_runner_tool_call_failure_is_inconclusive(self):
+        review = {
+            "verdict": "NEEDS_HUMAN",
+            "findings": [
+                {
+                    "category": "live_state",
+                    "description": (
+                        "Unable to perform required read-only PR inspection in this runner: "
+                        "tool calls are failing before any shell command can run."
+                    ),
+                    "evidence": (
+                        "The command channel rejected even the initial status command with "
+                        "an output-schema validation error before execution."
+                    ),
+                    "suggested_fix": "Rerun the Codex review job with command execution available.",
+                    "verifiable_check": "git rev-parse HEAD",
+                }
+            ],
+        }
+
+        outcome = build_envelope.review_outcome(review)
+
+        self.assertEqual(outcome["kind"], "inconclusive_infrastructure")
+        self.assertEqual(outcome["status_state"], "success")
+        self.assertEqual(outcome["status_description"], "Codex review inconclusive (runner/sandbox)")
+
+    def test_non_live_state_needs_human_still_requires_attention(self):
+        review = {
+            "verdict": "NEEDS_HUMAN",
+            "findings": [
+                {
+                    "category": "claim_vs_code",
+                    "description": "A human needs to decide whether this product claim is acceptable.",
+                    "evidence": "No runner or sandbox failure.",
+                    "suggested_fix": "Clarify the claim.",
+                    "verifiable_check": "manual review",
+                }
+            ],
+        }
+
+        outcome = build_envelope.review_outcome(review)
+
+        self.assertEqual(outcome["kind"], "requires_attention")
+        self.assertEqual(outcome["status_state"], "failure")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
- Treat Codex runner failures that say tool calls are failing before shell execution as infrastructure-inconclusive, not review-required-changes.
- Add a regression test for the exact #627 failure shape.

## Verification
- python3 scripts/codex-review-build-envelope.test.py
- python3 -m py_compile scripts/codex-review-build-envelope.py scripts/codex-review-build-envelope.test.py
- git diff --check

## Context
#627 received a failing codex-review/deep-pass status even though the model output was NEEDS_HUMAN/category live_state and the failure was runner/tooling-only.