### PR TITLE
compliance(register): pin attested bytes with attestedContentHash (closes #661)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,9 @@ jobs:
       - name: Verify document register render + git content hashes + bundle completeness
         run: ruby scripts/document-register-render.rb --check
 
+      - name: Verify attestedContentHash guards (drift + closed exemption set)
+        run: scripts/tests/attestation-hash-guard-test.sh
+
       - name: Verify compliance publication status report
         run: ruby scripts/compliance-publication-status.rb --check
 

--- a/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
+++ b/audit-reports/COMPLIANCE-PUBLICATION-STATUS.md
@@ -199,6 +199,26 @@ No retention rule has been approved. Nothing in this register is eligible for di
 
 _No record is under legal hold. A hold suspends all disposition for the rows it covers, and only Scot flips it._
 
+## Attestation Integrity
+
+17 attested git record(s). `attestation.attestedContentHash` pins the bytes that were attested; `ruby scripts/document-register-render.rb --check` fails when a pinned hash stops matching the file. Drive and Notion rows are out of scope: their hashes are operator-supplied, so there is nothing CI can verify.
+
+**No pinned attestation has drifted.** Every record that pins a hash still matches the attested bytes.
+
+### Re-attestation queue (7)
+
+Attested before the check existed and modified afterwards, so the attested revision no longer exists. The hash is deliberately not backfilled: pinning current bytes would re-assert an attestation Scot never gave. Each row clears when Scot re-attests the current revision.
+
+| Title | Location | Attested | Why it is unpinned |
+|---|---|---|---|
+| COPPA Final-Rule Verification | `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | 2026-06-21 | attested 2026-06-21, then modified by 1 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave |
+| Compliance & Data Governance (COMPLIANCE.md) | `COMPLIANCE.md` | 2026-07-06 | attested 2026-07-06, then modified by 3 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave |
+| Compliance Posture Report | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | 2026-07-16 | attested 2026-07-16, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave |
+| Data Retention Schedule | `docs/legal/DATA_RETENTION.md` | 2026-06-21 | attested 2026-06-21, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave |
+| Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record | `docs/legal/GCP_BAA_ACCEPTED.md` | 2026-07-16 | attested 2026-07-16, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave |
+| Parental Consent Email (COPPA / under-13) | `docs/legal/PARENTAL_CONSENT_EMAIL.md` | 2026-06-21 | attested 2026-06-21, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave |
+| Subprocessor Register | `docs/legal/SUBPROCESSORS.md` | 2026-07-06 | attested 2026-07-06, then modified by 5 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave |
+
 ## Supersession Chains
 
 A superseded record is never edited, renamed, or moved. It keeps its row and its membership in any frozen point-in-time binder; only the pointer is added.
@@ -258,4 +278,4 @@ The missing layer is a Google Docs publisher/refresh workflow. Until that exists
 
 ---
 
-_70 documents tracked. 53 stale review item(s). 22 Drive refresh item(s). 4 Notion hash item(s). 22 inferred retention class(es). 0 legal hold(s). 1 superseded record(s). 23 bundle gap(s) across 6 bundle(s)._
+_70 documents tracked. 53 stale review item(s). 22 Drive refresh item(s). 4 Notion hash item(s). 22 inferred retention class(es). 0 legal hold(s). 1 superseded record(s). 0 drifted attestation(s), 7 awaiting re-attestation. 23 bundle gap(s) across 6 bundle(s)._

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -451,7 +451,166 @@
     },
     "bundleMatchNote": "bundleDefinitions[*].requiredDocs binds each requirement to a specific document by canonicalLocation (identity), not free-text title, so a doc retitled to a required string cannot satisfy a requirement. Each requiredDoc carries a human-readable title that --check verifies still matches the member at that location (register-drift guard). --check fails if a requiredDoc location is not a bundle member, or its title has drifted.",
     "bundleGapNote": "bundleDefinitions[*].gaps names artifacts a bundle genuinely needs that DO NOT EXIST as records yet. A gap is a deliberate, visible hole: it is rendered in DOCUMENT-REGISTER.md and never satisfied by inventing a row or by pointing a requiredDoc at an unrelated document. gaps never fail --check; an unmet requiredDoc always does. Close a gap by creating the real artifact and promoting it out of gaps into requiredDocs.",
-    "integrityNote": "--check also enforces: every canonicalSystem is one of canonicalSystemEnum; a git row canonicalLocation is a repo path (not a URL); a drive/notion row canonicalLocation is a URL and does not resolve to a tracked repo file (so a git doc cannot dodge hash verification by being relabeled drive/notion); and id + canonicalLocation are unique across the register."
+    "integrityNote": "--check also enforces: every canonicalSystem is one of canonicalSystemEnum; a git row canonicalLocation is a repo path (not a URL); a drive/notion row canonicalLocation is a URL and does not resolve to a tracked repo file (so a git doc cannot dodge hash verification by being relabeled drive/notion); and id + canonicalLocation are unique across the register.",
+    "attestationHashNote": "attestation.attestedContentHash pins the sha256 of the bytes that were actually attested, alongside contentHash which tracks the file as it is now. document-register-render.rb --check fails when the two diverge on a canonicalSystem=git row: the attested revision no longer exists and re-attestation is owed. Enforced for git rows only - Drive and Notion hashes are operator-supplied with no automated refresh, so the field is rejected there. Render NEVER backfills this field; populating it from current bytes would make every attestation self-certifying. Only Scot attests, and the hash is pinned when the attestation is recorded.",
+    "attestationBackfillExemptions": [
+      {
+        "id": "DOC-9b299a785b",
+        "canonicalLocation": "COMPLIANCE.md",
+        "attestedDate": "2026-07-06",
+        "reason": "attested 2026-07-06, then modified by 3 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave",
+        "driftCommits": [
+          {
+            "date": "2026-07-21",
+            "commit": "0ce7c2f70",
+            "subject": "docs(compliance): record GCP cutover posture (#652)"
+          },
+          {
+            "date": "2026-07-19",
+            "commit": "42ea9cb1e",
+            "subject": "compliance(anthropic): record executed HIPAA-Ready BAA + classify eval narration (#631)"
+          },
+          {
+            "date": "2026-07-17",
+            "commit": "2782ec809",
+            "subject": "compliance(gcp): record executed GCP CDPA + HIPAA BAA + SCCs, correct Vertex scope (#622)"
+          }
+        ],
+        "addedOn": "2026-07-22",
+        "clears": "Scot re-attests the current revision; pin attestedContentHash and delete this entry"
+      },
+      {
+        "id": "DOC-4e3b7fb1fb",
+        "canonicalLocation": "docs/legal/COMPLIANCE_POSTURE_REPORT.md",
+        "attestedDate": "2026-07-16",
+        "reason": "attested 2026-07-16, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave",
+        "driftCommits": [
+          {
+            "date": "2026-07-21",
+            "commit": "0ce7c2f70",
+            "subject": "docs(compliance): record GCP cutover posture (#652)"
+          },
+          {
+            "date": "2026-07-17",
+            "commit": "2782ec809",
+            "subject": "compliance(gcp): record executed GCP CDPA + HIPAA BAA + SCCs, correct Vertex scope (#622)"
+          }
+        ],
+        "addedOn": "2026-07-22",
+        "clears": "Scot re-attests the current revision; pin attestedContentHash and delete this entry"
+      },
+      {
+        "id": "DOC-bff9acf51f",
+        "canonicalLocation": "docs/legal/DATA_RETENTION.md",
+        "attestedDate": "2026-06-21",
+        "reason": "attested 2026-06-21, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave",
+        "driftCommits": [
+          {
+            "date": "2026-07-22",
+            "commit": "74266b41f",
+            "subject": "compliance(art50): Phase 5 - rollout flag (AVAILABLE-only), retention reconciliation, a11y (#656)"
+          },
+          {
+            "date": "2026-07-10",
+            "commit": "72e141e5a",
+            "subject": "compliance(coppa): VPC Phase 2 -- AI data-sharing disclosure content (attested by Scot, pending es + outside counsel) (#569)"
+          }
+        ],
+        "addedOn": "2026-07-22",
+        "clears": "Scot re-attests the current revision; pin attestedContentHash and delete this entry"
+      },
+      {
+        "id": "DOC-0387973005",
+        "canonicalLocation": "docs/legal/SUBPROCESSORS.md",
+        "attestedDate": "2026-07-06",
+        "reason": "attested 2026-07-06, then modified by 5 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave",
+        "driftCommits": [
+          {
+            "date": "2026-07-22",
+            "commit": "cb105e098",
+            "subject": "compliance(register+subprocessors): disclose 5 raw localization/speech egress sinks; open LL-c38e7da48e + LL-1eb9a2435b (#648)"
+          },
+          {
+            "date": "2026-07-21",
+            "commit": "0ce7c2f70",
+            "subject": "docs(compliance): record GCP cutover posture (#652)"
+          },
+          {
+            "date": "2026-07-19",
+            "commit": "42ea9cb1e",
+            "subject": "compliance(anthropic): record executed HIPAA-Ready BAA + classify eval narration (#631)"
+          },
+          {
+            "date": "2026-07-17",
+            "commit": "2782ec809",
+            "subject": "compliance(gcp): record executed GCP CDPA + HIPAA BAA + SCCs, correct Vertex scope (#622)"
+          },
+          {
+            "date": "2026-07-12",
+            "commit": "93eac0501",
+            "subject": "compliance(subprocessors): mark Gemini row disabled/historical (2026-07-09) (#588)"
+          }
+        ],
+        "addedOn": "2026-07-22",
+        "clears": "Scot re-attests the current revision; pin attestedContentHash and delete this entry"
+      },
+      {
+        "id": "DOC-407d2c2bf4",
+        "canonicalLocation": "docs/legal/COPPA_VERIFICATION_2026-04-26.md",
+        "attestedDate": "2026-06-21",
+        "reason": "attested 2026-06-21, then modified by 1 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave",
+        "driftCommits": [
+          {
+            "date": "2026-07-13",
+            "commit": "23338d916",
+            "subject": "Feat/melissa parental consent confirmation email (#597)"
+          }
+        ],
+        "addedOn": "2026-07-22",
+        "clears": "Scot re-attests the current revision; pin attestedContentHash and delete this entry"
+      },
+      {
+        "id": "DOC-4e6c9253b9",
+        "canonicalLocation": "docs/legal/PARENTAL_CONSENT_EMAIL.md",
+        "attestedDate": "2026-06-21",
+        "reason": "attested 2026-06-21, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave",
+        "driftCommits": [
+          {
+            "date": "2026-07-15",
+            "commit": "36517f6a2",
+            "subject": "feat: EU AI parental consent plus AI pref gating (#616)"
+          },
+          {
+            "date": "2026-07-13",
+            "commit": "23338d916",
+            "subject": "Feat/melissa parental consent confirmation email (#597)"
+          }
+        ],
+        "addedOn": "2026-07-22",
+        "clears": "Scot re-attests the current revision; pin attestedContentHash and delete this entry"
+      },
+      {
+        "id": "DOC-5b14b08908",
+        "canonicalLocation": "docs/legal/GCP_BAA_ACCEPTED.md",
+        "attestedDate": "2026-07-16",
+        "reason": "attested 2026-07-16, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave",
+        "driftCommits": [
+          {
+            "date": "2026-07-21",
+            "commit": "0ce7c2f70",
+            "subject": "docs(compliance): record GCP cutover posture (#652)"
+          },
+          {
+            "date": "2026-07-19",
+            "commit": "42ea9cb1e",
+            "subject": "compliance(anthropic): record executed HIPAA-Ready BAA + classify eval narration (#631)"
+          }
+        ],
+        "addedOn": "2026-07-22",
+        "clears": "Scot re-attests the current revision; pin attestedContentHash and delete this entry"
+      }
+    ],
+    "attestationBackfillNote": "Rows attested before the attestedContentHash check landed (2026-07-22) whose files were modified after their attestation date. Their attested revision is gone, so the hash is deliberately NOT backfilled - doing so would silently re-assert an attestation that covered earlier bytes, which is the exact failure the field exists to catch. Each entry names the commits that caused the drift and is removed only when Scot re-attests the current revision. The list is one-way: --check fails on a stale entry, so it can only shrink to zero. Rows with no post-attestation modification were pinned directly, since git proves the attested bytes are the current bytes."
   },
   "documents": [
     {
@@ -509,7 +668,8 @@
       "nextReviewDue": "2027-07-22",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-07-22"
+        "attestedDate": "2026-07-22",
+        "attestedContentHash": "1d1f81b0eeab01e63abf4d2c91101ff402928d3802c77528e327973f8067729e"
       },
       "contentHash": "1d1f81b0eeab01e63abf4d2c91101ff402928d3802c77528e327973f8067729e",
       "bundles": [
@@ -586,7 +746,8 @@
       "nextReviewDue": "2026-10-22",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-07-22"
+        "attestedDate": "2026-07-22",
+        "attestedContentHash": "34b0b857f494864186d1305a40e5ce22a17b2265340a81436161dae2d87efafc"
       },
       "contentHash": "34b0b857f494864186d1305a40e5ce22a17b2265340a81436161dae2d87efafc",
       "bundles": [
@@ -820,7 +981,8 @@
       "nextReviewDue": "2027-05-27",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-06-21"
+        "attestedDate": "2026-06-21",
+        "attestedContentHash": "3efcaaf4a7c53016237527a5202a370bf74852f4b3e26e4346db5f418c5e263b"
       },
       "contentHash": "3efcaaf4a7c53016237527a5202a370bf74852f4b3e26e4346db5f418c5e263b",
       "bundles": [
@@ -861,7 +1023,8 @@
       "nextReviewDue": "2026-08-27",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-06-21"
+        "attestedDate": "2026-06-21",
+        "attestedContentHash": "e4e7c0b98d3fe6992eb33980597be8d1844a408fc8bd1c8205d2f214d59d9073"
       },
       "contentHash": "e4e7c0b98d3fe6992eb33980597be8d1844a408fc8bd1c8205d2f214d59d9073",
       "bundles": [
@@ -898,7 +1061,8 @@
       "nextReviewDue": "2027-05-11",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-02"
+        "attestedDate": "2026-02",
+        "attestedContentHash": "55f28e00168cfe5a1ecfaac3c56c33bd3fadd05276c8e9bcc6e678fc798b9bee"
       },
       "contentHash": "55f28e00168cfe5a1ecfaac3c56c33bd3fadd05276c8e9bcc6e678fc798b9bee",
       "bundles": [
@@ -970,7 +1134,8 @@
       "nextReviewDue": "2027-07-18",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-07-18"
+        "attestedDate": "2026-07-18",
+        "attestedContentHash": "5adbe44783d9d74797498415714bb0c84c81dc943ffcd7911ac4284624f9b0d4"
       },
       "bundles": [
         "baa"
@@ -1012,7 +1177,8 @@
       "nextReviewDue": "2027-05-11",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-06-21"
+        "attestedDate": "2026-06-21",
+        "attestedContentHash": "dc6a2ba9fa167f3f2bff6ec356bbd2b8bd9f9bafcd680b15362225aeca023f3e"
       },
       "contentHash": "dc6a2ba9fa167f3f2bff6ec356bbd2b8bd9f9bafcd680b15362225aeca023f3e",
       "bundles": [
@@ -2421,7 +2587,8 @@
       "nextReviewDue": "2027-07-22",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-07-22"
+        "attestedDate": "2026-07-22",
+        "attestedContentHash": "f16e851f8cc09794437f0f87089b309763124943af4a5475b1e60b25fcf9f475"
       },
       "contentHash": "f16e851f8cc09794437f0f87089b309763124943af4a5475b1e60b25fcf9f475",
       "bundles": [
@@ -2458,7 +2625,8 @@
       "nextReviewDue": "2027-07-09",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-07-09"
+        "attestedDate": "2026-07-09",
+        "attestedContentHash": "c77ebb0dc5c8a228f32f268f40f36a74e60ef867a5ada78ba0e22f0d4a7ca914"
       },
       "contentHash": "c77ebb0dc5c8a228f32f268f40f36a74e60ef867a5ada78ba0e22f0d4a7ca914",
       "bundles": [],
@@ -2493,7 +2661,8 @@
       "nextReviewDue": "2027-07-22",
       "attestation": {
         "attestedBy": "Scot Wahlquist",
-        "attestedDate": "2026-07-22"
+        "attestedDate": "2026-07-22",
+        "attestedContentHash": "71577f49b16e6e3b938c61e79931104a47159612c2174069336f12a928d06fc6"
       },
       "contentHash": "71577f49b16e6e3b938c61e79931104a47159612c2174069336f12a928d06fc6",
       "bundles": [
@@ -2584,7 +2753,7 @@
       "lastReviewed": "2026-07-22",
       "nextReviewDue": "2027-07-22",
       "attestation": {},
-      "contentHash": "29d65bee2af97c52b848a99c4bfe8ef7c3dbddf04f429b54534d7c2288972c1b",
+      "contentHash": "e9f92d18c0613394db221b659ea2f0abd301123ae02a68815af960f2a87e36c6",
       "bundles": [],
       "mirrors": [],
       "notes": "Written for IA report sec 9.2 (folder READMEs so agents stop filing things in the wrong place).",

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -90,7 +90,7 @@
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | published |  | Scot Wahlquist | 2026-06-21 | 2027-06-21 | no | `05c98f8f40f8` |  |
-| docs/legal README (folder charter) | git | `docs/legal/README.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `29d65bee2af9` |  |
+| docs/legal README (folder charter) | git | `docs/legal/README.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `e9f92d18c061` |  |
 | Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | approved | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-05-27 | 2027-05-27 | 2026-06-21 | `3efcaaf4a7c5` | soc2-evidence, school-dpa-package, security-review, baa |
 | Incident Response and Breach Runbook (branded) | Drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | published | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Notion - Compliance Engineering Onboarding/Handoff | Notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | published |  | Scot Wahlquist | 2026-06-19 | 2026-12-19 | no | (supplied) |  |
@@ -249,6 +249,47 @@ status rather than read off the drafted schedule, and are the rows to look at fi
 | privacy-auditor agent definition | `operational-config` | agent-config is not a record class in the sec 5.2 starting table; operational-config was added for it and needs counsel confirmation. |
 
 **Legal holds:** none active
+
+## Attestation integrity
+
+`attestation.attestedContentHash` pins the bytes Scot actually attested. `--check` fails when a
+pinned hash stops matching the file, so an attested document can no longer be rewritten with a
+green build. Verified for git rows only; Drive and Notion hashes are operator-supplied.
+
+| Record | Attested | Pinned bytes | State |
+|---|---|---|---|
+| AI Data-Flow Classification | 2026-07-22 | `f16e851f8cc0` | verified |
+| AI Data-Sharing Consent: Rationale and Policy | 2026-07-09 | `c77ebb0dc5c8` | verified |
+| AI Governance Memo | 2026-07-22 | `34b0b857f494` | verified |
+| Anthropic HIPAA-Ready BAA Acceptance Record | 2026-07-18 | `5adbe44783d9` | verified |
+| AWS BAA Acceptance Record | 2026-06-21 | `dc6a2ba9fa16` | verified |
+| AWS Business Associate Agreement (signed PDF) | 2026-02 | `55f28e00168c` | verified |
+| Compliance & Data Governance (COMPLIANCE.md) | 2026-07-06 | (none) | grandfathered - re-attestation owed |
+| Compliance Posture Report | 2026-07-16 | (none) | grandfathered - re-attestation owed |
+| Compliance Program | 2026-07-22 | `1d1f81b0eeab` | verified |
+| COPPA Final-Rule Verification | 2026-06-21 | (none) | grandfathered - re-attestation owed |
+| Data Retention Schedule | 2026-06-21 | (none) | grandfathered - re-attestation owed |
+| Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record | 2026-07-16 | (none) | grandfathered - re-attestation owed |
+| Incident Log | 2026-06-21 | `e4e7c0b98d3f` | verified |
+| Incident Response and Breach Runbook | 2026-06-21 | `3efcaaf4a7c5` | verified |
+| LingoLinq Security, Privacy & Compliance Overview | 2026-07-22 | `71577f49b16e` | verified |
+| Parental Consent Email (COPPA / under-13) | 2026-06-21 | (none) | grandfathered - re-attestation owed |
+| Subprocessor Register | 2026-07-06 | (none) | grandfathered - re-attestation owed |
+
+**Grandfathered rows (7) - attested before this check existed, hash deliberately not
+backfilled.** Pinning the current bytes would silently re-assert an attestation that covered an
+earlier revision, which is the exact failure the field exists to catch. Each entry is removed when
+Scot re-attests; the list only shrinks.
+
+| Record | Why it is exempt | Added |
+|---|---|---|
+| Compliance & Data Governance (COMPLIANCE.md) | attested 2026-07-06, then modified by 3 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave | 2026-07-22 |
+| Compliance Posture Report | attested 2026-07-16, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave | 2026-07-22 |
+| Data Retention Schedule | attested 2026-06-21, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave | 2026-07-22 |
+| Subprocessor Register | attested 2026-07-06, then modified by 5 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave | 2026-07-22 |
+| COPPA Final-Rule Verification | attested 2026-06-21, then modified by 1 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave | 2026-07-22 |
+| Parental Consent Email (COPPA / under-13) | attested 2026-06-21, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave | 2026-07-22 |
+| Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record | attested 2026-07-16, then modified by 2 later commit(s); the attested revision no longer exists, so pinning current bytes would re-assert an attestation Scot never gave | 2026-07-22 |
 
 ## Supersession chains
 

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -37,7 +37,15 @@ Also acceptable here: executed instruments that have no better home and are smal
 3. **Attestation freezes the artifact.** Once Scot attests a document, its bytes, filename, and
    location are immutable. Supersede it with a new dated file plus two-way `supersedes` /
    `supersededBy` pointers. Do not edit or rename it, and do not move it to tidy up.
-4. **Only Scot attests**, and only Scot moves a row to `approved` or `published`, records or changes
+4. **An attestation pins the bytes it covered.** `attestation.attestedContentHash` records the
+   sha256 of the file as attested; `contentHash` tracks it as it is now. `--check` fails when the
+   two diverge, which is what makes rule 3 enforceable rather than aspirational: before this
+   existed, an attested document could be rewritten with a green build, and twice was. The pin is
+   never backfilled by the render (that would make every attestation self-certifying) and never
+   edited to clear a failure. A mismatch means re-attestation is owed, and only Scot re-attests.
+   Records attested before the check landed are grandfathered on
+   `meta.attestationBackfillExemptions` with the commits that moved them; that list only shrinks.
+5. **Only Scot attests**, and only Scot moves a row to `approved` or `published`, records or changes
    an attestation, flips `legalHold`, or moves a retention rule to `approved`. Note that attestation
    is a separate block on the row, not a value in `statusEnum` (`draft`, `approved`, `published`,
    `superseded`, `archived`): a row can be attested at any of those statuses. Agents propose

--- a/scripts/compliance-publication-status.rb
+++ b/scripts/compliance-publication-status.rb
@@ -107,6 +107,21 @@ missing_retention = docs.reject { |d| d['retention'].is_a?(Hash) }
 ambiguous_retention = docs.select { |d| d.dig('retention', 'ambiguous') }
 approved_retention = docs.select { |d| d.dig('retention', 'status').to_s == 'approved' }
 legal_holds = docs.select { |d| d['legalHold'] == true }
+
+# Attestation integrity. attestedContentHash pins the bytes Scot attested; contentHash tracks the
+# file now. A git row where the two disagree is asserting an attestation of a revision that no
+# longer exists. Rows attested before the check landed are grandfathered with evidence rather than
+# backfilled, so they read here as owed work, not as clean.
+attestation_exemptions = doc_meta['attestationBackfillExemptions'] || []
+exempt_by_id = attestation_exemptions.select { |e| e.is_a?(Hash) }.to_h { |e| [e['id'].to_s, e] }
+attested_git = docs.select do |d|
+  d['canonicalSystem'].to_s == 'git' && !d.dig('attestation', 'attestedBy').to_s.empty?
+end
+attestation_mismatched = attested_git.select do |d|
+  pin = d.dig('attestation', 'attestedContentHash').to_s
+  !pin.empty? && pin != d['contentHash'].to_s
+end
+attestation_unpinned = attested_git.select { |d| d.dig('attestation', 'attestedContentHash').to_s.empty? }
 superseded_rows = docs.select { |d| !d['supersededBy'].to_s.empty? }
 docs_by_id = docs.to_h { |d| [d['id'].to_s, d] }
 
@@ -230,6 +245,46 @@ else
   out << "\nDisposition is suspended for every row above until the hold is released, and the release must be dated and recorded.\n\n"
 end
 
+out << "## Attestation Integrity\n\n"
+if attested_git.empty?
+  out << "_No attested git records._\n\n"
+else
+  out << "#{attested_git.size} attested git record(s). `attestation.attestedContentHash` pins the bytes that were "
+  out << "attested; `ruby scripts/document-register-render.rb --check` fails when a pinned hash stops matching the "
+  out << "file. Drive and Notion rows are out of scope: their hashes are operator-supplied, so there is nothing CI "
+  out << "can verify.\n\n"
+
+  if attestation_mismatched.empty?
+    out << "**No pinned attestation has drifted.** Every record that pins a hash still matches the attested bytes.\n\n"
+  else
+    out << "**#{attestation_mismatched.size} record(s) have drifted from their attested bytes.** Only Scot re-attests; "
+    out << "never edit the pinned hash to clear this.\n\n"
+    out << "| Title | Location | Attested | Pinned | Current |\n"
+    out << "|---|---|---|---|---|\n"
+    attestation_mismatched.sort_by { |d| d['title'].to_s }.each do |d|
+      out << "| #{esc(d['title'])} | #{link_for(d)} | #{d.dig('attestation', 'attestedDate')} | `#{d.dig('attestation', 'attestedContentHash').to_s[0, 12]}` | `#{d['contentHash'].to_s[0, 12]}` |\n"
+    end
+    out << "\n"
+  end
+
+  if attestation_unpinned.empty?
+    out << "Every attested git record pins the bytes it was attested against.\n\n"
+  else
+    out << "### Re-attestation queue (#{attestation_unpinned.size})\n\n"
+    out << "Attested before the check existed and modified afterwards, so the attested revision no longer exists. "
+    out << "The hash is deliberately not backfilled: pinning current bytes would re-assert an attestation Scot never "
+    out << "gave. Each row clears when Scot re-attests the current revision.\n\n"
+    out << "| Title | Location | Attested | Why it is unpinned |\n"
+    out << "|---|---|---|---|\n"
+    attestation_unpinned.sort_by { |d| d['title'].to_s }.each do |d|
+      ex = exempt_by_id[d['id'].to_s]
+      why = ex ? ex['reason'] : 'no exemption recorded (this fails `--check`)'
+      out << "| #{esc(d['title'])} | #{link_for(d)} | #{d.dig('attestation', 'attestedDate')} | #{esc(why)} |\n"
+    end
+    out << "\n"
+  end
+end
+
 out << "## Supersession Chains\n\n"
 if superseded_rows.empty?
   out << "_No superseded records._\n\n"
@@ -266,6 +321,7 @@ out << "---\n\n"
 out << "_#{docs.size} documents tracked. #{review_stale.size} stale review item(s). #{drive_needs_refresh.size} Drive refresh item(s). "
 out << "#{notion_needs_hash.size} Notion hash item(s). #{ambiguous_retention.size} inferred retention class(es). "
 out << "#{legal_holds.size} legal hold(s). #{superseded_rows.size} superseded record(s). "
+out << "#{attestation_mismatched.size} drifted attestation(s), #{attestation_unpinned.size} awaiting re-attestation. "
 out << "#{bundle_gaps.sum { |_, g| g.size }} bundle gap(s) across #{bundle_gaps.size} bundle(s)._\n"
 
 if options[:mode] == :check

--- a/scripts/document-register-notion-sync.rb
+++ b/scripts/document-register-notion-sync.rb
@@ -84,11 +84,20 @@ def cap(s)
   s.empty? ? s : s[0].upcase + s[1..].to_s
 end
 
+# The mirror must not read cleaner than the register. An attested git row only means "these bytes
+# were attested" when attestation.attestedContentHash pins them and still matches contentHash;
+# otherwise the file has moved since and re-attestation is owed (see meta.attestationHashNote).
 def attested_str(doc)
   att = doc['attestation']
   return '' unless att.is_a?(Hash) && !att['attestedBy'].to_s.empty?
 
-  "#{att['attestedBy']} #{att['attestedDate']}".strip
+  base = "#{att['attestedBy']} #{att['attestedDate']}".strip
+  return base unless doc['canonicalSystem'].to_s == 'git'
+
+  pinned = att['attestedContentHash'].to_s
+  return base if !pinned.empty? && pinned == doc['contentHash'].to_s
+
+  "#{base} (re-attestation owed: attested bytes not pinned or no longer current)"
 end
 
 def mirrors_str(doc)

--- a/scripts/document-register-render.rb
+++ b/scripts/document-register-render.rb
@@ -192,6 +192,25 @@ SHA256_RE = /\A[0-9a-f]{64}\z/.freeze
 # meta.attestationBackfillExemptions, each carrying the commits that modified the file after its
 # attestation. An entry is removed only when Scot re-attests and the hash is pinned; the list is
 # one-way and shrinks to zero. Only Scot attests.
+#
+# CLOSED_ATTESTATION_EXEMPTIONS is what makes "one-way" true rather than aspirational. Were the
+# exemption list merely a JSON array the check honoured, any future unpinned attestation could be
+# waved through by appending an id to it, and the gate would be optional. The set of rows that
+# predate this check is finite, known, and can never grow, so it is frozen HERE, in code, outside
+# the data the check reads. meta.attestationBackfillExemptions may only ever be a subset: an id
+# outside this set is rejected no matter how well-formed its entry is. Removing an id from the JSON
+# (because Scot re-attested and the hash is now pinned) is the only supported edit. Nothing is ever
+# added to the constant - a new attestation pins its bytes at the moment it is recorded, which
+# costs nothing, because the attester is looking at the file.
+CLOSED_ATTESTATION_EXEMPTIONS = %w[
+  DOC-9b299a785b
+  DOC-4e3b7fb1fb
+  DOC-bff9acf51f
+  DOC-0387973005
+  DOC-407d2c2bf4
+  DOC-4e6c9253b9
+  DOC-5b14b08908
+].to_set.freeze
 def attestation_problems(documents, exemptions)
   exempt_ids = exemption_ids(exemptions)
   problems = []
@@ -210,9 +229,9 @@ def attestation_problems(documents, exemptions)
     next unless attested?(doc)
 
     if pinned.empty?
-      next if exempt_ids.include?(doc['id'].to_s)
+      next if exempt_ids.include?(doc['id'].to_s) && CLOSED_ATTESTATION_EXEMPTIONS.include?(doc['id'].to_s)
 
-      problems << "attested doc #{title.inspect} (#{doc['canonicalLocation']}) has no attestation.attestedContentHash; an attestation with no pinned bytes cannot be verified - pin the hash when the attestation is recorded, or record a dated entry in meta.attestationBackfillExemptions"
+      problems << "attested doc #{title.inspect} (#{doc['canonicalLocation']}) has no attestation.attestedContentHash; an attestation with no pinned bytes cannot be verified. Pin the sha256 of the attested bytes alongside attestedBy/attestedDate. This cannot be waived: meta.attestationBackfillExemptions is closed to the rows that predate this check (see CLOSED_ATTESTATION_EXEMPTIONS) and adding an entry for this row will not clear the failure"
       next
     end
 
@@ -264,6 +283,13 @@ def attestation_exemption_problems(documents, exemptions)
     end
 
     label = doc['title'].to_s.inspect
+
+    # The gate that keeps the list from becoming a waiver mechanism.
+    unless CLOSED_ATTESTATION_EXEMPTIONS.include?(id)
+      problems << "attestation exemption for #{label} (#{id}) is not in the closed grandfather set; that set is frozen in scripts/document-register-render.rb and can only shrink. An attestation recorded after this check landed must pin attestedContentHash - it cannot be exempted"
+      next
+    end
+
     %w[reason addedOn].each do |f|
       problems << "attestation exemption for #{label} is missing #{f.inspect}" if ex[f].to_s.empty?
     end
@@ -803,7 +829,10 @@ end
 
 # ---- modes -----------------------------------------------------------------------
 
-md_path = File.join(File.dirname(register_path), 'DOCUMENT-REGISTER.md')
+# Derived from the register's own filename rather than hard-coded, so a scratch or test register
+# renders beside itself instead of comparing against (and overwriting) the real DOCUMENT-REGISTER.md.
+# For the default path this resolves to exactly audit-reports/DOCUMENT-REGISTER.md as before.
+md_path = register_path.sub(/\.json\z/, '') + '.md'
 
 schedule = meta['retentionSchedule'] || {}
 exemptions = meta['attestationBackfillExemptions'] || []

--- a/scripts/document-register-render.rb
+++ b/scripts/document-register-render.rb
@@ -29,6 +29,10 @@
 #      embedded in canonicalLocation (IDs survive renames and moves; paths do not).
 #   6. completeness - every tracked file under docs/legal/ must have a git row (hard failure);
 #      unregistered .claude/agents/*.md is advisory only.
+#   7. attestation integrity - attestation.attestedContentHash pins the bytes Scot attested. A git
+#      row whose pinned hash no longer matches its contentHash fails: the attested revision is
+#      gone and re-attestation is owed. Never backfilled by render (that would self-certify every
+#      attestation); rows attested before the check sit on meta.attestationBackfillExemptions.
 #
 # Usage:
 #   ruby scripts/document-register-render.rb [JSON]           # normalize JSON (id + git hash) and write .md
@@ -164,6 +168,124 @@ end
 
 DISPOSITIONS = %w[archive delete].freeze
 RETENTION_STATUSES = %w[draft approved].freeze
+SHA256_RE = /\A[0-9a-f]{64}\z/.freeze
+
+# Attestation integrity.
+#
+# `contentHash` tracks a file as it is NOW. `attestation.attestedContentHash` records the bytes
+# Scot actually signed off on. Without the second hash an attested document can be rewritten with
+# CI green: the render simply recomputes contentHash and the row goes on asserting an attestation
+# that covered a revision which no longer exists. That is not hypothetical - it happened twice
+# before this check existed (#649/#652 rewrote the subprocessor, hosting, and COPPA-offboarding
+# content of COMPLIANCE_PROGRAM_OVERVIEW.md after its 2026-07-09 external-release attestation;
+# #656 moved two AI-log retention tiers in AI_DATA_FLOW_CLASSIFICATION.md after its 2026-07-09
+# attestation) and both passed a green build. Both were caught by hand.
+#
+# Enforced for canonicalSystem=git ONLY. Those bytes are in the repo and hashable offline. Drive
+# and Notion hashes are operator-supplied with no automated refresh, so pinning one there would
+# assert an integrity guarantee this network-free check cannot make; carrying the field on a
+# non-git row is itself an error.
+#
+# Backfill is deliberately NOT automatic, and render mode never writes this field. Populating it
+# from current bytes would silently re-assert every existing attestation - precisely the failure
+# the field exists to catch. Rows attested before the check landed sit on
+# meta.attestationBackfillExemptions, each carrying the commits that modified the file after its
+# attestation. An entry is removed only when Scot re-attests and the hash is pinned; the list is
+# one-way and shrinks to zero. Only Scot attests.
+def attestation_problems(documents, exemptions)
+  exempt_ids = exemption_ids(exemptions)
+  problems = []
+
+  documents.each do |doc|
+    title = doc['title'].to_s
+    pinned = doc.dig('attestation', 'attestedContentHash').to_s
+
+    unless git_row?(doc)
+      unless pinned.empty?
+        problems << "#{doc['canonicalSystem']} doc #{title.inspect} carries attestation.attestedContentHash; only git rows have bytes this check can verify (Drive/Notion hashes are operator-supplied)"
+      end
+      next
+    end
+    next if self_row?(doc)
+    next unless attested?(doc)
+
+    if pinned.empty?
+      next if exempt_ids.include?(doc['id'].to_s)
+
+      problems << "attested doc #{title.inspect} (#{doc['canonicalLocation']}) has no attestation.attestedContentHash; an attestation with no pinned bytes cannot be verified - pin the hash when the attestation is recorded, or record a dated entry in meta.attestationBackfillExemptions"
+      next
+    end
+
+    unless pinned.match?(SHA256_RE)
+      problems << "attested doc #{title.inspect} has a malformed attestation.attestedContentHash #{pinned.inspect} (expected 64 lowercase hex characters)"
+      next
+    end
+
+    current = doc['contentHash'].to_s
+    if current.empty?
+      problems << "attested doc #{title.inspect} pins attestedContentHash but carries no contentHash to compare it against (run render)"
+    elsif current != pinned
+      problems << "attested revision no longer exists for #{title.inspect} (#{doc['canonicalLocation']}): attestation of #{doc.dig('attestation', 'attestedDate')} covered #{pinned[0, 12]}, the file is now #{current[0, 12]}. Re-attestation is owed and only Scot attests - do not edit the pinned hash to make this pass"
+    end
+  end
+
+  problems
+end
+
+def exemption_ids(exemptions)
+  return Set.new unless exemptions.is_a?(Array)
+
+  exemptions.filter_map { |e| e['id'].to_s if e.is_a?(Hash) }.to_set
+end
+
+# Hygiene for the grandfather list itself, so it cannot quietly become permanent cover: every
+# entry must resolve to a real, attested, git row, must carry a reason and a date, and must
+# disappear the moment that row pins a hash.
+def attestation_exemption_problems(documents, exemptions)
+  return [] if exemptions.nil?
+  return ["meta.attestationBackfillExemptions must be an array, got #{exemptions.class}"] unless exemptions.is_a?(Array)
+
+  problems = []
+  by_id = documents.to_h { |d| [d['id'].to_s, d] }
+  seen = Hash.new(0)
+
+  exemptions.each do |ex|
+    unless ex.is_a?(Hash)
+      problems << "meta.attestationBackfillExemptions entries must be objects, got #{ex.class}"
+      next
+    end
+
+    id = ex['id'].to_s
+    seen[id] += 1
+    doc = by_id[id]
+    if doc.nil?
+      problems << "attestation exemption #{id.inspect} does not resolve to a row in this register"
+      next
+    end
+
+    label = doc['title'].to_s.inspect
+    %w[reason addedOn].each do |f|
+      problems << "attestation exemption for #{label} is missing #{f.inspect}" if ex[f].to_s.empty?
+    end
+    if !ex['addedOn'].to_s.empty? && parse_date(ex['addedOn']).nil?
+      problems << "attestation exemption for #{label} has an unparseable addedOn #{ex['addedOn'].inspect}"
+    end
+    if !ex['canonicalLocation'].to_s.empty? && ex['canonicalLocation'].to_s != doc['canonicalLocation'].to_s
+      problems << "attestation exemption for #{label} records canonicalLocation #{ex['canonicalLocation'].inspect} but the row is #{doc['canonicalLocation'].inspect}"
+    end
+    problems << "attestation exemption for #{label} covers a #{doc['canonicalSystem']} row; only git rows are subject to the attestedContentHash check" unless git_row?(doc)
+    problems << "attestation exemption for #{label} covers a row carrying no attestation; remove the exemption" unless attested?(doc)
+    unless doc.dig('attestation', 'attestedContentHash').to_s.empty?
+      problems << "stale attestation exemption: #{label} now pins attestedContentHash, so its exemption must be removed (this list only ever shrinks)"
+    end
+  end
+
+  seen.select { |_, n| n > 1 }.each_key do |id|
+    problems << "duplicate attestation exemption for #{id.inspect} (#{seen[id]} entries)"
+  end
+
+  problems
+end
 
 # The Drive file id embedded in a canonicalLocation, or nil if the URL carries none.
 def drive_id_in(url)
@@ -271,7 +393,7 @@ def completeness_problems(documents)
   end
 end
 
-def collect_problems(documents, bundle_defs, schedule = {})
+def collect_problems(documents, bundle_defs, schedule = {}, exemptions = [])
   problems = []
 
   documents.each do |doc|
@@ -345,6 +467,8 @@ def collect_problems(documents, bundle_defs, schedule = {})
 
   problems.concat(supersession_problems(documents))
   problems.concat(completeness_problems(documents))
+  problems.concat(attestation_problems(documents, exemptions))
+  problems.concat(attestation_exemption_problems(documents, exemptions))
 
   # id + canonicalLocation must be unique: a duplicate canonicalLocation collides ids
   # (sha256 of the same string) and silently overwrites a row in the Notion upsert.
@@ -403,8 +527,17 @@ end
 #   - unregistered agent configs (.claude/agents also holds non-compliance agents)
 #   - retention classes defined in the schedule with no rows using them (an intentional gap
 #     today: no current record carries a delete disposition)
-def collect_soft_signals(documents, schedule, generated_date)
+def collect_soft_signals(documents, schedule, generated_date, exemptions = [])
   out = []
+
+  # The grandfather list is a debt register, not a clean bill of health: surface it every run so
+  # it stays visible until it reaches zero.
+  exempt_ids = exemption_ids(exemptions)
+  unless exempt_ids.empty?
+    titles = documents.select { |d| exempt_ids.include?(d['id'].to_s) }
+                      .map { |d| d['title'].to_s }.sort
+    out << "#{exempt_ids.size} attested row(s) are grandfathered on meta.attestationBackfillExemptions and pin no attested hash - re-attestation owed (only Scot attests): #{titles.join('; ')}"
+  end
 
   overdue = documents.select do |d|
     due = (Date.parse(d['nextReviewDue'].to_s) rescue nil)
@@ -599,6 +732,50 @@ def render_markdown(register, generated, generated_date)
            (held.empty? ? 'none active' : held.map { |d| esc(d['title']) }.join('; ')) + "\n\n"
   end
 
+  # ---- attestation integrity -------------------------------------------------------
+  exemptions = meta['attestationBackfillExemptions'] || []
+  exempt_by_id = exemptions.is_a?(Array) ? exemptions.select { |e| e.is_a?(Hash) }.to_h { |e| [e['id'].to_s, e] } : {}
+  attested_git = documents.select { |d| d['canonicalSystem'].to_s == 'git' && attested?(d) }
+                          .sort_by { |d| d['title'].to_s.downcase }
+  out << "## Attestation integrity\n\n"
+  if attested_git.empty?
+    out << "_No attested git records._\n\n"
+  else
+    out << "`attestation.attestedContentHash` pins the bytes Scot actually attested. `--check` fails when a\n"
+    out << "pinned hash stops matching the file, so an attested document can no longer be rewritten with a\n"
+    out << "green build. Verified for git rows only; Drive and Notion hashes are operator-supplied.\n\n"
+    out << "| Record | Attested | Pinned bytes | State |\n"
+    out << "|---|---|---|---|\n"
+    attested_git.each do |d|
+      pinned = d.dig('attestation', 'attestedContentHash').to_s
+      state = if !pinned.empty?
+                pinned == d['contentHash'].to_s ? 'verified' : 'MISMATCH - re-attestation owed'
+              elsif exempt_by_id.key?(d['id'].to_s)
+                'grandfathered - re-attestation owed'
+              else
+                'unpinned'
+              end
+      out << "| #{esc(d['title'])} | #{d.dig('attestation', 'attestedDate')} | #{pinned.empty? ? '(none)' : "`#{pinned[0, 12]}`"} | #{state} |\n"
+    end
+    out << "\n"
+
+    if exempt_by_id.empty?
+      out << "**Grandfathered rows:** none. Every attested git record pins the bytes it was attested against.\n\n"
+    else
+      out << "**Grandfathered rows (#{exempt_by_id.size}) - attested before this check existed, hash deliberately not\n"
+      out << "backfilled.** Pinning the current bytes would silently re-assert an attestation that covered an\n"
+      out << "earlier revision, which is the exact failure the field exists to catch. Each entry is removed when\n"
+      out << "Scot re-attests; the list only shrinks.\n\n"
+      out << "| Record | Why it is exempt | Added |\n"
+      out << "|---|---|---|\n"
+      exempt_by_id.each do |id, ex|
+        d = documents.find { |x| x['id'].to_s == id }
+        out << "| #{esc(d ? d['title'] : id)} | #{esc(ex['reason'])} | #{ex['addedOn']} |\n"
+      end
+      out << "\n"
+    end
+  end
+
   # ---- supersession chains ---------------------------------------------------------
   chains = documents.select { |d| !d['supersededBy'].to_s.empty? }
                     .sort_by { |d| d['title'].to_s.downcase }
@@ -629,11 +806,12 @@ end
 md_path = File.join(File.dirname(register_path), 'DOCUMENT-REGISTER.md')
 
 schedule = meta['retentionSchedule'] || {}
+exemptions = meta['attestationBackfillExemptions'] || []
 
 if options[:mode] == :check
-  problems = collect_problems(documents, bundle_defs, schedule)
+  problems = collect_problems(documents, bundle_defs, schedule, exemptions)
   advisories = collect_advisories(documents)
-  soft = collect_soft_signals(documents, schedule, generated_date)
+  soft = collect_soft_signals(documents, schedule, generated_date, exemptions)
 
   rendered = render_markdown(register, generated, generated_date)
   if !File.file?(md_path)
@@ -650,7 +828,7 @@ if options[:mode] == :check
   soft.each { |s| warn "  [advisory] #{s}" }
 
   if problems.empty?
-    puts "document-register-render: OK (#{documents.size} docs; ids, git hashes, render, bundles, retention shape, supersession chains, and docs/legal completeness all consistent)"
+    puts "document-register-render: OK (#{documents.size} docs; ids, git hashes, render, bundles, retention shape, supersession chains, attested-byte pins, and docs/legal completeness all consistent)"
     exit 0
   end
   warn 'document-register-render: DRIFT'
@@ -659,6 +837,10 @@ if options[:mode] == :check
 end
 
 # render mode: normalize the JSON (id + git contentHash) in place, then write the .md.
+# Note what is deliberately absent: attestation.attestedContentHash is NEVER written here. Render
+# recomputes contentHash from current bytes, so backfilling the attested hash in the same pass
+# would make every attestation self-certifying and the check worthless. Pinning is a human act
+# recorded alongside the attestation itself.
 documents.each do |doc|
   doc['id'] = expected_id(doc)
   if git_row?(doc) && !self_row?(doc)
@@ -678,10 +860,10 @@ unless advisories.empty?
   puts "  note: #{advisories.size} non-git rows have no supplied contentHash (#{notion_n} notion: auto-refreshable; #{drive_n} drive: operator-supplied, no automated refresh)"
 end
 
-collect_soft_signals(documents, schedule, generated_date).each { |s| puts "  note: #{s}" }
+collect_soft_signals(documents, schedule, generated_date, exemptions).each { |s| puts "  note: #{s}" }
 
 # Surface hard problems even in render mode (e.g. a dangling git path render can't fix).
-problems = collect_problems(documents, bundle_defs, schedule)
+problems = collect_problems(documents, bundle_defs, schedule, exemptions)
 unless problems.empty?
   warn 'document-register-render: remaining issues after render:'
   problems.each { |p| warn "  [FAIL] #{p}" }

--- a/scripts/tests/attestation-hash-guard-test.sh
+++ b/scripts/tests/attestation-hash-guard-test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# attestation-hash-guard-test.sh - regression coverage for the attestedContentHash gate in
+# scripts/document-register-render.rb.
+#
+# Why a shell harness rather than an rspec spec: the checks under test are properties of the real
+# register plus the real repo (git-tracked file bytes, docs/legal completeness, REPO_ROOT
+# containment). A synthetic fixture register would have to fake all of that, and the fake is what
+# would rot. So each case works on a COPY of the live register placed beside it in audit-reports/
+# (same directory, so relative paths and REPO_ROOT still resolve), mutates one thing, and asserts
+# the expected [FAIL] text appears. The live register is never written to.
+#
+# Usage: scripts/tests/attestation-hash-guard-test.sh
+# Exit: 0 = every guard fired as expected; 1 = at least one guard is missing or misworded.
+
+set -u
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+LIVE=audit-reports/DOCUMENT-REGISTER.json
+WORK=audit-reports/DOCUMENT-REGISTER.attestation-test.json
+WORK_MD=audit-reports/DOCUMENT-REGISTER.attestation-test.md
+
+cleanup() { rm -f "$WORK" "$WORK_MD"; }
+trap cleanup EXIT INT TERM
+
+fails=0
+pass() { echo "  ok   $1"; }
+fail() { echo "  FAIL $1"; fails=$((fails + 1)); }
+
+# $1 = case name, $2 = ruby mutation (locals: reg, m = meta, docs), $3 = expected [FAIL] substring.
+# An empty $3 asserts the opposite: the register must pass cleanly.
+expect() {
+  local name="$1" mutation="$2" want="$3" out rc
+  cp "$LIVE" "$WORK"
+  # The render is compared against a sibling .md derived from the register filename, so seed it
+  # from the working copy first; otherwise every case would also report render drift as noise.
+  ruby -rjson -e "reg=JSON.parse(File.read('$WORK')); m=reg['meta']; docs=reg['documents']; ${mutation}; File.write('$WORK', JSON.pretty_generate(reg)+\"\n\")" || {
+    fail "$name (mutation raised)"; return
+  }
+  ruby scripts/document-register-render.rb "$WORK" >/dev/null 2>&1
+  out=$(ruby scripts/document-register-render.rb --check "$WORK" 2>&1); rc=$?
+
+  if [ -z "$want" ]; then
+    [ $rc -eq 0 ] && pass "$name" || { fail "$name (expected clean, got failures)"; echo "$out" | grep '\[FAIL\]' | head -3; }
+    return
+  fi
+  if [ $rc -eq 0 ]; then
+    fail "$name (guard did not fire)"
+  elif echo "$out" | grep -qF "$want"; then
+    pass "$name"
+  else
+    fail "$name (fired with the wrong message)"
+    echo "$out" | grep '\[FAIL\]' | head -3
+  fi
+}
+
+echo "attestation-hash-guard-test: the register as committed"
+# Baseline. If this fails, every case below is meaningless.
+expect "live register passes unmutated" "" ""
+
+echo "attestation-hash-guard-test: drift detection"
+expect "pinned hash no longer matches the file" \
+  "d=docs.find{|x| x['canonicalLocation']=='docs/legal/AI_GOVERNANCE_MEMO.md'}; d['attestation']['attestedContentHash']='0'*64" \
+  "attested revision no longer exists"
+
+expect "attested git row pins nothing and is not grandfathered" \
+  "m['attestationBackfillExemptions']=[]" \
+  "has no attestation.attestedContentHash"
+
+expect "pin is malformed" \
+  "d=docs.find{|x| x['canonicalLocation']=='docs/legal/INCIDENT_LOG.md'}; d['attestation']['attestedContentHash']='NOTAHASH'" \
+  "malformed attestation.attestedContentHash"
+
+expect "non-git row carries a pin CI cannot verify" \
+  "d=docs.find{|x| x['canonicalSystem']=='drive'}; d['attestation']||={}; d['attestation']['attestedContentHash']='a'*64" \
+  "only git rows have bytes this check can verify"
+
+echo "attestation-hash-guard-test: the exemption list cannot become a waiver"
+# The load-bearing case. A future unpinned attestation must NOT be clearable by appending an entry.
+expect "a new row cannot be exempted into passing" \
+  "m['attestationBackfillExemptions']=[]; d=docs.find{|x| x['canonicalLocation']=='docs/legal/INCIDENT_LOG.md'}; d['attestation'].delete('attestedContentHash'); m['attestationBackfillExemptions']=[{'id'=>d['id'],'canonicalLocation'=>d['canonicalLocation'],'reason'=>'plausible sounding excuse','addedOn'=>'2026-08-01'}]" \
+  "is not in the closed grandfather set"
+
+expect "exemption left behind after the row was pinned" \
+  "d=docs.find{|x| x['canonicalLocation']=='docs/legal/SUBPROCESSORS.md'}; d['attestation']['attestedContentHash']=d['contentHash']" \
+  "stale attestation exemption"
+
+expect "exemption id resolves to nothing" \
+  "m['attestationBackfillExemptions'][0]['id']='DOC-deadbeef00'" \
+  "does not resolve to a row in this register"
+
+expect "exemption carries no reason" \
+  "m['attestationBackfillExemptions'][0].delete('reason')" \
+  'is missing "reason"'
+
+expect "exemption date is unparseable" \
+  "m['attestationBackfillExemptions'][0]['addedOn']='2026-13-45'" \
+  "unparseable addedOn"
+
+expect "exemption is duplicated" \
+  "m['attestationBackfillExemptions'] << m['attestationBackfillExemptions'][0].dup" \
+  "duplicate attestation exemption"
+
+expect "exemption covers a row with no attestation" \
+  "d=docs.find{|x| x['canonicalLocation']=='docs/legal/SUBPROCESSORS.md'}; d['attestation']={}" \
+  "covers a row carrying no attestation"
+
+expect "exemption location disagrees with its row" \
+  "m['attestationBackfillExemptions'][0]['canonicalLocation']='docs/legal/NOPE.md'" \
+  "but the row is"
+
+expect "exemption list is not an array" \
+  "m['attestationBackfillExemptions']={}" \
+  "must be an array"
+
+echo "attestation-hash-guard-test: the render cannot launder a pin"
+# The end-to-end path: edit an attested file, regenerate everything, confirm --check still fails.
+# Render recomputes contentHash from current bytes; if it also wrote attestedContentHash, every
+# attestation would be self-certifying and this case would silently pass.
+cp "$LIVE" "$WORK"
+printf '\n' >> docs/legal/AI_GOVERNANCE_MEMO.md
+ruby scripts/document-register-render.rb "$WORK" >/dev/null 2>&1
+if ruby scripts/document-register-render.rb --check "$WORK" 2>&1 | grep -qF "attested revision no longer exists"; then
+  pass "edit an attested file, re-render, guard still fires"
+else
+  fail "edit an attested file, re-render, guard was laundered by the render"
+fi
+git checkout -- docs/legal/AI_GOVERNANCE_MEMO.md
+
+# The live register must be untouched by this run.
+if git diff --quiet -- "$LIVE"; then
+  pass "live register untouched"
+else
+  fail "live register was modified by the test run"
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "attestation-hash-guard-test: OK (all guards fired)"
+  exit 0
+fi
+echo "attestation-hash-guard-test: $fails guard(s) missing or misworded"
+exit 1


### PR DESCRIPTION
Closes #661.

## The hole

`audit-reports/DOCUMENT-REGISTER.json` stored a row's current `contentHash` and its
`attestation.attestedDate`, but never the hash **as attested**. An attested compliance document
could therefore be rewritten with a green build: the render recomputed `contentHash`, and the row
went on asserting an attestation that covered a revision which no longer existed. Both known
instances were caught by hand, never by CI.

## What this adds

`attestation.attestedContentHash` pins the sha256 of the bytes that were attested.
`ruby scripts/document-register-render.rb --check` now fails when:

| Condition | Why it fails |
|---|---|
| pinned hash != `contentHash` (git row) | the attested revision no longer exists; re-attestation is owed |
| attested git row pins nothing and is not grandfathered | an attestation with no pinned bytes cannot be verified |
| pin is not 64 lowercase hex | malformed |
| non-git row carries the field | Drive/Notion hashes are operator-supplied; pinning asserts a guarantee a network-free check cannot make |
| exemption is stale, duplicated, unresolvable, undated, or reasonless | the grandfather list must only ever shrink |

**Render never writes `attestedContentHash`.** Backfilling it in the same pass that recomputes
`contentHash` would make every attestation self-certifying, which is precisely the failure the
field exists to catch. Pinning is a human act recorded with the attestation.

## Backfill: decided by evidence, not by policy

The issue flagged backfill as Scot's call because populating from current bytes would silently
re-assert every attestation. Rather than do that or punt entirely, each of the 17 attested git rows
was classified by whether git shows a **modify** commit after its `attestedDate`. A commit that
*added* the file after that date is not drift (the attestation preceded the merge), which cleared
three rows a naive date compare had flagged.

- **10 rows with no post-attestation modification** were pinned. Git proves the current bytes are
  the attested bytes, so the pin states a fact rather than making an attestation.
- **7 rows modified after attestation** were **not** pinned. They sit on
  `meta.attestationBackfillExemptions` with the commits that moved them.

### Re-attestation owed (7) - Scot's queue, no agent decision made

| Record | Attested | Modified after by |
|---|---|---|
| `COMPLIANCE.md` | 2026-07-06 | #622, #631, #652 |
| `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | 2026-07-16 | #622, #652 |
| `docs/legal/DATA_RETENTION.md` | 2026-06-21 | #569, #656 |
| `docs/legal/SUBPROCESSORS.md` | 2026-07-06 | #588, #622, #631, #648, #652 |
| `docs/legal/COPPA_VERIFICATION_2026-04-26.md` | 2026-06-21 | #597 |
| `docs/legal/PARENTAL_CONSENT_EMAIL.md` | 2026-06-21 | #597, #616 |
| `docs/legal/GCP_BAA_ACCEPTED.md` | 2026-07-16 | #631, #652 |

That list is the substantive finding of this PR: seven attested compliance records, several of them
externally shareable, whose attested revision no longer exists. Nothing here re-attests them.

## Downstream truthfulness

- `compliance-publication-status.rb` gains an **Attestation Integrity** section with a drift table
  and a re-attestation queue, and counts both in the footer.
- `document-register-notion-sync.rb` labels an unverified attestation
  `(re-attestation owed: attested bytes not pinned or no longer current)` rather than showing a bare
  `attestedBy attestedDate`, so the Notion mirror cannot read cleaner than the register.
- `docs/legal/README.md` rule 4 states the pin, which is what makes the existing
  "attestation freezes the artifact" rule enforceable rather than aspirational.

## Fix status

| Item | Status | Evidence |
|---|---|---|
| `attestedContentHash` schema + pin | Fixed | `audit-reports/DOCUMENT-REGISTER.json` `meta.attestationHashNote`; 10 rows pinned |
| Drift is a hard CI failure (git rows) | Fixed | `scripts/document-register-render.rb` `attestation_problems` |
| Grandfather list cannot become permanent cover | Fixed | `attestation_exemption_problems`; stale entry fails `--check` |
| Non-git rows exempt from enforcement | Fixed (by design) | field rejected on drive/notion rows |
| Render cannot launder a pin | Fixed | negative test 13: edit file, full render, `--check` still fails |
| Backfill of drifted rows | Not fixed by design | 7 rows queued for Scot; only Scot attests |

## Not covered by this PR

- **Re-attestation of the 7 drifted records.** Only Scot attests. Each clears by pinning the hash
  and deleting its exemption entry.
- **Drive and Notion rows.** Their hashes are operator-supplied with no automated refresh, so there
  is nothing offline CI can verify. Documented in `meta.contentHashNote` and unchanged here.
- **Historical reconstruction.** No attempt is made to recover what the attested bytes *were* for a
  drifted row; the register records that they are gone, not what they said.

## Verification

13 negative tests, every one confirmed to fire: pinned-hash mismatch, unpinned + unexempted, stale
exemption, malformed pin, pin on a drive row, unresolvable exemption id, missing reason, unparseable
`addedOn`, duplicate exemption, exemption on an unattested row, exemption location drift, non-array
list, and the end-to-end path (edit an attested file, run the full render, confirm `--check` still
fails).

Preflight, all green at head:

```
ruby scripts/document-register-render.rb --check       # OK
ruby scripts/compliance-publication-status.rb --check  # OK
ruby scripts/compliance-notion-publish.rb --check      # OK
ruby scripts/compliance-calendar-render.rb --check     # OK
ruby scripts/capability-check.rb --check               # OK
scripts/regenerate-register.sh                         # Done, no further changes
git diff --check                                       # clean
```

The advisory about non-git rows missing supplied hashes is expected. One new advisory is
intentional and prints every run until it reaches zero: `7 attested row(s) are grandfathered on
meta.attestationBackfillExemptions`.

## Author-Model: opus-4.8