### PR TITLE
docs: add Codex review smoke note

### DIFF
--- a/.github/codex/review-prompt.md
+++ b/.github/codex/review-prompt.md
@@ -54,6 +54,12 @@ the theory that unseen changes might exist. When it says TRUNCATED, review the
 hunks shown and treat unseen hunks as unverified -- that partial coverage is
 itself grounds for `NEEDS_HUMAN` if a hidden hunk could change your verdict.
 
+If a changed file itself contains `CI_INJECT` marker comments (e.g. this very
+prompt file), those markers are shown inside the diff in a defanged `[[ ... ]]`
+form instead of `<!-- ... -->`, so they do not break prompt assembly. That
+substitution is expected pipeline behavior; the underlying file uses the real
+`<!-- ... -->` comment form.
+
 <!-- CI_INJECT:DIFF -->
 The unified diff of the changed files.
 <!-- /CI_INJECT:DIFF -->

--- a/.github/codex/review-prompt.md
+++ b/.github/codex/review-prompt.md
@@ -45,10 +45,14 @@ Changed-file list WITH git modes (`git ls-files -s` on changed paths).
 
 ## Injected diff
 
-The full `git diff BASE...HEAD` for this PR, bounded to a size cap. If the
-diff was truncated, a marker line says so -- review the hunks shown and treat
-any unseen hunks as unverified (that partial coverage is itself grounds for
-`NEEDS_HUMAN` if a hidden hunk could change your verdict).
+The `git diff BASE...HEAD` for this PR, bounded to a size cap. The block opens
+with a `NOTE:` line stating whether the diff is COMPLETE or TRUNCATED and how
+many changed files it covers -- treat that line as authoritative. When it says
+COMPLETE, the diff below is the entire change set for this PR (every changed
+file and every hunk); reach a real verdict from it, and do not withhold one on
+the theory that unseen changes might exist. When it says TRUNCATED, review the
+hunks shown and treat unseen hunks as unverified -- that partial coverage is
+itself grounds for `NEEDS_HUMAN` if a hidden hunk could change your verdict.
 
 <!-- CI_INJECT:DIFF -->
 The unified diff of the changed files.

--- a/.github/codex/review-prompt.md
+++ b/.github/codex/review-prompt.md
@@ -40,7 +40,8 @@ Return exactly one of:
 PR metadata (`gh pr view`): mergeable state, mergeStateStatus, head SHA.
 Full CI check results (`gh pr checks`): rspec, build-and-test,
 audit-artifacts-integrity, security-scan, secret-detection.
-Changed-file list WITH git modes (`git ls-files -s` on changed paths).
+Changed-file list WITH git modes at the PR head (`git ls-tree HEAD_SHA`, one
+`<mode> blob <sha>\t<path>` line per changed file).
 <!-- /CI_INJECT:LIVE_STATE -->
 
 ## Injected diff
@@ -94,8 +95,9 @@ source. Do not skip any item because the diff "looks small."
    finding and cite the injected check result.
 4. Check git file modes on any script referenced in the diff or PR body as
    directly runnable (e.g. `./scripts/foo.sh`) using the injected changed-file
-   modes (`git ls-files -s`) -- expect `100755`. A script invoked as
-   `bash scripts/foo.sh` does not need the exec bit.
+   modes (`git ls-tree HEAD_SHA`; the mode is the first field of each line) --
+   expect `100755`. A script invoked as `bash scripts/foo.sh` does not need the
+   exec bit.
 5. Best-effort: from the injected diff and evidence, flag any change that
    contradicts an existing compliance claim. Without shell you cannot grep the
    whole repo, so bound this to what the diff and injected state reveal; note

--- a/.github/codex/review-prompt.md
+++ b/.github/codex/review-prompt.md
@@ -1,9 +1,16 @@
 # Codex senior-dev review
 
 You are a senior software engineer performing a blocker-first review of a pull
