### PR TITLE
fix: Class-11 Ember 5 regressions — 3 dead checkboxes (@type) + Phrase Substitutions keystroke crash

### DIFF
--- a/app/frontend/app/components/focus-words.hbs
+++ b/app/frontend/app/components/focus-words.hbs
@@ -273,7 +273,7 @@
           {{#if this.model.user}}
             <div class="col-sm-12" style='margin-top: 4px;'>
               <label style='display: flex; align-items: center; gap: 10px; border: 1px solid #ccc; border-radius: 20px; padding: 6px 14px; cursor: pointer; width: fit-content; font-weight: normal; margin-bottom: 0;'>
-                <Input type="checkbox" @checked={{this.reuse}} style='margin: 0; width: 16px; height: 16px; cursor: pointer;' />
+                <Input @type="checkbox" @checked={{this.reuse}} style='margin: 0; width: 16px; height: 16px; cursor: pointer;' />
                 <span>{{t "Save for Re-Use" key="save_for_reuse"}}{{#if this.model.user.user_name}} {{t "(%{user_name})" user_name=this.model.user.user_name key="paren_user_name"}}{{/if}}</span>
               </label>
             </div>

--- a/app/frontend/app/components/masquerade.hbs
+++ b/app/frontend/app/components/masquerade.hbs
@@ -16,7 +16,7 @@
       <div class='col-sm-12'>
         <div class="checkbox big_checkbox">
           <label>
-            <Input @checked={{this.confirmed}} type="checkbox" />
+            <Input @checked={{this.confirmed}} @type="checkbox" />
             {{t "I agree only to use this masquerading tool for support or training purposes, and to respect the privacy of the user's information." key="masquerade agreement"}}
           </label>
         </div>

--- a/app/frontend/app/controllers/user/preferences.js
+++ b/app/frontend/app/controllers/user/preferences.js
@@ -190,6 +190,7 @@ export default Controller.extend({
       this.set('original_preferences.word_suggestion_position', 'side_rail');
     }
     this.set('phrase_categories_string', (this.get('pending_preferences.phrase_categories') || []).join(', '));
+    this.set('_substitution_string', undefined);
     this.set('advanced', true);
     this.set('skip_save_on_transition', false);
     this.set('eu_ai_parent_email', this.get('model.eu_ai_parental_consent_parent_email') || '');
@@ -636,8 +637,23 @@ export default Controller.extend({
     });
     return htmlSafe(div.innerHTML);
   }),
-  substitution_string: computed('pending_preferences.substitutions', function() {
-    return editManager.stringify_rules(this.get('pending_preferences.substitutions') || []);
+  // Writable: the Phrase Substitutions textarea two-way-binds @value to this
+  // property. A get-only computed crashes on every keystroke in Ember 5 (setting
+  // a setter-less computed throws; pre-4.0 it silently clobbered the computed,
+  // which is how this originally worked). Same pattern as
+  // organization/settings.js home_board_key_lines.
+  substitution_string: computed('pending_preferences.substitutions', {
+    get() {
+      var cached = this.get('_substitution_string');
+      if(cached !== undefined && cached !== null) {
+        return cached;
+      }
+      return editManager.stringify_rules(this.get('pending_preferences.substitutions') || []);
+    },
+    set(key, value) {
+      this.set('_substitution_string', value);
+      return value;
+    }
   }),
   set_auto_sync: observer('model.id', 'model.auto_sync', function() {
     if(this.get('pending_preferences.device')) {
@@ -1136,6 +1152,7 @@ export default Controller.extend({
         this.set('pending_preferences.logging_code', 'false');
       }
       this.set('pending_preferences.substitutions', editManager.parse_rules(this.get('substitution_string')));
+      this.set('_substitution_string', undefined);
       this.set('phrase_categories_string', (this.get('pending_preferences.phrase_categories') || []).join(', '));
 
       // Persist the sidebar list the user sees (active options), not a stale raw pref.

--- a/app/frontend/app/templates/organization/extras.hbs
+++ b/app/frontend/app/templates/organization/extras.hbs
@@ -189,7 +189,7 @@
           <div style='margin-top: -15px;'>
             <div class="checkbox big_checkbox">
               <label>
-                <Input @checked={{this.include_extras}} type="checkbox" />
+                <Input @checked={{this.include_extras}} @type="checkbox" />
                 {{t "include premium symbols" key="include_premium_symbols"}}
               </label>
             </div>


### PR DESCRIPTION
## What this fixes

Four of the 14 adversary-confirmed findings from the first `/ember-audit-run` (register lands with PR #636; ids referenced below). All four are the Class-11 pattern distilled from #621 — two-way template binds to non-settable or mis-typed targets. Every mechanism was verified against the installed ember-source 5.12 dist before fixing.

| Finding | Severity | File | Fix |
|---|---|---|---|
| LL-da717dd8d6 | High | `components/masquerade.hbs:19` | `type="checkbox"` → `@type="checkbox"` — the confirm checkbox rendered as a **text field** (Input's `isCheckbox` reads only the `@type` named arg; splatted attrs are clobbered by the later `type={{this.type}}` write), so `@checked` never bound and **Continue was permanently inert** |
| LL-f95415c037 | High | `controllers/user/preferences.js` | `substitution_string` was a get-only computed; `<Textarea @value>` **threw on every keystroke** (Ember 5 removed computed clobbering — pre-4.0 the set silently overwrote the computed, which is how this worked). Now a writable `{get,set}` computed with an `_substitution_string` edit cache, cleared in `setup()` and after the save-path `parse_rules` round-trip — the exact `home_board_key_lines` pattern from #621 |
| LL-43c3d11094 | Medium | `components/focus-words.hbs:276` | Same `@type` fix — Save-for-Re-Use toggle was dead; `save_set()` could never run |
| LL-ed9a5c4c56 | Medium | `templates/organization/extras.hbs:192` | Same `@type` fix — admins couldn't toggle `include_extras` on purchase gifts |

## Verification

- `ember test` on this branch (Node 22): **run 2 fully green — 1,733 tests, 1,693 pass / 40 skip / 0 fail**. Run 1 had a single intermittent failure that did not reproduce on identical code; the test name wasn't captured, consistent with the documented persistence-sync flake (issue #589, ~8/day, fails 1–2 tests by timeout). Not claiming both-runs-green: one of two runs was green, the other's single failure was non-deterministic.
- `eslint` on `preferences.js`: no new errors (the one new warning — undeclared `_substitution_string` cache dep — matches the reference `home_board_key_lines` pattern exactly).
- Mechanisms verified in `ember-source` dist: `isCheckbox` named-arg semantics, splat-order clobbering, setter-less `ComputedProperty.set` throw (debug assert + prod TypeError).

## Manual click-test requested (P6 — I cannot exercise these UI flows from this environment)

1. **Masquerade**: user page → Masquerade → tick the confirmation **checkbox** (should now render as a checkbox, not a text box) → Continue proceeds
2. **Preferences → Phrase Substitutions**: type in the textarea — no console error on keystrokes; save; reopen — substitutions round-trip correctly (edits parse via `parse_rules`, field re-derives after save)
3. **Focus Words modal**: tick "Save for Re-Use" → save → list persists (a new set is created rather than stashed)
4. **Org → Extras → purchase gift**: tick include-extras → create purchase → gift includes premium symbols

## Fix status
| Item | Status | Evidence |
|------|--------|----------|
| 4 findings above | Fixed (pending manual click-test + Scot's register closure) | this diff; test suite green on run 2 |

## Not covered by this PR
- The other 10 open findings (5 LOW `type="date|number"` widget degradations, GA `didTransition` rewire, register.hbs `{{action}}` 6.0-blockers, babel peer hygiene, deprecation-workflow, test gaps)
- Register status updates — only Scot closes findings, after verification

## Author-Model: fable-5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiGm8QiFckNe5sBGbCAfaZ)_