### PR TITLE
docs(ops): automatic n8n/W1 codex-review smoke of merged pipeline

### DIFF
--- a/docs/ops/codex-review-smoke.md
+++ b/docs/ops/codex-review-smoke.md
@@ -1,3 +1,4 @@
 # Codex Review Smoke
 
 - 2026-07-22: docs-only smoke change to verify the W1/W2 Codex review approval path before making `codex-review/deep-pass` a required branch-protection status.
+- 2026-07-23: automatic n8n/W1 smoke of the MERGED codex-review pipeline (fail-closed inconclusive, shell-optional evidence injection). Verifies the auto-dispatched staging-ref review produces a real verdict, not the old fail-open inconclusive.


### PR DESCRIPTION
Trivial docs-only PR to trigger a FRESH AUTOMATIC n8n/W1 codex-review pass now that the pipeline fixes (#655) are on staging.

Goal: confirm the auto-dispatched (staging-ref) review produces a real verdict via the new pipeline (shell-optional evidence injection + fail-closed inconclusive), not the old fail-open 'inconclusive (runner/sandbox)'.

This is a smoke; not intended as a feature change.