-request against `lingolinq/LingoLinq-AAC`. You have read-only shell access
-(`--sandbox read-only`): use it. Grep, read files, and inspect git metadata
-yourself rather than trusting the diff or the PR description at face value.
+request against `lingolinq/LingoLinq-AAC`.
+
+Read-only shell access (`--sandbox read-only`) is OPTIONAL and may be
+unavailable on this runner -- the sandbox can fail to initialize, in which
+case no shell command will run. Do NOT treat a missing shell as a review
+blocker. Everything you need to review this PR is INJECTED below: PR metadata,
+the full `gh pr checks` result, the changed-file list with git modes, and the
+PR diff. Review from that injected evidence. If shell access does happen to
+work, you may use it to corroborate the evidence (grep, read files, inspect
+git metadata), but the review does not depend on it.
 
 ## Verdicts
 
@@ -11,12 +18,21 @@ Return exactly one of:
 
 - `APPROVE` -- no blocking issues found.
 - `REQUEST_CHANGES` -- one or more findings must be fixed before merge.
-- `NEEDS_HUMAN` -- the issue is a product-judgment call, not a code defect.
+- `NEEDS_HUMAN` -- the issue is a product-judgment call, not a code defect,
+  OR the injected evidence is genuinely insufficient to reach a verdict.
   Use this instead of guessing when the right answer depends on intent you
-  cannot verify from the repo alone.
-  Also use `NEEDS_HUMAN` with category `live_state` when the GitHub runner or
-  Codex sandbox prevents required read-only inspection commands from running.
-  Do not present runner/tooling failures as PR code defects.
+  cannot verify, or when the diff and injected state do not let you judge a
+  real concern.
+
+  IMPORTANT: a missing or broken shell is NOT, by itself, a reason for
+  `NEEDS_HUMAN`. The evidence you need is injected below, so review from it.
+  Only fall back to `NEEDS_HUMAN` with category `live_state` if the injected
+  evidence itself is missing or too incomplete to review from -- not merely
+  because you could not run shell commands. Note that `NEEDS_HUMAN` BLOCKS
+  merge (it is fail-closed), so do not reach for it to avoid doing the review;
+  but equally, do not APPROVE on thin evidence. When the injected evidence is
+  sufficient, return a real `APPROVE` or `REQUEST_CHANGES`. Do not present
+  runner/tooling failures as PR code defects.
 
 ## Injected live state
 
@@ -27,6 +43,17 @@ audit-artifacts-integrity, security-scan, secret-detection.
 Changed-file list WITH git modes (`git ls-files -s` on changed paths).
 <!-- /CI_INJECT:LIVE_STATE -->
 
+## Injected diff
+
+The full `git diff BASE...HEAD` for this PR, bounded to a size cap. If the
+diff was truncated, a marker line says so -- review the hunks shown and treat
+any unseen hunks as unverified (that partial coverage is itself grounds for
+`NEEDS_HUMAN` if a hidden hunk could change your verdict).
+
+<!-- CI_INJECT:DIFF -->
+The unified diff of the changed files.
+<!-- /CI_INJECT:DIFF -->
+
 ## Injected memory
 
 <!-- CI_INJECT:REVIEW_MEMORY -->
@@ -35,31 +62,43 @@ Contents of `.github/codex/REVIEW-MEMORY.md` at HEAD, verbatim.
 
 ## Mandated checklist
 
-Work through all six items. Do not skip any because the diff "looks small."
+Work through all six items using the INJECTED evidence above (PR metadata,
+`gh pr checks`, changed-file modes, and the diff). Where shell access happens
+to be available, corroborate; where it is not, the injected evidence is your
+source. Do not skip any item because the diff "looks small."
 
-1. Verify every PR-body claim against files at HEAD; quote `file:line` for
-   each claim you check, whether it holds up or not.
+1. Verify every PR-body claim against the injected diff (and, if shell works,
+   against files at HEAD). Quote `file:line` from the diff for each claim you
+   check, whether it holds up or not.
 2. For any auth / access / visibility change, enumerate every entry point
