### PR TITLE
security(tts): GA v1 Text-to-Speech endpoint + drop unauthenticated consumer fallback (BAA Pre-GA exclusion)

### DIFF
--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -364,10 +364,10 @@ class Api::SearchController < ApplicationController
         json = JSON.parse(cache) rescue nil
       end
       if !json || json['voices'].length == 0
-        req = Typhoeus.get("https://texttospeech.googleapis.com/v1beta1/voices?languageCode=#{CGI.escape(params['locale'] || 'en')}&key=#{ENV['GOOGLE_TTS_TOKEN']}")
+        req = Typhoeus.get("https://texttospeech.googleapis.com/v1/voices?languageCode=#{CGI.escape(params['locale'] || 'en')}&key=#{ENV['GOOGLE_TTS_TOKEN']}")
         json = JSON.parse(req.body) rescue nil
         if json && (!json['voices'] || json['voices'].length == 0)
-          req = Typhoeus.get("https://texttospeech.googleapis.com/v1beta1/voices?languageCode=#{CGI.escape((params['locale'] || 'en').split(/-|_/)[0])}&key=#{ENV['GOOGLE_TTS_TOKEN']}")
+          req = Typhoeus.get("https://texttospeech.googleapis.com/v1/voices?languageCode=#{CGI.escape((params['locale'] || 'en').split(/-|_/)[0])}&key=#{ENV['GOOGLE_TTS_TOKEN']}")
           json = JSON.parse(req.body) rescue nil
         end
         cache = nil
@@ -391,7 +391,7 @@ class Api::SearchController < ApplicationController
         end
         # https://cloud.google.com/text-to-speech/?hl=en_US&_ga=2.240949507.-1294930961.1646091692
         content_type = 'audio/mp3' if params['mp3'] != '0'
