### PR TITLE
fix(landing): remove duplicate SLP spotlight section

### DIFF
--- a/app/frontend/app/components/landing-alt-page.hbs
+++ b/app/frontend/app/components/landing-alt-page.hbs
@@ -147,23 +147,9 @@
         </div>
       </section>
 
-      {{!-- ── Speech-Therapist Spotlight (DESKTOP version, >1024px only — sits above the parallax zone; the mobile mirror inside the parallax zone is hidden at this width) ── --}}
-      <section id="la-slp-spotlight-desktop" class="la-slp-spotlight la-spotlight-desktop" aria-labelledby="la-slp-spotlight-desktop-title">
-        <div class="la-parallax-card-outer la-slp-spotlight__card">
-          <div class="la-parallax-card-inner la-slp-spotlight__inner">
-            <div class="la-plan-text la-slp-spotlight__header">
-              <span class="la-section-eyebrow-badge">{{t "Built for schools & therapists" key='fsa_slp_spotlight_eyebrow'}}</span>
-              <h2 id="la-slp-spotlight-desktop-title" class="la-plan-title la-slp-spotlight__title">{{t "We focus on" key='fsa_slp_spotlight_title_1'}} <em>{{t "everyone's needs" key='fsa_slp_spotlight_title_2'}}</em></h2>
-            </div>
-            <p class="la-plan-subtitle la-slp-spotlight__body">{{t "Speech-language pathologists love LingoLinq because the features are tailored to the way they actually work — from session logging and goal tracking to flexible board sharing. We listen to your suggestions and ship the ones that make your day easier." key='fsa_slp_spotlight_body'}}</p>
-            <div class="la-slp-spotlight__image" role="img" aria-label={{t "AAC user practicing with a speech-language pathologist" key='fsa_slp_spotlight_image_alt'}}></div>
-          </div>
-        </div>
-      </section>
-
-      {{!-- Parallax zone: from "Included in every plan" through footer --}}
+      {{!-- Parallax zone: from SLP spotlight through footer --}}
       <div class="la-parallax-zone">
-      {{!-- ── Speech-Therapist Spotlight (≤1024px only — replaces the parallax background image, which doesn't render well on small screens) ── --}}
+      {{!-- ── Speech-Therapist Spotlight (single copy at all widths) ── --}}
       <section id="la-slp-spotlight" class="la-slp-spotlight" aria-labelledby="la-slp-spotlight-title">
         <div class="la-parallax-card-outer la-slp-spotlight__card">
           <div class="la-parallax-card-inner la-slp-spotlight__inner">

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -20,6 +20,7 @@ file (see [README.md](README.md)).
 
 ## Index
 
+- [Gotcha: `ensure_senner_baud!` in beta_seed_spec hits live Typhoeus/libcurl and can segfault CI](#gotcha-ensure_senner_baud-in-beta_seed_spec-hits-live-typhoeuslibcurl-and-can-segfault-ci)
 - [Gotcha: Textarea `@value` on a get-only computed crashes on keystroke — needs a setter/cache](#gotcha-textarea-value-on-a-get-only-computed-crashes-on-keystroke--needs-a-settercache)
 - [Gotcha: Ember `<Input>` checkboxes need `@type`, and bound-select must stopPropagation](#gotcha-ember-input-checkboxes-need-type-and-bound-select-must-stoppropagation)
 - [Gotcha: Ember strict-mode templates treat bare names as helpers — use `this.` for controller props](#gotcha-ember-strict-mode-templates-treat-bare-names-as-helpers--use-this-for-controller-props)
@@ -6987,3 +6988,7 @@ version strings) or `NNN_NNN` underscore-digit tokens (global_id scrubber — av
 numeric literals like `100_000` in snippets); and runtime findings (no file anchor)
 id-anchor on `ruleKey` with `evidence.source`, exempt from the snippet-at-SHA citation
 gate. (2026-07-16)
+
+## Gotcha: `ensure_senner_baud!` in beta_seed_spec hits live Typhoeus/libcurl and can segfault CI
+
+`BetaSeed.ensure_baseline!` calls `SystemBoardSources.ensure_senner_baud!`, which fetches an OBZ from S3 and imports media via `upload_to_remote` → `Typhoeus.post` → ethon/libcurl. In CI that path has segfaulted (`ethon ... [BUG] Segmentation fault` in `curl_mime_type`). Stub it in `spec/lib/beta_seed_spec.rb` the same way as `ensure_crisis_vocabulary!` (`and_return(nil)`) whenever the example only needs starter boards / verify helpers — do not exercise live multipart curl from seed specs. (2026-07-22; task log `2026-07-22-stub-senner-baud-beta-seed-spec.md`)

--- a/spec/lib/beta_seed_spec.rb
+++ b/spec/lib/beta_seed_spec.rb
@@ -4,6 +4,8 @@ describe BetaSeed do
   describe '.ensure_baseline!' do
     it 'creates beta baseline users, admin access, and lingolinq starter boards' do
       allow(SystemBoardSources).to receive(:ensure_crisis_vocabulary!).and_return(nil)
+      # Avoid live S3 OBZ fetch + Typhoeus upload (ethon/libcurl can segfault in CI).
+      allow(SystemBoardSources).to receive(:ensure_senner_baud!).and_return(nil)
 
       described_class.ensure_baseline!
 
@@ -26,6 +28,7 @@ describe BetaSeed do
   describe '.verify_beta_seed' do
     it 'returns no baseline misses after required templates are present' do
       allow(SystemBoardSources).to receive(:ensure_crisis_vocabulary!).and_return(nil)
+      allow(SystemBoardSources).to receive(:ensure_senner_baud!).and_return(nil)
       described_class.ensure_baseline!
 
       UserIntegration.create!(template: true, integration_key: 'core_word_list', settings: {})
@@ -43,6 +46,7 @@ describe BetaSeed do
 
     it 'reports missing signup library boards when required' do
       allow(SystemBoardSources).to receive(:ensure_crisis_vocabulary!).and_return(nil)
+      allow(SystemBoardSources).to receive(:ensure_senner_baud!).and_return(nil)
       described_class.ensure_baseline!
 
       missing = described_class.verify_beta_seed(require_library_boards: true)
@@ -149,6 +153,7 @@ describe BetaSeed do
 
     it 'deletes and re-seeds when pre-flight checks pass' do
       allow(SystemBoardSources).to receive(:ensure_crisis_vocabulary!).and_return(nil)
+      allow(SystemBoardSources).to receive(:ensure_senner_baud!).and_return(nil)
       owner = User.create(user_name: 'lingolinq')
       Board.process_new({name: 'Old', public: true}, {user: owner, key: 'old-lib'})
 


### PR DESCRIPTION
CSS already treats the SLP spotlight as a single copy, but the desktop duplicate above the parallax zone was still in the template and showed alongside the in-zone section on wide viewports.