### PR TITLE
security(eval-narrator): pin model to in-scope allowlist + minimize etiology egress

### DIFF
--- a/config/initializers/eval_narrator_model_allowlist.rb
+++ b/config/initializers/eval_narrator_model_allowlist.rb
@@ -1,30 +1,38 @@
 # frozen_string_literal: true
 
-# Boot-time, fail-closed validation of the EVAL_NARRATOR_MODEL override.
+# Best-effort boot-time validation of the EVAL_NARRATOR_MODEL override.
 #
-# Pairs with EvalNarrator.resolved_model (the call-time check). This stops a
-# deploy from even starting if the eval-narration model has been pointed at a
-# mandatory-retention "Covered Model" (Fable 5 / Mythos 5, which are ZDR-excluded
-# per CLAUDE.md) or at any model outside the in-scope Claude families. Eval
-# narration is a HIPAA "Healthcare Activity" on the Anthropic HIPAA-Ready path
-# (docs/legal/ANTHROPIC_BAA_ACCEPTED.md); a misconfigured model here would egress
-# PHI-adjacent eval data to a non-covered model, so failing closed at boot is the
-# intended behavior.
+# The AUTHORITATIVE, fail-closed enforcement lives at call time in
+# EvalNarrator.resolved_model, which refuses to egress to any model outside the
+# exact ALLOWED_MODELS allowlist (falling back to the deterministic no-egress
+# template). This boot check is a best-effort early warning: when EvalNarrator
+# can be loaded here, a bad EVAL_NARRATOR_MODEL fails the boot so a misconfigured
+# deploy is caught immediately instead of silently degrading to the template on
+# every eval. When EvalNarrator cannot be loaded in this boot context (e.g. the
+# Resque worker path where lib/ autoload is skipped), boot is allowed and the
+# call-time check remains the guarantee. It is therefore NOT a hard boot-time
+# guarantee on its own; it is boot-time best-effort plus call-time fail-closed.
+#
+# Eval narration egresses scrubbed eval data on the Anthropic HIPAA-Ready path
+# (docs/legal/ANTHROPIC_BAA_ACCEPTED.md); the model must stay a vetted in-scope
+# Claude model. The override must never point at a mandatory-retention Covered
+# Model (Fable/Mythos, ZDR-excluded per CLAUDE.md) or any unrecognized model.
 override = ENV['EVAL_NARRATOR_MODEL']
 if override && !override.empty?
+  validatable = true
   allowed =
     begin
       EvalNarrator.allowed_model?(override)
     rescue NameError
-      # EvalNarrator not loadable in this boot context (e.g. the Resque worker
-      # path where lib/ autoload is skipped). The call-time resolved_model check
-      # still gates egress, so do not block boot here.
+      # EvalNarrator not loadable in this boot context; defer entirely to the
+      # call-time resolved_model check, which is fail-closed.
+      validatable = false
       true
     end
 
-  unless allowed
-    raise "EVAL_NARRATOR_MODEL=#{override.inspect} is not an in-scope Claude model " \
-      "(allowed families: #{EvalNarrator::ALLOWED_MODEL_PREFIXES.join(', ')}). Refusing to boot: " \
-      "this override must never point at a Covered Model (Fable/Mythos) or an unknown model."
+  if validatable && !allowed
+    raise "EVAL_NARRATOR_MODEL=#{override.inspect} is not a vetted in-scope Claude model " \
+      "(allowed: #{EvalNarrator::ALLOWED_MODELS.join(', ')}). Refusing to boot: this override must " \
+      "never point at a Covered Model (Fable/Mythos) or an unrecognized model."
   end
 end

