### PR TITLE
ci(secrets): allowlist 'Render/AWS/GCP' prose false positive blocking release #660

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -44,3 +44,10 @@ targetRules = ["generic-api-key"]
 regexes = [
   '''trends_explainer2''',
 ]
+
+[[allowlists]]
+description = "Prose literal 'Render/AWS/GCP' in .claude/agents/infra-auditor.md trips generic-api-key. The rule's keyword heuristic fires on the word 'secrets' and then treats the adjacent slash-separated platform list as a high-entropy value (entropy 3.52), so the sentence 'no secrets in git history, Render/AWS/GCP least-privilege' is flagged as if it contained one. It is the auditor agent's own scan checklist, not a credential. This must be an allowlist rather than a reword: gitleaks scans a COMMIT RANGE, so the string persists at d294d4c941f4 no matter what HEAD says, and every wide-range release PR (staging -> main) re-surfaces it. Same narrowest-possible scope as the entries above: matched by the exact literal via regexes, and only generic-api-key is relaxed, so every other rule (AWS keys, private keys, tokens) still scans that file and every other value is still scanned by every rule."
+targetRules = ["generic-api-key"]
+regexes = [
+  '''Render/AWS/GCP''',
+]


### PR DESCRIPTION
Unblocks release PR #660. One-line config change.

## What gitleaks is actually flagging

`generic-api-key` fires on the infra-auditor agent's own scan checklist. Its keyword heuristic triggers on the word *secrets*, then treats the adjacent slash-separated platform list as a high-entropy value (entropy **3.52**):

```
no secrets in git history, Render/AWS/GCP least-privilege
                           ^^^^^^^^^^^^^^
                           reported as the "secret"
```

So the literal being reported as a leaked credential is the string `Render/AWS/GCP`, in a sentence about **not** having secrets in git history. It is documentation, in a read-only auditor agent definition, at `.claude/agents/infra-auditor.md:62`.

## Why this surfaced now

Nothing changed. `secret-detection` scans `base.sha..head.sha`. Ordinary PRs into `staging` scan a handful of commits; **release PR #660 scans 451**, which reaches back to `d294d4c941f4` (13 June, the Phase 2 `.claude/` migration) where the line was introduced.

Every future `staging -> main` release will hit the same thing until this lands.

## Why an allowlist and not a reword

Rewording the sentence does **not** fix it. Gitleaks scans a **commit range**, not the worktree, so the string persists at `d294d4c941f4` regardless of what `HEAD` says. Only an allowlist clears the gate.

## Scope

Identical to the four existing entries in `.gitleaks.toml`:

- `targetRules = ["generic-api-key"]` — only that one noisy rule is relaxed. AWS keys, private keys, and token rules still scan this file.
- `regexes = ['''Render/AWS/GCP''']` — only that exact literal is exempted. No path is broadened, no other value is allowlisted.

## Verification

`gitleaks 8.30.1`, over the full release range `f7e89fe2..82e8c3c4a`:

| | Leaks found |
|---|---|
| Before | **1** (`generic-api-key`, `.claude/agents/infra-auditor.md:62`) |
| After | **0** |

Also confirmed clean against the isolated offending commit `d294d4c941f4~1..d294d4c941f4`.

## Unrelated fragility worth noting separately

`ci.yml` resolves the **latest** gitleaks release at run time and only falls back to the pinned `8.30.1` if that lookup fails. A new upstream release can add rules and turn `secret-detection` red with no repo change. Not fixed here, flagged for triage.