### PR TITLE
docs(gcp): add stale-cert-backoff pre-flip check to cutover runbook

### DIFF
--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -612,6 +612,25 @@ the realistic timing and the AAAA/CAA pre-checks.
        Check: `dig CAA lingolinq.com +short` should be **empty**, or list both CAs.
     3. **One claimant.** Confirm only ONE cert resource claims the domain (a second managed cert on
        the same domain stalls both).
+    4. **Stale cert in retry-backoff (VERIFIED trap, 2026-07-22 cutover).** If the managed cert was
+       created BEFORE `app.lingolinq.com` existed, it has been failing validation on every retry
+       since creation, and Google-managed certs use **exponential backoff**. After days of failures
+       it only re-checks every several hours, so it will **not** flip to `ACTIVE` promptly after the
+       DNS cut even though everything is now correct - our cert was 22 days old and sat at
+       `FAILED_NOT_VISIBLE` for 66+ min post-cut with config verified clean (attached to the
+       https-proxy, DNS->LB, no AAAA, no CAA). **Pre-flip check:** compare the cert's
+       `creationTimestamp` to now; if it predates the DNS record you are about to create, it is
+       stale. **Fix (fast):** create a FRESH managed cert and swap it onto the proxy - a new cert
+       starts a clean retry schedule and validates in minutes because DNS is already in place:
+       ```
+       gcloud compute ssl-certificates create lingolinq-cert-v2 \
+           --domains app.lingolinq.com --global --project lingolinq-prod
+       gcloud compute target-https-proxies update lingolinq-https-proxy \
+           --ssl-certificates lingolinq-cert-v2 --global --project lingolinq-prod
+       ```
+       This is safe mid-cutover: HTTPS is not serving anything while the old cert is stuck, so the
+       swap can only improve state, and it is reversible (the old cert is left in place). Better
+       still, recreate the cert as part of pre-flip prep so the window starts from a clean cert.
   (To eliminate the window entirely instead, pre-provision via Certificate Manager DNS-authorization
   before the flip - deliberately NOT chosen for this cut.)
 


### PR DESCRIPTION
Adds one pre-flip gotcha to `PHASE5-CUTOVER-RUNBOOK.md`, learned the hard way during the 2026-07-22 Gate 1 cutover.

## What happened

The managed cert `lingolinq-cert` was created **2026-06-30**, 22 days before `app.lingolinq.com` existed. So it had been failing validation on every retry for 22 days, and Google-managed certs use **exponential backoff** — after that long it only re-checks every several hours. It did **not** flip to `ACTIVE` after the DNS cut, sitting at `FAILED_NOT_VISIBLE` for 66+ minutes with all config verified clean (attached to the https-proxy, DNS points to the LB, no AAAA, no CAA).

The existing gotchas (stale AAAA, CAA, single claimant) all check DNS/config — none catch this, because the cause is cert **age**, not config.

## The fix (documented with exact commands)

Create a fresh cert and swap it onto the proxy. It validated in **~6 minutes** because DNS was already in place. Safe mid-cutover: HTTPS isn't serving anything while the old cert is stuck, so the swap only improves state and is reversible.

Docs-only. Live infra is untouched by this PR.