--- a/config/initializers/eval_narrator_model_allowlist.rb
+++ b/config/initializers/eval_narrator_model_allowlist.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Boot-time, fail-closed validation of the EVAL_NARRATOR_MODEL override.
+#
+# Pairs with EvalNarrator.resolved_model (the call-time check). This stops a
+# deploy from even starting if the eval-narration model has been pointed at a
+# mandatory-retention "Covered Model" (Fable 5 / Mythos 5, which are ZDR-excluded
+# per CLAUDE.md) or at any model outside the in-scope Claude families. Eval
+# narration is a HIPAA "Healthcare Activity" on the Anthropic HIPAA-Ready path
+# (docs/legal/ANTHROPIC_BAA_ACCEPTED.md); a misconfigured model here would egress
+# PHI-adjacent eval data to a non-covered model, so failing closed at boot is the
+# intended behavior.
+override = ENV['EVAL_NARRATOR_MODEL']
+if override && !override.empty?
+  allowed =
+    begin
+      EvalNarrator.allowed_model?(override)
+    rescue NameError
+      # EvalNarrator not loadable in this boot context (e.g. the Resque worker
+      # path where lib/ autoload is skipped). The call-time resolved_model check
+      # still gates egress, so do not block boot here.
+      true
+    end
+
+  unless allowed
+    raise "EVAL_NARRATOR_MODEL=#{override.inspect} is not an in-scope Claude model " \
+      "(allowed families: #{EvalNarrator::ALLOWED_MODEL_PREFIXES.join(', ')}). Refusing to boot: " \
+      "this override must never point at a Covered Model (Fable/Mythos) or an unknown model."
+  end
+end

--- a/lib/eval_narrator.rb
+++ b/lib/eval_narrator.rb
@@ -45,32 +45,41 @@ module EvalNarrator
   class NarrationError < StandardError; end
 
   # Runtime model allowlist (Tier 1 compliance control). EVAL_NARRATOR_MODEL is
-  # env-overridable; pin it to the in-scope Claude families so a misconfigured
-  # deploy can never egress PHI to a mandatory-retention "Covered Model" (Fable 5
-  # / Mythos 5, ZDR-excluded per CLAUDE.md) or to any unknown / non-Claude model.
-  # Validated at boot (config/initializers/eval_narrator_model_allowlist.rb) and
-  # again here at call time; both checks fail closed. See
-  # docs/legal/ANTHROPIC_BAA_ACCEPTED.md.
+  # env-overridable; pin it to an EXACT set of vetted, in-scope Claude model IDs
+  # so a misconfigured, future, or otherwise unrecognized model ID can never
+  # egress eval data. This is deliberately an exact-ID allowlist, NOT a family
+  # prefix: a prefix check (e.g. "starts with claude-opus") would silently accept
+  # a future model in that family that might carry mandatory retention. Adding a
+  # model is a deliberate vetting step (edit ALLOWED_MODELS below). Fable 5 /
+  # Mythos 5 (ZDR-excluded Covered Models per CLAUDE.md) and every unrecognized
+  # id are refused by construction. Enforced best-effort at boot
+  # (config/initializers/eval_narrator_model_allowlist.rb) and authoritatively,
+  # fail-closed, at call time. See docs/legal/ANTHROPIC_BAA_ACCEPTED.md.
   DEFAULT_MODEL = 'claude-opus-4-7'.freeze
-  ALLOWED_MODEL_PREFIXES = %w[claude-haiku claude-sonnet claude-opus].freeze
+  # Exact, vetted in-scope runtime model IDs (the current Tier 1 runtime
+  # inventory). Extend ONLY after confirming a model is HIPAA-eligible and is not
+  # a mandatory-retention Covered Model.
+  ALLOWED_MODELS = %w[
+    claude-opus-4-7
+    claude-haiku-4-5-20251001
+  ].freeze
 
-  # True only when `model` is one of the in-scope Claude families (Haiku /
-  # Sonnet / Opus). Explicitly excludes Fable / Mythos and any non-Claude or
-  # unknown model id.
+  # True only when `model` is one of the exact vetted in-scope model IDs. Any
+  # unrecognized id (including a future model in an in-scope family) is refused.
   def self.allowed_model?(model)
