### PR TITLE
chore(mcp): drop non-functional project-scoped filesystem server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,14 +8,6 @@
         "description": "Semantic code search and architecture understanding for LingoLinq-AAC"
       }
     },
-    "filesystem": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem"],
-      "env": {
-        "ALLOWED_DIRECTORIES": "/workspaces/LingoLinq-AAC"
-      }
-    },
     "github": {
       "type": "stdio",
       "command": "npx",


### PR DESCRIPTION
## What

Removes the `filesystem` entry from the repo's project-scoped `.mcp.json`.

## Why

The project-scoped entry was never functional:

- It passes **no directory arguments** to `@modelcontextprotocol/server-filesystem` (`args: ["-y", "@modelcontextprotocol/server-filesystem"]`). That server takes its allowed roots as argv, so with none supplied it grants no access.
- It instead set `ALLOWED_DIRECTORIES=/workspaces/LingoLinq-AAC`, a Codespaces path that does not exist in any current local, WSL, or Cloud Run checkout.

Because a working `filesystem` server is also defined at user scope (with real roots), Claude Code emits a scope-conflict warning on every session:

```
Server "filesystem" is defined in multiple scopes with different endpoints:
user (... /home/scotw /mnt/c/Users/scotw/Projects ...), project (npx -y @modelcontextprotocol/server-filesystem).
```

Dropping the dead project entry resolves the conflict and leaves the working user-scope definition as the single source. The companion `postgres-dev` scope conflict was already resolved by removing its user-scope duplicate; `postgres-dev` remains project-scoped only, unchanged by this PR.

## Risk

None. The removed server could not serve any path. No other `.mcp.json` entry is touched.