### PR TITLE
test(env_wrap): scope ENV overrides to the block + faithful restore

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,15 +99,34 @@ RSpec.configure do |config|
 end
 
 def env_wrap(overrides, &block)
-  fallbacks = {}
-  overrides.each{|k, v| fallbacks[k] = ENV[k] }
-  before(:each) do
-    overrides.each{|k, v| ENV[k] = v }
+  # Run `block`'s examples with the given ENV overrides, then restore the prior state.
+  #
+  # Two isolation defects are fixed here vs the old implementation:
+  #   1. Scoping: the overrides now apply ONLY to the examples defined inside `block`,
+  #      by nesting them in their own example group. The old version attached its
+  #      before/after hooks to the *enclosing* group, so the overrides leaked into
+  #      every sibling example in that group.
+  #   2. Restore fidelity: the original values are captured at RUN time (inside the
+  #      around hook), not at spec-definition time, and a key that was originally
+  #      UNSET is deleted on teardown rather than left behind. The old version
+  #      snapshotted ENV once when the file loaded, so a value that changed between
+  #      load and run (e.g. via a prior env_wrap) was "restored" to a stale value.
+  unset = :__env_wrap_unset__
+  describe "with env: #{overrides.keys.sort.join(', ')}" do
+    around(:each) do |example|
+      originals = overrides.keys.each_with_object({}) do |k, h|
+        h[k] = ENV.key?(k) ? ENV[k] : unset
+      end
+      overrides.each { |k, v| ENV[k] = v }
+      begin
+        example.run
+      ensure
+        originals.each { |k, v| v.equal?(unset) ? ENV.delete(k) : ENV[k] = v }
+      end
+    end
+
+    instance_exec(&block)
   end
-  after(:each) do
-    fallbacks.each{|k, v| ENV[k] = v }
-  end
-  block.call
 end
 
 def write_this_test


### PR DESCRIPTION
## What & why
Tiny test-isolation fix for the `env_wrap` spec helper (flagged during the TTS security work, #667). Helper-only; no product code.

Two defects:
1. **Leak to siblings** — `env_wrap` attached its `before`/`after` hooks to the **enclosing** example group, so the ENV overrides applied to every sibling example in that group, not just the ones inside the block. (This is why a `GOOGLE_TTS_TOKEN` override leaked into a sibling "no token" test in `search_controller_spec`, which had to work around it.)
2. **Stale restore** — it snapshotted ENV once at spec-definition (file-load) time and "restored" an originally-**unset** key by setting it to `nil`.

## Fix
- Nest the block's examples in their own group so overrides are scoped to them only.
- Capture originals at **run** time in an `around(:each)`.
- **Delete** keys that were originally unset on teardown instead of leaving them set.

## Verification
All 10 `env_wrap`-using spec files pass: **545 examples, 0 failures**. No test relied on the old leak.

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| Overrides scoped to block | Fixed | `spec/spec_helper.rb` (nested group + `around`) |
| ENV restored faithfully (delete-on-unset, runtime capture) | Fixed | `spec/spec_helper.rb` |
| No regressions | Fixed | 10 files, 545 examples, 0 failures |

## Author-Model: opus-4.8