### PR TITLE
security(pii-scrubber): redact surnames after first names + honorifics

### DIFF
--- a/lib/pii_scrubber.rb
+++ b/lib/pii_scrubber.rb
@@ -652,9 +652,48 @@ module PiiScrubber
       end
     end
 
-    # Redact common first-name matches from text, recording findings.
+    # Honorifics that strongly signal the immediately-following Capitalized token
+    # is a surname (e.g. "Dr. Smith", "Mrs. Johnson"). The honorific itself is not
+    # PII and is preserved; only the surname is redacted.
+    HONORIFIC_SURNAME_PATTERN =
+      /\b((?:Mr|Mrs|Ms|Miss|Mx|Dr|Drs|Prof|Professor)\.?\s+)([A-Z][A-Za-z'’-]+)\b/
+
+    # A Capitalized token immediately following an already-redacted name placeholder
+    # is the likely surname (e.g. "[REDACTED_NAME] Johnson"). Applied AFTER the
+    # first-name / blocklist passes so the placeholder is present.
+    TRAILING_SURNAME_PATTERN = /\[REDACTED_NAME\](\s+)([A-Z][A-Za-z'’-]+)\b/
+
+    # Redact person names from free text, recording findings. Three passes, all
+    # deliberately biased toward over-redaction (the safe direction for an AI
+    # egress path, consistent with the COMMON_FIRST_NAMES gazetteer's own bias):
+    #   1. honorific + Capitalized surname ("Dr. Smith")   -> redact the surname
+    #   2. standalone common first name ("Sarah", "Bobby")  -> redact it
+    #   3. a Capitalized token right after a name placeholder ("[REDACTED_NAME]
+    #      Johnson") -> redact it too (the likely surname of a first name from
+    #      pass 2 or a blocklisted account-holder name)
+    # Ordering matters: pass 2 runs before pass 3 so a "First Last" pair becomes
+    # "[REDACTED_NAME] Last" and pass 3 then catches "Last" -- a single left-to-right
+    # two-word regex would instead consume "<preceding word> First" and miss the
+    # surname. Passes 1 and 3 close the surname gap the first-name gazetteer alone
+    # cannot (the residual the eval-narration review flagged for free-typed
+    # third-party names). A bare surname with no honorific and no preceding
+    # first/blocklisted name is still not caught here -- that needs a surname
+    # gazetteer, which over-matches ordinary English words -- so a UI affordance
+    # discouraging free-typed third-party names remains the primary point-of-entry
+    # control (tracked as a follow-up).
     def redact_common_names(text, findings)
-      text.gsub(/\b[A-Za-z]+\b/) do |word|
+      result = text.gsub(HONORIFIC_SURNAME_PATTERN) do
+        prefix = Regexp.last_match(1)
+        surname = Regexp.last_match(2)
+        findings << {
+          type: :person_name,
+          value: redact_value_preview(surname),
+          position: Regexp.last_match.begin(2)
+        }
+        "#{prefix}[REDACTED_NAME]"
+      end
+
+      result = result.gsub(/\b[A-Za-z]+\b/) do |word|
         if COMMON_FIRST_NAMES.include?(word.downcase)
           findings << {
             type: :common_name,
@@ -665,6 +704,17 @@ module PiiScrubber
         else
           word
         end
+      end
+
+      result.gsub(TRAILING_SURNAME_PATTERN) do
+        separator = Regexp.last_match(1)
+        surname = Regexp.last_match(2)
+        findings << {
+          type: :person_name,
+          value: redact_value_preview(surname),
+          position: Regexp.last_match.begin(2)
+        }
+        "[REDACTED_NAME]#{separator}[REDACTED_NAME]"
       end
     end
 

--- a/spec/lib/pii_scrubber_spec.rb
+++ b/spec/lib/pii_scrubber_spec.rb
@@ -527,6 +527,57 @@ describe PiiScrubber do
       expect(result[:findings].map { |f| f[:type] }).to include(:common_name)
     end
 
+    context "surname and honorific hardening (free-typed third-party names)" do
+      before { PiiScrubber.reset_blocklist! }
+
+      it "redacts a surname following a common first name" do
+        result = PiiScrubber.redact_for_ai("SLP notes: met with Sarah Johnson today")
+        expect(result[:payload]).not_to include('Sarah')
+        expect(result[:payload]).not_to include('Johnson')
+        expect(result[:payload]).to include('[REDACTED_NAME] [REDACTED_NAME]')
+        expect(result[:findings].map { |f| f[:type] }).to include(:person_name)
+      end
+
+      it "redacts a surname following an honorific and keeps the honorific" do
+        result = PiiScrubber.redact_for_ai("referred by Dr. Smith for evaluation")
+        expect(result[:payload]).to include('Dr. [REDACTED_NAME]')
+        expect(result[:payload]).not_to include('Smith')
+      end
+
+      it "handles Mr./Mrs./Prof. honorifics" do
+        expect(PiiScrubber.redact_for_ai("spoke to Mrs. Green")[:payload]).to include('Mrs. [REDACTED_NAME]')
+        expect(PiiScrubber.redact_for_ai("Mr. Anderson called")[:payload]).to include('Mr. [REDACTED_NAME]')
+        expect(PiiScrubber.redact_for_ai("per Prof. Williams")[:payload]).not_to include('Williams')
+      end
+
+      it "redacts all third-party names in a combined clinical note" do
+        result = PiiScrubber.redact_for_ai("met with Sarah Johnson, Dr. Smith, and Mrs. Green about grid access")
+        %w[Sarah Johnson Smith Green].each do |name|
+          expect(result[:payload]).not_to include(name)
+        end
+      end
+
+      it "redacts a third-party surname even when the first name is a blocklisted account holder" do
+        PiiScrubber.configure_blocklist(['Sarah', 'Johnson'])
+        result = PiiScrubber.redact_for_ai("Sarah Johnson met Mrs. Green")
+        %w[Sarah Johnson Green].each { |name| expect(result[:payload]).not_to include(name) }
+      end
+
+      it "still redacts a standalone common first name (single token)" do
+        result = PiiScrubber.redact_for_ai("Sarah was independent at 80%")
+        expect(result[:payload]).not_to include('Sarah')
+        expect(result[:payload].scan('[REDACTED_NAME]').size).to eq(1)
+      end
+
+      it "does not over-redact place names or neutral capitalized phrases" do
+        ['board about Salt Lake City Utah', 'board about Fox in Sox'].each do |phrase|
+          result = PiiScrubber.redact_for_ai(phrase)
+          expect(result[:payload]).to eq(phrase), "unexpectedly redacted: #{result[:payload].inspect}"
+          expect(result[:pii_found]).to eq(false)
+        end
+      end
+    end
+
     it "should not flag ordinary neutral topic prompts as containing PII" do
       %w[
         Generate\ a\ board\ about\ the\ zoo


### PR DESCRIPTION
Closes the residual flagged in the eval-narration review: free-typed third-party names in `slp_notes` (and any AI-egress free text) whose **surname** the first-name gazetteer alone could not catch. Small, scoped to `PiiScrubber`.

## What the residual actually was
`redact_string` already scrubs `slp_notes` for email/phone/SSN/IP/global-id, the account-holder blocklist, **and** common first names (`COMMON_FIRST_NAMES` gazetteer). The real gap was **surnames** (and honorific-prefixed names): "Sarah **Johnson**" or "Dr. **Smith**" left the surname in place.

## Change
`redact_common_names` now runs three over-redaction-biased passes:
1. **honorific + Capitalized surname** ("Dr. Smith", "Mrs. Green") -> redact the surname, keep the honorific.
2. **standalone common first name** ("Sarah") -> redact (existing behavior).
3. **Capitalized token after a name placeholder** ("[REDACTED_NAME] Johnson") -> redact it too — the surname of a first name from pass 2 or a blocklisted account-holder name.

Pass 3 uses placeholder-adjacency rather than a two-word `First Last` regex on purpose: a left-to-right `gsub` would consume `<preceding word> First` and miss the surname (verified — the naive version left "Johnson" in "met with Sarah Johnson").

## Scope / blast radius (please note)
This lives in the **shared** `PiiScrubber` free-text path, so it hardens **all** AI-egress seams (word prediction, board generation, eval narration) as defense-in-depth, not just eval narration. All passes are biased toward **over-redaction** (the safe direction for PII egress), consistent with the existing gazetteer's stated bias.

## What this does NOT do
- A **bare surname** with no honorific and no preceding first/blocklisted name is still not caught — that needs a surname gazetteer, which over-matches ordinary English words ("Green", "Baker", "Rose"). The proportionate control there is a **UI affordance** discouraging free-typed third-party names in `slp_notes` (tracked as a follow-up), not a lossy surname denylist.

## Verification
Standalone against the real gazetteer (PiiScrubber is pure Ruby): honorific/first-name/surname cases redact; combined clinical notes leak no names; blocklist + third-party names all redacted; neutral/place-name prompts ("Salt Lake City Utah", "Fox in Sox") unchanged with `pii_found == false`. New specs cover each. (Local full RSpec boot is blocked by an unrelated test-DB key mismatch; CI runs the suite.)

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| Surname-after-first-name redaction | Fixed | `lib/pii_scrubber.rb` `TRAILING_SURNAME_PATTERN` pass |
| Honorific + surname redaction | Fixed | `HONORIFIC_SURNAME_PATTERN` pass |
| No over-redaction of place/neutral phrases | Verified | spec: neutral-phrase test + standalone |
| Tests | Fixed | `spec/lib/pii_scrubber_spec.rb` (surname/honorific context) |

## Not covered by this PR
- UI affordance for `slp_notes` free-text (point-of-entry control) — separate small frontend follow-up.
- Bare surnames without an adjacency signal (deliberately not attempted; see above).

## Author-Model: opus-4-8