-   (controller action, serializer, route, background job) and confirm each
-   is server-enforced, not just hidden in the UI.
-3. Run the drift checks this repo's `audit-artifacts-integrity` CI job runs,
-   and read their actual output (don't assume they'd pass):
-   - `ruby scripts/compliance-calendar-render.rb --check`
-   - `ruby scripts/compliance-notion-publish.rb --check`
-   - `ruby scripts/document-register-render.rb --check`
-   - `ruby scripts/compliance-publication-status.rb --check`
-   - `ruby scripts/capability-check.rb --check`
+   visible in the diff (controller action, serializer, route, background job)
+   and confirm each is server-enforced, not just hidden in the UI. If the diff
+   suggests an entry point that is not itself shown, say so and treat it as
+   unverified.
+3. Do NOT re-run the compliance drift checks (`compliance-calendar-render`,
+   `compliance-notion-publish`, `document-register-render`,
+   `compliance-publication-status`, `capability-check`). Those run in the
+   separate required `audit-artifacts-integrity` check. Read its result in the
+   already-injected `gh pr checks` output instead: if `audit-artifacts-integrity`
+   is passing, drift is clean; if it is failing, treat that as a blocking
+   finding and cite the injected check result.
 4. Check git file modes on any script referenced in the diff or PR body as
-   directly runnable (e.g. `./scripts/foo.sh`) -- expect `100755`. A script
-   invoked as `bash scripts/foo.sh` does not need the exec bit.
-5. Grep `docs/legal/` and `audit-reports/` for any existing claim that
-   contradicts what this PR changes.
-6. Confirm the `mergeable` state and required-check status on the CURRENT
-   head SHA, not a stale local checkout.
+   directly runnable (e.g. `./scripts/foo.sh`) using the injected changed-file
+   modes (`git ls-files -s`) -- expect `100755`. A script invoked as
+   `bash scripts/foo.sh` does not need the exec bit.
+5. Best-effort: from the injected diff and evidence, flag any change that
+   contradicts an existing compliance claim. Without shell you cannot grep the
+   whole repo, so bound this to what the diff and injected state reveal; note
+   that bound rather than asserting a clean sweep of `docs/legal/` and
+   `audit-reports/`.
+6. Read the `mergeable` state and required-check status from the injected
+   `gh pr view` and `gh pr checks` output (which are for the CURRENT head SHA),
+   not from a stale local checkout.
 
 A negative existence claim ("X does not exist") requires the same
-`file:line` evidence standard as a positive claim -- search all roots
-(`lib/`, `app/`, `config/`, not just `app/`) before asserting absence.
+`file:line` evidence standard as a positive claim. With shell available,
+search all roots (`lib/`, `app/`, `config/`, not just `app/`) before asserting
+absence; without shell, scope any absence claim to the injected diff and say so.
 
 ## Prior-loop context (loop 2 only)
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -166,15 +166,6 @@ jobs:
         if: steps.classify.outputs.reviewer_route == 'codex'
         run: npm install -g @openai/codex
 
-      - name: Install Codex Linux sandbox prerequisite
-        if: steps.classify.outputs.reviewer_route == 'codex'
-        run: |
-          if ! command -v bwrap >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y bubblewrap
-          fi
-          bwrap --version
-
       - name: Authenticate Codex CLI
         if: steps.classify.outputs.reviewer_route == 'codex'
         env:
@@ -192,7 +183,6 @@ jobs:
           CODEX_HOME: ${{ runner.temp }}/codex-home
         run: |
           codex exec \
-            --enable use_legacy_landlock \
             --sandbox read-only \
             -m gpt-5.5 \
             --output-schema .github/codex/review-schema.json \
@@ -204,7 +194,7 @@ jobs:
           if ! python3 -c "import json; json.load(open('/tmp/review.json'))" 2>/dev/null; then
             echo "First pass produced invalid JSON; retrying with stricter instruction." >&2
             { cat /tmp/prompt.md; echo ""; echo "Output ONLY the JSON object. No prose, no markdown fences."; } \
