### PR TITLE
security: disable Irish TTS (Abair, no DPA) + remove client voice option

### DIFF
--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -335,14 +335,11 @@ class Api::SearchController < ApplicationController
     req = nil
     content_type = 'audio/wav'
     if params['locale'] && params['locale'].match(/^ga/)
-      req = Typhoeus.post("https://abair.ie/aac_irish", body: {text: params['text'], voice: params['voice_id'] || 'Ulster'}, timeout: 5)
-      if req.success?
-        # src = Nokogiri(req.body).css('audio source')[0]['src']
-        # req = Typhoeus.get("https://abair.ie#{src}")
-      else
-        return api_error 400, {error: 'endpoint failed to respond'}
-        req = nil
-      end
+      # Irish (Gaeilge) TTS via abair.ie is DISABLED. The Trinity College Dublin / ADAPT
+      # endpoint has no DPA/SCCs on file and would receive raw, unscrubbed user utterance
+      # text (finding LL-a167848115, docs/legal/SUBPROCESSORS.md #17). Disabled 2026-07-23
+      # per CEO decision rather than executing a DPA. Re-enable only once a DPA/SCCs exist.
+      return api_error 400, {error: 'irish tts disabled'}
     # elsif params['locale'] && params['locale'].match(/^uk/)
     #   req = Typhoeus.post("https://hf.space/gradioiframe/robinhad/ukrainian-tts/+/api/predict/", body: {data: [params['text'], "uk/mai/vits-tts"]}.to_json, headers: {'Content-Type': 'application/json'})
     #   json = JSON.parse(req.body) rescue nil

--- a/app/frontend/app/utils/speecher.js
+++ b/app/frontend/app/utils/speecher.js
@@ -197,12 +197,10 @@ var speecher = EmberObject.extend({
         voiceURI: "remote:uk-UA:female"
       });
     }