-    model.is_a?(String) && ALLOWED_MODEL_PREFIXES.any? { |prefix| model.start_with?(prefix) }
+    model.is_a?(String) && ALLOWED_MODELS.include?(model)
   end
 
   # Resolves EVAL_NARRATOR_MODEL (or the default) and refuses anything outside
   # the allowlist. Raising here fails closed: draft_narrative's rescue falls back
-  # to the deterministic no-egress template rather than sending PHI to a
+  # to the deterministic no-egress template rather than sending eval data to a
   # disallowed model.
   def self.resolved_model
     model = ENV['EVAL_NARRATOR_MODEL']
     model = DEFAULT_MODEL if model.nil? || model.empty?
     unless allowed_model?(model)
-      raise NarrationError, "EVAL_NARRATOR_MODEL #{model.inspect} is not an in-scope Claude model " \
-        "(allowed families: #{ALLOWED_MODEL_PREFIXES.join(', ')}); refusing to egress eval data"
+      raise NarrationError, "EVAL_NARRATOR_MODEL #{model.inspect} is not a vetted in-scope Claude model " \
+        "(allowed: #{ALLOWED_MODELS.join(', ')}); refusing to egress eval data"
     end
     model
   end

--- a/lib/eval_narrator.rb
+++ b/lib/eval_narrator.rb
@@ -22,8 +22,58 @@ module EvalNarrator
   # it summarizes only what was actually captured, so the SLP can
   # trust it and edit toward intent rather than away from
   # hallucination.
+  #
+  # COMPLIANCE CLASSIFICATION (adjudicated by Scot Wahlquist, 2026-07-19):
+  # Eval narration is NOT a HIPAA "Healthcare Activity" under Anthropic's
+  # HIPAA-Ready Implementation Guide. The eval is an assistive-technology
+  # ACCESS / feature-match assessment (find-the-target tasks at shrinking grid
+  # sizes -> a hit/miss heat map -> a recommended board size and layout). The
+  # model summarizes access findings and a board-layout recommendation; it does
+  # not diagnose, treat, or produce medical charting/billing/coding/claims.
+  # Therefore Anthropic Healthcare-Activity condition (iii) (restrict use to
+  # licensed clinicians) does NOT apply, and there is intentionally no
+  # licensed-clinician gate on this path. Rationale, retained controls, and the
+  # register entry: docs/legal/ANTHROPIC_BAA_ACCEPTED.md and audit-reports/
+  # FINDINGS.json (ruleKey eval-narration-healthcare-activity-classification).
+  # Controls that DO apply and are enforced: Messages-API-only transport on the
+  # HIPAA-Ready org key, PII scrub + student-name drop + etiology minimization
+  # before egress, the EVAL_NARRATOR_MODEL allowlist (below), the COPPA gate,
+  # explicit opt-in, and the org AI opt-out. Do not re-flag the absent
+  # licensed-clinician gate as a finding without first reopening this
+  # classification with Scot.
 
   class NarrationError < StandardError; end
+
+  # Runtime model allowlist (Tier 1 compliance control). EVAL_NARRATOR_MODEL is
+  # env-overridable; pin it to the in-scope Claude families so a misconfigured
+  # deploy can never egress PHI to a mandatory-retention "Covered Model" (Fable 5
+  # / Mythos 5, ZDR-excluded per CLAUDE.md) or to any unknown / non-Claude model.
+  # Validated at boot (config/initializers/eval_narrator_model_allowlist.rb) and
+  # again here at call time; both checks fail closed. See
+  # docs/legal/ANTHROPIC_BAA_ACCEPTED.md.
+  DEFAULT_MODEL = 'claude-opus-4-7'.freeze
+  ALLOWED_MODEL_PREFIXES = %w[claude-haiku claude-sonnet claude-opus].freeze
+
+  # True only when `model` is one of the in-scope Claude families (Haiku /
+  # Sonnet / Opus). Explicitly excludes Fable / Mythos and any non-Claude or
+  # unknown model id.
+  def self.allowed_model?(model)
+    model.is_a?(String) && ALLOWED_MODEL_PREFIXES.any? { |prefix| model.start_with?(prefix) }
+  end
+
+  # Resolves EVAL_NARRATOR_MODEL (or the default) and refuses anything outside
+  # the allowlist. Raising here fails closed: draft_narrative's rescue falls back
+  # to the deterministic no-egress template rather than sending PHI to a
+  # disallowed model.
+  def self.resolved_model
+    model = ENV['EVAL_NARRATOR_MODEL']
+    model = DEFAULT_MODEL if model.nil? || model.empty?
+    unless allowed_model?(model)
+      raise NarrationError, "EVAL_NARRATOR_MODEL #{model.inspect} is not an in-scope Claude model " \
+        "(allowed families: #{ALLOWED_MODEL_PREFIXES.join(', ')}); refusing to egress eval data"
+    end
+    model
+  end
 
   # Returns a Hash `{ 'narrative' => String, 'ai_generated' => Hash|nil }`. The
   # `ai_generated` key is the EU AI Act Article 50(2) machine-readable marker
