### PR TITLE
compliance(docs): re-attest AI data-flow classification and program overview

### DIFF
--- a/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
+++ b/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
@@ -50,7 +50,6 @@
 | Subprocessor Register (branded) | drive | [open](https://docs.google.com/document/d/13i7PUAZO-_lyUrObdB3CLDQ5KB9s5GNL7XHpcBCRn_M/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
 | Vendor and Subprocessor Management Policy | drive | [open](https://docs.google.com/document/d/1fmBOfw-peYUpdwmttHC3hqzU_5c3OMNgBSN4NDK7mAM/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
 | Written Information Security Program (WISP) | drive | [open](https://docs.google.com/document/d/1wvjHGzOYfnpfqonKmr9HwK2wZKxWf-PTuOV20mS8zkE/edit) | 2026-06-19 | published | Review date is older than 2026-07-22. |
-| AI Data-Flow Classification | git | `docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` | 2026-07-09 | draft | Review date is older than 2026-07-22. |
 | AI Data-Sharing Consent: Rationale and Policy | git | `docs/legal/AI_DATA_SHARING_CONSENT.md` | 2026-07-09 | approved | Review date is older than 2026-07-22. |
 | AWS BAA Acceptance Record | git | `docs/legal/AWS_BAA_ACCEPTED.md` | 2026-05-11 | approved | Review date is older than 2026-07-22. |
 | AWS Business Associate Agreement (signed PDF) | git | `docs/legal/AWS_BAA_2026-02.pdf` | 2026-05-11 | published | Review date is older than 2026-07-22. |
@@ -70,7 +69,6 @@
 | Incident Log | git | `docs/legal/INCIDENT_LOG.md` | 2026-05-27 | approved | Review date is older than 2026-07-22. |
 | Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | 2026-05-27 | approved | Review date is older than 2026-07-22. |
 | LingoLinq Capability Ledger (rendered) | git | `docs/legal/CAPABILITY_LEDGER.md` | 2026-07-12 | published | Review date is older than 2026-07-22. |
-| LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | 2026-07-09 | draft | Review date is older than 2026-07-22. |
 | Parental Consent Email (COPPA / under-13) | git | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | 2026-06-11 | approved | Review date is older than 2026-07-22. |
 | Subprocessor Register | git | `docs/legal/SUBPROCESSORS.md` | 2026-06-18 | approved | Review date is older than 2026-07-22. |
 | accessibility-auditor agent definition | git | `.claude/agents/accessibility-auditor.md` | 2026-06-21 | published | Review date is older than 2026-07-22. |
@@ -260,4 +258,4 @@ The missing layer is a Google Docs publisher/refresh workflow. Until that exists
 
 ---
 
-_70 documents tracked. 55 stale review item(s). 22 Drive refresh item(s). 4 Notion hash item(s). 22 inferred retention class(es). 0 legal hold(s). 1 superseded record(s). 23 bundle gap(s) across 6 bundle(s)._
+_70 documents tracked. 53 stale review item(s). 22 Drive refresh item(s). 4 Notion hash item(s). 22 inferred retention class(es). 0 legal hold(s). 1 superseded record(s). 23 bundle gap(s) across 6 bundle(s)._

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -2410,24 +2410,27 @@
       "owner": "Scot Wahlquist",
       "canonicalSystem": "git",
       "canonicalLocation": "docs/legal/AI_DATA_FLOW_CLASSIFICATION.md",
-      "status": "draft",
+      "status": "approved",
       "frameworks": [
         "FERPA",
         "COPPA",
         "HIPAA",
         "GDPR"
       ],
-      "lastReviewed": "2026-07-09",
-      "nextReviewDue": "2027-07-09",
-      "attestation": {},
-      "contentHash": "b75b6271e3682e1b5ec366c34b1610c9f9397472e17df83e9b4eb461b565b92a",
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-07-22",
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-07-22"
+      },
+      "contentHash": "f16e851f8cc09794437f0f87089b309763124943af4a5475b1e60b25fcf9f475",
       "bundles": [
         "school-dpa-package",
         "security-review",
         "dsar"
       ],
       "mirrors": [],
-      "notes": "Scot attested this document (provisional) on 2026-07-09, per its own header line, but the file has MATERIALLY CHANGED SINCE: commit 74266b41f (#656, 2026-07-22) rewrote the AI-log retention tiers, moving the children and general tiers from \"Decided, rolling out\" to \"Decided, not yet enforced\" and the EU tier from inert to functional. The 2026-07-09 attestation therefore covered an earlier revision, not the bytes this row now hashes. Held at draft with an empty attestation until Scot re-attests. This is not a finding that the original attestation was invalid; it is a refusal to imply he attested the current bytes.",
+      "notes": "Re-attested (provisional) by Scot Wahlquist 2026-07-22, covering the current revision. The prior 2026-07-09 attestation covered an earlier revision (PR #656 rewrote the AI-log retention tiers). Before the re-attestation was recorded, the changed claims were verified against live code: AiApiLog.purge_old_eu_logs!(years: 5) exists at app/models/ai_api_log.rb and is dispatched from lib/tasks/scheduler.rake, and LingoLinq::Article50CallContext.for(user) stamps jurisdiction at exactly the three AI call sites. Outside-counsel review remains deferred until the full 5-phase VPC is built, so this stays a provisional attestation.",
       "retention": {
         "class": "policy-version",
         "rule": "supersession + 7 years",
@@ -2478,7 +2481,7 @@
       "owner": "Scot Wahlquist",
       "canonicalSystem": "git",
       "canonicalLocation": "docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md",
-      "status": "draft",
+      "status": "approved",
       "frameworks": [
         "FERPA",
         "COPPA",
@@ -2486,15 +2489,18 @@
         "GDPR",
         "SOC2"
       ],
-      "lastReviewed": "2026-07-09",
-      "nextReviewDue": "2027-07-09",
-      "attestation": {},
-      "contentHash": "c8030f10b9e437ab08a877d9ff9d0ebd2695a5ccc7129c50ddd0fed265ad8a45",
+      "lastReviewed": "2026-07-22",
+      "nextReviewDue": "2027-07-22",
+      "attestation": {
+        "attestedBy": "Scot Wahlquist",
+        "attestedDate": "2026-07-22"
+      },
+      "contentHash": "71577f49b16e6e3b938c61e79931104a47159612c2174069336f12a928d06fc6",
       "bundles": [
         "security-review"
       ],
       "mirrors": [],
-      "notes": "Scot attested this document for external release on 2026-07-09 (rev. 2026-07-09-c), per its own header banner, but the file has MATERIALLY CHANGED SINCE: commits 3d1bf2f70 (#649, 2026-07-21) and 0ce7c2f70 (#652, 2026-07-21) rewrote the subprocessor and hosting posture (GCP as live production host, Render as a write-frozen fallback, Anthropic HIPAA-ready BAA executed) and inverted the COPPA offboarding section from an open gap to an implemented control. The banner still reads rev. 2026-07-09-c. Because this document is EXTERNALLY SHAREABLE, the gap between the attested revision and the current bytes matters more here than anywhere else in the register. Held at draft with an empty attestation until Scot re-attests.",
+      "notes": "Re-attested for EXTERNAL RELEASE by Scot Wahlquist 2026-07-22 (rev. 2026-07-22-a). The prior 2026-07-09 attestation (rev. 2026-07-09-c) covered an earlier revision, superseded by PR #649 (COPPA offboarding rewritten from open gap to implemented control) and PR #652 (subprocessor and hosting posture rewritten for the GCP cutover). Because this document is externally shareable, the newer claims were verified against live code before the re-attestation was recorded: Organization#remove_user calls User#begin_family_offboarding_consents!, parent email is collected at next login via submit_parental_consent_email, and full login is genuinely blocked while consent is pending because the device token is only issued \"unless coppa_pending\".",
       "retention": {
         "class": "policy-version",
         "rule": "supersession + 7 years",

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -8,9 +8,9 @@
 
 ## Headline
 
-- **Status:** draft 10, approved 14, published 43, superseded 3
+- **Status:** draft 8, approved 16, published 43, superseded 3
 - **Overdue for review** (as of 2026-07-22): none
-- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); AI Data-Flow Classification; LingoLinq Security, Privacy & Compliance Overview; EU AI Act Article 50 Transparency: Implementation Milestone Plan; Compliance Posture Report (branded, 2026-07-16 re-attest); Anthropic Business Associate Agreement (2026-05-06); Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14); Annex A - Clinical BAA Template (DRAFT); Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT)
+- **Drafts awaiting attestation:** Accessibility Conformance Report (ACR / VPAT); Accessibility Conformance Report (ACR / VPAT) (branded); EU AI Act Article 50 Transparency: Implementation Milestone Plan; Compliance Posture Report (branded, 2026-07-16 re-attest); Anthropic Business Associate Agreement (2026-05-06); Google Cloud Platform - Accepted Compliance Agreements (captured 2026-07-14); Annex A - Clinical BAA Template (DRAFT); Annex B - US Schools SDPA Package (NDPA v2.1 + Exhibits) (DRAFT)
 
 ## Documents by type
 
@@ -19,7 +19,7 @@
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Access Control Policy | Drive | [open](https://docs.google.com/document/d/1yyibyEBfMiaS8NoHVVW629SkK61C0jo5P5OjUGojOck/edit) | published | SOC2, HIPAA, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence, security-review, baa |
-| AI Data-Flow Classification | git | `docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` | draft | FERPA, COPPA, HIPAA, GDPR | Scot Wahlquist | 2026-07-09 | 2027-07-09 | no | `b75b6271e368` | school-dpa-package, security-review, dsar |
+| AI Data-Flow Classification | git | `docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` | approved | FERPA, COPPA, HIPAA, GDPR | Scot Wahlquist | 2026-07-22 | 2027-07-22 | 2026-07-22 | `f16e851f8cc0` | school-dpa-package, security-review, dsar |
 | AI Data-Sharing Consent: Rationale and Policy | git | `docs/legal/AI_DATA_SHARING_CONSENT.md` | approved | FERPA, COPPA, GDPR | Scot Wahlquist | 2026-07-09 | 2027-07-09 | 2026-07-09 | `c77ebb0dc5c8` |  |
 | Business Continuity and Disaster Recovery Plan | Drive | [open](https://docs.google.com/document/d/1WIr3aBuFjworFtv9EOisOCSdfLvMSMFWQrFMzkhda00/edit) | published | SOC2 | Scot Wahlquist | 2026-06-19 | 2026-12-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Compliance & Data Governance (COMPLIANCE.md) | git | `COMPLIANCE.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-06 | 2027-06-23 | 2026-07-06 | `1e75223be75e` | soc2-evidence |
@@ -46,7 +46,7 @@
 | Compliance Posture Report (branded) | Drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | superseded | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 | Compliance Posture Report (branded, 2026-07-16 re-attest) | Drive | [open](https://docs.google.com/document/d/1yx-jVYesJ0ZQM0myir6d0rRMMzGEoH5EL5_luicucYo/edit) | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-22 | 2027-01-22 | no | (supplied) | school-dpa-package, security-review |
 | Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-22 | 2027-07-22 | 2026-07-22 | `1d1f81b0eeab` | compliance-records-set-2026-06 |
-| LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-09 | 2027-07-09 | no | `c8030f10b9e4` | security-review |
+| LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-22 | 2027-07-22 | 2026-07-22 | `71577f49b16e` | security-review |
 | Records of Processing Activities (RoPA) and Data Map | Drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | published | GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, dsar |
 
 ### evidence (9)

--- a/docs/legal/AI_DATA_FLOW_CLASSIFICATION.md
+++ b/docs/legal/AI_DATA_FLOW_CLASSIFICATION.md
@@ -2,8 +2,17 @@
 
 **Owner:** Privacy Office (privacy@lingolinq.com)
 **Created:** 2026-07-09 (VPC Phase 2, Task 02-01.1)
-**Status:** Attested (provisional) by Scot Wahlquist, CEO, 2026-07-09 -- formal outside counsel
-review deferred until the full 5-phase VPC is built. See `AI_DATA_SHARING_CONSENT.md` section 9.
+**Status:** Re-attested (provisional) by Scot Wahlquist, CEO, **2026-07-22**, covering the current
+revision. Formal outside counsel review remains deferred until the full 5-phase VPC is built. See
+`AI_DATA_SHARING_CONSENT.md` section 9.
+**Attestation history:** first attested (provisional) 2026-07-09. That attestation covered an
+earlier revision: PR #656 (2026-07-22) rewrote the AI-log retention tiers, moving the children and
+general tiers from "Decided, rolling out" to "Decided, not yet enforced" with the blocker named, and
+the EU tier from inert to functional. The 2026-07-22 re-attestation was taken only after the changed
+claims were re-verified against live code: `AiApiLog.purge_old_eu_logs!(years: 5)`
+(`app/models/ai_api_log.rb`) is dispatched from `lib/tasks/scheduler.rake`, and
+`LingoLinq::Article50CallContext.for(user)` stamps jurisdiction at exactly the three AI call sites
+(`lib/eval_narrator.rb`, `lib/ai_word_predictor.rb`, `lib/ai_board_generator.rb`).
 **Related:** `docs/legal/AI_DATA_SHARING_CONSENT.md`, `docs/legal/AI_GOVERNANCE_MEMO.md` (attested
 2026-06-19, the authoritative live model inventory), `docs/legal/SUBPROCESSORS.md`,
 `docs/legal/DATA_RETENTION.md`, `.planning/phases/02-disclosures-content/PLAN.md`

--- a/docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md
+++ b/docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md
@@ -1,13 +1,23 @@
 # LingoLinq Security, Privacy & Compliance Overview
 
-> **Attested for external release by Scot Wahlquist (CEO) on 2026-07-09 (rev. 2026-07-09-c).**
-> This attestation covers the version corrected after the Codex senior-dev re-review: the Sentry
-> scrubber, password-hashing, right-to-erasure, WCAG, vendor-list, and text-to-speech statements
-> were reconciled with the live code before this attestation, including the final recording-delete
-> and IP-geolocation processor scoping corrections. Reflects the current
-> production build. Present tense describes controls that exist in the product today. The
-> "Planned" section describes controls we intend to add and is written in the future tense on
-> purpose. This document deliberately claims only what we actually do.
+> **Re-attested for external release by Scot Wahlquist (CEO) on 2026-07-22 (rev. 2026-07-22-a).**
+> Reflects the current production build. Present tense describes controls that exist in the product
+> today. The "Planned" section describes controls we intend to add and is written in the future tense
+> on purpose. This document deliberately claims only what we actually do.
+>
+> **Attestation history.** First attested for external release 2026-07-09 (rev. 2026-07-09-c), after
+> a Codex senior-dev re-review reconciled the Sentry scrubber, password-hashing, right-to-erasure,
+> WCAG, vendor-list, text-to-speech, recording-delete, and IP-geolocation statements against live
+> code. That revision was then superseded by two edits on 2026-07-21: PR #649 rewrote the COPPA
+> offboarding section from an open gap to an implemented control, and PR #652 rewrote the
+> subprocessor and hosting posture for the Google Cloud cutover. Because this document is externally
+> shareable, it was held as unattested in the document register until those newer claims were
+> re-verified against live code on 2026-07-22:
+> `Organization#remove_user` (`app/models/organization.rb`) calls
+> `User#begin_family_offboarding_consents!` (`app/models/user.rb`); parent email is collected at next
+> login via `submit_parental_consent_email` (`app/controllers/api/users_controller.rb`,
+> `app/models/user.rb`); and full login is genuinely blocked while consent is pending, because the
+> device token is only issued `unless coppa_pending`. This re-attestation covers rev. 2026-07-22-a.
 >
 > **Purpose:** this is the short, externally shareable overview of our program. It is the
 > honest, right-sized replacement for the aspirational 85-page draft. It does not replace the
@@ -16,8 +26,8 @@
 > district, or a partner. Status of every implemented claim is verifiable against live code and
 > the findings register (`audit-reports/FINDINGS.json`).
 >
-> **Owner:** Scot Wahlquist, CEO. **Authorized for external sharing** as of the 2026-07-09 CEO
-> attestation of this version.
+> **Owner:** Scot Wahlquist, CEO. **Authorized for external sharing** as of the 2026-07-22 CEO
+> re-attestation of this version.
 
 ---
 


### PR DESCRIPTION
Follow-up to #658, which held these two rows at `draft` with empty attestations because their 2026-07-09 attestations covered revisions that had since been edited away. Scot has re-attested both at 2026-07-22.

## Claims re-verified against live code first

The 2026-07-09 attestation on the overview was itself taken only *after* a claim-vs-code reconciliation. Re-attesting without repeating that would have reintroduced the same problem in the other direction, so every claim added after 2026-07-09 was checked:

**`AI_DATA_FLOW_CLASSIFICATION.md`** (changed by #656)

| Claim | Verified at |
|---|---|
| `AiApiLog.purge_old_eu_logs!(years: 5)` shipped | `app/models/ai_api_log.rb:244` |
| ...and runs via `scheduler:dispatch` | `lib/tasks/scheduler.rake:170` |
| Jurisdiction stamped at "the three AI call sites" | exactly 3: `eval_narrator.rb:299`, `ai_word_predictor.rb:236`, `ai_board_generator.rb:649` |

**`COMPLIANCE_PROGRAM_OVERVIEW.md`** (changed by #649 and #652, and **externally shareable**)

| Claim | Verified at |
|---|---|
| `Organization#remove_user` → `User#begin_family_offboarding_consents!` | `organization.rb:1064` → `user.rb:451` |
| Parent email collected at next login | `users_controller.rb:842`, `user.rb:574` |
| "Full login stays blocked until a parent grants COPPA consent" | device token issued only `unless coppa_pending` — none generated while consent is outstanding |

All held. Nothing was softened or removed.

## What changed

Each document's banner now carries the new attestation date **and an explicit attestation-history block** naming the superseding PRs and the verification performed. That is the part that prevents a recurrence of the specific failure: previously the banner asserted `rev. 2026-07-09-c` while the bytes had moved twice, with nothing in the document saying so.

The overview moves to `rev. 2026-07-22-a` and its external-sharing authorization line is re-dated to match.

Register rows move `draft` → `approved`, `attestedDate: 2026-07-22`, review dates refreshed, with notes recording the drift and the verification.

`AI_DATA_SHARING_CONSENT.md` is untouched. It never drifted and kept its original attestation throughout.

## This does not close the underlying gap

The register still cannot **detect** an attested file's bytes moving: it stores `contentHash` and `attestedDate` but never the hash *as attested*. Both instances so far were caught by hand and passed green CI. That remains issue #661 (`attestedContentHash`). This PR fixes the two known cases; it does not prevent the third.

## Gate

```
ruby scripts/document-register-render.rb --check      # OK (70 docs)
ruby scripts/compliance-publication-status.rb --check # OK
scripts/regenerate-register.sh                        # all integrity checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PY8F7uMWCiW1Gqvy5T8ik