### PR TITLE
compliance(register): retention, supersession, Drive IDs, and 4 new bundles

### DIFF
--- a/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
+++ b/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
@@ -3,13 +3,13 @@
 > Generated from `audit-reports/FINDINGS.json` and `audit-reports/DOCUMENT-REGISTER.json` by `scripts/compliance-publication-status.rb`.
 > Do not hand-edit; update the registers and re-render.
 
-**Generated:** 2026-06-21
+**Generated:** 2026-07-22
 
-**Latest source date:** 2026-07-08
+**Latest source date:** 2026-07-22
 
 **Findings audited date:** 2026-07-08
 
-**Document register generated date:** 2026-06-21
+**Document register generated date:** 2026-07-22
 
 ## What Updates Automatically
 
@@ -28,54 +28,61 @@
 
 | Title | System | Location | Last reviewed | Status | Why |
 |---|---|---|---|---|---|
-| AI Governance Memo (branded) | drive | [open](https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Access Control Policy | drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Accessibility Conformance Report (ACR / VPAT) (branded) | drive | [open](https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit) | 2026-06-19 | draft | Review date is older than 2026-07-08. |
-| Audit Results Report | drive | [open](https://docs.google.com/document/d/1n6z-76-awsAtWq-2clQ340vfcn_gAtJbkCmVnIxL4tY/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Business Continuity and Disaster Recovery Plan | drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| COPPA Final-Rule Verification (branded) | drive | [open](https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Compliance & Security - Semi-Annual Program Report (H1 2026) | drive | [open](https://docs.google.com/document/d/1VKTOxmGjLiRYy9U3_Y4gzQ2gsmfnZZTeq5RZ7mkHAIM/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Compliance & Security Overhaul - Completion Report | drive | [open](https://docs.google.com/document/d/1en3MCE47qKj1nwg6wb_MA7h3TwwsDMs33oUM-0GhdEM/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Compliance & Security Program v1.0 (Attested) | drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Compliance Calendar (branded) | drive | [open](https://docs.google.com/document/d/19IT_GKK1PzC7zLnGNr-RNT0Rw1fFR68syUvnuBBA2CI/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Compliance Posture Report (branded) | drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Compliance Program - Claim vs Code Review | drive | [open](https://docs.google.com/document/d/1IHQ5yFkoU39N01wyTt5SRXM-Q71aKa9wuXvnGVWnbRg/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Data & Compliance Pipeline - Build Inventory (dated) | drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | 2026-06-22 | approved | Review date is older than 2026-07-08. |
-| Data Retention Schedule (branded) | drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Incident Log (branded) | drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Incident Response and Breach Runbook (branded) | drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Parental Consent (COPPA / under-13) (branded) | drive | [open](https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Records of Processing Activities (RoPA) and Data Map | drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Roadmap - What's Left (2026-06-19) | drive | [open](https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit) | 2026-06-19 | approved | Review date is older than 2026-07-08. |
-| Security Risk Assessment 2026 Q2 | drive | [open](https://docs.google.com/document/d/1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Subprocessor Register (branded) | drive | [open](https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Vendor and Subprocessor Management Policy | drive | [open](https://docs.google.com/document/d/1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Written Information Security Program (WISP) | drive | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | 2026-05-11 | approved | Review date is older than 2026-07-08. |
-| AWS Business Associate Agreement (signed PDF) | git | `docs/legal/AWS_BAA_2026-02.pdf` | 2026-05-11 | published | Review date is older than 2026-07-08. |
-| Accessibility Conformance Report (ACR / VPAT) | git | `docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md` | 2026-06-16 | draft | Review date is older than 2026-07-08. |
-| Audit Reports Index (audit-reports/README.md) | git | `audit-reports/README.md` | 2026-06-16 | published | Review date is older than 2026-07-08. |
-| COPPA Final-Rule Verification | git | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | 2026-04-26 | approved | Review date is older than 2026-07-08. |
-| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | 2026-07-06 | approved | Review date is older than 2026-07-08. |
-| Compliance Calendar (compliance-calendar.json) | git | `audit-reports/compliance-calendar.json` | 2026-06-16 | published | Review date is older than 2026-07-08. |
-| Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | 2026-06-21 | published | Review date is older than 2026-07-08. |
-| Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | 2026-06-18 | approved | Review date is older than 2026-07-08. |
-| Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | 2026-06-21 | published | Review date is older than 2026-07-08. |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Incident Log | git | `docs/legal/INCIDENT_LOG.md` | 2026-05-27 | approved | Review date is older than 2026-07-08. |
-| Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | 2026-05-27 | approved | Review date is older than 2026-07-08. |
-| Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | 2026-06-11 | approved | Review date is older than 2026-07-08. |
-| Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | 2026-06-18 | approved | Review date is older than 2026-07-08. |
-| accessibility-auditor agent definition | git | `.claude/agents/accessibility-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-08. |
-| api-auditor agent definition | git | `.claude/agents/api-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-08. |
-| compliance-officer agent definition | git | `.claude/agents/compliance-officer.md` | 2026-06-21 | published | Review date is older than 2026-07-08. |
-| dependency-auditor agent definition | git | `.claude/agents/dependency-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-08. |
-| infra-auditor agent definition | git | `.claude/agents/infra-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-08. |
-| privacy-auditor agent definition | git | `.claude/agents/privacy-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-08. |
-| Notion - Compliance & Audits hub | notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Notion - Compliance Documents board (LL) | notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | 2026-06-21 | published | Review date is older than 2026-07-08. |
-| Notion - Compliance Engineering Onboarding/Handoff | notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | 2026-06-19 | published | Review date is older than 2026-07-08. |
-| Notion - Compliance Findings board (LL) | notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | 2026-06-20 | published | Review date is older than 2026-07-08. |
+| AI Governance Memo (branded) | drive | [open](https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Access Control Policy | drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Accessibility Conformance Report (ACR / VPAT) (branded) | drive | [open](https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit) | 2026-06-19 | draft | Review date is older than 2026-07-22. |
+| Audit Results Report | drive | [open](https://docs.google.com/document/d/1n6z-76-awsAtWq-2clQ340vfcn_gAtJbkCmVnIxL4tY/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Business Continuity and Disaster Recovery Plan | drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| COPPA Final-Rule Verification (branded) | drive | [open](https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Compliance & Security - Semi-Annual Program Report (H1 2026) | drive | [open](https://docs.google.com/document/d/1VKTOxmGjLiRYy9U3_Y4gzQ2gsmfnZZTeq5RZ7mkHAIM/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Compliance & Security Overhaul - Completion Report | drive | [open](https://docs.google.com/document/d/1en3MCE47qKj1nwg6wb_MA7h3TwwsDMs33oUM-0GhdEM/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Compliance & Security Program v1.0 (Attested) | drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Compliance Calendar (branded) | drive | [open](https://docs.google.com/document/d/19IT_GKK1PzC7zLnGNr-RNT0Rw1fFR68syUvnuBBA2CI/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Compliance Program - Claim vs Code Review | drive | [open](https://docs.google.com/document/d/1IHQ5yFkoU39N01wyTt5SRXM-Q71aKa9wuXvnGVWnbRg/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Data & Compliance Pipeline - Build Inventory (dated) | drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | 2026-06-22 | approved | Review date is older than 2026-07-22. |
+| Data Retention Schedule (branded) | drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Incident Log (branded) | drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Incident Response and Breach Runbook (branded) | drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Parental Consent (COPPA / under-13) (branded) | drive | [open](https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Records of Processing Activities (RoPA) and Data Map | drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Roadmap - What's Left (2026-06-19) | drive | [open](https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit) | 2026-06-19 | approved | Review date is older than 2026-07-22. |
+| Security Risk Assessment 2026 Q2 | drive | [open](https://docs.google.com/document/d/1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Subprocessor Register (branded) | drive | [open](https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Vendor and Subprocessor Management Policy | drive | [open](https://docs.google.com/document/d/1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Written Information Security Program (WISP) | drive | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| AI Data-Flow Classification | git | `docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` | 2026-07-09 | approved | Review date is older than 2026-07-22. |
+| AI Data-Sharing Consent: Rationale and Policy | git | `docs/legal/AI_DATA_SHARING_CONSENT.md` | 2026-07-09 | approved | Review date is older than 2026-07-22. |
+| AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | 2026-05-11 | approved | Review date is older than 2026-07-22. |
+| AWS Business Associate Agreement (signed PDF) | git | `docs/legal/AWS_BAA_2026-02.pdf` | 2026-05-11 | published | Review date is older than 2026-07-22. |
+| Accessibility Conformance Report (ACR / VPAT) | git | `docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md` | 2026-06-16 | draft | Review date is older than 2026-07-22. |
+| Anthropic HIPAA-Ready BAA Acceptance Record | git | `docs/legal/ANTHROPIC_BAA_ACCEPTED.md` | 2026-07-18 | approved | Review date is older than 2026-07-22. |
+| Audit Reports Index (audit-reports/README.md) | git | `audit-reports/README.md` | 2026-06-16 | published | Review date is older than 2026-07-22. |
+| COPPA Final-Rule Verification | git | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | 2026-04-26 | approved | Review date is older than 2026-07-22. |
+| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | 2026-07-06 | approved | Review date is older than 2026-07-22. |
+| Compliance Calendar (compliance-calendar.json) | git | `audit-reports/compliance-calendar.json` | 2026-06-16 | published | Review date is older than 2026-07-22. |
+| Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | 2026-06-21 | published | Review date is older than 2026-07-22. |
+| Compliance Posture Report | git | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | 2026-07-16 | published | Review date is older than 2026-07-22. |
+| Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | 2026-06-18 | approved | Review date is older than 2026-07-22. |
+| Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | 2026-06-21 | published | Review date is older than 2026-07-22. |
+| EU AI Act Article 50 Transparency: Implementation Milestone Plan | git | `docs/legal/EU_AI_ACT_ARTICLE_50_PLAN.md` | 2026-07-14 | draft | Review date is older than 2026-07-22. |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record | git | `docs/legal/GCP_BAA_ACCEPTED.md` | 2026-07-16 | approved | Review date is older than 2026-07-22. |
+| Incident Log | git | `docs/legal/INCIDENT_LOG.md` | 2026-05-27 | approved | Review date is older than 2026-07-22. |
+| Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | 2026-05-27 | approved | Review date is older than 2026-07-22. |
+| LingoLinq Capability Ledger (rendered) | git | `docs/legal/CAPABILITY_LEDGER.md` | 2026-07-12 | published | Review date is older than 2026-07-22. |
+| LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | 2026-07-09 | approved | Review date is older than 2026-07-22. |
+| Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | 2026-06-11 | approved | Review date is older than 2026-07-22. |
+| Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | 2026-06-18 | approved | Review date is older than 2026-07-22. |
+| accessibility-auditor agent definition | git | `.claude/agents/accessibility-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-22. |
+| api-auditor agent definition | git | `.claude/agents/api-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-22. |
+| compliance-officer agent definition | git | `.claude/agents/compliance-officer.md` | 2026-06-21 | published | Review date is older than 2026-07-22. |
+| dependency-auditor agent definition | git | `.claude/agents/dependency-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-22. |
+| infra-auditor agent definition | git | `.claude/agents/infra-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-22. |
+| privacy-auditor agent definition | git | `.claude/agents/privacy-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-22. |
+| Notion - Compliance & Audits hub | notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Notion - Compliance Documents board (LL) | notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | 2026-06-21 | published | Review date is older than 2026-07-22. |
+| Notion - Compliance Engineering Onboarding/Handoff | notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | 2026-06-19 | published | Review date is older than 2026-07-22. |
+| Notion - Compliance Findings board (LL) | notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | 2026-06-20 | published | Review date is older than 2026-07-22. |
 
 ## Drive Refresh Queue
 
@@ -91,7 +98,6 @@
 | Compliance & Security Overhaul - Completion Report | [open](https://docs.google.com/document/d/1en3MCE47qKj1nwg6wb_MA7h3TwwsDMs33oUM-0GhdEM/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
 | Compliance & Security Program v1.0 (Attested) | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
 | Compliance Calendar (branded) | [open](https://docs.google.com/document/d/19IT_GKK1PzC7zLnGNr-RNT0Rw1fFR68syUvnuBBA2CI/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
-| Compliance Posture Report (branded) | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
 | Compliance Program - Claim vs Code Review | [open](https://docs.google.com/document/d/1IHQ5yFkoU39N01wyTt5SRXM-Q71aKa9wuXvnGVWnbRg/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
 | Data & Compliance Pipeline - Build Inventory (dated) | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | 2026-06-22 | approved | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
 | Data Retention Schedule (branded) | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | 2026-06-19 | published | Refresh or explicitly mark frozen/point-in-time, then update `lastReviewed` and `contentHash` if available. |
@@ -112,6 +118,9 @@
 | AI Governance Memo (branded) | drive | [open](https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Access Control Policy | drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Accessibility Conformance Report (ACR / VPAT) (branded) | drive | [open](https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Annex A - Clinical BAA Template (DRAFT) | drive | [open](https://docs.google.com/document/d/1Q6hDhooIQVMArkpn4ppxr4om3-Hx64QmYiIQe0sSWmY/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT) | drive | [open](https://docs.google.com/document/d/1vPwlcZwllRPuTU1TlqFeSwxJZ445pxsh6O0cBrGyE6M/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Anthropic Business Associate Agreement (2026-05-06) | drive | [open](https://drive.google.com/file/d/1sL3di9GRP4hlids-baZDT26n3SKjzwD5/view) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Audit Results Report | drive | [open](https://docs.google.com/document/d/1n6z-76-awsAtWq-2clQ340vfcn_gAtJbkCmVnIxL4tY/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Business Continuity and Disaster Recovery Plan | drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | COPPA Final-Rule Verification (branded) | drive | [open](https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
@@ -120,9 +129,11 @@
 | Compliance & Security Program v1.0 (Attested) | drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Compliance Calendar (branded) | drive | [open](https://docs.google.com/document/d/19IT_GKK1PzC7zLnGNr-RNT0Rw1fFR68syUvnuBBA2CI/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Compliance Posture Report (branded) | drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Compliance Posture Report (branded, 2026-07-16 re-attest) | drive | [open](https://docs.google.com/document/d/1yx-jVYesJ0ZQM0myir6d0rRMMzGEoH5EL5_luicucYo/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Compliance Program - Claim vs Code Review | drive | [open](https://docs.google.com/document/d/1IHQ5yFkoU39N01wyTt5SRXM-Q71aKa9wuXvnGVWnbRg/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Data & Compliance Pipeline - Build Inventory (dated) | drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Data Retention Schedule (branded) | drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
+| Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14) | drive | [open](https://docs.google.com/document/d/1CcyQpNfg8aiuY5VA7RHYbYqQEQtzHAdEkjpxcQIhNmM/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Incident Log (branded) | drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Incident Response and Breach Runbook (branded) | drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
 | Parental Consent (COPPA / under-13) (branded) | drive | [open](https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit) | Supply hash during Drive review; the repo has no Google Docs body fetch/write workflow yet. |
@@ -137,10 +148,116 @@
 | Notion - Compliance Engineering Onboarding/Handoff | notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | Run `ruby scripts/document-register-notion-sync.rb --refresh-notion-hashes` with `NOTION_TOKEN`. |
 | Notion - Compliance Findings board (LL) | notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | Run `ruby scripts/document-register-notion-sync.rb --refresh-notion-hashes` with `NOTION_TOKEN`. |
 
+## Retention Draft Coverage
+
+Every rule is `status: draft` and legally inert. No deletion behaviour is wired anywhere in this repo. Only Scot moves a rule to `approved`, and only after counsel review.
+
+| Class | Rule | Disposition | Rows | Status |
+|---|---|---|---|---|
+| `executed-agreement` | term + 7 years | archive | 6 | draft |
+| `corporate-permanent` | permanent | archive | 0 | unused (no record of this class exists yet) |
+| `grant-record` | award + 7 years | archive | 0 | unused (no record of this class exists yet) |
+| `policy-version` | supersession + 7 years | archive | 33 | draft |
+| `audit-evidence` | 7 years | archive | 17 | draft |
+| `attestation-record` | permanent | archive | 0 | unused (no record of this class exists yet) |
+| `dsar-case` | 3 years | delete | 0 | unused (no record of this class exists yet) |
+| `questionnaire-response` | 3 years | delete | 0 | unused (no record of this class exists yet) |
+| `superseded-draft` | 1 year | delete | 0 | unused (no record of this class exists yet) |
+| `working-note` | 90 days | delete | 0 | unused (no record of this class exists yet) |
+| `operational-config` | retain while in use; supersession + 1 year | archive | 14 | draft |
+
+All 70 rows carry a retention block.
+
+No retention rule has been approved. Nothing in this register is eligible for disposition.
+
+### Inferred retention classes (counsel review these first)
+
+| Title | System | Class | Why it is ambiguous |
+|---|---|---|---|
+| Compliance Posture Report (branded) | drive | `policy-version` | sec 5.2 offers two readings for a superseded record: "policies (each version)" (7yr, archive) and "superseded drafts with no attestation" (1yr, delete). This was a published artifact, not a draft, so the archive reading was taken. Confirm with counsel. |
+| Agent config - diff-compliance-check | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Agent config - ember-upgrade-auditor | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Agent config - rails-implementer | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Agent config - security-reviewer | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Audit Reports Index (audit-reports/README.md) | git | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| Compliance Calendar (compliance-calendar.json) | git | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| Compliance Status Snapshot (2026-04-23) | git | `policy-version` | sec 5.2 offers two readings for a superseded record: "policies (each version)" (7yr, archive) and "superseded drafts with no attestation" (1yr, delete). This was a published artifact, not a draft, so the archive reading was taken. Confirm with counsel. |
+| Compliance Status Snapshot (2026-06-18) | git | `policy-version` | sec 5.2 offers two readings for a superseded record: "policies (each version)" (7yr, archive) and "superseded drafts with no attestation" (1yr, delete). This was a published artifact, not a draft, so the archive reading was taken. Confirm with counsel. |
+| Document Register (this file) | git | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| Findings Register (FINDINGS.json) | git | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| LingoLinq Capability Ledger (rendered) | git | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| accessibility-auditor agent definition | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| api-auditor agent definition | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| compliance-officer agent definition | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| dependency-auditor agent definition | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| infra-auditor agent definition | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| privacy-auditor agent definition | git | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Notion - Compliance & Audits hub | notion | `operational-config` | One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors. |
+| Notion - Compliance Documents board (LL) | notion | `operational-config` | One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors. |
+| Notion - Compliance Engineering Onboarding/Handoff | notion | `operational-config` | One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors. |
+| Notion - Compliance Findings board (LL) | notion | `operational-config` | One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors. |
+
+## Legal Holds
+
+_No record is under legal hold. A hold suspends all disposition for the rows it covers, and only Scot flips it._
+
+## Supersession Chains
+
+A superseded record is never edited, renamed, or moved. It keeps its row and its membership in any frozen point-in-time binder; only the pointer is added.
+
+| Superseded | Location | Replaced by | Still bundled in |
+|---|---|---|---|
+| Compliance Posture Report (branded) | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | Compliance Posture Report (branded, 2026-07-16 re-attest) | compliance-records-set-2026-06 |
+
+## Bundle Gaps
+
+Artifacts a bundle needs that do not exist yet. These are never satisfied by inventing a register row; they are closed by creating the real document and promoting it into `requiredDocs`.
+
+**soc2-evidence** (3)
+
+- Independent penetration-test report (none commissioned)
+- Workforce security-training completion records
+- Formal change-management policy as a standalone record
+
+**school-dpa-package** (3)
+
+- Signed per-district NDPA instances (register-backed series; none executed yet)
+- State-specific NDPA exhibits beyond the standing set
+- Standalone deletion/return commitment (currently only a clause inside DATA_RETENTION.md)
+
+**security-review** (3)
+
+- SSO / authentication description as a standalone record
+- Dependency and vulnerability posture summary as a customer-facing record
+- Independent penetration-test or third-party audit summary
+
+**baa** (3)
+
+- HIPAA workforce training records (do not exist; owed before real PHI, per the Melissa GCP-admin note)
+- Audit-logging control description as a standalone record (currently only prose inside larger documents)
+- Executed downstream customer BAAs (none executed yet; will become a register-backed series)
+
+**dsar** (5)
+
+- Data-subject identity-verification procedure (does not exist)
+- Export / deletion operational runbook (does not exist as a record)
+- DSAR response-letter templates (do not exist)
+- DSAR case-log template (does not exist; must hold no case content with PII)
+- GDPR Art. 27 EU representative designation (Annex G in Drive is a recommendation, not a designation)
+
+**grant** (6)
+
+- Corporate formation documents (exist in Drive 610 but are unregistered)
+- PI bio-sketch (does not exist as a standing record)
+- Prior-award and commercialization history (does not exist)
+- Data-management plan (does not exist)
+- Human-subjects / IRB posture statement (does not exist)
+- D-U-N-S and SAM.gov registration evidence (unregistered; gates the native-apps initiative too)
+
 ## Next Automation Gap
 
 The missing layer is a Google Docs publisher/refresh workflow. Until that exists, the compliance agent should use this report as its work queue: update canonical registers, sync Notion boards, then refresh or explicitly freeze affected Drive documents.
 
 ---
 
-_55 documents tracked. 48 stale review item(s). 23 Drive refresh item(s). 4 Notion hash item(s)._
+_70 documents tracked. 55 stale review item(s). 22 Drive refresh item(s). 4 Notion hash item(s). 22 inferred retention class(es). 0 legal hold(s). 1 superseded record(s). 23 bundle gap(s) across 6 bundle(s)._

--- a/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
+++ b/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
@@ -50,7 +50,7 @@
 | Subprocessor Register (branded) | drive | [open](https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
 | Vendor and Subprocessor Management Policy | drive | [open](https://docs.google.com/document/d/1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
 | Written Information Security Program (WISP) | drive | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
-| AI Data-Flow Classification | git | `docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` | 2026-07-09 | approved | Review date is older than 2026-07-22. |
+| AI Data-Flow Classification | git | `docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` | 2026-07-09 | draft | Review date is older than 2026-07-22. |
 | AI Data-Sharing Consent: Rationale and Policy | git | `docs/legal/AI_DATA_SHARING_CONSENT.md` | 2026-07-09 | approved | Review date is older than 2026-07-22. |
 | AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | 2026-05-11 | approved | Review date is older than 2026-07-22. |
 | AWS Business Associate Agreement (signed PDF) | git | `docs/legal/AWS_BAA_2026-02.pdf` | 2026-05-11 | published | Review date is older than 2026-07-22. |
@@ -70,7 +70,7 @@
 | Incident Log | git | `docs/legal/INCIDENT_LOG.md` | 2026-05-27 | approved | Review date is older than 2026-07-22. |
 | Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | 2026-05-27 | approved | Review date is older than 2026-07-22. |
 | LingoLinq Capability Ledger (rendered) | git | `docs/legal/CAPABILITY_LEDGER.md` | 2026-07-12 | published | Review date is older than 2026-07-22. |
-| LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | 2026-07-09 | approved | Review date is older than 2026-07-22. |
+| LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | 2026-07-09 | draft | Review date is older than 2026-07-22. |
 | Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | 2026-06-11 | approved | Review date is older than 2026-07-22. |
 | Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | 2026-06-18 | approved | Review date is older than 2026-07-22. |
 | accessibility-auditor agent definition | git | `.claude/agents/accessibility-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-22. |

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -3,7 +3,7 @@
     "schemaVersion": "1.0",
     "register": "LingoLinq-AAC compliance document register",
     "description": "Single source of truth for WHERE every compliance document lives across the codebase (git), Google Drive, and Notion - its canonical home, its mirrors, its owner, its review dates, and which compliance bundles it belongs to. This is the document-level analogue of audit-reports/FINDINGS.json (which tracks finding status). The codebase copy is canonical; the Notion board is a one-way mirror; Drive docs are referenced by URL, never copied. See docs/legal/COMPLIANCE_DOCS_GUIDE.md.",
-    "generatedDate": "2026-06-21",
+    "generatedDate": "2026-07-22",
     "idAlgorithm": "id = 'DOC-' + sha256(canonicalLocation) first 10 hex chars; stable across runs so a moved/renamed doc reads as a diff. Computed and written back by scripts/document-register-render.rb.",
     "contentHashNote": "contentHash is sha256 of the canonical content. For canonicalSystem=git rows the render script computes it from the file bytes at its repo path and CI verifies it in --check (a tracked doc edited without updating its row fails). For drive/notion rows the hash is externally supplied: Notion-row hashes can be refreshed automatically by the network-capable Notion-sync run (--refresh-notion-hashes); DRIVE-row hashes have NO automated refresh and must be supplied by the operator (the sync script carries no Google credentials), so Drive freshness is a dated review obligation, not an automated guarantee. CI is network-free: a null/empty drive/notion hash is allowed and surfaced as an advisory, never a CI failure.",
     "typeEnum": [
@@ -35,7 +35,100 @@
       "WCAG",
       "SOC2"
     ],
+    "retentionClassEnum": [
+      "executed-agreement",
+      "corporate-permanent",
+      "grant-record",
+      "policy-version",
+      "audit-evidence",
+      "attestation-record",
+      "dsar-case",
+      "questionnaire-response",
+      "superseded-draft",
+      "working-note",
+      "operational-config"
+    ],
+    "dispositionEnum": [
+      "archive",
+      "delete"
+    ],
+    "retentionStatusEnum": [
+      "draft",
+      "approved"
+    ],
     "governance": "Only Scot changes a document's attestation, or moves its status to approved/published. The compliance-officer agent and the main session keep the index current (add/retire rows, refresh review dates, maintain bundles and contentHash) but never attest. Drafts stay status:draft with an empty attestation until Scot signs. No student/patient data ever appears here; entries are titles, paths/URLs, and hashes only.",
+    "retentionSchedule": {
+      "executed-agreement": {
+        "rule": "term + 7 years",
+        "trigger": "contract-end",
+        "disposition": "archive",
+        "source": "IA report 2026-07-22 sec 5.2"
+      },
+      "corporate-permanent": {
+        "rule": "permanent",
+        "trigger": "n/a",
+        "disposition": "archive",
+        "source": "IA report 2026-07-22 sec 5.2"
+      },
+      "grant-record": {
+        "rule": "award + 7 years",
+        "trigger": "close-out",
+        "disposition": "archive",
+        "source": "IA report 2026-07-22 sec 5.2 (federal record floors)"
+      },
+      "policy-version": {
+        "rule": "supersession + 7 years",
+        "trigger": "superseded",
+        "disposition": "archive",
+        "source": "IA report 2026-07-22 sec 5.2; exceeds the 45 CFR 164.530(j) six-year HIPAA floor"
+      },
+      "audit-evidence": {
+        "rule": "7 years",
+        "trigger": "finding-closed",
+        "disposition": "archive",
+        "source": "IA report 2026-07-22 sec 5.2; exceeds the 45 CFR 164.530(j) six-year HIPAA floor"
+      },
+      "attestation-record": {
+        "rule": "permanent",
+        "trigger": "n/a",
+        "disposition": "archive",
+        "source": "IA report 2026-07-22 sec 5.2"
+      },
+      "dsar-case": {
+        "rule": "3 years",
+        "trigger": "case-closed",
+        "disposition": "delete",
+        "source": "IA report 2026-07-22 sec 5.2"
+      },
+      "questionnaire-response": {
+        "rule": "3 years",
+        "trigger": "sent",
+        "disposition": "delete",
+        "source": "IA report 2026-07-22 sec 5.2"
+      },
+      "superseded-draft": {
+        "rule": "1 year",
+        "trigger": "superseded",
+        "disposition": "delete",
+        "source": "IA report 2026-07-22 sec 5.2 (unattested drafts only)"
+      },
+      "working-note": {
+        "rule": "90 days",
+        "trigger": "created",
+        "disposition": "delete",
+        "source": "IA report 2026-07-22 sec 5.2"
+      },
+      "operational-config": {
+        "rule": "retain while in use; supersession + 1 year",
+        "trigger": "superseded",
+        "disposition": "archive",
+        "source": "ADDED BEYOND the sec 5.2 starting table: agent configs and generated repo artifacts are not a record class counsel has been given. Flagged on every row that uses it."
+      }
+    },
+    "retentionNote": "EVERY retention block is status:draft and legally inert. Nothing in this register wires, schedules, or authorises deletion. --check performs SHAPE validation only: required fields present, class resolves to meta.retentionSchedule, and the row's denormalised rule/disposition match that schedule entry. dispositionEligibleAfter MUST stay null while retention.status is not \"approved\" - --check enforces that, so a draft schedule can never produce a disposition date. Only Scot moves a retention rule to approved, and only after counsel review. retention.ambiguous:true marks a row whose class was inferred rather than read off the sec 5.2 table; those are the rows counsel should look at first. Note also that no current row carries a delete disposition: where sec 5.2 was ambiguous the assignment was made conservatively toward archive, so the delete-disposition classes exist in the schedule with zero members.",
+    "supersessionNote": "supersedes / supersededBy form a two-way chain and --check enforces reciprocity: if A.supersededBy == B then B.supersedes must == A, neither may self-reference, both ids must resolve to real rows, and a row carrying supersededBy must have status:superseded. Attestation freezes bytes: a superseded record is never edited, renamed, or moved - it keeps its row, its title, and its bundle membership in any frozen point-in-time binder, and only the pointer is added.",
+    "driveFileIdNote": "driveFileId is the stable Google Drive file ID, required on every canonicalSystem=drive row and forbidden on git/notion rows. Drive IDs survive renames and moves; path-shaped URLs do not. --check verifies the id is the one embedded in canonicalLocation, so the two can never disagree.",
+    "completenessNote": "Register/reality drift is checked in both directions. Registered-but-missing has always been a hard failure (a git row must resolve to a real in-repo file). Present-but-unregistered is now checked too: every tracked file under docs/legal/ must have a git row or --check fails, because that directory is unambiguously the compliance corpus. The .claude/agents/ sweep is advisory only, since that directory also holds non-compliance agents. Drive and Notion completeness cannot be checked here (CI is network-free) and remains a dated review obligation.",
     "bundleDefinitions": {
       "compliance-records-set-2026-06": {
         "description": "The attested, externally-released branded binder generated 2026-06-19 and held in the Drive 'Branded Records Set' folder. Frozen point-in-time records; the living sources are the git docs and the auto-synced Notion findings board.",
@@ -144,7 +237,24 @@
           {
             "title": "Incident Log",
             "location": "docs/legal/INCIDENT_LOG.md"
+          },
+          {
+            "title": "Business Continuity and Disaster Recovery Plan",
+            "location": "https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit"
+          },
+          {
+            "title": "Compliance & Data Governance (COMPLIANCE.md)",
+            "location": "COMPLIANCE.md"
+          },
+          {
+            "title": "Subprocessor Register",
+            "location": "docs/legal/SUBPROCESSORS.md"
           }
+        ],
+        "gaps": [
+          "Independent penetration-test report (none commissioned)",
+          "Workforce security-training completion records",
+          "Formal change-management policy as a standalone record"
         ]
       },
       "school-dpa-package": {
@@ -173,11 +283,174 @@
           {
             "title": "Accessibility Conformance Report (ACR / VPAT)",
             "location": "docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md"
+          },
+          {
+            "title": "Incident Response and Breach Runbook",
+            "location": "docs/legal/BREACH_RUNBOOK.md"
+          },
+          {
+            "title": "AI Data-Flow Classification",
+            "location": "docs/legal/AI_DATA_FLOW_CLASSIFICATION.md"
+          },
+          {
+            "title": "Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT)",
+            "location": "https://docs.google.com/document/d/1vPwlcZwllRPuTU1TlqFeSwxJZ445pxsh6O0cBrGyE6M/edit"
           }
+        ],
+        "gaps": [
+          "Signed per-district NDPA instances (register-backed series; none executed yet)",
+          "State-specific NDPA exhibits beyond the standing set",
+          "Standalone deletion/return commitment (currently only a clause inside DATA_RETENTION.md)"
+        ]
+      },
+      "security-review": {
+        "description": "What a school district or hospital IT security questionnaire asks for. Deliberately SEPARATE from soc2-evidence: this is the customer-facing diligence pack (posture, accessibility, AI data-flow, subprocessors), whereas soc2-evidence is the internal controls-evidence pack. Merging them would force each to carry documents the other reviewer never asks for.",
+        "requiredDocs": [
+          {
+            "title": "Compliance Posture Report",
+            "location": "docs/legal/COMPLIANCE_POSTURE_REPORT.md"
+          },
+          {
+            "title": "LingoLinq Security, Privacy & Compliance Overview",
+            "location": "docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md"
+          },
+          {
+            "title": "Subprocessor Register",
+            "location": "docs/legal/SUBPROCESSORS.md"
+          },
+          {
+            "title": "Data Retention Schedule",
+            "location": "docs/legal/DATA_RETENTION.md"
+          },
+          {
+            "title": "Incident Response and Breach Runbook",
+            "location": "docs/legal/BREACH_RUNBOOK.md"
+          },
+          {
+            "title": "Accessibility Conformance Report (ACR / VPAT)",
+            "location": "docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md"
+          },
+          {
+            "title": "AI Data-Flow Classification",
+            "location": "docs/legal/AI_DATA_FLOW_CLASSIFICATION.md"
+          },
+          {
+            "title": "AI Governance Memo",
+            "location": "docs/legal/AI_GOVERNANCE_MEMO.md"
+          },
+          {
+            "title": "Written Information Security Program (WISP)",
+            "location": "https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit"
+          },
+          {
+            "title": "Access Control Policy",
+            "location": "https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit"
+          }
+        ],
+        "gaps": [
+          "SSO / authentication description as a standalone record",
+          "Dependency and vulnerability posture summary as a customer-facing record",
+          "Independent penetration-test or third-party audit summary"
+        ]
+      },
+      "baa": {
+        "description": "What a covered entity (hospital, clinic, or district health service) asks for before executing a BAA. Covers both directions: the BAAs LingoLinq holds upstream with its subprocessors, and the BAA LingoLinq offers downstream to customers.",
+        "requiredDocs": [
+          {
+            "title": "AWS Business Associate Agreement (signed PDF)",
+            "location": "docs/legal/AWS_BAA_2026-02.pdf"
+          },
+          {
+            "title": "AWS BAA acceptance record",
+            "location": "docs/legal/AWS_BAA_ACCEPTED.md"
+          },
+          {
+            "title": "Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record",
+            "location": "docs/legal/GCP_BAA_ACCEPTED.md"
+          },
+          {
+            "title": "Anthropic HIPAA-Ready BAA Acceptance Record",
+            "location": "docs/legal/ANTHROPIC_BAA_ACCEPTED.md"
+          },
+          {
+            "title": "Anthropic Business Associate Agreement (2026-05-06)",
+            "location": "https://drive.google.com/file/d/1sL3di9GRP4hlids-baZDT26n3SKjzwD5/view"
+          },
+          {
+            "title": "Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14)",
+            "location": "https://docs.google.com/document/d/1CcyQpNfg8aiuY5VA7RHYbYqQEQtzHAdEkjpxcQIhNmM/edit"
+          },
+          {
+            "title": "Annex A - Clinical BAA Template (DRAFT)",
+            "location": "https://docs.google.com/document/d/1Q6hDhooIQVMArkpn4ppxr4om3-Hx64QmYiIQe0sSWmY/edit"
+          },
+          {
+            "title": "Incident Response and Breach Runbook",
+            "location": "docs/legal/BREACH_RUNBOOK.md"
+          },
+          {
+            "title": "Written Information Security Program (WISP)",
+            "location": "https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit"
+          },
+          {
+            "title": "Access Control Policy",
+            "location": "https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit"
+          }
+        ],
+        "gaps": [
+          "HIPAA workforce training records (do not exist; owed before real PHI, per the Melissa GCP-admin note)",
+          "Audit-logging control description as a standalone record (currently only prose inside larger documents)",
+          "Executed downstream customer BAAs (none executed yet; will become a register-backed series)"
+        ]
+      },
+      "dsar": {
+        "description": "What a GDPR data-subject access, rectification, or erasure request requires. The Article 30 RoPA is the spine: it is the artifact a supervisory authority asks for first, and LingoLinq does not qualify for the small-business exemption because it processes children's data systematically and at scale.",
+        "requiredDocs": [
+          {
+            "title": "Records of Processing Activities (RoPA) and Data Map",
+            "location": "https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit"
+          },
+          {
+            "title": "Data Retention Schedule",
+            "location": "docs/legal/DATA_RETENTION.md"
+          },
+          {
+            "title": "AI Data-Flow Classification",
+            "location": "docs/legal/AI_DATA_FLOW_CLASSIFICATION.md"
+          }
+        ],
+        "gaps": [
+          "Data-subject identity-verification procedure (does not exist)",
+          "Export / deletion operational runbook (does not exist as a record)",
+          "DSAR response-letter templates (do not exist)",
+          "DSAR case-log template (does not exist; must hold no case content with PII)",
+          "GDPR Art. 27 EU representative designation (Annex G in Drive is a recommendation, not a designation)"
+        ]
+      },
+      "grant": {
+        "description": "What a federal or foundation grant application needs from the compliance library. Mostly gap today: the SBIR Phase IB material in Drive is application drafting, not the standing records a reviewer asks for.",
+        "requiredDocs": [
+          {
+            "title": "Accessibility Conformance Report (ACR / VPAT)",
+            "location": "docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md"
+          },
+          {
+            "title": "Compliance Posture Report",
+            "location": "docs/legal/COMPLIANCE_POSTURE_REPORT.md"
+          }
+        ],
+        "gaps": [
+          "Corporate formation documents (exist in Drive 610 but are unregistered)",
+          "PI bio-sketch (does not exist as a standing record)",
+          "Prior-award and commercialization history (does not exist)",
+          "Data-management plan (does not exist)",
+          "Human-subjects / IRB posture statement (does not exist)",
+          "D-U-N-S and SAM.gov registration evidence (unregistered; gates the native-apps initiative too)"
         ]
       }
     },
     "bundleMatchNote": "bundleDefinitions[*].requiredDocs binds each requirement to a specific document by canonicalLocation (identity), not free-text title, so a doc retitled to a required string cannot satisfy a requirement. Each requiredDoc carries a human-readable title that --check verifies still matches the member at that location (register-drift guard). --check fails if a requiredDoc location is not a bundle member, or its title has drifted.",
+    "bundleGapNote": "bundleDefinitions[*].gaps names artifacts a bundle genuinely needs that DO NOT EXIST as records yet. A gap is a deliberate, visible hole: it is rendered in DOCUMENT-REGISTER.md and never satisfied by inventing a row or by pointing a requiredDoc at an unrelated document. gaps never fail --check; an unmet requiredDoc always does. Close a gap by creating the real artifact and promoting it out of gaps into requiredDocs.",
     "integrityNote": "--check also enforces: every canonicalSystem is one of canonicalSystemEnum; a git row canonicalLocation is a repo path (not a URL); a drive/notion row canonicalLocation is a URL and does not resolve to a tracked repo file (so a git doc cannot dodge hash verification by being relabeled drive/notion); and id + canonicalLocation are unique across the register."
   },
   "documents": [
@@ -203,9 +476,19 @@
         "attestedDate": "2026-07-06"
       },
       "contentHash": "1e75223be75eadb026a8a4eedd730a3b2a97049383dd095e8fcc530fbf8db609",
-      "bundles": [],
+      "bundles": [
+        "soc2-evidence"
+      ],
       "mirrors": [],
-      "id": "DOC-9b299a785b"
+      "id": "DOC-9b299a785b",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Compliance Program",
@@ -233,7 +516,15 @@
         "compliance-records-set-2026-06"
       ],
       "mirrors": [],
-      "id": "DOC-b61994933c"
+      "id": "DOC-b61994933c",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Compliance Posture Report",
@@ -259,7 +550,9 @@
       },
       "contentHash": "80af6f2c5b34d5697942cead1f88bdc79d1141c8ffa180a011078468148c4cf1",
       "bundles": [
-        "school-dpa-package"
+        "school-dpa-package",
+        "security-review",
+        "grant"
       ],
       "mirrors": [
         {
@@ -267,7 +560,15 @@
           "location": "https://docs.google.com/document/d/1yx-jVYesJ0ZQM0myir6d0rRMMzGEoH5EL5_luicucYo/edit"
         }
       ],
-      "id": "DOC-4e3b7fb1fb"
+      "id": "DOC-4e3b7fb1fb",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "AI Governance Memo",
@@ -289,7 +590,8 @@
       },
       "contentHash": "34b0b857f494864186d1305a40e5ce22a17b2265340a81436161dae2d87efafc",
       "bundles": [
-        "compliance-records-set-2026-06"
+        "compliance-records-set-2026-06",
+        "security-review"
       ],
       "mirrors": [
         {
@@ -297,7 +599,15 @@
           "location": "https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit"
         }
       ],
-      "id": "DOC-39f37f8200"
+      "id": "DOC-39f37f8200",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Accessibility Conformance Report (ACR / VPAT)",
@@ -315,7 +625,9 @@
       "attestation": {},
       "contentHash": "e68ef80b2638ddb15ccf2c351513ec83508d7073a0e6576ca2d3fdee98f815bd",
       "bundles": [
-        "school-dpa-package"
+        "school-dpa-package",
+        "security-review",
+        "grant"
       ],
       "mirrors": [
         {
@@ -323,7 +635,15 @@
           "location": "https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit"
         }
       ],
-      "id": "DOC-a744f8f663"
+      "id": "DOC-a744f8f663",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Data Retention Schedule",
@@ -348,7 +668,9 @@
       "contentHash": "b1bee6c56129f610f2d4e8b9d5ae83a0f80a0404a8efe4dad85d431a3e894194",
       "bundles": [
         "soc2-evidence",
-        "school-dpa-package"
+        "school-dpa-package",
+        "security-review",
+        "dsar"
       ],
       "mirrors": [
         {
@@ -356,7 +678,15 @@
           "location": "https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit"
         }
       ],
-      "id": "DOC-bff9acf51f"
+      "id": "DOC-bff9acf51f",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Subprocessor Register",
@@ -379,7 +709,9 @@
       },
       "contentHash": "e76da3475c16c79927e58625e90c900eb506d8bfaccc1fe086aefb638463b6e3",
       "bundles": [
-        "school-dpa-package"
+        "school-dpa-package",
+        "soc2-evidence",
+        "security-review"
       ],
       "mirrors": [
         {
@@ -387,7 +719,15 @@
           "location": "https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit"
         }
       ],
-      "id": "DOC-0387973005"
+      "id": "DOC-0387973005",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "COPPA Final-Rule Verification",
@@ -416,7 +756,15 @@
           "location": "https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit"
         }
       ],
-      "id": "DOC-407d2c2bf4"
+      "id": "DOC-407d2c2bf4",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Parental Consent Email (COPPA / under-13)",
@@ -445,7 +793,15 @@
           "location": "https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit"
         }
       ],
-      "id": "DOC-4e6c9253b9"
+      "id": "DOC-4e6c9253b9",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Incident Response and Breach Runbook",
@@ -468,7 +824,10 @@
       },
       "contentHash": "3efcaaf4a7c53016237527a5202a370bf74852f4b3e26e4346db5f418c5e263b",
       "bundles": [
-        "soc2-evidence"
+        "soc2-evidence",
+        "school-dpa-package",
+        "security-review",
+        "baa"
       ],
       "mirrors": [
         {
@@ -476,7 +835,15 @@
           "location": "https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit"
         }
       ],
-      "id": "DOC-d4e3b8be32"
+      "id": "DOC-d4e3b8be32",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Incident Log",
@@ -506,7 +873,15 @@
           "location": "https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit"
         }
       ],
-      "id": "DOC-1ea9f75b4f"
+      "id": "DOC-1ea9f75b4f",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "AWS Business Associate Agreement (signed PDF)",
@@ -526,9 +901,19 @@
         "attestedDate": "2026-02"
       },
       "contentHash": "55f28e00168cfe5a1ecfaac3c56c33bd3fadd05276c8e9bcc6e678fc798b9bee",
-      "bundles": [],
+      "bundles": [
+        "baa"
+      ],
       "mirrors": [],
-      "id": "DOC-0ef0df93d9"
+      "id": "DOC-0ef0df93d9",
+      "retention": {
+        "class": "executed-agreement",
+        "rule": "term + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record",
@@ -549,7 +934,9 @@
         "attestedDate": "2026-07-16"
       },
       "contentHash": "70671328fe90b51b7d2689cfa417d49cb37fb4407cd09c439fcafd26dd6bf719",
-      "bundles": [],
+      "bundles": [
+        "baa"
+      ],
       "mirrors": [
         {
           "system": "drive",
@@ -557,7 +944,15 @@
         }
       ],
       "notes": "Parity with the AWS acceptance record (docs/legal/AWS_BAA_ACCEPTED.md). Companion Drive doc plus console screenshots ('Google Cloud Console Agreements 07-14-2026') are the source evidence, mirrored here. Referenced by docs/legal/SUBPROCESSORS.md section 5.7, COMPLIANCE.md section 4, and docs/legal/COMPLIANCE_POSTURE_REPORT.md. Approved and attested by Scot Wahlquist 2026-07-16 per explicit instruction; git contentHash is computed and CI-verified.",
-      "id": "DOC-5b14b08908"
+      "id": "DOC-5b14b08908",
+      "retention": {
+        "class": "executed-agreement",
+        "rule": "term + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Anthropic HIPAA-Ready BAA Acceptance Record",
@@ -577,7 +972,9 @@
         "attestedBy": "Scot Wahlquist",
         "attestedDate": "2026-07-18"
       },
-      "bundles": [],
+      "bundles": [
+        "baa"
+      ],
       "mirrors": [
         {
           "system": "drive",
@@ -590,7 +987,15 @@
       ],
       "notes": "Parity with the AWS (docs/legal/AWS_BAA_ACCEPTED.md) and GCP (docs/legal/GCP_BAA_ACCEPTED.md) acceptance records. Model-provider BAA for the Anthropic runtime egress path; supersedes the prior 'no model-provider BAA / provisional pending CEO review' posture in COMPLIANCE.md, SUBPROCESSORS.md row 4, GCP_BAA_ACCEPTED.md, and AI_GOVERNANCE_MEMO.md (all reconciled in the same PR). Live enablement verified 2026-07-18 (Messages API 200; Files API 400 'not available for HIPAA-regulated organizations without Zero Data Retention'). Attested by Scot Wahlquist 2026-07-18 per explicit confirmation; git contentHash computed and CI-verified. The broader AI_GOVERNANCE_MEMO body was fully updated and re-attested by Scot Wahlquist on 2026-07-19 in the AI governance memo re-attestation PR.",
       "id": "DOC-ab3a8c3ed4",
-      "contentHash": "5adbe44783d9d74797498415714bb0c84c81dc943ffcd7911ac4284624f9b0d4"
+      "contentHash": "5adbe44783d9d74797498415714bb0c84c81dc943ffcd7911ac4284624f9b0d4",
+      "retention": {
+        "class": "executed-agreement",
+        "rule": "term + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "AWS BAA Acceptance Record",
@@ -610,9 +1015,19 @@
         "attestedDate": "2026-06-21"
       },
       "contentHash": "dc6a2ba9fa167f3f2bff6ec356bbd2b8bd9f9bafcd680b15362225aeca023f3e",
-      "bundles": [],
+      "bundles": [
+        "baa"
+      ],
       "mirrors": [],
-      "id": "DOC-286318ff28"
+      "id": "DOC-286318ff28",
+      "retention": {
+        "class": "executed-agreement",
+        "rule": "term + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Compliance Status Snapshot (2026-06-18)",
@@ -629,7 +1044,17 @@
       "contentHash": "94b8288187ead04f26a0c929afab0a234b3154ed7ba0dca06adad69a50d053a6",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-d19d6ab8e6"
+      "id": "DOC-d19d6ab8e6",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "sec 5.2 offers two readings for a superseded record: \"policies (each version)\" (7yr, archive) and \"superseded drafts with no attestation\" (1yr, delete). This was a published artifact, not a draft, so the archive reading was taken. Confirm with counsel."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Compliance Status Snapshot (2026-04-23)",
@@ -646,7 +1071,17 @@
       "contentHash": "0cacd835e906fc81d94e4dc032b004245dce8092fa4949e27935292f6605564d",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-9d29260615"
+      "id": "DOC-9d29260615",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "sec 5.2 offers two readings for a superseded record: \"policies (each version)\" (7yr, archive) and \"superseded drafts with no attestation\" (1yr, delete). This was a published artifact, not a draft, so the archive reading was taken. Confirm with counsel."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Findings Register (FINDINGS.json)",
@@ -675,7 +1110,17 @@
           "location": "https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805"
         }
       ],
-      "id": "DOC-62baffb3b1"
+      "id": "DOC-62baffb3b1",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete)."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Compliance Calendar (compliance-calendar.json)",
@@ -705,7 +1150,17 @@
           "location": "https://docs.google.com/document/d/19IT_GKK1PzC7zLnGNr-RNT0Rw1fFR68syUvnuBBA2CI/edit"
         }
       ],
-      "id": "DOC-94b1de84ef"
+      "id": "DOC-94b1de84ef",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete)."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Audit Reports Index (audit-reports/README.md)",
@@ -722,7 +1177,17 @@
       "contentHash": "22b5592fb46a3e8f00467451f6789569a657f41dc8935647362661b9d6873a11",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-b35f7a3444"
+      "id": "DOC-b35f7a3444",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete)."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Document Register (this file)",
@@ -744,7 +1209,17 @@
           "location": "https://www.notion.so/3865fe8215c28174aef3ce32239ced5c"
         }
       ],
-      "id": "DOC-2d4e00befa"
+      "id": "DOC-2d4e00befa",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete)."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Compliance Docs Guide (runbook)",
@@ -761,7 +1236,15 @@
       "contentHash": "05c98f8f40f85ddbdae308e2a8721467377f92b9a286cf51501111ff66f5d5c5",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-a936b01d6a"
+      "id": "DOC-a936b01d6a",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "compliance-officer agent definition",
@@ -778,7 +1261,17 @@
       "contentHash": "fffaf2ed085616af30a6814e805d65ae0d605f470ce9cf8101ac4d290c6f31f3",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-d9f17c6919"
+      "id": "DOC-d9f17c6919",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "privacy-auditor agent definition",
@@ -800,7 +1293,17 @@
       "contentHash": "ef397e5cfe5326879405524d3803fcfe65d3c539ae987a9d93da6df98759b4e4",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-869279c9fa"
+      "id": "DOC-869279c9fa",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "infra-auditor agent definition",
@@ -819,7 +1322,17 @@
       "contentHash": "33dc0fdd939e7673c97afd514fe3711d7ee1c6f26a780cca415fa5df889ffcf1",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-75b4889dfd"
+      "id": "DOC-75b4889dfd",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "api-auditor agent definition",
@@ -836,7 +1349,17 @@
       "contentHash": "3895f7acff6a17b2d559b0f1a8fa6d84320d64bcadeea765e3050616cb63c1fb",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-ee90a1cf59"
+      "id": "DOC-ee90a1cf59",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "dependency-auditor agent definition",
@@ -853,7 +1376,17 @@
       "contentHash": "60f14c798bdb796ba90c7f3a0754fd3a45546dbeda0d0e00f8eb97372e007bb1",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-2c8d32b86c"
+      "id": "DOC-2c8d32b86c",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "accessibility-auditor agent definition",
@@ -872,7 +1405,17 @@
       "contentHash": "bd8a7cadd8b2404f237caae6f024850d26ab80514d6ed8f624d7ab522f440e41",
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-a04fd87b5c"
+      "id": "DOC-a04fd87b5c",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Compliance & Security Program v1.0 (Attested)",
@@ -906,7 +1449,16 @@
         }
       ],
       "notes": "Externally released 2026-06-19; distribution governed by Drive folder access controls. Frozen point-in-time record.",
-      "id": "DOC-a7761b41b8"
+      "id": "DOC-a7761b41b8",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg"
     },
     {
       "title": "Compliance & Security - Semi-Annual Program Report (H1 2026)",
@@ -935,7 +1487,16 @@
         "compliance-records-set-2026-06"
       ],
       "mirrors": [],
-      "id": "DOC-a11fb54085"
+      "id": "DOC-a11fb54085",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1VKTOxmGjLiRYy9U3_Y4gzQ2gsmfnZZTeq5RZ7mkHAIM"
     },
     {
       "title": "Compliance Posture Report (branded)",
@@ -944,7 +1505,7 @@
       "owner": "Scot Wahlquist",
       "canonicalSystem": "drive",
       "canonicalLocation": "https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit",
-      "status": "published",
+      "status": "superseded",
       "frameworks": [
         "FERPA",
         "COPPA",
@@ -961,8 +1522,7 @@
       },
       "contentHash": null,
       "bundles": [
-        "compliance-records-set-2026-06",
-        "school-dpa-package"
+        "compliance-records-set-2026-06"
       ],
       "mirrors": [
         {
@@ -970,8 +1530,20 @@
           "location": "docs/legal/COMPLIANCE_POSTURE_REPORT.md"
         }
       ],
-      "notes": "Hard-codes a point-in-time posture count; the Notion findings board is the live source. Treat as a frozen record.",
-      "id": "DOC-9f6a2412ad"
+      "notes": "FROZEN point-in-time record: stays a member of compliance-records-set-2026-06 and keeps its title, because that binder is an attested 2026-06-19 set and its requiredDocs are never mutated. Superseded 2026-07-16 by DOC-ae3f9d06ef; removed from school-dpa-package so no live district pack points at it. Drive has retitled this file \"[SUPERSEDED 2026-07-16 - see current version] ...\" IN PLACE, which is an edit to an attested artifact and is exactly what IA report sec 3.2 forbids. Recorded, not corrected: the fix is the pointer, never the file.",
+      "id": "DOC-9f6a2412ad",
+      "supersededBy": "DOC-ae3f9d06ef",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "sec 5.2 offers two readings for a superseded record: \"policies (each version)\" (7yr, archive) and \"superseded drafts with no attestation\" (1yr, delete). This was a published artifact, not a draft, so the archive reading was taken. Confirm with counsel."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk"
     },
     {
       "title": "Audit Results Report",
@@ -1006,7 +1578,16 @@
         }
       ],
       "notes": "Companion '5 Domain Reports' live in subfolder 1FNSX8BCMynkrnfyb3lOONXmnCZGuLAON.",
-      "id": "DOC-79c93a29a3"
+      "id": "DOC-79c93a29a3",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1n6z-76-awsAtWq-2clQ340vfcn_gAtJbkCmVnIxL4tY"
     },
     {
       "title": "Compliance Calendar (branded)",
@@ -1039,7 +1620,16 @@
           "location": "audit-reports/compliance-calendar.json"
         }
       ],
-      "id": "DOC-df19938e01"
+      "id": "DOC-df19938e01",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "19IT_GKK1PzC7zLnGNr-RNT0Rw1fFR68syUvnuBBA2CI"
     },
     {
       "title": "Records of Processing Activities (RoPA) and Data Map",
@@ -1060,10 +1650,20 @@
       },
       "contentHash": null,
       "bundles": [
-        "compliance-records-set-2026-06"
+        "compliance-records-set-2026-06",
+        "dsar"
       ],
       "mirrors": [],
-      "id": "DOC-3987298c7f"
+      "id": "DOC-3987298c7f",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg"
     },
     {
       "title": "Data Retention Schedule (branded)",
@@ -1097,7 +1697,16 @@
           "location": "docs/legal/DATA_RETENTION.md"
         }
       ],
-      "id": "DOC-52c8c33583"
+      "id": "DOC-52c8c33583",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k"
     },
     {
       "title": "Subprocessor Register (branded)",
@@ -1129,7 +1738,16 @@
           "location": "docs/legal/SUBPROCESSORS.md"
         }
       ],
-      "id": "DOC-b0cde875f5"
+      "id": "DOC-b0cde875f5",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M"
     },
     {
       "title": "COPPA Final-Rule Verification (branded)",
@@ -1159,7 +1777,16 @@
           "location": "docs/legal/COPPA_VERIFICATION_2026-04-26.md"
         }
       ],
-      "id": "DOC-509843e543"
+      "id": "DOC-509843e543",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY"
     },
     {
       "title": "Parental Consent (COPPA / under-13) (branded)",
@@ -1189,7 +1816,16 @@
           "location": "docs/legal/PARENTAL_CONSENT_EMAIL.md"
         }
       ],
-      "id": "DOC-7c9b3b876c"
+      "id": "DOC-7c9b3b876c",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE"
     },
     {
       "title": "Written Information Security Program (WISP)",
@@ -1212,10 +1848,21 @@
       "contentHash": null,
       "bundles": [
         "compliance-records-set-2026-06",
-        "soc2-evidence"
+        "soc2-evidence",
+        "security-review",
+        "baa"
       ],
       "mirrors": [],
-      "id": "DOC-4aaffa8efd"
+      "id": "DOC-4aaffa8efd",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE"
     },
     {
       "title": "Security Risk Assessment 2026 Q2",
@@ -1240,7 +1887,16 @@
         "soc2-evidence"
       ],
       "mirrors": [],
-      "id": "DOC-2ae6e003f0"
+      "id": "DOC-2ae6e003f0",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc"
     },
     {
       "title": "Access Control Policy",
@@ -1264,10 +1920,21 @@
       "contentHash": null,
       "bundles": [
         "compliance-records-set-2026-06",
-        "soc2-evidence"
+        "soc2-evidence",
+        "security-review",
+        "baa"
       ],
       "mirrors": [],
-      "id": "DOC-b8cb4b3bed"
+      "id": "DOC-b8cb4b3bed",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck"
     },
     {
       "title": "Vendor and Subprocessor Management Policy",
@@ -1293,7 +1960,16 @@
         "soc2-evidence"
       ],
       "mirrors": [],
-      "id": "DOC-98ec5238bb"
+      "id": "DOC-98ec5238bb",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM"
     },
     {
       "title": "AI Governance Memo (branded)",
@@ -1323,7 +1999,16 @@
           "location": "docs/legal/AI_GOVERNANCE_MEMO.md"
         }
       ],
-      "id": "DOC-082273934e"
+      "id": "DOC-082273934e",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U"
     },
     {
       "title": "Accessibility Conformance Report (ACR / VPAT) (branded)",
@@ -1351,7 +2036,16 @@
         }
       ],
       "notes": "Held-by-design: not a published conformance claim until assistive-technology user testing + adversary review close the gaps.",
-      "id": "DOC-6093912673"
+      "id": "DOC-6093912673",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs"
     },
     {
       "title": "Business Continuity and Disaster Recovery Plan",
@@ -1372,11 +2066,21 @@
       },
       "contentHash": null,
       "bundles": [
-        "compliance-records-set-2026-06"
+        "compliance-records-set-2026-06",
+        "soc2-evidence"
       ],
       "mirrors": [],
       "notes": "Marked proposed, not yet tested - accuracy caveat preserved in the doc.",
-      "id": "DOC-c58765c47d"
+      "id": "DOC-c58765c47d",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00"
     },
     {
       "title": "Incident Response and Breach Runbook (branded)",
@@ -1408,7 +2112,16 @@
           "location": "docs/legal/BREACH_RUNBOOK.md"
         }
       ],
-      "id": "DOC-f576f43250"
+      "id": "DOC-f576f43250",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po"
     },
     {
       "title": "Incident Log (branded)",
@@ -1439,7 +2152,16 @@
           "location": "docs/legal/INCIDENT_LOG.md"
         }
       ],
-      "id": "DOC-50629fc487"
+      "id": "DOC-50629fc487",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ"
     },
     {
       "title": "Compliance Program - Claim vs Code Review",
@@ -1459,7 +2181,16 @@
       "contentHash": null,
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-401893ddc9"
+      "id": "DOC-401893ddc9",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1IHQ5yFkoU39N01wyTt5SRXM-Q71aKa9wuXvnGVWnbRg"
     },
     {
       "title": "Compliance & Security Overhaul - Completion Report",
@@ -1479,7 +2210,16 @@
       "contentHash": null,
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-450ac8e3fe"
+      "id": "DOC-450ac8e3fe",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1en3MCE47qKj1nwg6wb_MA7h3TwwsDMs33oUM-0GhdEM"
     },
     {
       "title": "Roadmap - What's Left (2026-06-19)",
@@ -1500,7 +2240,16 @@
       "bundles": [],
       "mirrors": [],
       "notes": "Internal roadmap; not part of the externally-released set. Attested by Scot Wahlquist 2026-06-21 per CEO direction.",
-      "id": "DOC-912b28f375"
+      "id": "DOC-912b28f375",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E"
     },
     {
       "title": "Data & Compliance Pipeline - Build Inventory (dated)",
@@ -1523,7 +2272,16 @@
         }
       ],
       "notes": "Current Drive search also shows an undated companion document, LingoLinq Data & Compliance Pipeline - Build Inventory, at 1ZcYdaCc2eo5EGoaqlOgTLo9IXsbAvb-myw6pgO9Urtw. Treat this dated row as the tracked review artifact until the living/frozen ownership split is reconciled.",
-      "id": "DOC-71d0861ff9"
+      "id": "DOC-71d0861ff9",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY"
     },
     {
       "title": "Notion - Compliance Findings board (LL)",
@@ -1546,7 +2304,17 @@
         }
       ],
       "notes": "Auto-synced from FINDINGS.json on push to staging via .github/workflows/sync-findings-to-notion.yml. The live source for posture counts.",
-      "id": "DOC-f994e09fcf"
+      "id": "DOC-f994e09fcf",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Notion - Compliance & Audits hub",
@@ -1563,7 +2331,17 @@
       "contentHash": null,
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-8fc50f083c"
+      "id": "DOC-8fc50f083c",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Notion - Compliance Engineering Onboarding/Handoff",
@@ -1580,7 +2358,17 @@
       "contentHash": null,
       "bundles": [],
       "mirrors": [],
-      "id": "DOC-44080e322c"
+      "id": "DOC-44080e322c",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
     },
     {
       "title": "Notion - Compliance Documents board (LL)",
@@ -1603,7 +2391,506 @@
         }
       ],
       "notes": "Auto-synced from DOCUMENT-REGISTER.json on push to staging via .github/workflows/sync-document-register-to-notion.yml. The team-facing board for the document index.",
-      "id": "DOC-791a05d70e"
+      "id": "DOC-791a05d70e",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null
+    },
+    {
+      "title": "AI Data-Flow Classification",
+      "description": "Classifies every AI data flow in the product: which model sees what, under which lawful basis, with which scrubbing applied. The data-flow/classification artifact a district DPA review asks for.",
+      "type": "policy",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": "docs/legal/AI_DATA_FLOW_CLASSIFICATION.md",
+      "status": "approved",
+      "frameworks": [
+        "FERPA",
+        "COPPA",
+        "HIPAA",
+        "GDPR"
+      ],
+      "lastReviewed": "2026-07-09",
+      "nextReviewDue": "2027-07-09",
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-07-09"
+      },
+      "contentHash": "b75b6271e3682e1b5ec366c34b1610c9f9397472e17df83e9b4eb461b565b92a",
+      "bundles": [
+        "school-dpa-package",
+        "security-review",
+        "dsar"
+      ],
+      "mirrors": [],
+      "notes": "Register bookkeeping from the in-document attestation line (\"Attested (provisional) by Scot Wahlquist, CEO, 2026-07-09\"). Provisional: formal outside-counsel review is deferred until the full 5-phase VPC is built. Scot to confirm or correct this row.",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-90b5d33227"
+    },
+    {
+      "title": "AI Data-Sharing Consent: Rationale and Policy",
+      "description": "Why AI data-sharing consent is separate from signup-time COPPA consent, and the conservative-default position taken until counsel review.",
+      "type": "policy",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": "docs/legal/AI_DATA_SHARING_CONSENT.md",
+      "status": "approved",
+      "frameworks": [
+        "FERPA",
+        "COPPA",
+        "GDPR"
+      ],
+      "lastReviewed": "2026-07-09",
+      "nextReviewDue": "2027-07-09",
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-07-09"
+      },
+      "contentHash": "c77ebb0dc5c8a228f32f268f40f36a74e60ef867a5ada78ba0e22f0d4a7ca914",
+      "bundles": [],
+      "mirrors": [],
+      "notes": "Register bookkeeping from the in-document attestation line (2026-07-09, provisional, conservative-default). Not yet reviewed by outside counsel. Scot to confirm or correct.",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-2e9fdc06e4"
+    },
+    {
+      "title": "LingoLinq Security, Privacy & Compliance Overview",
+      "description": "The short, externally shareable program overview. Deliberately claims only controls that exist in the live production build.",
+      "type": "legal",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": "docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md",
+      "status": "approved",
+      "frameworks": [
+        "FERPA",
+        "COPPA",
+        "HIPAA",
+        "GDPR",
+        "SOC2"
+      ],
+      "lastReviewed": "2026-07-09",
+      "nextReviewDue": "2027-07-09",
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-07-09"
+      },
+      "contentHash": "c8030f10b9e437ab08a877d9ff9d0ebd2695a5ccc7129c50ddd0fed265ad8a45",
+      "bundles": [
+        "security-review"
+      ],
+      "mirrors": [],
+      "notes": "Register bookkeeping from the in-document line \"Attested for external release by Scot Wahlquist (CEO) on 2026-07-09 (rev. 2026-07-09-c)\". Scot to confirm or correct.",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-03cb9fe91f"
+    },
+    {
+      "title": "EU AI Act Article 50 Transparency: Implementation Milestone Plan",
+      "description": "Milestone plan for Article 50 transparency obligations. Art. 50 applies 2026-08-02; the machine-readable marking duty under 50(2) has a grace period to 2026-12-02 for systems already on market.",
+      "type": "policy",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": "docs/legal/EU_AI_ACT_ARTICLE_50_PLAN.md",
+      "status": "draft",
+      "frameworks": [
+        "GDPR"
+      ],
+      "lastReviewed": "2026-07-14",
+      "nextReviewDue": "2026-08-02",
+      "attestation": {},
+      "contentHash": "1a557d9d5b3d0fa00fbee146b773f1af979bf2379748564fa46c0fc7de7b1c89",
+      "bundles": [],
+      "mirrors": [],
+      "notes": "Self-declared DRAFT for review. Regulatory deadline 2026-08-02 is tracked in audit-reports/compliance-calendar.json.",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-771d214850"
+    },
+    {
+      "title": "LingoLinq Capability Ledger (rendered)",
+      "description": "Human-readable render of audit-reports/CAPABILITY-LEDGER.json. Every built/partial claim has currentEvidence validated at HEAD by capability-check.rb in CI.",
+      "type": "audit-artifact",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": "docs/legal/CAPABILITY_LEDGER.md",
+      "status": "published",
+      "frameworks": [],
+      "lastReviewed": "2026-07-12",
+      "nextReviewDue": "2027-01-12",
+      "attestation": {},
+      "contentHash": "e0b25b0bb51f5b6ed493dfedef4d993ec9dafc71b63bf706b6a6fa4eda776fac",
+      "bundles": [],
+      "mirrors": [
+        {
+          "system": "git",
+          "location": "audit-reports/CAPABILITY-LEDGER.json"
+        }
+      ],
+      "notes": "GENERATED - do not hand-edit. Rendered by scripts/capability-check.rb --render from the JSON ledger, and CI-enforced by audit-artifacts-integrity.",
+      "retention": {
+        "class": "audit-evidence",
+        "rule": "7 years",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete)."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-eb861d7d4f"
+    },
+    {
+      "title": "docs/legal README (folder charter)",
+      "description": "Folder-level charter for docs/legal/: what belongs here, what does not, who owns it, and the retention class that applies.",
+      "type": "runbook",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": "docs/legal/README.md",
+      "status": "published",
+      "frameworks": [],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-07-22",
+      "attestation": {},
+      "contentHash": "b16c7b88d38c223de3f639f6b5942ba6277696a665986288f25e73442a756b3b",
+      "bundles": [],
+      "mirrors": [],
+      "notes": "Written for IA report sec 9.2 (folder READMEs so agents stop filing things in the wrong place).",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-6e34e8251a"
+    },
+    {
+      "title": "Agent config - diff-compliance-check",
+      "description": "Read-only FERPA/HIPAA/COPPA gap check scoped to a single diff, PR, or plan step.",
+      "type": "agent-config",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": ".claude/agents/diff-compliance-check.md",
+      "status": "published",
+      "frameworks": [
+        "FERPA",
+        "COPPA",
+        "HIPAA"
+      ],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-07-22",
+      "attestation": {},
+      "contentHash": "3ec5a0034774f60b09d68c2b558286c6515aa1ab7da569d2e2cdbc9b20605e07",
+      "bundles": [],
+      "mirrors": [],
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-da49470b80"
+    },
+    {
+      "title": "Agent config - security-reviewer",
+      "description": "Read-only reviewer for org_id scoping gaps, AuditEvent lifecycle gaps, serializer permission leaks, and audit payload minimization violations.",
+      "type": "agent-config",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": ".claude/agents/security-reviewer.md",
+      "status": "published",
+      "frameworks": [
+        "SOC2"
+      ],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-07-22",
+      "attestation": {},
+      "contentHash": "f54ce5aa4c45e4dc83f00ef6b123ebb539579df6c7a1e75d215587fbb837cd49",
+      "bundles": [],
+      "mirrors": [],
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-920d8d7d66"
+    },
+    {
+      "title": "Agent config - rails-implementer",
+      "description": "Applies surgical, org_id-scoped, audit-logged Rails fixes for compliance and security findings.",
+      "type": "agent-config",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": ".claude/agents/rails-implementer.md",
+      "status": "published",
+      "frameworks": [
+        "SOC2"
+      ],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-07-22",
+      "attestation": {},
+      "contentHash": "6ecdf690295374ae704724798c4f635435e97fe38b7a8b59ec128a8d0abe10bd",
+      "bundles": [],
+      "mirrors": [],
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-8e353e5c8d"
+    },
+    {
+      "title": "Agent config - ember-upgrade-auditor",
+      "description": "Migration-era Ember upgrade finder. Retired from the /audit-run fan-out; registered for completeness of the agent-config class.",
+      "type": "agent-config",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "git",
+      "canonicalLocation": ".claude/agents/ember-upgrade-auditor.md",
+      "status": "published",
+      "frameworks": [],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-07-22",
+      "attestation": {},
+      "contentHash": "e62d81741c82c741da069fb4e817dc658dbf86522b6b694de41c6986bfac967c",
+      "bundles": [],
+      "mirrors": [],
+      "notes": "Retired from the audit fan-out after the Ember 3.28 -> 5.12 upgrade shipped. Kept for provenance.",
+      "retention": {
+        "class": "operational-config",
+        "rule": "retain while in use; supersession + 1 year",
+        "disposition": "archive",
+        "status": "draft",
+        "ambiguous": true,
+        "ambiguityNote": "agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation."
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "id": "DOC-9e70bd81e4"
+    },
+    {
+      "title": "Compliance Posture Report (branded, 2026-07-16 re-attest)",
+      "description": "Current branded render of the compliance posture report, replacing the 2026-06-19 branded cut.",
+      "type": "legal",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "drive",
+      "canonicalLocation": "https://docs.google.com/document/d/1yx-jVYesJ0ZQM0myir6d0rRMMzGEoH5EL5_luicucYo/edit",
+      "status": "draft",
+      "frameworks": [
+        "FERPA",
+        "COPPA",
+        "HIPAA",
+        "GDPR",
+        "SOC2"
+      ],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-01-22",
+      "attestation": {},
+      "contentHash": null,
+      "bundles": [
+        "school-dpa-package",
+        "security-review"
+      ],
+      "mirrors": [
+        {
+          "system": "git",
+          "location": "docs/legal/COMPLIANCE_POSTURE_REPORT.md"
+        }
+      ],
+      "notes": "Drive titles this \"(2026-07-16, re-attested)\" but no attestation is recorded here: only Scot attests, and only Scot moves a row to approved/published. Held at draft with an empty attestation until he signs. Supersedes the 2026-06-19 branded cut, which Drive has retitled \"[SUPERSEDED 2026-07-16 ...]\" in place.",
+      "supersedes": "DOC-9f6a2412ad",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1yx-jVYesJ0ZQM0myir6d0rRMMzGEoH5EL5_luicucYo",
+      "id": "DOC-ae3f9d06ef"
+    },
+    {
+      "title": "Anthropic Business Associate Agreement (2026-05-06)",
+      "description": "Executed upstream BAA with Anthropic covering the HIPAA-eligible model route.",
+      "type": "legal",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "drive",
+      "canonicalLocation": "https://drive.google.com/file/d/1sL3di9GRP4hlids-baZDT26n3SKjzwD5/view",
+      "status": "draft",
+      "frameworks": [
+        "HIPAA"
+      ],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-07-22",
+      "attestation": {},
+      "contentHash": null,
+      "bundles": [
+        "baa"
+      ],
+      "mirrors": [
+        {
+          "system": "git",
+          "location": "docs/legal/ANTHROPIC_BAA_ACCEPTED.md"
+        }
+      ],
+      "notes": "Executed instrument held in Drive because it is a signed PDF. The git row docs/legal/ANTHROPIC_BAA_ACCEPTED.md is the acceptance record. Held at draft pending Scot.",
+      "retention": {
+        "class": "executed-agreement",
+        "rule": "term + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1sL3di9GRP4hlids-baZDT26n3SKjzwD5",
+      "id": "DOC-34d5ae69f1"
+    },
+    {
+      "title": "Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14)",
+      "description": "Capture of the GCP console state showing which compliance agreements, including the BAA, are accepted for the lingolinq-prod organisation.",
+      "type": "evidence",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "drive",
+      "canonicalLocation": "https://docs.google.com/document/d/1CcyQpNfg8aiuY5VA7RHYbYqQEQtzHAdEkjpxcQIhNmM/edit",
+      "status": "draft",
+      "frameworks": [
+        "HIPAA"
+      ],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-01-22",
+      "attestation": {},
+      "contentHash": null,
+      "bundles": [
+        "baa"
+      ],
+      "mirrors": [
+        {
+          "system": "git",
+          "location": "docs/legal/GCP_BAA_ACCEPTED.md"
+        }
+      ],
+      "notes": "Point-in-time console capture. Held at draft pending Scot.",
+      "retention": {
+        "class": "executed-agreement",
+        "rule": "term + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1CcyQpNfg8aiuY5VA7RHYbYqQEQtzHAdEkjpxcQIhNmM",
+      "id": "DOC-36ff3e85d6"
+    },
+    {
+      "title": "Annex A - Clinical BAA Template (DRAFT)",
+      "description": "Downstream BAA template offered to covered-entity customers (hospitals and clinics).",
+      "type": "template",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "drive",
+      "canonicalLocation": "https://docs.google.com/document/d/1Q6hDhooIQVMArkpn4ppxr4om3-Hx64QmYiIQe0sSWmY/edit",
+      "status": "draft",
+      "frameworks": [
+        "HIPAA"
+      ],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-01-22",
+      "attestation": {},
+      "contentHash": null,
+      "bundles": [
+        "baa"
+      ],
+      "mirrors": [],
+      "notes": "Part of the 641.1 annex set in Drive. Self-declared DRAFT; never sent to a customer as-is without counsel review.",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1Q6hDhooIQVMArkpn4ppxr4om3-Hx64QmYiIQe0sSWmY",
+      "id": "DOC-4af407049c"
+    },
+    {
+      "title": "Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT)",
+      "description": "The SDPC National Data Privacy Agreement text LingoLinq signs against, plus standing exhibits.",
+      "type": "template",
+      "owner": "Scot Wahlquist",
+      "canonicalSystem": "drive",
+      "canonicalLocation": "https://docs.google.com/document/d/1vPwlcZwllRPuTU1TlqFeSwxJZ445pxsh6O0cBrGyE6M/edit",
+      "status": "draft",
+      "frameworks": [
+        "FERPA",
+        "COPPA"
+      ],
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-01-22",
+      "attestation": {},
+      "contentHash": null,
+      "bundles": [
+        "school-dpa-package"
+      ],
+      "mirrors": [],
+      "notes": "Part of the 641.1 annex set in Drive. Self-declared DRAFT. Note that any modification to the standard NDPA clause set that is not expressed as an exhibit voids use of the NDPA name.",
+      "retention": {
+        "class": "policy-version",
+        "rule": "supersession + 7 years",
+        "disposition": "archive",
+        "status": "draft"
+      },
+      "legalHold": false,
+      "dispositionEligibleAfter": null,
+      "driveFileId": "1vPwlcZwllRPuTU1TlqFeSwxJZ445pxsh6O0cBrGyE6M",
+      "id": "DOC-78b0aa1618"
     }
   ]
 }

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -2410,7 +2410,7 @@
       "owner": "Scot Wahlquist",
       "canonicalSystem": "git",
       "canonicalLocation": "docs/legal/AI_DATA_FLOW_CLASSIFICATION.md",
-      "status": "approved",
+      "status": "draft",
       "frameworks": [
         "FERPA",
         "COPPA",
@@ -2419,10 +2419,7 @@
       ],
       "lastReviewed": "2026-07-09",
       "nextReviewDue": "2027-07-09",
-      "attestation": {
-        "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-07-09"
-      },
+      "attestation": {},
       "contentHash": "b75b6271e3682e1b5ec366c34b1610c9f9397472e17df83e9b4eb461b565b92a",
       "bundles": [
         "school-dpa-package",
@@ -2430,7 +2427,7 @@
         "dsar"
       ],
       "mirrors": [],
-      "notes": "Register bookkeeping from the in-document attestation line (\"Attested (provisional) by Scot Wahlquist, CEO, 2026-07-09\"). Provisional: formal outside-counsel review is deferred until the full 5-phase VPC is built. Scot to confirm or correct this row.",
+      "notes": "Scot attested this document (provisional) on 2026-07-09, per its own header line, but the file has MATERIALLY CHANGED SINCE: commit 74266b41f (#656, 2026-07-22) rewrote the AI-log retention tiers, moving the children and general tiers from \"Decided, rolling out\" to \"Decided, not yet enforced\" and the EU tier from inert to functional. The 2026-07-09 attestation therefore covered an earlier revision, not the bytes this row now hashes. Held at draft with an empty attestation until Scot re-attests. This is not a finding that the original attestation was invalid; it is a refusal to imply he attested the current bytes.",
       "retention": {
         "class": "policy-version",
         "rule": "supersession + 7 years",
@@ -2481,7 +2478,7 @@
       "owner": "Scot Wahlquist",
       "canonicalSystem": "git",
       "canonicalLocation": "docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md",
-      "status": "approved",
+      "status": "draft",
       "frameworks": [
         "FERPA",
         "COPPA",
@@ -2491,16 +2488,13 @@
       ],
       "lastReviewed": "2026-07-09",
       "nextReviewDue": "2027-07-09",
-      "attestation": {
-        "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-07-09"
-      },
+      "attestation": {},
       "contentHash": "c8030f10b9e437ab08a877d9ff9d0ebd2695a5ccc7129c50ddd0fed265ad8a45",
       "bundles": [
         "security-review"
       ],
       "mirrors": [],
-      "notes": "Register bookkeeping from the in-document line \"Attested for external release by Scot Wahlquist (CEO) on 2026-07-09 (rev. 2026-07-09-c)\". Scot to confirm or correct.",
+      "notes": "Scot attested this document for external release on 2026-07-09 (rev. 2026-07-09-c), per its own header banner, but the file has MATERIALLY CHANGED SINCE: commits 3d1bf2f70 (#649, 2026-07-21) and 0ce7c2f70 (#652, 2026-07-21) rewrote the subprocessor and hosting posture (GCP as live production host, Render as a write-frozen fallback, Anthropic HIPAA-ready BAA executed) and inverted the COPPA offboarding section from an open gap to an implemented control. The banner still reads rev. 2026-07-09-c. Because this document is EXTERNALLY SHAREABLE, the gap between the attested revision and the current bytes matters more here than anywhere else in the register. Held at draft with an empty attestation until Scot re-attests.",
       "retention": {
         "class": "policy-version",
         "rule": "supersession + 7 years",

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -2584,7 +2584,7 @@
       "lastReviewed": "2026-07-22",
       "nextReviewDue": "2027-07-22",
       "attestation": {},
-      "contentHash": "b16c7b88d38c223de3f639f6b5942ba6277696a665986288f25e73442a756b3b",
+      "contentHash": "29d65bee2af97c52b848a99c4bfe8ef7c3dbddf04f429b54534d7c2288972c1b",
       "bundles": [],
       "mirrors": [],
       "notes": "Written for IA report sec 9.2 (folder READMEs so agents stop filing things in the wrong place).",

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -4,59 +4,66 @@
 > Do not hand-edit; edit the JSON (the source of truth) and re-render.
 > The codebase copy is canonical; the Notion board is a one-way mirror; Drive docs are linked, never copied.
 >
-> Generated: 2026-06-21 | Documents: 55 (git 28 / drive 23 / notion 4)
+> Generated: 2026-07-22 | Documents: 70 (git 38 / drive 28 / notion 4)
 
 ## Headline
 
-- **Status:** draft 2, approved 13, published 38, superseded 2
-- **Overdue for review** (as of 2026-06-21): none
-- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded)
+- **Status:** draft 8, approved 16, published 43, superseded 3
+- **Overdue for review** (as of 2026-07-22): none
+- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); EU AI Act Article 50 Transparency: Implementation Milestone Plan; Compliance Posture Report (branded, 2026-07-16 re-attest); Anthropic Business Associate Agreement (2026-05-06); Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14); Annex A - Clinical BAA Template (DRAFT); Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT)
 
 ## Documents by type
 
-### policy (9)
+### policy (12)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
-| Access Control Policy | Drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | published | SOC2, HIPAA, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
-| Business Continuity and Disaster Recovery Plan | Drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
-| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-06 | 2027-06-23 | 2026-07-06 | `1e75223be75e` |  |
-| Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | approved | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `b1bee6c56129` | soc2-evidence, school-dpa-package |
+| Access Control Policy | Drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | published | SOC2, HIPAA, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence, security-review, baa |
+| AI Data-Flow Classification | git | `docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` | approved | FERPA, COPPA, HIPAA, GDPR | Scot Wahlquist | 2026-07-09 | 2027-07-09 | 2026-07-09 | `b75b6271e368` | school-dpa-package, security-review, dsar |
+| AI Data-Sharing Consent: Rationale and Policy | git | `docs/legal/AI_DATA_SHARING_CONSENT.md` | approved | FERPA, COPPA, GDPR | Scot Wahlquist | 2026-07-09 | 2027-07-09 | 2026-07-09 | `c77ebb0dc5c8` |  |
+| Business Continuity and Disaster Recovery Plan | Drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
+| Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-06 | 2027-06-23 | 2026-07-06 | `1e75223be75e` | soc2-evidence |
+| Data Retention Schedule | git | `docs/legal/DATA_RETENTION.md` | approved | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-06-21 | `b1bee6c56129` | soc2-evidence, school-dpa-package, security-review, dsar |
 | Data Retention Schedule (branded) | Drive | [open](https://docs.google.com/document/d/1GRFuvaacbUbcAixhaOAOsdGKhOfclAByYS53bWap14k/edit) | published | FERPA, GDPR, HIPAA, COPPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence, school-dpa-package |
-| Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | approved | GDPR, FERPA, HIPAA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-07-06 | `e76da3475c16` | school-dpa-package |
+| EU AI Act Article 50 Transparency: Implementation Milestone Plan | git | `docs/legal/EU_AI_ACT_ARTICLE_50_PLAN.md` | draft | GDPR | Scot Wahlquist | 2026-07-14 | 2026-08-02 | no | `1a557d9d5b3d` |  |
+| Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | approved | GDPR, FERPA, HIPAA | Scot Wahlquist | 2026-06-18 | 2027-06-18 | 2026-07-06 | `e76da3475c16` | school-dpa-package, soc2-evidence, security-review |
 | Subprocessor Register (branded) | Drive | [open](https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit) | published | GDPR, FERPA, HIPAA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
 | Vendor and Subprocessor Management Policy | Drive | [open](https://docs.google.com/document/d/1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM/edit) | published | SOC2, GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
-| Written Information Security Program (WISP) | Drive | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | published | SOC2, HIPAA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
+| Written Information Security Program (WISP) | Drive | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | published | SOC2, HIPAA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence, security-review, baa |
 
-### legal (10)
+### legal (13)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
-| Accessibility Conformance Report (ACR / VPAT) | git | `docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md` | draft | WCAG | Scot Wahlquist | 2026-06-16 | 2026-09-16 | no | `e68ef80b2638` | school-dpa-package |
+| Accessibility Conformance Report (ACR / VPAT) | git | `docs/legal/ACCESSIBILITY_CONFORMANCE_REPORT.md` | draft | WCAG | Scot Wahlquist | 2026-06-16 | 2026-09-16 | no | `e68ef80b2638` | school-dpa-package, security-review, grant |
 | Accessibility Conformance Report (ACR / VPAT) (branded) | Drive | [open](https://docs.google.com/document/d/1ez60NG2PVKnkcjjbz4NgHOeL_0OcQtVkdhToImcnihs/edit) | draft | WCAG | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| AI Governance Memo | git | `docs/legal/AI_GOVERNANCE_MEMO.md` | published | GDPR, COPPA | Scot Wahlquist | 2026-07-22 | 2026-10-22 | 2026-07-22 | `34b0b857f494` | compliance-records-set-2026-06 |
+| AI Governance Memo | git | `docs/legal/AI_GOVERNANCE_MEMO.md` | published | GDPR, COPPA | Scot Wahlquist | 2026-07-22 | 2026-10-22 | 2026-07-22 | `34b0b857f494` | compliance-records-set-2026-06, security-review |
 | AI Governance Memo (branded) | Drive | [open](https://docs.google.com/document/d/1HEuWT7cS5zPmGI-o9SB2zsc1DJgArEAlCgJz0ECJK9U/edit) | published | GDPR, COPPA | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
-| AWS Business Associate Agreement (signed PDF) | git | `docs/legal/AWS_BAA_2026-02.pdf` | published | HIPAA | Scot Wahlquist | 2026-05-11 | 2027-05-11 | 2026-02 | `55f28e00168c` |  |
+| Anthropic Business Associate Agreement (2026-05-06) | Drive | [open](https://drive.google.com/file/d/1sL3di9GRP4hlids-baZDT26n3SKjzwD5/view) | draft | HIPAA | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | (supplied) | baa |
+| AWS Business Associate Agreement (signed PDF) | git | `docs/legal/AWS_BAA_2026-02.pdf` | published | HIPAA | Scot Wahlquist | 2026-05-11 | 2027-05-11 | 2026-02 | `55f28e00168c` | baa |
 | Compliance & Security Program v1.0 (Attested) | Drive | [open](https://docs.google.com/document/d/1bvVQClfhbNUCCPnmFZoDABlBA9hGNCEHQnWA2Z-r9Dg/edit) | published | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
-| Compliance Posture Report | git | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-07-16 | 2026-10-16 | 2026-07-16 | `80af6f2c5b34` | school-dpa-package |
-| Compliance Posture Report (branded) | Drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
+| Compliance Posture Report | git | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-07-16 | 2026-10-16 | 2026-07-16 | `80af6f2c5b34` | school-dpa-package, security-review, grant |
+| Compliance Posture Report (branded) | Drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | superseded | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
+| Compliance Posture Report (branded, 2026-07-16 re-attest) | Drive | [open](https://docs.google.com/document/d/1yx-jVYesJ0ZQM0myir6d0rRMMzGEoH5EL5_luicucYo/edit) | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-22 | 2027-01-22 | no | (supplied) | school-dpa-package, security-review |
 | Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-22 | 2027-07-22 | 2026-07-22 | `1d1f81b0eeab` | compliance-records-set-2026-06 |
-| Records of Processing Activities (RoPA) and Data Map | Drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | published | GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
+| LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-09 | 2027-07-09 | 2026-07-09 | `c8030f10b9e4` | security-review |
+| Records of Processing Activities (RoPA) and Data Map | Drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | published | GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, dsar |
 
-### evidence (8)
+### evidence (9)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
-| Anthropic HIPAA-Ready BAA Acceptance Record | git | `docs/legal/ANTHROPIC_BAA_ACCEPTED.md` | approved | HIPAA, GDPR | Scot Wahlquist | 2026-07-18 | 2027-07-18 | 2026-07-18 | `5adbe44783d9` |  |
-| AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | approved | HIPAA | Scot Wahlquist | 2026-05-11 | 2027-05-11 | 2026-06-21 | `dc6a2ba9fa16` |  |
+| Anthropic HIPAA-Ready BAA Acceptance Record | git | `docs/legal/ANTHROPIC_BAA_ACCEPTED.md` | approved | HIPAA, GDPR | Scot Wahlquist | 2026-07-18 | 2027-07-18 | 2026-07-18 | `5adbe44783d9` | baa |
+| AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | approved | HIPAA | Scot Wahlquist | 2026-05-11 | 2027-05-11 | 2026-06-21 | `dc6a2ba9fa16` | baa |
 | COPPA Final-Rule Verification | git | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | approved | COPPA | Scot Wahlquist | 2026-04-26 | 2026-07-26 | 2026-06-21 | `b826e9beeec3` | school-dpa-package |
 | COPPA Final-Rule Verification (branded) | Drive | [open](https://docs.google.com/document/d/1p_pPVDr6FocvdQ7UjK3ElmPXOlQvRX9n2XdFpiqZeXY/edit) | published | COPPA | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
-| Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record | git | `docs/legal/GCP_BAA_ACCEPTED.md` | approved | HIPAA, GDPR | Scot Wahlquist | 2026-07-16 | 2027-07-16 | 2026-07-16 | `70671328fe90` |  |
+| Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14) | Drive | [open](https://docs.google.com/document/d/1CcyQpNfg8aiuY5VA7RHYbYqQEQtzHAdEkjpxcQIhNmM/edit) | draft | HIPAA | Scot Wahlquist | 2026-07-22 | 2027-01-22 | no | (supplied) | baa |
+| Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record | git | `docs/legal/GCP_BAA_ACCEPTED.md` | approved | HIPAA, GDPR | Scot Wahlquist | 2026-07-16 | 2027-07-16 | 2026-07-16 | `70671328fe90` | baa |
 | Incident Log | git | `docs/legal/INCIDENT_LOG.md` | approved | HIPAA, GDPR | Scot Wahlquist | 2026-05-27 | 2026-08-27 | 2026-06-21 | `e4e7c0b98d3f` | soc2-evidence |
 | Incident Log (branded) | Drive | [open](https://docs.google.com/document/d/1i5XFqAtgbxpDMLMdd80KS09WP7kWQ-GnTJU0ox7JGqQ/edit) | published | HIPAA, GDPR | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Security Risk Assessment 2026 Q2 | Drive | [open](https://docs.google.com/document/d/1bvdVI_ftFaUu7CFVR8ajVZAQleruaIlqKxwI50iBRrc/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 
-### audit-artifact (16)
+### audit-artifact (17)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
@@ -72,32 +79,40 @@
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
 | Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `46671a8fa5b3` |  |
+| LingoLinq Capability Ledger (rendered) | git | `docs/legal/CAPABILITY_LEDGER.md` | published |  | Scot Wahlquist | 2026-07-12 | 2027-01-12 | no | `e0b25b0bb51f` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |
 | Notion - Compliance Findings board (LL) | Notion | [open](https://app.notion.com/p/1f8451c4a17b4f5b868878ac4386b805) | published |  | Scot Wahlquist | 2026-06-20 | 2026-09-20 | no | (supplied) |  |
 | Roadmap - What's Left (2026-06-19) | Drive | [open](https://docs.google.com/document/d/1f9haDNHifkZQ4qDbZBYMODaWO2KiuwEkrBpUq2Edq4E/edit) | approved |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-21 | (supplied) |  |
 
-### runbook (4)
+### runbook (5)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | published |  | Scot Wahlquist | 2026-06-21 | 2027-06-21 | no | `05c98f8f40f8` |  |
-| Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | approved | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-05-27 | 2027-05-27 | 2026-06-21 | `3efcaaf4a7c5` | soc2-evidence |
+| docs/legal README (folder charter) | git | `docs/legal/README.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `b16c7b88d38c` |  |
+| Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | approved | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-05-27 | 2027-05-27 | 2026-06-21 | `3efcaaf4a7c5` | soc2-evidence, school-dpa-package, security-review, baa |
 | Incident Response and Breach Runbook (branded) | Drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | published | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Notion - Compliance Engineering Onboarding/Handoff | Notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | published |  | Scot Wahlquist | 2026-06-19 | 2026-12-19 | no | (supplied) |  |
 
-### template (2)
+### template (4)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
+| Annex A - Clinical BAA Template (DRAFT) | Drive | [open](https://docs.google.com/document/d/1Q6hDhooIQVMArkpn4ppxr4om3-Hx64QmYiIQe0sSWmY/edit) | draft | HIPAA | Scot Wahlquist | 2026-07-22 | 2027-01-22 | no | (supplied) | baa |
+| Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT) | Drive | [open](https://docs.google.com/document/d/1vPwlcZwllRPuTU1TlqFeSwxJZ445pxsh6O0cBrGyE6M/edit) | draft | FERPA, COPPA | Scot Wahlquist | 2026-07-22 | 2027-01-22 | no | (supplied) | school-dpa-package |
 | Parental Consent (COPPA / under-13) (branded) | Drive | [open](https://docs.google.com/document/d/1ljRwXPEAkQdJT81iGgAMHkfZTdbJ3EZPkIbHNuDtNxE/edit) | published | COPPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, school-dpa-package |
 | Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | approved | COPPA | Scot Wahlquist | 2026-06-11 | 2027-06-11 | 2026-06-21 | `cab41be40abc` | school-dpa-package |
 
-### agent-config (6)
+### agent-config (10)
 
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | accessibility-auditor agent definition | git | `.claude/agents/accessibility-auditor.md` | published | WCAG | Scot Wahlquist | 2026-06-21 | 2026-12-21 | no | `bd8a7cadd8b2` |  |
+| Agent config - diff-compliance-check | git | `.claude/agents/diff-compliance-check.md` | published | FERPA, COPPA, HIPAA | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `3ec5a0034774` |  |
+| Agent config - ember-upgrade-auditor | git | `.claude/agents/ember-upgrade-auditor.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `e62d81741c82` |  |
+| Agent config - rails-implementer | git | `.claude/agents/rails-implementer.md` | published | SOC2 | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `6ecdf6902953` |  |
+| Agent config - security-reviewer | git | `.claude/agents/security-reviewer.md` | published | SOC2 | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `f54ce5aa4c45` |  |
 | api-auditor agent definition | git | `.claude/agents/api-auditor.md` | published |  | Scot Wahlquist | 2026-06-21 | 2026-12-21 | no | `3895f7acff6a` |  |
 | compliance-officer agent definition | git | `.claude/agents/compliance-officer.md` | published |  | Scot Wahlquist | 2026-06-21 | 2026-12-21 | no | `fffaf2ed0856` |  |
 | dependency-auditor agent definition | git | `.claude/agents/dependency-auditor.md` | published |  | Scot Wahlquist | 2026-06-21 | 2026-12-21 | no | `60f14c798bdb` |  |
@@ -112,21 +127,138 @@ The attested, externally-released branded binder generated 2026-06-19 and held i
 
 - **Members (22):** Access Control Policy; Accessibility Conformance Report (ACR / VPAT) (branded); AI Governance Memo; AI Governance Memo (branded); Audit Results Report; Business Continuity and Disaster Recovery Plan; Compliance & Security - Semi-Annual Program Report (H1 2026); Compliance & Security Program v1.0 (Attested); Compliance Calendar (branded); Compliance Calendar (compliance-calendar.json); Compliance Posture Report (branded); Compliance Program; COPPA Final-Rule Verification (branded); Data Retention Schedule (branded); Incident Log (branded); Incident Response and Breach Runbook (branded); Parental Consent (COPPA / under-13) (branded); Records of Processing Activities (RoPA) and Data Map; Security Risk Assessment 2026 Q2; Subprocessor Register (branded); Vendor and Subprocessor Management Policy; Written Information Security Program (WISP)
 - **Completeness:** complete
+- **Known gaps:** none recorded
 
 ### soc2-evidence
 
 Documents a SOC 2 readiness reviewer expects to see for the security-program controls.
 
-- **Members (10):** Access Control Policy; Data Retention Schedule; Data Retention Schedule (branded); Incident Log; Incident Log (branded); Incident Response and Breach Runbook; Incident Response and Breach Runbook (branded); Security Risk Assessment 2026 Q2; Vendor and Subprocessor Management Policy; Written Information Security Program (WISP)
+- **Members (13):** Access Control Policy; Business Continuity and Disaster Recovery Plan; Compliance & Data Governance (COMPLIANCE.md); Data Retention Schedule; Data Retention Schedule (branded); Incident Log; Incident Log (branded); Incident Response and Breach Runbook; Incident Response and Breach Runbook (branded); Security Risk Assessment 2026 Q2; Subprocessor Register; Vendor and Subprocessor Management Policy; Written Information Security Program (WISP)
 - **Completeness:** complete
+- **Known gaps (3) - artifacts this bundle needs that do not exist yet:**
+  - Independent penetration-test report (none commissioned)
+  - Workforce security-training completion records
+  - Formal change-management policy as a standalone record
 
 ### school-dpa-package
 
 What a US school-district diligence / DPA review asks for (FERPA / COPPA / accessibility).
 
-- **Members (12):** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); Compliance Posture Report; Compliance Posture Report (branded); COPPA Final-Rule Verification; COPPA Final-Rule Verification (branded); Data Retention Schedule; Data Retention Schedule (branded); Parental Consent (COPPA / under-13) (branded); Parental Consent Email (COPPA / under-13); Subprocessor Register; Subprocessor Register (branded)
+- **Members (15):** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); AI Data-Flow Classification; Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT); Compliance Posture Report; Compliance Posture Report (branded, 2026-07-16 re-attest); COPPA Final-Rule Verification; COPPA Final-Rule Verification (branded); Data Retention Schedule; Data Retention Schedule (branded); Incident Response and Breach Runbook; Parental Consent (COPPA / under-13) (branded); Parental Consent Email (COPPA / under-13); Subprocessor Register; Subprocessor Register (branded)
 - **Completeness:** complete
+- **Known gaps (3) - artifacts this bundle needs that do not exist yet:**
+  - Signed per-district NDPA instances (register-backed series; none executed yet)
+  - State-specific NDPA exhibits beyond the standing set
+  - Standalone deletion/return commitment (currently only a clause inside DATA_RETENTION.md)
+
+### security-review
+
+What a school district or hospital IT security questionnaire asks for. Deliberately SEPARATE from soc2-evidence: this is the customer-facing diligence pack (posture, accessibility, AI data-flow, subprocessors), whereas soc2-evidence is the internal controls-evidence pack. Merging them would force each to carry documents the other reviewer never asks for.
+
+- **Members (11):** Access Control Policy; Accessibility Conformance Report (ACR / VPAT); AI Data-Flow Classification; AI Governance Memo; Compliance Posture Report; Compliance Posture Report (branded, 2026-07-16 re-attest); Data Retention Schedule; Incident Response and Breach Runbook; LingoLinq Security, Privacy & Compliance Overview; Subprocessor Register; Written Information Security Program (WISP)
+- **Completeness:** complete
+- **Known gaps (3) - artifacts this bundle needs that do not exist yet:**
+  - SSO / authentication description as a standalone record
+  - Dependency and vulnerability posture summary as a customer-facing record
+  - Independent penetration-test or third-party audit summary
+
+### baa
+
+What a covered entity (hospital, clinic, or district health service) asks for before executing a BAA. Covers both directions: the BAAs LingoLinq holds upstream with its subprocessors, and the BAA LingoLinq offers downstream to customers.
+
+- **Members (10):** Access Control Policy; Annex A - Clinical BAA Template (DRAFT); Anthropic Business Associate Agreement (2026-05-06); Anthropic HIPAA-Ready BAA Acceptance Record; AWS BAA Acceptance Record; AWS Business Associate Agreement (signed PDF); Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14); Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record; Incident Response and Breach Runbook; Written Information Security Program (WISP)
+- **Completeness:** complete
+- **Known gaps (3) - artifacts this bundle needs that do not exist yet:**
+  - HIPAA workforce training records (do not exist; owed before real PHI, per the Melissa GCP-admin note)
+  - Audit-logging control description as a standalone record (currently only prose inside larger documents)
+  - Executed downstream customer BAAs (none executed yet; will become a register-backed series)
+
+### dsar
+
+What a GDPR data-subject access, rectification, or erasure request requires. The Article 30 RoPA is the spine: it is the artifact a supervisory authority asks for first, and LingoLinq does not qualify for the small-business exemption because it processes children's data systematically and at scale.
+
+- **Members (3):** AI Data-Flow Classification; Data Retention Schedule; Records of Processing Activities (RoPA) and Data Map
+- **Completeness:** complete
+- **Known gaps (5) - artifacts this bundle needs that do not exist yet:**
+  - Data-subject identity-verification procedure (does not exist)
+  - Export / deletion operational runbook (does not exist as a record)
+  - DSAR response-letter templates (do not exist)
+  - DSAR case-log template (does not exist; must hold no case content with PII)
+  - GDPR Art. 27 EU representative designation (Annex G in Drive is a recommendation, not a designation)
+
+### grant
+
+What a federal or foundation grant application needs from the compliance library. Mostly gap today: the SBIR Phase IB material in Drive is application drafting, not the standing records a reviewer asks for.
+
+- **Members (2):** Accessibility Conformance Report (ACR / VPAT); Compliance Posture Report
+- **Completeness:** complete
+- **Known gaps (6) - artifacts this bundle needs that do not exist yet:**
+  - Corporate formation documents (exist in Drive 610 but are unregistered)
+  - PI bio-sketch (does not exist as a standing record)
+  - Prior-award and commercialization history (does not exist)
+  - Data-management plan (does not exist)
+  - Human-subjects / IRB posture statement (does not exist)
+  - D-U-N-S and SAM.gov registration evidence (unregistered; gates the native-apps initiative too)
+
+## Retention (draft, inert)
+
+> Every rule below is `status: draft`. No deletion behaviour is wired anywhere in this repo,
+> and `dispositionEligibleAfter` is held at null until a rule is explicitly approved.
+> Only Scot moves a retention rule to approved, and only after counsel review.
+
+| Class | Rule | Trigger | Disposition | Rows |
+|---|---|---|---|---|
+| `executed-agreement` | term + 7 years | contract-end | archive | 6 |
+| `corporate-permanent` | permanent | n/a | archive | 0 |
+| `grant-record` | award + 7 years | close-out | archive | 0 |
+| `policy-version` | supersession + 7 years | superseded | archive | 33 |
+| `audit-evidence` | 7 years | finding-closed | archive | 17 |
+| `attestation-record` | permanent | n/a | archive | 0 |
+| `dsar-case` | 3 years | case-closed | delete | 0 |
+| `questionnaire-response` | 3 years | sent | delete | 0 |
+| `superseded-draft` | 1 year | superseded | delete | 0 |
+| `working-note` | 90 days | created | delete | 0 |
+| `operational-config` | retain while in use; supersession + 1 year | superseded | archive | 14 |
+
+**Inferred classes needing counsel review (22):** these were derived from type and
+status rather than read off the drafted schedule, and are the rows to look at first.
+
+| Title | Class | Why it is ambiguous |
+|---|---|---|
+| accessibility-auditor agent definition | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Agent config - diff-compliance-check | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Agent config - ember-upgrade-auditor | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Agent config - rails-implementer | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Agent config - security-reviewer | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| api-auditor agent definition | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Audit Reports Index (audit-reports/README.md) | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| Compliance Calendar (compliance-calendar.json) | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| Compliance Posture Report (branded) | `policy-version` | sec 5.2 offers two readings for a superseded record: "policies (each version)" (7yr, archive) and "superseded drafts with no attestation" (1yr, delete). This was a published artifact, not a draft, so the archive reading was taken. Confirm with counsel. |
+| Compliance Status Snapshot (2026-04-23) | `policy-version` | sec 5.2 offers two readings for a superseded record: "policies (each version)" (7yr, archive) and "superseded drafts with no attestation" (1yr, delete). This was a published artifact, not a draft, so the archive reading was taken. Confirm with counsel. |
+| Compliance Status Snapshot (2026-06-18) | `policy-version` | sec 5.2 offers two readings for a superseded record: "policies (each version)" (7yr, archive) and "superseded drafts with no attestation" (1yr, delete). This was a published artifact, not a draft, so the archive reading was taken. Confirm with counsel. |
+| compliance-officer agent definition | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| dependency-auditor agent definition | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| Document Register (this file) | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| Findings Register (FINDINGS.json) | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| infra-auditor agent definition | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+| LingoLinq Capability Ledger (rendered) | `audit-evidence` | Living generated register rather than a point-in-time evidence artifact; sec 5.2 has no row for the index itself. Assigned the evidence rule conservatively (archive, never delete). |
+| Notion - Compliance & Audits hub | `operational-config` | One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors. |
+| Notion - Compliance Documents board (LL) | `operational-config` | One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors. |
+| Notion - Compliance Engineering Onboarding/Handoff | `operational-config` | One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors. |
+| Notion - Compliance Findings board (LL) | `operational-config` | One-way mirror. Retention should follow the canonical source it mirrors, not run independently; sec 5.2 does not model mirrors. |
+| privacy-auditor agent definition | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
+
+**Legal holds:** none active
+
+## Supersession chains
+
+Attestation freezes bytes: a superseded record keeps its row, its title, and its membership in any
+frozen point-in-time binder. Only the pointer is added.
+
+| Superseded record | Replaced by | Still bundled in |
+|---|---|---|
+| Compliance Posture Report (branded) (`DOC-9f6a2412ad`) | Compliance Posture Report (branded, 2026-07-16 re-attest) (`DOC-ae3f9d06ef`) | compliance-records-set-2026-06 |
 
 ---
 
-_55 documents. Re-run `ruby scripts/document-register-render.rb --check` to validate ids, git content hashes, and bundle completeness._
+_70 documents. Re-run `ruby scripts/document-register-render.rb --check` to validate ids, git content hashes, and bundle completeness._

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -90,7 +90,7 @@
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | published |  | Scot Wahlquist | 2026-06-21 | 2027-06-21 | no | `05c98f8f40f8` |  |
-| docs/legal README (folder charter) | git | `docs/legal/README.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `b16c7b88d38c` |  |
+| docs/legal README (folder charter) | git | `docs/legal/README.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `29d65bee2af9` |  |
 | Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | approved | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-05-27 | 2027-05-27 | 2026-06-21 | `3efcaaf4a7c5` | soc2-evidence, school-dpa-package, security-review, baa |
 | Incident Response and Breach Runbook (branded) | Drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | published | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Notion - Compliance Engineering Onboarding/Handoff | Notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | published |  | Scot Wahlquist | 2026-06-19 | 2026-12-19 | no | (supplied) |  |
@@ -126,7 +126,7 @@
 The attested, externally-released branded binder generated 2026-06-19 and held in the Drive 'Branded Records Set' folder. Frozen point-in-time records; the living sources are the git docs and the auto-synced Notion findings board.
 
 - **Members (22):** Access Control Policy; Accessibility Conformance Report (ACR / VPAT) (branded); AI Governance Memo; AI Governance Memo (branded); Audit Results Report; Business Continuity and Disaster Recovery Plan; Compliance & Security - Semi-Annual Program Report (H1 2026); Compliance & Security Program v1.0 (Attested); Compliance Calendar (branded); Compliance Calendar (compliance-calendar.json); Compliance Posture Report (branded); Compliance Program; COPPA Final-Rule Verification (branded); Data Retention Schedule (branded); Incident Log (branded); Incident Response and Breach Runbook (branded); Parental Consent (COPPA / under-13) (branded); Records of Processing Activities (RoPA) and Data Map; Security Risk Assessment 2026 Q2; Subprocessor Register (branded); Vendor and Subprocessor Management Policy; Written Information Security Program (WISP)
-- **Completeness:** complete
+- **Required member check:** passing
 - **Known gaps:** none recorded
 
 ### soc2-evidence
@@ -134,7 +134,7 @@ The attested, externally-released branded binder generated 2026-06-19 and held i
 Documents a SOC 2 readiness reviewer expects to see for the security-program controls.
 
 - **Members (13):** Access Control Policy; Business Continuity and Disaster Recovery Plan; Compliance & Data Governance (COMPLIANCE.md); Data Retention Schedule; Data Retention Schedule (branded); Incident Log; Incident Log (branded); Incident Response and Breach Runbook; Incident Response and Breach Runbook (branded); Security Risk Assessment 2026 Q2; Subprocessor Register; Vendor and Subprocessor Management Policy; Written Information Security Program (WISP)
-- **Completeness:** complete
+- **Required member check:** passing, but 3 known gap(s) recorded below - this bundle is NOT complete
 - **Known gaps (3) - artifacts this bundle needs that do not exist yet:**
   - Independent penetration-test report (none commissioned)
   - Workforce security-training completion records
@@ -145,7 +145,7 @@ Documents a SOC 2 readiness reviewer expects to see for the security-program con
 What a US school-district diligence / DPA review asks for (FERPA / COPPA / accessibility).
 
 - **Members (15):** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); AI Data-Flow Classification; Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT); Compliance Posture Report; Compliance Posture Report (branded, 2026-07-16 re-attest); COPPA Final-Rule Verification; COPPA Final-Rule Verification (branded); Data Retention Schedule; Data Retention Schedule (branded); Incident Response and Breach Runbook; Parental Consent (COPPA / under-13) (branded); Parental Consent Email (COPPA / under-13); Subprocessor Register; Subprocessor Register (branded)
-- **Completeness:** complete
+- **Required member check:** passing, but 3 known gap(s) recorded below - this bundle is NOT complete
 - **Known gaps (3) - artifacts this bundle needs that do not exist yet:**
   - Signed per-district NDPA instances (register-backed series; none executed yet)
   - State-specific NDPA exhibits beyond the standing set
@@ -156,7 +156,7 @@ What a US school-district diligence / DPA review asks for (FERPA / COPPA / acces
 What a school district or hospital IT security questionnaire asks for. Deliberately SEPARATE from soc2-evidence: this is the customer-facing diligence pack (posture, accessibility, AI data-flow, subprocessors), whereas soc2-evidence is the internal controls-evidence pack. Merging them would force each to carry documents the other reviewer never asks for.
 
 - **Members (11):** Access Control Policy; Accessibility Conformance Report (ACR / VPAT); AI Data-Flow Classification; AI Governance Memo; Compliance Posture Report; Compliance Posture Report (branded, 2026-07-16 re-attest); Data Retention Schedule; Incident Response and Breach Runbook; LingoLinq Security, Privacy & Compliance Overview; Subprocessor Register; Written Information Security Program (WISP)
-- **Completeness:** complete
+- **Required member check:** passing, but 3 known gap(s) recorded below - this bundle is NOT complete
 - **Known gaps (3) - artifacts this bundle needs that do not exist yet:**
   - SSO / authentication description as a standalone record
   - Dependency and vulnerability posture summary as a customer-facing record
@@ -167,7 +167,7 @@ What a school district or hospital IT security questionnaire asks for. Deliberat
 What a covered entity (hospital, clinic, or district health service) asks for before executing a BAA. Covers both directions: the BAAs LingoLinq holds upstream with its subprocessors, and the BAA LingoLinq offers downstream to customers.
 
 - **Members (10):** Access Control Policy; Annex A - Clinical BAA Template (DRAFT); Anthropic Business Associate Agreement (2026-05-06); Anthropic HIPAA-Ready BAA Acceptance Record; AWS BAA Acceptance Record; AWS Business Associate Agreement (signed PDF); Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14); Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record; Incident Response and Breach Runbook; Written Information Security Program (WISP)
-- **Completeness:** complete
+- **Required member check:** passing, but 3 known gap(s) recorded below - this bundle is NOT complete
 - **Known gaps (3) - artifacts this bundle needs that do not exist yet:**
   - HIPAA workforce training records (do not exist; owed before real PHI, per the Melissa GCP-admin note)
   - Audit-logging control description as a standalone record (currently only prose inside larger documents)
@@ -178,7 +178,7 @@ What a covered entity (hospital, clinic, or district health service) asks for be
 What a GDPR data-subject access, rectification, or erasure request requires. The Article 30 RoPA is the spine: it is the artifact a supervisory authority asks for first, and LingoLinq does not qualify for the small-business exemption because it processes children's data systematically and at scale.
 
 - **Members (3):** AI Data-Flow Classification; Data Retention Schedule; Records of Processing Activities (RoPA) and Data Map
-- **Completeness:** complete
+- **Required member check:** passing, but 5 known gap(s) recorded below - this bundle is NOT complete
 - **Known gaps (5) - artifacts this bundle needs that do not exist yet:**
   - Data-subject identity-verification procedure (does not exist)
   - Export / deletion operational runbook (does not exist as a record)
@@ -191,7 +191,7 @@ What a GDPR data-subject access, rectification, or erasure request requires. The
 What a federal or foundation grant application needs from the compliance library. Mostly gap today: the SBIR Phase IB material in Drive is application drafting, not the standing records a reviewer asks for.
 
 - **Members (2):** Accessibility Conformance Report (ACR / VPAT); Compliance Posture Report
-- **Completeness:** complete
+- **Required member check:** passing, but 6 known gap(s) recorded below - this bundle is NOT complete
 - **Known gaps (6) - artifacts this bundle needs that do not exist yet:**
   - Corporate formation documents (exist in Drive 610 but are unregistered)
   - PI bio-sketch (does not exist as a standing record)

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -8,9 +8,9 @@
 
 ## Headline
 
-- **Status:** draft 8, approved 16, published 43, superseded 3
+- **Status:** draft 10, approved 14, published 43, superseded 3
 - **Overdue for review** (as of 2026-07-22): none
-- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); EU AI Act Article 50 Transparency: Implementation Milestone Plan; Compliance Posture Report (branded, 2026-07-16 re-attest); Anthropic Business Associate Agreement (2026-05-06); Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14); Annex A - Clinical BAA Template (DRAFT); Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT)
+- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); AI Data-Flow Classification; LingoLinq Security, Privacy & Compliance Overview; EU AI Act Article 50 Transparency: Implementation Milestone Plan; Compliance Posture Report (branded, 2026-07-16 re-attest); Anthropic Business Associate Agreement (2026-05-06); Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14); Annex A - Clinical BAA Template (DRAFT); Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT)
 
 ## Documents by type
 
@@ -19,7 +19,7 @@
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Access Control Policy | Drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | published | SOC2, HIPAA, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence, security-review, baa |
-| AI Data-Flow Classification | git | `docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` | approved | FERPA, COPPA, HIPAA, GDPR | Scot Wahlquist | 2026-07-09 | 2027-07-09 | 2026-07-09 | `b75b6271e368` | school-dpa-package, security-review, dsar |
+| AI Data-Flow Classification | git | `docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` | draft | FERPA, COPPA, HIPAA, GDPR | Scot Wahlquist | 2026-07-09 | 2027-07-09 | no | `b75b6271e368` | school-dpa-package, security-review, dsar |
 | AI Data-Sharing Consent: Rationale and Policy | git | `docs/legal/AI_DATA_SHARING_CONSENT.md` | approved | FERPA, COPPA, GDPR | Scot Wahlquist | 2026-07-09 | 2027-07-09 | 2026-07-09 | `c77ebb0dc5c8` |  |
 | Business Continuity and Disaster Recovery Plan | Drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-06 | 2027-06-23 | 2026-07-06 | `1e75223be75e` | soc2-evidence |
@@ -46,7 +46,7 @@
 | Compliance Posture Report (branded) | Drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | superseded | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 | Compliance Posture Report (branded, 2026-07-16 re-attest) | Drive | [open](https://docs.google.com/document/d/1yx-jVYesJ0ZQM0myir6d0rRMMzGEoH5EL5_luicucYo/edit) | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-22 | 2027-01-22 | no | (supplied) | school-dpa-package, security-review |
 | Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-22 | 2027-07-22 | 2026-07-22 | `1d1f81b0eeab` | compliance-records-set-2026-06 |
-| LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-09 | 2027-07-09 | 2026-07-09 | `c8030f10b9e4` | security-review |
+| LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-09 | 2027-07-09 | no | `c8030f10b9e4` | security-review |
 | Records of Processing Activities (RoPA) and Data Map | Drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | published | GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, dsar |
 
 ### evidence (9)

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -1,0 +1,65 @@
+# docs/legal - folder charter
+
+> Every compliance document has exactly one canonical home, one permanent ID, and one row in
+> `audit-reports/DOCUMENT-REGISTER.json`. Bundles reference documents by identity, never by copy.
+> Attested files are never edited, renamed, or moved. Nothing is deleted without a tombstone.
+
+## What belongs here
+
+This directory is the **canonical source** for compliance and legal content whose value is in its
+text: policies, program documents, posture reports, memos, runbooks, and templates. Git is the right
+home for these because they are diffable, reviewable, hashable, and CI-verifiable, and because
+`scripts/document-register-render.rb --check` computes and verifies a `contentHash` for every file
+here on every CI run. A tracked doc edited without updating its register row fails the build.
+
+Also acceptable here: executed instruments that have no better home and are small enough to track
+(for example `AWS_BAA_2026-02.pdf`), plus generated renders that are clearly labelled as such
+(`CAPABILITY_LEDGER.md`).
+
+## What does not belong here
+
+- **Signed PDFs of executed agreements.** NDPAs and their exhibits, customer BAAs, insurance
+  certificates, and incorporation documents are canonical in **Google Drive**. Git can hold the
+  bytes but cannot meaningfully review them, and they cannot be re-rendered. Register them with
+  `canonicalSystem: drive` and a `driveFileId`.
+- **Branded customer-facing renders.** The Markdown source stays canonical here; the branded Google
+  Doc that was actually sent is a dated render, canonical in Drive.
+- **Workflow state.** Triage boards, task rows, and "who owes what" live in Notion. Notion holds no
+  record of last resort.
+- **Anything containing student or patient data.** No exceptions. The register and this directory are
+  titles, paths, and hashes only, which is what keeps compliance work in the Tier 2 lane.
+
+## Rules that are mechanically enforced
+
+1. **Every tracked file in this directory must have a register row.** `--check` fails otherwise. If
+   you add a document here, add its row in the same PR and run `scripts/regenerate-register.sh`.
+2. **Content hashes are verified at HEAD.** Edit the file, re-render, commit both.
+3. **Attestation freezes the artifact.** Once Scot attests a document, its bytes, filename, and
+   location are immutable. Supersede it with a new dated file plus two-way `supersedes` /
+   `supersededBy` pointers. Do not edit or rename it, and do not move it to tidy up.
+4. **Only Scot attests**, and only Scot moves a row to `approved`, `published`, or `attested`, flips
+   `legalHold`, or moves a retention rule to `approved`. Agents propose register rows; a human merges.
+
+## Naming
+
+`<YYYY-MM-DD>_<kebab-slug>_<status>.<ext>` for new dated records, ISO dates only so lexical sort
+equals chronological sort. Status is a controlled token from the register's `statusEnum`. No `v2`,
+no `final`, no initials: the date plus the status carries everything a version number was doing and
+cannot lie. Existing `SCREAMING_SNAKE.md` filenames are grandfathered and are not being renamed,
+because renaming breaks every inbound reference for no compliance benefit.
+
+## Retention
+
+Retention class is declared per row in the register, not per folder. Documents in this directory are
+predominantly `policy-version` (supersession + 7 years, archive), which exceeds the six-year HIPAA
+documentation floor at 45 CFR 164.530(j). Executed agreements are `executed-agreement` (term +
+7 years, archive).
+
+**All retention rules are currently `status: draft` and legally inert.** No deletion behaviour is
+wired anywhere in this repo. Nothing is deleted on a schedule until counsel reviews the schedule and
+Scot approves it.
+
+## Owner
+
+Scot Wahlquist (CEO). Questions about what belongs where: read
+`audit-reports/DOCUMENT-REGISTER.json` first, then `docs/legal/COMPLIANCE_DOCS_GUIDE.md`.

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -37,8 +37,11 @@ Also acceptable here: executed instruments that have no better home and are smal
 3. **Attestation freezes the artifact.** Once Scot attests a document, its bytes, filename, and
    location are immutable. Supersede it with a new dated file plus two-way `supersedes` /
    `supersededBy` pointers. Do not edit or rename it, and do not move it to tidy up.
-4. **Only Scot attests**, and only Scot moves a row to `approved`, `published`, or `attested`, flips
-   `legalHold`, or moves a retention rule to `approved`. Agents propose register rows; a human merges.
+4. **Only Scot attests**, and only Scot moves a row to `approved` or `published`, records or changes
+   an attestation, flips `legalHold`, or moves a retention rule to `approved`. Note that attestation
+   is a separate block on the row, not a value in `statusEnum` (`draft`, `approved`, `published`,
+   `superseded`, `archived`): a row can be attested at any of those statuses. Agents propose
+   register rows; a human merges.
 
 ## Naming
 

--- a/scripts/compliance-publication-status.rb
+++ b/scripts/compliance-publication-status.rb
@@ -102,6 +102,23 @@ notion_needs_hash = notion_docs.select do |d|
   d['contentHash'].to_s.empty?
 end
 
+retention_schedule = doc_meta['retentionSchedule'] || {}
+missing_retention = docs.reject { |d| d['retention'].is_a?(Hash) }
+ambiguous_retention = docs.select { |d| d.dig('retention', 'ambiguous') }
+approved_retention = docs.select { |d| d.dig('retention', 'status').to_s == 'approved' }
+legal_holds = docs.select { |d| d['legalHold'] == true }
+superseded_rows = docs.select { |d| !d['supersededBy'].to_s.empty? }
+docs_by_id = docs.to_h { |d| [d['id'].to_s, d] }
+
+# A bundle gap is an artifact the bundle needs that does not exist yet. It is deliberately not a
+# failure anywhere; it is a work queue.
+bundle_gaps = (doc_meta['bundleDefinitions'] || {}).filter_map do |name, defn|
+  gaps = defn['gaps']
+  next unless gaps.is_a?(Array) && !gaps.empty?
+
+  [name, gaps]
+end
+
 out = +''
 out << "# Compliance Publication Status\n\n"
 out << "> Generated from `#{FINDINGS_PATH}` and `#{DOCS_PATH}` by `scripts/compliance-publication-status.rb`.\n"
@@ -160,11 +177,96 @@ else
   out << "\n"
 end
 
+out << "## Retention Draft Coverage\n\n"
+if retention_schedule.empty?
+  out << "_No retention schedule is defined in the document register._\n\n"
+else
+  out << "Every rule is `status: draft` and legally inert. No deletion behaviour is wired anywhere in this repo. "
+  out << "Only Scot moves a rule to `approved`, and only after counsel review.\n\n"
+  out << "| Class | Rule | Disposition | Rows | Status |\n"
+  out << "|---|---|---|---|---|\n"
+  retention_schedule.each do |klass, entry|
+    rows = docs.count { |d| d.dig('retention', 'class').to_s == klass }
+    state = rows.zero? ? 'unused (no record of this class exists yet)' : 'draft'
+    out << "| `#{klass}` | #{esc(entry['rule'])} | #{entry['disposition']} | #{rows} | #{state} |\n"
+  end
+  out << "\n"
+
+  if missing_retention.empty?
+    out << "All #{docs.size} rows carry a retention block.\n\n"
+  else
+    out << "**#{missing_retention.size} row(s) have NO retention block:** "
+    out << missing_retention.map { |d| esc(d['title']) }.join('; ') << "\n\n"
+  end
+
+  if approved_retention.empty?
+    out << "No retention rule has been approved. Nothing in this register is eligible for disposition.\n\n"
+  else
+    out << "**#{approved_retention.size} row(s) carry an APPROVED retention rule.** Verify Scot signed each one.\n\n"
+  end
+
+  if ambiguous_retention.empty?
+    out << "No retention class was inferred; every class was read off the drafted schedule.\n\n"
+  else
+    out << "### Inferred retention classes (counsel review these first)\n\n"
+    out << "| Title | System | Class | Why it is ambiguous |\n"
+    out << "|---|---|---|---|\n"
+    ambiguous_retention.sort_by { |d| [d['canonicalSystem'].to_s, d['title'].to_s] }.each do |d|
+      out << "| #{esc(d['title'])} | #{d['canonicalSystem']} | `#{d.dig('retention', 'class')}` | #{esc(d.dig('retention', 'ambiguityNote'))} |\n"
+    end
+    out << "\n"
+  end
+end
+
+out << "## Legal Holds\n\n"
+if legal_holds.empty?
+  out << "_No record is under legal hold. A hold suspends all disposition for the rows it covers, and only Scot flips it._\n\n"
+else
+  out << "| Title | System | Location | Status |\n"
+  out << "|---|---|---|---|\n"
+  legal_holds.sort_by { |d| d['title'].to_s }.each do |d|
+    out << "| #{esc(d['title'])} | #{d['canonicalSystem']} | #{link_for(d)} | #{d['status']} |\n"
+  end
+  out << "\nDisposition is suspended for every row above until the hold is released, and the release must be dated and recorded.\n\n"
+end
+
+out << "## Supersession Chains\n\n"
+if superseded_rows.empty?
+  out << "_No superseded records._\n\n"
+else
+  out << "A superseded record is never edited, renamed, or moved. It keeps its row and its membership in any frozen "
+  out << "point-in-time binder; only the pointer is added.\n\n"
+  out << "| Superseded | Location | Replaced by | Still bundled in |\n"
+  out << "|---|---|---|---|\n"
+  superseded_rows.sort_by { |d| d['title'].to_s }.each do |d|
+    succ = docs_by_id[d['supersededBy'].to_s]
+    bundles = (d['bundles'] || []).join(', ')
+    out << "| #{esc(d['title'])} | #{link_for(d)} | #{esc(succ ? succ['title'] : '(unresolved)')} | #{esc(bundles.empty? ? '(none)' : bundles)} |\n"
+  end
+  out << "\n"
+end
+
+out << "## Bundle Gaps\n\n"
+if bundle_gaps.empty?
+  out << "_No bundle records a missing artifact._\n\n"
+else
+  out << "Artifacts a bundle needs that do not exist yet. These are never satisfied by inventing a register row; "
+  out << "they are closed by creating the real document and promoting it into `requiredDocs`.\n\n"
+  bundle_gaps.each do |name, gaps|
+    out << "**#{name}** (#{gaps.size})\n\n"
+    gaps.each { |g| out << "- #{esc(g)}\n" }
+    out << "\n"
+  end
+end
+
 out << "## Next Automation Gap\n\n"
 out << "The missing layer is a Google Docs publisher/refresh workflow. Until that exists, the compliance agent should use this report as its work queue: update canonical registers, sync Notion boards, then refresh or explicitly freeze affected Drive documents.\n\n"
 
 out << "---\n\n"
-out << "_#{docs.size} documents tracked. #{review_stale.size} stale review item(s). #{drive_needs_refresh.size} Drive refresh item(s). #{notion_needs_hash.size} Notion hash item(s)._\n"
+out << "_#{docs.size} documents tracked. #{review_stale.size} stale review item(s). #{drive_needs_refresh.size} Drive refresh item(s). "
+out << "#{notion_needs_hash.size} Notion hash item(s). #{ambiguous_retention.size} inferred retention class(es). "
+out << "#{legal_holds.size} legal hold(s). #{superseded_rows.size} superseded record(s). "
+out << "#{bundle_gaps.sum { |_, g| g.size }} bundle gap(s) across #{bundle_gaps.size} bundle(s)._\n"
 
 if options[:mode] == :check
   unless File.file?(REPORT_PATH)

--- a/scripts/document-register-render.rb
+++ b/scripts/document-register-render.rb
@@ -18,6 +18,17 @@
 #   2. bundles - named compliance bundles (e.g. soc2-evidence). Each bundle in
 #      meta.bundleDefinitions lists requiredTitles; --check fails if a bundle is missing a
 #      required member, or if a doc references a bundle that is not defined.
+#   3. retention - a DRAFT, legally inert retention block per row. Validation here is SHAPE
+#      ONLY: required fields present, class resolves to meta.retentionSchedule, and the row's
+#      denormalised rule/disposition agree with that schedule entry. No deletion behaviour is
+#      wired anywhere, and dispositionEligibleAfter is forced to stay null until a rule is
+#      explicitly approved, so a draft schedule can never produce a disposition date.
+#   4. supersession - supersedes / supersededBy must form a reciprocal, resolvable, non-self-
+#      referential chain, and a superseded-by row must carry status:superseded.
+#   5. driveFileId - required on drive rows, forbidden elsewhere, and must be the id actually
+#      embedded in canonicalLocation (IDs survive renames and moves; paths do not).
+#   6. completeness - every tracked file under docs/legal/ must have a git row (hard failure);
+#      unregistered .claude/agents/*.md is advisory only.
 #
 # Usage:
 #   ruby scripts/document-register-render.rb [JSON]           # normalize JSON (id + git hash) and write .md
@@ -29,6 +40,7 @@ require 'json'
 require 'digest'
 require 'date'
 require 'optparse'
+require 'set'
 
 DEFAULT_REGISTER = 'audit-reports/DOCUMENT-REGISTER.json'
 
@@ -150,7 +162,116 @@ def attested?(doc)
   att.is_a?(Hash) && !att['attestedBy'].to_s.empty?
 end
 
-def collect_problems(documents, bundle_defs)
+DISPOSITIONS = %w[archive delete].freeze
+RETENTION_STATUSES = %w[draft approved].freeze
+
+# The Drive file id embedded in a canonicalLocation, or nil if the URL carries none.
+def drive_id_in(url)
+  url.to_s[%r{/(?:document|file|spreadsheets|presentation)/d/([A-Za-z0-9_-]+)}, 1]
+end
+
+# Shape-only retention validation. Deliberately does NOT interpret the rule, compute a
+# disposition date, or authorise anything: it checks that the block is well-formed and that the
+# row's denormalised copy still agrees with meta.retentionSchedule.
+def retention_problems(doc, schedule)
+  title = doc['title'].to_s
+  ret = doc['retention']
+  return ["doc #{title.inspect} has no retention block (every row needs one; status must be draft)"] unless ret.is_a?(Hash)
+
+  problems = []
+  klass = ret['class'].to_s
+  entry = schedule[klass]
+  if entry.nil?
+    problems << "doc #{title.inspect} has retention.class #{klass.inspect} which is not defined in meta.retentionSchedule"
+    return problems
+  end
+
+  %w[class rule disposition status].each do |f|
+    problems << "doc #{title.inspect} retention is missing required field #{f.inspect}" if ret[f].to_s.empty?
+  end
+
+  unless DISPOSITIONS.include?(ret['disposition'].to_s)
+    problems << "doc #{title.inspect} has retention.disposition #{ret['disposition'].inspect} (expected #{DISPOSITIONS.join('|')})"
+  end
+  unless RETENTION_STATUSES.include?(ret['status'].to_s)
+    problems << "doc #{title.inspect} has retention.status #{ret['status'].inspect} (expected #{RETENTION_STATUSES.join('|')})"
+  end
+
+  # The row carries a denormalised copy of the schedule so a row is self-describing. If the two
+  # ever disagree, the register is lying about which rule applies - fail rather than pick one.
+  if !ret['rule'].to_s.empty? && ret['rule'].to_s != entry['rule'].to_s
+    problems << "doc #{title.inspect} retention.rule #{ret['rule'].inspect} does not match meta.retentionSchedule[#{klass.inspect}].rule #{entry['rule'].inspect}"
+  end
+  if !ret['disposition'].to_s.empty? && ret['disposition'].to_s != entry['disposition'].to_s
+    problems << "doc #{title.inspect} retention.disposition #{ret['disposition'].inspect} does not match meta.retentionSchedule[#{klass.inspect}].disposition #{entry['disposition'].inspect}"
+  end
+
+  # The hard safety interlock: a draft schedule may never yield a disposition date.
+  if ret['status'].to_s != 'approved' && !doc['dispositionEligibleAfter'].nil?
+    problems << "doc #{title.inspect} has dispositionEligibleAfter set while retention.status is #{ret['status'].inspect}; only an approved rule may carry a disposition date"
+  end
+
+  unless [true, false].include?(doc['legalHold'])
+    problems << "doc #{title.inspect} legalHold must be true or false, got #{doc['legalHold'].inspect}"
+  end
+
+  problems
+end
+
+# supersedes / supersededBy must resolve, must not self-reference, and must be reciprocal.
+def supersession_problems(documents)
+  problems = []
+  by_id = documents.to_h { |d| [d['id'].to_s, d] }
+
+  documents.each do |doc|
+    title = doc['title'].to_s
+    { 'supersedes' => 'supersededBy', 'supersededBy' => 'supersedes' }.each do |field, inverse|
+      target_id = doc[field].to_s
+      next if target_id.empty?
+
+      if target_id == doc['id'].to_s
+        problems << "doc #{title.inspect} #{field} points at itself (#{target_id})"
+        next
+      end
+      target = by_id[target_id]
+      if target.nil?
+        problems << "doc #{title.inspect} #{field} references #{target_id.inspect}, which is not a row in this register"
+        next
+      end
+      unless target[inverse].to_s == doc['id'].to_s
+        problems << "supersession chain is one-sided: #{title.inspect} (#{doc['id']}) has #{field}=#{target_id} but #{target['title'].inspect} has #{inverse}=#{target[inverse].inspect} (expected #{doc['id'].inspect})"
+      end
+    end
+
+    if !doc['supersededBy'].to_s.empty? && doc['status'].to_s != 'superseded'
+      problems << "doc #{title.inspect} has supersededBy set but status is #{doc['status'].inspect} (expected \"superseded\")"
+    end
+  end
+
+  problems
+end
+
+# Tracked files under a repo prefix, via git so untracked local scratch never trips CI.
+# Falls back to a glob if git is unavailable (undated scratch runs outside a checkout).
+def tracked_files(prefix)
+  out = `git ls-files -z -- #{prefix} 2>/dev/null`
+  return out.split("\x00").reject(&:empty?) if $?.success? && !out.empty?
+
+  Dir.glob(File.join(prefix, '**', '*')).select { |p| File.file?(p) }
+end
+
+# Register/reality drift in the "present but unregistered" direction. docs/legal/ is
+# unambiguously the compliance corpus, so a gap there is a hard failure; .claude/agents/ also
+# holds non-compliance agents, so that sweep is advisory (see collect_advisories).
+def completeness_problems(documents)
+  registered = documents.select { |d| d['canonicalSystem'].to_s == 'git' }
+                        .map { |d| d['canonicalLocation'].to_s }.to_set
+  tracked_files('docs/legal').reject { |f| registered.include?(f) }.sort.map do |f|
+    "unregistered compliance document #{f} (every tracked file under docs/legal/ needs a register row; add one and re-render)"
+  end
+end
+
+def collect_problems(documents, bundle_defs, schedule = {})
   problems = []
 
   documents.each do |doc|
@@ -199,10 +320,31 @@ def collect_problems(documents, bundle_defs)
       end
     end
 
+    # driveFileId: stable id required on drive rows, forbidden elsewhere, and it must be the id
+    # actually embedded in the URL so the two can never disagree.
+    if sys == 'drive'
+      stored = doc['driveFileId'].to_s
+      embedded = drive_id_in(loc).to_s
+      if stored.empty?
+        problems << "drive doc #{title.inspect} has no driveFileId (Drive ids survive renames and moves; path-shaped URLs do not)"
+      elsif embedded.empty?
+        problems << "drive doc #{title.inspect} has driveFileId #{stored.inspect} but no id could be parsed from its canonicalLocation: #{loc}"
+      elsif stored != embedded
+        problems << "drive doc #{title.inspect} driveFileId #{stored.inspect} does not match the id in its canonicalLocation (#{embedded.inspect})"
+      end
+    elsif !doc['driveFileId'].to_s.empty?
+      problems << "#{sys} doc #{title.inspect} carries a driveFileId (#{doc['driveFileId'].inspect}); only drive rows may have one"
+    end
+
+    problems.concat(retention_problems(doc, schedule))
+
     (doc['bundles'] || []).each do |b|
       problems << "doc #{title.inspect} references undefined bundle #{b.inspect}" unless bundle_defs.key?(b)
     end
   end
+
+  problems.concat(supersession_problems(documents))
+  problems.concat(completeness_problems(documents))
 
   # id + canonicalLocation must be unique: a duplicate canonicalLocation collides ids
   # (sha256 of the same string) and silently overwrites a row in the Notion upsert.
@@ -216,6 +358,19 @@ def collect_problems(documents, bundle_defs)
 
   bundle_defs.each do |name, defn|
     members = documents.select { |d| (d['bundles'] || []).include?(name) }
+
+    # gaps name artifacts that do NOT exist yet. They are rendered, never satisfied, and never
+    # fail the build - the whole point is that an honest hole beats an invented row. Only the
+    # shape is enforced here.
+    gaps = defn['gaps']
+    if !gaps.nil?
+      if !gaps.is_a?(Array)
+        problems << "bundle #{name.inspect} gaps must be an array of strings, got #{gaps.class}"
+      elsif gaps.any? { |g| !g.is_a?(String) || g.strip.empty? }
+        problems << "bundle #{name.inspect} gaps must contain only non-empty strings"
+      end
+    end
+
     (defn['requiredDocs'] || []).each do |req|
       loc = req['location'].to_s
       member = bundle_member_for(members, loc)
@@ -241,6 +396,44 @@ def collect_advisories(documents)
              refresh = d['canonicalSystem'].to_s == 'notion' ? 'auto-refreshed by the Notion-sync run' : 'must be supplied by the operator (no automated Drive refresh)'
              "no supplied contentHash for #{d['canonicalSystem']} doc #{d['title'].inspect} (#{refresh})"
            end
+end
+
+# Soft signals: real, worth surfacing, never a CI failure.
+#   - staleness: a review date that has passed (anchored to generatedDate, not Date.today)
+#   - unregistered agent configs (.claude/agents also holds non-compliance agents)
+#   - retention classes defined in the schedule with no rows using them (an intentional gap
+#     today: no current record carries a delete disposition)
+def collect_soft_signals(documents, schedule, generated_date)
+  out = []
+
+  overdue = documents.select do |d|
+    due = (Date.parse(d['nextReviewDue'].to_s) rescue nil)
+    due && due < generated_date && !%w[superseded archived].include?(d['status'].to_s)
+  end
+  overdue.sort_by { |d| d['nextReviewDue'].to_s }.each do |d|
+    out << "review overdue: #{d['title'].inspect} was due #{d['nextReviewDue']}"
+  end
+
+  registered = documents.select { |d| d['canonicalSystem'].to_s == 'git' }
+                        .map { |d| d['canonicalLocation'].to_s }.to_set
+  tracked_files('.claude/agents').reject { |f| registered.include?(f) }.sort.each do |f|
+    out << "unregistered agent config #{f} (advisory: .claude/agents also holds non-compliance agents)"
+  end
+
+  used = documents.map { |d| d.dig('retention', 'class').to_s }.to_set
+  (schedule.keys - used.to_a).sort.each do |k|
+    out << "retention class #{k.inspect} is defined in meta.retentionSchedule but no row uses it (gap, not an error)"
+  end
+
+  ambiguous = documents.select { |d| d.dig('retention', 'ambiguous') }
+  unless ambiguous.empty?
+    out << "#{ambiguous.size} row(s) have an inferred retention class flagged retention.ambiguous - review these with counsel first"
+  end
+
+  held = documents.select { |d| d['legalHold'] == true }
+  out << "#{held.size} row(s) are under legal hold; all disposition is suspended for them" unless held.empty?
+
+  out
 end
 
 # ---- markdown render -------------------------------------------------------------
@@ -343,8 +536,75 @@ def render_markdown(register, generated, generated_date)
       out << "### #{name}\n\n"
       out << "#{defn['description']}\n\n" if defn['description']
       out << "- **Members (#{members.size}):** " + (members.empty? ? '(none)' : members.map { |m| esc(m['title']) }.join('; ')) + "\n"
-      out << "- **Completeness:** " + (missing.empty? ? 'complete' : "MISSING required member(s): #{missing.join('; ')}") + "\n\n"
+      out << "- **Completeness:** " + (missing.empty? ? 'complete' : "MISSING required member(s): #{missing.join('; ')}") + "\n"
+      # Tolerate a malformed gaps value here: collect_problems already reports the shape error,
+      # and the render must not die before those problems reach the operator.
+      gaps = defn['gaps'].is_a?(Array) ? defn['gaps'] : []
+      if gaps.empty?
+        out << "- **Known gaps:** none recorded\n\n"
+      else
+        out << "- **Known gaps (#{gaps.size}) - artifacts this bundle needs that do not exist yet:**\n"
+        gaps.each { |g| out << "  - #{esc(g)}\n" }
+        out << "\n"
+      end
     end
+  end
+
+  # ---- retention (DRAFT, inert) ----------------------------------------------------
+  schedule = meta['retentionSchedule'] || {}
+  out << "## Retention (draft, inert)\n\n"
+  out << "> Every rule below is `status: draft`. No deletion behaviour is wired anywhere in this repo,\n"
+  out << "> and `dispositionEligibleAfter` is held at null until a rule is explicitly approved.\n"
+  out << "> Only Scot moves a retention rule to approved, and only after counsel review.\n\n"
+  if schedule.empty?
+    out << "_No retention schedule defined._\n\n"
+  else
+    out << "| Class | Rule | Trigger | Disposition | Rows |\n"
+    out << "|---|---|---|---|---|\n"
+    schedule.each do |klass, entry|
+      n = documents.count { |d| d.dig('retention', 'class').to_s == klass }
+      out << "| `#{klass}` | #{esc(entry['rule'])} | #{esc(entry['trigger'])} | #{entry['disposition']} | #{n} |\n"
+    end
+    out << "\n"
+
+    ambiguous = documents.select { |d| d.dig('retention', 'ambiguous') }
+                         .sort_by { |d| d['title'].to_s.downcase }
+    if ambiguous.empty?
+      out << "**Inferred classes needing counsel review:** none\n\n"
+    else
+      out << "**Inferred classes needing counsel review (#{ambiguous.size}):** these were derived from type and\n"
+      out << "status rather than read off the drafted schedule, and are the rows to look at first.\n\n"
+      out << "| Title | Class | Why it is ambiguous |\n"
+      out << "|---|---|---|\n"
+      ambiguous.each do |d|
+        out << "| #{esc(d['title'])} | `#{d.dig('retention', 'class')}` | #{esc(d.dig('retention', 'ambiguityNote'))} |\n"
+      end
+      out << "\n"
+    end
+
+    held = documents.select { |d| d['legalHold'] == true }
+    out << "**Legal holds:** " +
+           (held.empty? ? 'none active' : held.map { |d| esc(d['title']) }.join('; ')) + "\n\n"
+  end
+
+  # ---- supersession chains ---------------------------------------------------------
+  chains = documents.select { |d| !d['supersededBy'].to_s.empty? }
+                    .sort_by { |d| d['title'].to_s.downcase }
+  out << "## Supersession chains\n\n"
+  if chains.empty?
+    out << "_No superseded records._\n\n"
+  else
+    by_id = documents.to_h { |d| [d['id'].to_s, d] }
+    out << "Attestation freezes bytes: a superseded record keeps its row, its title, and its membership in any\n"
+    out << "frozen point-in-time binder. Only the pointer is added.\n\n"
+    out << "| Superseded record | Replaced by | Still bundled in |\n"
+    out << "|---|---|---|\n"
+    chains.each do |d|
+      succ = by_id[d['supersededBy'].to_s]
+      bundles = (d['bundles'] || []).join(', ')
+      out << "| #{esc(d['title'])} (`#{d['id']}`) | #{esc(succ ? succ['title'] : '(unresolved)')} (`#{d['supersededBy']}`) | #{esc(bundles.empty? ? '(none)' : bundles)} |\n"
+    end
+    out << "\n"
   end
 
   out << "---\n\n"
@@ -356,9 +616,12 @@ end
 
 md_path = File.join(File.dirname(register_path), 'DOCUMENT-REGISTER.md')
 
+schedule = meta['retentionSchedule'] || {}
+
 if options[:mode] == :check
-  problems = collect_problems(documents, bundle_defs)
+  problems = collect_problems(documents, bundle_defs, schedule)
   advisories = collect_advisories(documents)
+  soft = collect_soft_signals(documents, schedule, generated_date)
 
   rendered = render_markdown(register, generated, generated_date)
   if !File.file?(md_path)
@@ -372,9 +635,10 @@ if options[:mode] == :check
     notion_n = advisories.size - drive_n
     warn "  [advisory] #{advisories.size} non-git rows have no supplied contentHash (#{notion_n} notion: auto-refreshable via --refresh-notion-hashes; #{drive_n} drive: operator-supplied, no automated refresh)"
   end
+  soft.each { |s| warn "  [advisory] #{s}" }
 
   if problems.empty?
-    puts "document-register-render: OK (#{documents.size} docs; ids, git hashes, render, and bundles all consistent)"
+    puts "document-register-render: OK (#{documents.size} docs; ids, git hashes, render, bundles, retention shape, supersession chains, and docs/legal completeness all consistent)"
     exit 0
   end
   warn 'document-register-render: DRIFT'
@@ -402,8 +666,10 @@ unless advisories.empty?
   puts "  note: #{advisories.size} non-git rows have no supplied contentHash (#{notion_n} notion: auto-refreshable; #{drive_n} drive: operator-supplied, no automated refresh)"
 end
 
+collect_soft_signals(documents, schedule, generated_date).each { |s| puts "  note: #{s}" }
+
 # Surface hard problems even in render mode (e.g. a dangling git path render can't fix).
-problems = collect_problems(documents, bundle_defs)
+problems = collect_problems(documents, bundle_defs, schedule)
 unless problems.empty?
   warn 'document-register-render: remaining issues after render:'
   problems.each { |p| warn "  [FAIL] #{p}" }

--- a/scripts/document-register-render.rb
+++ b/scripts/document-register-render.rb
@@ -536,10 +536,22 @@ def render_markdown(register, generated, generated_date)
       out << "### #{name}\n\n"
       out << "#{defn['description']}\n\n" if defn['description']
       out << "- **Members (#{members.size}):** " + (members.empty? ? '(none)' : members.map { |m| esc(m['title']) }.join('; ')) + "\n"
-      out << "- **Completeness:** " + (missing.empty? ? 'complete' : "MISSING required member(s): #{missing.join('; ')}") + "\n"
       # Tolerate a malformed gaps value here: collect_problems already reports the shape error,
       # and the render must not die before those problems reach the operator.
       gaps = defn['gaps'].is_a?(Array) ? defn['gaps'] : []
+
+      # Deliberately NOT labelled "Completeness". Every requiredDoc resolving is a much weaker
+      # claim than the bundle being complete, and a bundle can pass this check while recording
+      # gaps immediately below. Conflating the two would let a reader take a bundle with six
+      # missing artifacts as ready to send.
+      required_state = if !missing.empty?
+                         "FAILING - missing required member(s): #{missing.join('; ')}"
+                       elsif gaps.empty?
+                         'passing'
+                       else
+                         "passing, but #{gaps.size} known gap(s) recorded below - this bundle is NOT complete"
+                       end
+      out << "- **Required member check:** #{required_state}\n"
       if gaps.empty?
         out << "- **Known gaps:** none recorded\n\n"
       else


### PR DESCRIPTION
Phase 2 of the compliance records IA reorganization. **Repo-only: no Google Drive writes, no Notion writes, no attested or signed record moved, renamed, or edited.** Phase 3 (Drive mutations) and Phase 4 (retention activation) are deliberately not in this PR.

Extends `audit-reports/DOCUMENT-REGISTER.json` and the two scripts that serve it. No `audit-reports/bundles/*.json`, no new drift-check script, no second bundle model.

## The repair that motivated the schema

`DOC-9f6a2412ad` (branded Compliance Posture Report) was `published` and a live member of `school-dpa-package`, while Drive had retitled the file `[SUPERSEDED 2026-07-16 - see current version]` **in place** and a replacement existed with no register row at all. `--check` was green through this, because the bundle drift guard compares a requirement's title to the *register row's* title, not to Drive.

Now:

| | Before | After |
|---|---|---|
| `DOC-9f6a2412ad` status | `published` | `superseded`, `supersededBy` set |
| its bundles | frozen binder + `school-dpa-package` | frozen binder **only** |
| replacement | unregistered | registered, `supersedes` set, held at `draft` with empty attestation |

It keeps its title, its attestation, and its membership in the frozen 2026-06 binder. The binder's `requiredDocs` are **byte-identical to staging** (verified by diff). The fix is the pointer, never the file.

## Register: 55 → 70 rows

New per-row fields: `retention {class, rule, disposition, status}`, `legalHold`, `supersedes` / `supersededBy`, `dispositionEligibleAfter`, `driveFileId` (28 drive rows).

**Retention is draft-only and legally inert.** No deletion behaviour is wired anywhere. `dispositionEligibleAfter` is held at `null` and `--check` enforces that it stays null until a rule is explicitly `approved` — so a draft schedule can never produce a disposition date. 22 rows whose class was *inferred* rather than read off the drafted table are flagged `retention.ambiguous` with the reason. No current row carries a `delete` disposition: where the table was ambiguous the assignment went conservatively to `archive`, so the four delete-disposition classes exist with zero members.

15 new rows: the 9 tracked compliance files that had no row, `docs/legal/README.md`, and 5 real Drive artifacts the new bundles need.

## Bundles: 3 → 7

Adds `grant`, `baa`, `dsar`, `security-review`. Extends `school-dpa-package` and `soc2-evidence`. Frozen binder untouched.

`security-review` is **separate from** `soc2-evidence`, not an alias: a district IT questionnaire wants the customer-facing diligence pack (posture, ACR/VPAT, AI data-flow, subprocessors), while `soc2-evidence` is the internal controls-evidence pack. Overloading one name would force each to carry documents the other reviewer never asks for.

**21 gaps across 6 bundles** are recorded in a new `bundleDefinitions[*].gaps` field. A gap is a named artifact that does not exist yet. Nothing was invented to make `--check` pass. Highlights: HIPAA workforce training records, the entire DSAR runbook/template/case-log set, and every standing grant record (PI bio-sketch, data-management plan, prior-award history).

## Scripts

`document-register-render.rb` gains, as hard failures: retention shape validation, reciprocal `supersedes`/`supersededBy` chains, `driveFileId` presence/absence/URL agreement, and a completeness sweep that fails on any **tracked** file under `docs/legal/` with no register row. Advisory only: staleness, unregistered agent configs, unused retention classes, ambiguous classes.

`compliance-publication-status.rb` gains Retention Draft Coverage, Legal Holds, Supersession Chains, and Bundle Gaps sections.

Every new validation was negative-tested to confirm it actually fails when violated (bad class, rule/schedule disagreement, missing block, disposition date on a draft rule, non-boolean `legalHold`, one-sided/dangling/self-referential supersession, status not `superseded`, missing/mismatched/misplaced `driveFileId`, malformed `gaps`, tracked-but-unregistered file). Untracked scratch files correctly do **not** trip the sweep.

## Gate

All three pass on this branch:

```
ruby scripts/document-register-render.rb --check     # OK (70 docs)
ruby scripts/compliance-publication-status.rb --check # OK
scripts/regenerate-register.sh                        # Done, all integrity checks passed
```

The advisory about non-git rows lacking supplied hashes is expected and is not a failure.

## Governance

No row was attested and no status was moved to `approved`/`published` on Scot's behalf **except** where a document's own text records an attestation Scot already made — those 3 rows cite the in-document line in `notes` and are marked for Scot to confirm or correct. The re-attested posture report is held at `draft` with an empty attestation despite its Drive title, because only Scot attests. No retention rule is `approved`. `legalHold` is `false` everywhere.

## Deliberately out of scope

`audit-reports/tombstones.json` and retention/review deadlines in `compliance-calendar.json` appear in the design brief's §9.2 tree but not in its §10 Phase 2 step list. Both are inert until a retention rule is approved, so they belong with Phase 4. Also not done: registering the rest of the Drive 641.1 annex set, most of which duplicates already-registered documents and would create competing-source rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PY8F7uMWCiW1Gqvy5T8ik