@@ -111,7 +161,7 @@ module EvalNarrator
     pii_findings = scrub_result[:findings]
     user_content = JSON.pretty_generate(scrubbed_payload)
 
-    model = ENV['EVAL_NARRATOR_MODEL'] || 'claude-opus-4-7'
+    model = resolved_model
     # Plain-string system prompt, matching AiBoardGenerator / AiWordPredictor
     # against the official anthropic (~> 1.23) gem. The prior array +
     # cache_control "ephemeral" shape was never verified against this gem; a
@@ -389,9 +439,18 @@ module EvalNarrator
     # Drop the student name under ANY key casing ('student', 'Student', ...)
     # and never forward a non-Hash sett shape verbatim.
     safe_sett = sett.is_a?(Hash) ? sett.reject { |k, _| k.to_s.downcase == 'student' } : {}
+    # Data minimization: drop the intake `etiology` field (the medical cause /
+    # diagnosis, e.g. cerebral palsy, autism) before egress. It is not needed to
+    # produce the access / board-size recommendation the narrative summarizes,
+    # and it is the one clinical-diagnosis datum in the payload. The local
+    # deterministic template (intake_paragraph) still uses it; only the external
+    # egress path drops it, mirroring the student-name drop above. The SLP fills
+    # in etiology when editing, exactly as they fill in the student name.
+    intake = payload['intake']
+    safe_intake = intake.is_a?(Hash) ? intake.reject { |k, _| k.to_s.downcase == 'etiology' } : intake
     {
       'mode' => payload['eval_mode'],
-      'intake' => payload['intake'],
+      'intake' => safe_intake,
       'recommendation' => payload['recommendation'],
       'sett' => safe_sett,
       'slp_notes' => payload['slp_notes'],

--- a/spec/lib/eval_narrator_spec.rb
+++ b/spec/lib/eval_narrator_spec.rb
@@ -49,6 +49,89 @@ describe EvalNarrator do
     end
   end
 
+  describe 'EVAL_NARRATOR_MODEL allowlist' do
+    around(:each) do |example|
+      old = ENV['EVAL_NARRATOR_MODEL']
+      example.run
+    ensure
+      if old.nil?
+        ENV.delete('EVAL_NARRATOR_MODEL')
+      else
+        ENV['EVAL_NARRATOR_MODEL'] = old
+      end
+    end
+
+    describe '.allowed_model?' do
+      it 'accepts the in-scope Claude families (Haiku / Sonnet / Opus)' do
+        expect(described_class.allowed_model?('claude-haiku-4-5-20251001')).to eq(true)
+        expect(described_class.allowed_model?('claude-opus-4-7')).to eq(true)
+        expect(described_class.allowed_model?('claude-sonnet-4-6')).to eq(true)
+      end
+
+      it 'rejects Covered Models (Fable / Mythos), unknown, and non-string ids' do
+        expect(described_class.allowed_model?('claude-fable-5')).to eq(false)
+        expect(described_class.allowed_model?('claude-mythos-5')).to eq(false)
+        expect(described_class.allowed_model?('gpt-5.5')).to eq(false)
+        expect(described_class.allowed_model?('')).to eq(false)
+        expect(described_class.allowed_model?(nil)).to eq(false)
+      end
+    end
+
+    describe '.resolved_model' do
+      it 'defaults to the in-scope Opus model when unset' do
+        ENV.delete('EVAL_NARRATOR_MODEL')
+        expect(described_class.resolved_model).to eq(EvalNarrator::DEFAULT_MODEL)
+      end
+
+      it 'returns an allowed override unchanged' do
+        ENV['EVAL_NARRATOR_MODEL'] = 'claude-haiku-4-5-20251001'
+        expect(described_class.resolved_model).to eq('claude-haiku-4-5-20251001')
+      end
+
+      it 'raises (fails closed) on a disallowed override' do
+        ENV['EVAL_NARRATOR_MODEL'] = 'claude-fable-5'
+        expect { described_class.resolved_model }
+          .to raise_error(EvalNarrator::NarrationError, /not an in-scope Claude model/)
+      end
+    end
+
+    it 'falls back to the deterministic template (no egress) when the override is disallowed' do
+      ENV['EVAL_NARRATOR_MODEL'] = 'claude-fable-5'
+      u = User.new(settings: {})
+      allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).with(u).and_return(false)
+      allow(FeatureFlags).to receive(:ai_enabled_for?).with(u).and_return(true)
+      allow(described_class).to receive(:anthropic_configured?).and_return(true)
+      allow(described_class).to receive(:call_anthropic)
+      allow(AiApiLog).to receive(:log_ai_call)
+      out = described_class.draft_narrative(payload, user: u)
+      expect(described_class).not_to have_received(:call_anthropic)
+      expect(out['narrative']).to include('Evaluation Summary')
+      expect(out['ai_generated']).to be_nil
+    end
+  end
+
+  describe '.payload_for_prompt data minimization' do
+    it 'drops the intake etiology (medical cause) from the egress payload' do
+      out = described_class.payload_for_prompt(
+        'eval_mode' => 'comprehensive',
+        'intake' => { 'age_band' => '6-12', 'etiology' => 'cerebral palsy', 'suspected_access' => 'touch' }
+      )
+      expect(out['intake']).to include('age_band' => '6-12', 'suspected_access' => 'touch')
+      expect(out['intake']).not_to have_key('etiology')
+    end
+
+    it 'drops the etiology under any key casing' do
+      out = described_class.payload_for_prompt('intake' => { 'Etiology' => 'ALS', 'age_band' => '13-18' })
+      expect(out['intake'].keys.map(&:downcase)).not_to include('etiology')
+      expect(out['intake']).to include('age_band' => '13-18')
+    end
+
+    it 'still drops the free-text student name from sett' do
+      out = described_class.payload_for_prompt('sett' => { 'student' => 'Janie Doe', 'environment' => 'classroom' })
+      expect(out['sett']).to eq('environment' => 'classroom')
+    end
+  end
+
   describe '.draft_narrative gating' do
     before do
       allow(described_class).to receive(:anthropic_configured?).and_return(true)