-        res = Typhoeus.post("https://texttospeech.googleapis.com/v1beta1/text:synthesize?key=#{ENV['GOOGLE_TTS_TOKEN']}", body: 
+        res = Typhoeus.post("https://texttospeech.googleapis.com/v1/text:synthesize?key=#{ENV['GOOGLE_TTS_TOKEN']}", body: 
           {
             audioConfig: {audioEncoding: content_type == 'audio/mp3' ? 'MP3' : 'LINEAR16', pitch: 0, speakingRate: 1},
             input: {text: params['text']},
@@ -405,7 +405,11 @@ class Api::SearchController < ApplicationController
         end
       end
     else
-      req = Typhoeus.get("https://translate.google.com/translate_tts?id=UTF-8&tl=#{params['locale'] || 'en'}&q=#{URI.escape(params['text'] || "")}&total=1&idx=0&textlen=#{(params['text'] || '').length}&client=tw-ob", timeout: 5, headers: {'Referer' => "https://translate.google.com/", 'User-Agent' => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"})
+      # No contracted TTS provider is configured (GOOGLE_TTS_TOKEN unset) and the
+      # locale is not Irish/Abair. The former consumer translate.google.com/translate_tts
+      # fallback was removed: it is an unauthenticated consumer endpoint with no DPA/BAA
+      # basis and must never receive user utterance text (finding LL-a167848115).
+      return api_error 400, {error: 'no tts provider configured'}
     end
     return api_error 400, {error: 'remote request failed'} unless req && !req.body.blank?
     response.headers['Content-Type'] = content_type

--- a/lib/tts.rb
+++ b/lib/tts.rb
@@ -18,7 +18,9 @@ module Tts
         return generate_google(text, locale: locale, mp3: mp3)
       end
 
-      # Fallback: unscraped translate.google.com (fragile, not for batch use)
+      # No contracted TTS provider configured: return nil rather than falling back to
+      # the unauthenticated consumer translate.google.com endpoint, which has no DPA/BAA
+      # basis (see LL-a167848115 and docs/legal/SUBPROCESSORS.md §5.8).
       nil
     end
 
@@ -54,7 +56,7 @@ module Tts
       content_type = mp3 ? 'audio/mp3' : 'audio/wav'
       encoding = mp3 ? 'MP3' : 'LINEAR16'
       res = Typhoeus.post(
-        "https://texttospeech.googleapis.com/v1beta1/text:synthesize?key=#{ENV['GOOGLE_TTS_TOKEN']}",
+        "https://texttospeech.googleapis.com/v1/text:synthesize?key=#{ENV['GOOGLE_TTS_TOKEN']}",
         body: {
           audioConfig: { audioEncoding: encoding, pitch: 0, speakingRate: 1 },
           input: { text: text },
@@ -80,14 +82,14 @@ module Tts
         return JSON.parse(cache) rescue nil
       end
       req = Typhoeus.get(
-        "https://texttospeech.googleapis.com/v1beta1/voices?languageCode=#{CGI.escape(locale)}&key=#{ENV['GOOGLE_TTS_TOKEN']}",
+        "https://texttospeech.googleapis.com/v1/voices?languageCode=#{CGI.escape(locale)}&key=#{ENV['GOOGLE_TTS_TOKEN']}",
         timeout: 10,
         connecttimeout: 5
       )
       json = JSON.parse(req.body) rescue nil
       if json && (!json['voices'] || json['voices'].length == 0)
         req = Typhoeus.get(
-          "https://texttospeech.googleapis.com/v1beta1/voices?languageCode=#{CGI.escape(locale.split(/-|_/)[0])}&key=#{ENV['GOOGLE_TTS_TOKEN']}",
+          "https://texttospeech.googleapis.com/v1/voices?languageCode=#{CGI.escape(locale.split(/-|_/)[0])}&key=#{ENV['GOOGLE_TTS_TOKEN']}",
           timeout: 10,
           connecttimeout: 5
         )

--- a/spec/controllers/api/search_controller_spec.rb
+++ b/spec/controllers/api/search_controller_spec.rb
@@ -689,22 +689,25 @@ describe Api::SearchController, :type => :controller do
     before(:each) do
       RedisInit.permissions.del("google/voices/fr")
     end
-    it 'should not require an api token' do
-      expect(Typhoeus).to receive(:get).and_return(OpenStruct.new({
-        headers: {
-          'Content-Type' => 'audio/mp3'
-        },
-        body: 'asdf'
-      }))
+    it 'returns an error when no TTS provider is configured (consumer fallback removed)' do
+      # The unauthenticated consumer translate.google.com/translate_tts fallback was
+      # removed: no DPA/BAA basis, must never receive user utterance text (LL-a167848115).
+      # With no GOOGLE_TTS_TOKEN and a non-Irish locale, no external call is made.
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('GOOGLE_TTS_TOKEN').and_return(nil)
+      expect(Typhoeus).to_not receive(:get)
+      expect(Typhoeus).to_not receive(:post)
       get :audio, params: {text: 'asdf'}
+      expect(response.code).to eq('400')
+      expect(JSON.parse(response.body)['error']).to eq('no tts provider configured')
     end
 
     env_wrap('GOOGLE_TTS_TOKEN' => 'test_tts_key') do
       it "should use the token if there is one" do
-        expect(Typhoeus).to receive(:get).with("https://texttospeech.googleapis.com/v1beta1/voices?languageCode=fr&key=test_tts_key").and_return(OpenStruct.new({
+        expect(Typhoeus).to receive(:get).with("https://texttospeech.googleapis.com/v1/voices?languageCode=fr&key=test_tts_key").and_return(OpenStruct.new({
           body: {voices: [{'ssmlGender' => 'male', 'name' => 'Bob'}]}.to_json
         }))
-        expect(Typhoeus).to receive(:post).with("https://texttospeech.googleapis.com/v1beta1/text:synthesize?key=test_tts_key", body: {
+        expect(Typhoeus).to receive(:post).with("https://texttospeech.googleapis.com/v1/text:synthesize?key=test_tts_key", body: {
           audioConfig: {audioEncoding: 'MP3', pitch: 0, speakingRate: 1},
           input: {text: 'asdf'},
           voice: {languageCode: 'fr', name: 'Bob'}
@@ -717,10 +720,10 @@ describe Api::SearchController, :type => :controller do
       end
 
       it "should cache the voices list when retrieved" do
-        expect(Typhoeus).to receive(:get).with("https://texttospeech.googleapis.com/v1beta1/voices?languageCode=fr&key=test_tts_key").and_return(OpenStruct.new({
+        expect(Typhoeus).to receive(:get).with("https://texttospeech.googleapis.com/v1/voices?languageCode=fr&key=test_tts_key").and_return(OpenStruct.new({
           body: {voices: [{'ssmlGender' => 'male', 'name' => 'Bob'}]}.to_json
         }))
-        expect(Typhoeus).to receive(:post).with("https://texttospeech.googleapis.com/v1beta1/text:synthesize?key=test_tts_key", body: {
+        expect(Typhoeus).to receive(:post).with("https://texttospeech.googleapis.com/v1/text:synthesize?key=test_tts_key", body: {
           audioConfig: {audioEncoding: 'MP3', pitch: 0, speakingRate: 1},
           input: {text: 'asdf'},
           voice: {languageCode: 'fr', name: 'Bob'}
@@ -743,8 +746,8 @@ describe Api::SearchController, :type => :controller do
 
       it "should use the cached voices list when available" do
         RedisInit.permissions.setex("google/voices/fr", 10.seconds.to_i, {voices: [{'ssmlGender' => 'male', 'name' => 'Bob'}]}.to_json)
-        expect(Typhoeus).to_not receive(:get).with("https://texttospeech.googleapis.com/v1beta1/voices?languageCode=fr&key=test_tts_key")
-        expect(Typhoeus).to receive(:post).with("https://texttospeech.googleapis.com/v1beta1/text:synthesize?key=test_tts_key", body: {
+        expect(Typhoeus).to_not receive(:get).with("https://texttospeech.googleapis.com/v1/voices?languageCode=fr&key=test_tts_key")
+        expect(Typhoeus).to receive(:post).with("https://texttospeech.googleapis.com/v1/text:synthesize?key=test_tts_key", body: {
           audioConfig: {audioEncoding: 'MP3', pitch: 0, speakingRate: 1},
           input: {text: 'asdf'},
           voice: {languageCode: 'fr', name: 'Bob'}

--- a/spec/lib/tts_spec.rb
+++ b/spec/lib/tts_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Tts do
+  describe 'generate_audio' do
+    it 'returns nil for blank text' do
+      expect(Tts.generate_audio('', locale: 'en')).to eq(nil)
+      expect(Tts.generate_audio(nil, locale: 'en')).to eq(nil)
+    end
+
+    env_wrap('GOOGLE_TTS_TOKEN' => 'test_tts_key') do
+      it 'calls the GA v1 Text-to-Speech endpoints, never the Pre-GA v1beta1 (Google BAA excludes Pre-GA from PHI)' do
+        # Regression guard for the BAA covered-service fix: the Google Cloud BAA
+        # excludes Pre-GA offerings from PHI, so TTS must ride the GA v1 endpoint.
+        allow(RedisInit.permissions).to receive(:get).and_return(nil)
+        allow(Permissions).to receive(:setex)
+        expect(Typhoeus).to receive(:get).with(
+          "https://texttospeech.googleapis.com/v1/voices?languageCode=fr&key=test_tts_key",
+          timeout: 10, connecttimeout: 5
+        ).and_return(OpenStruct.new(body: { voices: [{ 'name' => 'Bob', 'languageCodes' => ['fr'] }] }.to_json))
+        expect(Typhoeus).to receive(:post).with(
+          "https://texttospeech.googleapis.com/v1/text:synthesize?key=test_tts_key",
+          hash_including(headers: { 'Content-Type' => 'application/json' })
+        ).and_return(OpenStruct.new(body: { audioContent: Base64.strict_encode64('audio-bytes') }.to_json))
+
+        res = Tts.generate_audio('hello', locale: 'fr', mp3: true)
+        expect(res).to_not eq(nil)
+        expect(res[:content_type]).to eq('audio/mp3')
+        expect(res[:body]).to eq('audio-bytes')
+      end
+    end
+
+    it 'routes Irish (ga) locales to the Abair endpoint, not Google' do
+      obj = OpenStruct.new(body: 'irishaudio', headers: { 'Content-Type' => 'audio/wav' })
+      allow(obj).to receive(:success?).and_return(true)
+      expect(Typhoeus).to receive(:post).with(
+        'https://abair.ie/aac_irish',
+        hash_including(body: { text: 'Dia dhuit', voice: 'Ulster' })
+      ).and_return(obj)
+      res = Tts.generate_audio('Dia dhuit', locale: 'ga')
+      expect(res[:body]).to eq('irishaudio')
+    end
+  end
+end


### PR DESCRIPTION
## What & why
BAA-coverage hardening for the Google Cloud localization/speech egress surface documented in **#648** (findings **LL-a167848115**, **LL-c38e7da48e**, **LL-1eb9a2435b**).

Google's Cloud BAA covers Text-to-Speech as a **product**, but its canonical HIPAA page explicitly **excludes Pre-GA offerings from PHI**: *"Do not use Pre-GA offerings ... in connection with PHI"* ([cloud.google.com/security/compliance/hipaa](https://cloud.google.com/security/compliance/hipaa)). All six TTS call sites used the Pre-GA **`v1beta1`** endpoint, so that traffic sat outside BAA coverage.

## Changes
1. **Repoint TTS `v1beta1` → GA `v1`** — `lib/tts.rb` (x3) and `app/controllers/api/search_controller.rb` (x3). Verified drop-in against Google's v1 REST reference: `v1/text:synthesize` takes the same `input`/`voice`/`audioConfig`, and `v1/voices` takes `languageCode`. Translation (`/v2`) and Speech-to-Text (`/v1`) were already GA and are untouched.
2. **Remove the unauthenticated consumer `translate.google.com/translate_tts` fallback** — no DPA/BAA basis; must never receive user utterance text. Only reachable with `GOOGLE_TTS_TOKEN` unset (dead in prod, where it's set). Now returns `400 "no tts provider configured"`.
3. **Abair Irish TTS left untouched** — separate open CEO decision (DPA vs disable).

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| TTS on GA `v1` endpoint | Fixed | `lib/tts.rb`, `search_controller.rb` (no `v1beta1` remains) |
| Consumer `translate_tts` removed | Fixed | `search_controller.rb` audio `else` → 400 |
| Regression tests | Fixed | `spec/lib/tts_spec.rb` (new) + audio specs; 62 examples, 0 failures |
| Abair DPA/disable | Not in scope | open CEO decision (LL-a167848115) |

## Not covered
- Abair Irish TTS DPA-or-disable (CEO decision).
- Voice-transcription (#18) consent/flag posture (register documents it; separate decision).

## Test evidence
`bundle exec rspec spec/lib/tts_spec.rb spec/controllers/api/search_controller_spec.rb` → **62 examples, 0 failures**.

## Author-Model: opus-4.8