### PR TITLE
chore(ci): rename Node 20 CI labels to match node-version 22

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ Key characteristics:
 - **Quoting**: 
     - User-facing strings: Use DOUBLE QUOTES `"string"`.
     - Code/Internal strings: Use SINGLE QUOTES `'string'`.
-- **Node Version**: Use Node 20.
+- **Node Version**: Use Node 22 (pinned in `.nvmrc` and `app/frontend/.nvmrc`). The repo was on Node 20 while it ran Ember 3.28; the Ember 5.12 upgrade (#490) lifted that ceiling and it moved to Node 22.
 - **jQuery**: Prefer native DOM APIs or Ember patterns over jQuery (`$`) where practical.
 
 ## Architecture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -80,9 +80,9 @@ jobs:
           path: |
             app/frontend/node_modules
             ~/.cache/puppeteer
-          key: ${{ runner.os }}-node20-${{ hashFiles('app/frontend/package-lock.json') }}
+          key: ${{ runner.os }}-node22-${{ hashFiles('app/frontend/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node20-
+            ${{ runner.os }}-node22-
 
       - name: Install frontend dependencies
         working-directory: app/frontend
@@ -179,7 +179,7 @@ jobs:
           gem install bundler-audit
           bundle-audit check --update
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
CI already installs Node 22 (`node-version: 22` in both jobs), but the surrounding cosmetics still said 20:

- two `Setup Node 20` step names → `Setup Node 22`
- frontend cache `key` / `restore-keys` prefix `runner.os-node20-` → `node22-`
- `.github/copilot-instructions.md` flatly told Copilot **"Use Node 20"** → corrected to Node 22, with the Ember-3.28 → 5.12 history kept as context

Nothing functional was wrong — the runner was on 22 — but the labels lied about it, and the Copilot instruction would actively steer a session to the wrong major.

**Cache note:** the key rename is a one-time cache miss on the first post-merge run, then it repopulates under `node22-`. Intended, and more honest than a `node20-`-named cache built on Node 22.

Companion to lingolinq/ai-company-brain#145, which corrects the same stale Node 20 mandate in the agent instruction mirrors (`global-claude.md` / `ANTIGRAVITY.md` / `CODEX.md`). Neither changes the actual Node version — both just stop the tooling and instructions from contradicting the reality that LingoLinq-AAC has been on Node 22 since the Ember 5.12 upgrade (#490).

## Fix status
| Item | Status | Evidence |
|---|---|---|
| Step names | Fixed | ci.yml:72, 182 |
| Cache key prefix | Fixed | ci.yml:83, 85 |
| Copilot instruction | Fixed | copilot-instructions.md:22 |

## Not covered by this PR
- The agent instruction mirrors — separate repo, ai-company-brain#145.

## Author-Model: opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)