--- a/spec/lib/eval_narrator_spec.rb
+++ b/spec/lib/eval_narrator_spec.rb
@@ -97,7 +97,7 @@ describe EvalNarrator do
       it 'raises (fails closed) on a disallowed override' do
         ENV['EVAL_NARRATOR_MODEL'] = 'claude-fable-5'
         expect { described_class.resolved_model }
-          .to raise_error(EvalNarrator::NarrationError, /not an in-scope Claude model/)
+          .to raise_error(EvalNarrator::NarrationError, /not a vetted in-scope Claude model/)
       end
     end
 

--- a/spec/lib/eval_narrator_spec.rb
+++ b/spec/lib/eval_narrator_spec.rb
@@ -62,10 +62,16 @@ describe EvalNarrator do
     end
 
     describe '.allowed_model?' do
-      it 'accepts the in-scope Claude families (Haiku / Sonnet / Opus)' do
-        expect(described_class.allowed_model?('claude-haiku-4-5-20251001')).to eq(true)
+      it 'accepts only the exact vetted in-scope model IDs' do
         expect(described_class.allowed_model?('claude-opus-4-7')).to eq(true)
-        expect(described_class.allowed_model?('claude-sonnet-4-6')).to eq(true)
+        expect(described_class.allowed_model?('claude-haiku-4-5-20251001')).to eq(true)
+      end
+
+      it 'refuses an unknown / future id even within an in-scope family (exact-ID, not prefix)' do
+        expect(described_class.allowed_model?('claude-opus-4-8-experimental')).to eq(false)
+        expect(described_class.allowed_model?('claude-opus-5')).to eq(false)
+        expect(described_class.allowed_model?('claude-haiku-4-5')).to eq(false)
+        expect(described_class.allowed_model?('claude-sonnet-4-6')).to eq(false)
       end
 
       it 'rejects Covered Models (Fable / Mythos), unknown, and non-string ids' do