-    list.push({
-      name: i18n.t('irish_female_internet_required', "Irish Female *Internet Required*"),
-      lang: 'ga-IE',
-      remote_voice: true,
-      voiceURI: "remote:ga-IE:Ulster"
-    });
+    // Irish (ga-IE) remote voice removed: the server-side Abair TTS endpoint was disabled
+    // 2026-07-23 (no DPA -- finding LL-a167848115), so /api/v1/search/audio now returns 400
+    // for `ga` locales. Offering it here would give Irish users a voice that can never
+    // succeed. Restore this option only if Irish TTS is re-enabled behind a DPA/SCCs.
     if(add_low) {
       var locale = ((i18n.langs || {}).preferred || window.navigator.language).replace(/_/, '-');
       var loc = 'en-us';

--- a/lib/tts.rb
+++ b/lib/tts.rb
@@ -11,7 +11,11 @@ module Tts
       return nil if text.blank?
 
       if locale.to_s.match(/^ga/)
-        return generate_irish(text, locale)
+        # Irish (Gaeilge) TTS via abair.ie is DISABLED. The Trinity College Dublin / ADAPT
+        # endpoint has no DPA/SCCs on file and would receive raw, unscrubbed user utterance
+        # text (finding LL-a167848115, docs/legal/SUBPROCESSORS.md #17). Disabled 2026-07-23
+        # per CEO decision rather than executing a DPA. Re-enable only once a DPA/SCCs exist.
+        return nil
       end
 
       if ENV['GOOGLE_TTS_TOKEN']
@@ -25,20 +29,6 @@ module Tts
     end
 
     private
-
-    def generate_irish(text, locale)
-      req = Typhoeus.post(
-        'https://abair.ie/aac_irish',
-        body: { text: text, voice: 'Ulster' },
-        timeout: 5,
-        connecttimeout: 3
-      )
-      return nil unless req.success? && req.body.present?
-      {
-        body: req.body,
-        content_type: req.headers['Content-Type'].to_s.split(';').first.presence || 'audio/wav'
-      }
-    end
 
     def generate_google(text, locale: 'en', mp3: true)
       json = voices_for_locale(locale)

--- a/spec/controllers/api/search_controller_spec.rb
+++ b/spec/controllers/api/search_controller_spec.rb
@@ -760,11 +760,10 @@ describe Api::SearchController, :type => :controller do
       end
     end
 
-    it "should use the irish voice service" do
-      obj = OpenStruct.new(body: "<audio><source src='/abcde'/></audio>", headers: {'Content-Type' => 'audio/wav'})
-      expect(obj).to receive(:success?).and_return(true)
-      expect(Typhoeus).to receive(:post).with("https://abair.ie/aac_irish", body: {text: 'aha', voice: 'a1'}, timeout: 5).and_return(obj)
+    it "returns an error for Irish (ga) locales without calling Abair (disabled, no DPA -- LL-a167848115)" do
+      expect(Typhoeus).not_to receive(:post)
       get :audio, params: {locale: 'ga', text: 'aha', voice_id: 'a1'}
+      assert_error('irish tts disabled', 400)
     end
   end
 

--- a/spec/lib/tts_spec.rb
+++ b/spec/lib/tts_spec.rb
@@ -29,15 +29,9 @@ describe Tts do
       end
     end
 
-    it 'routes Irish (ga) locales to the Abair endpoint, not Google' do
-      obj = OpenStruct.new(body: 'irishaudio', headers: { 'Content-Type' => 'audio/wav' })
-      allow(obj).to receive(:success?).and_return(true)
-      expect(Typhoeus).to receive(:post).with(
-        'https://abair.ie/aac_irish',
-        hash_including(body: { text: 'Dia dhuit', voice: 'Ulster' })
-      ).and_return(obj)
-      res = Tts.generate_audio('Dia dhuit', locale: 'ga')
-      expect(res[:body]).to eq('irishaudio')
+    it 'returns nil for Irish (ga) locales without making any external call (Abair disabled, no DPA -- LL-a167848115)' do
+      expect(Typhoeus).not_to receive(:post)
+      expect(Tts.generate_audio('Dia dhuit', locale: 'ga')).to be_nil
     end
   end
 end


### PR DESCRIPTION
Code-only half of the Irish-TTS disable (split out from #673 so the diff is small and fully reviewable by the deep-pass gate).

## What
The Abair (`abair.ie`, Trinity College Dublin / ADAPT) Irish-language TTS flow had **no DPA/SCCs** and would receive raw, unscrubbed user utterance text. Per CEO decision it is **disabled** rather than executing a DPA. Google Cloud TTS has **no Irish (`ga-IE`) voice** ([Google supported voices](https://docs.cloud.google.com/text-to-speech/docs/list-voices-and-types)), so there is no covered drop-in replacement.

- `lib/tts.rb#generate_audio` -> returns `nil` for `ga` locales; dead `generate_irish` removed.
- `app/controllers/api/search_controller.rb#audio` -> returns `400 {error:'irish tts disabled'}` for `ga`.
- `app/frontend/app/utils/speecher.js` -> removed the `remote:ga-IE:Ulster` voice option (would otherwise offer a voice that now always 400s).
- Specs assert no external call (lib) and a 400 (API); board auto-sound already `next`s on a `nil` return.

## Companion PR
- **#673** carries the compliance-register disposition (findings triage + `SUBPROCESSORS.md`). Merge **this** PR first, then #673.

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| Irish TTS disabled (lib) | Fixed | `lib/tts.rb:13-19`; `spec/lib/tts_spec.rb` |
| Irish TTS disabled (API) | Fixed | `app/controllers/api/search_controller.rb:337-342`; `spec/controllers/api/search_controller_spec.rb` |
| Client no longer offers Irish voice | Fixed | `app/frontend/app/utils/speecher.js:200-203` |

## Not covered by this PR
- Compliance-register triage + subprocessor reconciliation -> #673.

## Author-Model: opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)