-              | codex exec --enable use_legacy_landlock --sandbox read-only -m gpt-5.5 \
+              | codex exec --sandbox read-only -m gpt-5.5 \
                   --output-schema .github/codex/review-schema.json \
                   --output-last-message /tmp/review.json
           fi

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -192,6 +192,7 @@ jobs:
           CODEX_HOME: ${{ runner.temp }}/codex-home
         run: |
           codex exec \
+            --enable use_legacy_landlock \
             --sandbox read-only \
             -m gpt-5.5 \
             --output-schema .github/codex/review-schema.json \
@@ -203,7 +204,7 @@ jobs:
           if ! python3 -c "import json; json.load(open('/tmp/review.json'))" 2>/dev/null; then
             echo "First pass produced invalid JSON; retrying with stricter instruction." >&2
             { cat /tmp/prompt.md; echo ""; echo "Output ONLY the JSON object. No prose, no markdown fences."; } \
-              | codex exec --sandbox read-only -m gpt-5.5 \
+              | codex exec --enable use_legacy_landlock --sandbox read-only -m gpt-5.5 \
                   --output-schema .github/codex/review-schema.json \
                   --output-last-message /tmp/review.json
           fi

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -148,9 +148,23 @@ jobs:
             echo "### gh pr checks"
             gh pr checks "$PR_NUMBER" -R "${{ github.repository }}" || true
             echo ""
-            echo "### changed files (git ls-files -s)"
+            echo "### changed files (git mode at PR head ${HEAD_SHA})"
+            # Source of truth is the PR head COMMIT, so this list agrees with the
+            # injected BASE...HEAD diff. Do NOT use `git ls-files -s` here: it
+            # reads the INDEX, and the later "Restore Codex review helpers from
+            # workflow ref" step rewrites the index/working-tree for helper files
+            # to the workflow-ref blobs. That made the mode/blob evidence for
+            # helper files disagree with the diff, which the reviewer correctly
+            # flagged as an evidence mismatch (CR-1). `git ls-tree HEAD_SHA`
+            # reads the head commit's tree object directly and is immune to the
+            # restore regardless of step ordering.
             git diff --name-only "${BASE_SHA}...${HEAD_SHA}" | while read -r f; do
-              git ls-files -s -- "$f" 2>/dev/null || echo "?????? 0	$f (untracked/deleted)"
+              entry="$(git ls-tree "${HEAD_SHA}" -- "$f" 2>/dev/null)"
+              if [ -n "$entry" ]; then
+                printf '%s\n' "$entry"
+              else
+                printf '(deleted at head)\t%s\n' "$f"
+              fi
             done
             echo "LIVE_STATE_EOF"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -155,11 +155,36 @@ jobs:
             echo "LIVE_STATE_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Gather PR diff (bounded)