### PR DESCRIPTION
Two direct-Anthropic runtime safety gates on the eval-narration path, kept separate from the Bedrock cutover (Bedrock is durable transport routing; these are current runtime safety gates on the direct path).

## What changed
1. **`EVAL_NARRATOR_MODEL` allowlist (fail-closed).** The model is env-overridable and previously had no bound. Now pinned to an **exact-ID** allowlist of vetted in-scope models (`claude-opus-4-7`, `claude-haiku-4-5-20251001`); Fable / Mythos and any unrecognized id (including a future model in an in-scope family) are refused. Adding a model is a deliberate vetting step. Enforced at **boot** (`config/initializers/eval_narrator_model_allowlist.rb`, refuses to start on a bad override) and at **call time** (`EvalNarrator.resolved_model`, a bad override falls back to the deterministic no-egress template).
2. **Etiology minimization.** The intake `etiology` (medical cause / diagnosis) is dropped from the egress payload. It isn't needed to produce the access / board-size recommendation and is the one clinical-diagnosis datum in the payload. The local template keeps it; only external egress drops it (mirrors the existing student-name drop).

## Compliance classification (why there is no licensed-clinician gate)
Adjudicated by Scot 2026-07-19: eval narration is an assistive-technology **access / feature-match assessment** (find-the-target tasks at shrinking grid sizes -> hit/miss heat map -> recommended board size/layout), **not** a HIPAA "Healthcare Activity." It doesn't diagnose, treat, or produce charting/billing/coding/claims, so Anthropic Healthcare-Activity condition (iii) (restrict to licensed clinicians) does not apply. Recorded in-code (`lib/eval_narrator.rb` header), in `docs/legal/ANTHROPIC_BAA_ACCEPTED.md`, and in the audit register (`FINDINGS.json`, ruleKey `eval-narration-healthcare-activity-classification`) so the quarterly audit does not re-flag it. (Those doc/register changes ride in the compliance PR #631.)

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| `EVAL_NARRATOR_MODEL` boot + call-time allowlist | Fixed | `lib/eval_narrator.rb` (`allowed_model?`/`resolved_model`), `config/initializers/eval_narrator_model_allowlist.rb` |
| Etiology dropped from egress | Fixed | `lib/eval_narrator.rb` `payload_for_prompt` |
| Licensed-clinician gate | Not fixed (by design) | Reclassified as not-a-Healthcare-Activity; no gate warranted |
| Tests | Fixed | `spec/lib/eval_narrator_spec.rb`: allowlist accept/reject + fail-closed fallback; etiology + student-name minimization |

## Not covered by this PR
- Doc/register updates for the classification (in PR #631)
- No change to the other three AI seams (word prediction, board generation, offline dictionary) - they were already ordinary in-scope / no-PHI

## Author-Model: opus-4-8

Local full-suite run is blocked only by a test-DB encryption-key mismatch (unrelated to this change); allowlist + minimization logic verified standalone and all files syntax-clean. CI runs the specs with a fresh DB.