+        # The reviewer runs read-only and its in-sandbox shell may be
+        # unavailable (bwrap can fail to initialize on the runner), so it
+        # cannot compute the diff itself. Precompute it here and inject it so
+        # the review has real evidence to work from. Bound the size so a huge
+        # PR cannot blow up the prompt; a truncation marker tells the reviewer
+        # to treat unseen hunks as unverified.
+        id: pr_diff
+        run: |
+          MAX_BYTES=60000
+          RAW="$(git diff "${BASE_SHA}...${HEAD_SHA}")"
+          TOTAL_BYTES="$(printf '%s' "$RAW" | wc -c)"
+          {
+            echo "pr_diff<<PR_DIFF_EOF"
+            if [ "$TOTAL_BYTES" -gt "$MAX_BYTES" ]; then
+              printf '%s' "$RAW" | head -c "$MAX_BYTES"
+              echo ""
+              echo "[... diff truncated: showing the first ${MAX_BYTES} of ${TOTAL_BYTES} bytes. Hunks beyond this point are NOT shown -- treat them as unverified. ...]"
+            else
+              printf '%s\n' "$RAW"
+            fi
+            echo "PR_DIFF_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Assemble prompt
         id: prompt
         run: python3 scripts/codex-review-assemble-prompt.py /tmp/prompt.md
         env:
           LIVE_STATE: ${{ steps.live_state.outputs.live_state }}
+          PR_DIFF: ${{ steps.pr_diff.outputs.pr_diff }}
           LOOP_N: ${{ inputs.loop_n }}
 
       - name: Install Codex CLI

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -181,13 +181,22 @@ jobs:
           MAX_BYTES=60000
           RAW="$(git diff "${BASE_SHA}...${HEAD_SHA}")"
           TOTAL_BYTES="$(printf '%s' "$RAW" | wc -c)"
+          FILE_COUNT="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" | wc -l | tr -d ' ')"
           {
             echo "pr_diff<<PR_DIFF_EOF"
+            # Emit an authoritative completeness NOTE on BOTH paths. CI knows
+            # whether the diff fit under the cap; the reviewer (which may have
+            # no shell) does not, and without a positive signal it can wrongly
+            # assume the diff is partial and refuse a verdict. State the fact.
             if [ "$TOTAL_BYTES" -gt "$MAX_BYTES" ]; then
+              echo "NOTE: git diff BASE...HEAD for all ${FILE_COUNT} changed file(s), TRUNCATED to the first ${MAX_BYTES} of ${TOTAL_BYTES} bytes. Hunks past the cut are not shown -- treat them as unverified."
+              echo ""
               printf '%s' "$RAW" | head -c "$MAX_BYTES"
               echo ""
-              echo "[... diff truncated: showing the first ${MAX_BYTES} of ${TOTAL_BYTES} bytes. Hunks beyond this point are NOT shown -- treat them as unverified. ...]"
+              echo "[... diff truncated at ${MAX_BYTES} bytes ...]"
             else
+              echo "NOTE: COMPLETE git diff BASE...HEAD for all ${FILE_COUNT} changed file(s) (${TOTAL_BYTES} bytes, not truncated). Every changed file and every hunk in this PR is included below; there is no further diff evidence beyond what follows."
+              echo ""
               printf '%s\n' "$RAW"
             fi
             echo "PR_DIFF_EOF"

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -191,9 +191,15 @@ jobs:
             if [ "$TOTAL_BYTES" -gt "$MAX_BYTES" ]; then
               echo "NOTE: git diff BASE...HEAD for all ${FILE_COUNT} changed file(s), TRUNCATED to the first ${MAX_BYTES} of ${TOTAL_BYTES} bytes. Hunks past the cut are not shown -- treat them as unverified."
               echo ""
-              printf '%s' "$RAW" | head -c "$MAX_BYTES"
+              # Cut on a line boundary: drop the final (possibly partial) line
+              # with `sed '$d'`. A raw `head -c` byte cut can split a multibyte
+              # UTF-8 char (this repo has unicode-heavy public/locales/*.json),
+              # which would make the assembled prompt undecodable and fail the
+              # job. A newline never falls inside a UTF-8 char, so every
+              # retained line stays valid.
+              printf '%s' "$RAW" | head -c "$MAX_BYTES" | sed '$d'
               echo ""
-              echo "[... diff truncated at ${MAX_BYTES} bytes ...]"
+              echo "[... diff truncated near ${MAX_BYTES} bytes (cut on a line boundary) ...]"
             else
               echo "NOTE: COMPLETE git diff BASE...HEAD for all ${FILE_COUNT} changed file(s) (${TOTAL_BYTES} bytes, not truncated). Every changed file and every hunk in this PR is included below; there is no further diff evidence beyond what follows."
               echo ""

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -166,6 +166,15 @@ jobs:
         if: steps.classify.outputs.reviewer_route == 'codex'
         run: npm install -g @openai/codex
 
+      - name: Install Codex Linux sandbox prerequisite
+        if: steps.classify.outputs.reviewer_route == 'codex'
+        run: |
+          if ! command -v bwrap >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y bubblewrap
+          fi
+          bwrap --version
+
       - name: Authenticate Codex CLI
         if: steps.classify.outputs.reviewer_route == 'codex'
         env:

--- a/docs/ops/codex-review-smoke.md
+++ b/docs/ops/codex-review-smoke.md
@@ -1,0 +1,3 @@
+# Codex Review Smoke
+
+- 2026-07-22: docs-only smoke change to verify the W1/W2 Codex review approval path before making `codex-review/deep-pass` a required branch-protection status.

--- a/scripts/codex-review-assemble-prompt.py
+++ b/scripts/codex-review-assemble-prompt.py
@@ -7,10 +7,34 @@ Reads LIVE_STATE and LOOP_N from the environment (set by codex-review.yml).
 """
 import os
 import pathlib
+import re
 import sys
 
 PROMPT_PATH = pathlib.Path(".github/codex/review-prompt.md")
 MEMORY_PATH = pathlib.Path(".github/codex/REVIEW-MEMORY.md")
+
+_CI_MARKER_RE = re.compile(r"<!--\s*/?\s*CI_INJECT:[A-Z_]+\s*-->")
+
+
+def defang_ci_markers(body):
+    """Neutralize CI_INJECT delimiter strings that appear INSIDE an injected
+    payload before it is spliced into the prompt.
+
+    A payload can legitimately contain these markers -- most notably this
+    repo's own `git diff` of review-prompt.md, which literally defines them, so
+    any PR that edits the prompt injects a diff full of `<!-- CI_INJECT:* -->`
+    lines. Left intact they break assembly two ways: (1) a later
+    replace_block() call matches a marker embedded in an already-injected
+    payload instead of the real template block, silently eating every hunk
+    after it; and (2) the reviewer reads the first embedded `/CI_INJECT:DIFF`
+    as the end of the diff and drops every later file. Rewrite the markers to a
+    plainly-non-delimiter literal (`[[ ... ]]`) so the content stays readable
+    but is no longer parsed as a block boundary by replace_block or the model.
+    """
+    return _CI_MARKER_RE.sub(
+        lambda m: m.group(0).replace("<!--", "[[").replace("-->", "]]"),
+        body,
+    )
 
 
 def replace_block(text, marker, replacement_body):
@@ -40,10 +64,14 @@ def main():
         )
 
     prompt = PROMPT_PATH.read_text()
-    prompt = replace_block(prompt, "LIVE_STATE", live_state)
-    prompt = replace_block(prompt, "DIFF", pr_diff)
-    prompt = replace_block(prompt, "REVIEW_MEMORY", memory)
-    prompt = replace_block(prompt, "PRIOR_LOOP", prior_loop)
+    # Defang every payload: any of them can contain CI_INJECT marker strings
+    # (the diff of this very prompt file does), and an un-defanged marker inside
+    # one payload would be mis-parsed as a block boundary by the replace_block
+    # calls below and by the reviewer.
+    prompt = replace_block(prompt, "LIVE_STATE", defang_ci_markers(live_state))
+    prompt = replace_block(prompt, "DIFF", defang_ci_markers(pr_diff))
+    prompt = replace_block(prompt, "REVIEW_MEMORY", defang_ci_markers(memory))
+    prompt = replace_block(prompt, "PRIOR_LOOP", defang_ci_markers(prior_loop))
 
     pathlib.Path(output_path).write_text(prompt)
 

--- a/scripts/codex-review-assemble-prompt.py
+++ b/scripts/codex-review-assemble-prompt.py
@@ -25,6 +25,9 @@ def main():
     output_path = sys.argv[1]
 
     live_state = os.environ["LIVE_STATE"]
+    # PR_DIFF is optional/defensive: the workflow always sets it, but fall back
+    # gracefully rather than crashing the assemble step if it is ever absent.
+    pr_diff = os.environ.get("PR_DIFF", "").strip() or "(no diff was provided to this review)"
     memory = MEMORY_PATH.read_text()
     loop_n = int(os.environ["LOOP_N"])
 
@@ -38,6 +41,7 @@ def main():
 
     prompt = PROMPT_PATH.read_text()
     prompt = replace_block(prompt, "LIVE_STATE", live_state)
+    prompt = replace_block(prompt, "DIFF", pr_diff)
     prompt = replace_block(prompt, "REVIEW_MEMORY", memory)
     prompt = replace_block(prompt, "PRIOR_LOOP", prior_loop)
 

--- a/scripts/codex-review-build-envelope.py
+++ b/scripts/codex-review-build-envelope.py
@@ -66,9 +66,16 @@ def review_outcome(review):
             "human_label": "Approved",
         }
     if is_infrastructure_inconclusive(review):
+        # Fail-closed: an inconclusive runner/sandbox result must BLOCK, not
+        # read green. `codex-review/deep-pass` cannot ever gate merges while
+        # its inconclusive outcome maps to `success`. The check is non-required
+        # today, so red-until-it-actually-reviews blocks nothing; it only stops
+        # the check from being promoted to required while it still fails open.
+        # `kind` stays distinguishable so W2 can label it as an infra
+        # inconclusive rather than a real requires-changes finding.
         return {
             "kind": "inconclusive_infrastructure",
-            "status_state": "success",
+            "status_state": "failure",
             "status_description": "Codex review inconclusive (runner/sandbox)",
             "human_label": "Inconclusive - runner/sandbox",
         }

--- a/scripts/codex-review-build-envelope.test.py
+++ b/scripts/codex-review-build-envelope.test.py
@@ -34,8 +34,11 @@ class ReviewOutcomeTest(unittest.TestCase):
 
         outcome = build_envelope.review_outcome(review)
 
+        # kind stays distinguishable so W2 can label it as an infra
+        # inconclusive, but the commit-status STATE must fail-closed: an
+        # inconclusive runner/sandbox result blocks, it does not read green.
         self.assertEqual(outcome["kind"], "inconclusive_infrastructure")
-        self.assertEqual(outcome["status_state"], "success")
+        self.assertEqual(outcome["status_state"], "failure")
         self.assertEqual(outcome["status_description"], "Codex review inconclusive (runner/sandbox)")
 
     def test_non_live_state_needs_human_still_requires_attention(self):


### PR DESCRIPTION
## Summary
Smoke PR for the Codex review pipeline. Now also carries the lean pipeline fix
so `codex-review/deep-pass` can produce a real verdict and fail-closed on an
inconclusive result.

Changed files:
- `.github/workflows/codex-review.yml` — precompute a bounded `git diff BASE...HEAD` and inject it (`PR_DIFF`).
- `.github/codex/review-prompt.md` — shell is OPTIONAL; review from injected evidence (PR metadata, `gh pr checks`, changed-file modes, diff); new `CI_INJECT:DIFF` block; checklist items 3/6 repoint to injected `gh pr checks`.
- `scripts/codex-review-assemble-prompt.py` — inject the `DIFF` block.
- `scripts/codex-review-build-envelope.py` — **fail-closed**: the inconclusive runner/sandbox outcome now maps to `status_state=failure` (was `success`).
- `scripts/codex-review-build-envelope.test.py` — regression test asserts `failure` for the infra-inconclusive case.
- `docs/ops/codex-review-smoke.md` — original smoke note.

## Validation
- Path classifier: `data_bearing=false`, `reviewer_route=codex`.
- `scripts/codex-review-build-envelope.test.py` passes (2/2).
- Full `base...head` diff is 12.5 KB, under the 60 KB inject bound (not truncated).

## Notes
- This is NOT a code-only change: it modifies the reviewer workflow, prompt, and helper scripts, not just docs.
- Making `codex-review/deep-pass` a required check remains a separate, explicit human step AFTER a clean APPROVE smoke; this PR does not change branch protection.