### PR TITLE
perf(speak): paint board-detail from root_only before full /tree warm

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -411,6 +411,10 @@ class Api::BoardsController < ApplicationController
   # Capped at MAX_TREE descendants for safety — a healthy AAC vocab
   # tree is well under that ceiling; extremely large trees fall back
   # to the depth-1 prefetch on the client.
+  #
+  # root_only=1 skips descendant load/serialize so speak-mode can paint
+  # the visible board first, then call /tree again (without root_only)
+  # in the background to warm folder targets. Same lite root JSON either way.
   MAX_TREE = 500
   def tree
     # Member route is GET /api/v1/boards/:board_id/tree, so Rails supplies
@@ -425,19 +429,22 @@ class Api::BoardsController < ApplicationController
     return unless exists?(root)
     return unless allowed?(root, 'view')
 
-    descendant_ids = ((root.settings || {})['downstream_board_ids'] || []).first(MAX_TREE)
+    root_only = params['root_only'].to_s =~ /^(1|true|yes)$/i
     descendants = []
-    if descendant_ids.any?
-      ApplicationRecord.using(:master) do
-        descendants = Board.find_all_by_global_id(descendant_ids)
+    unless root_only
+      descendant_ids = ((root.settings || {})['downstream_board_ids'] || []).first(MAX_TREE)
+      if descendant_ids.any?
+        ApplicationRecord.using(:master) do
+          descendants = Board.find_all_by_global_id(descendant_ids)
+        end
+        # Permission filter. Use the Permissable model method `allows?`
+        # directly — NOT the controller's `allowed?`, which renders an
+        # error response as a side effect (it's designed for single-
+        # resource gates, not list filtering). `scopes` mirrors what
+        # `allowed?` computes internally via `api_permission_scopes`.
+        scopes = api_permission_scopes
+        descendants = descendants.select { |b| b && b.allows?(@api_user, 'view', scopes) }
       end
-      # Permission filter. Use the Permissable model method `allows?`
-      # directly — NOT the controller's `allowed?`, which renders an
-      # error response as a side effect (it's designed for single-
-      # resource gates, not list filtering). `scopes` mirrors what
-      # `allowed?` computes internally via `api_permission_scopes`.
-      scopes = api_permission_scopes
-      descendants = descendants.select { |b| b && b.allows?(@api_user, 'view', scopes) }
     end
 
     # as_lite drops the per-board N+1 enrichment (parent_board, find_copies_by,

--- a/app/frontend/app/routes/user/board-detail.js
+++ b/app/frontend/app/routes/user/board-detail.js
@@ -9,6 +9,7 @@ import contentGrabbers from '../../utils/content_grabbers';
 import persistence from '../../utils/persistence';
 import capabilities from '../../utils/capabilities';
 import boardDetailCache from '../../utils/board_detail_cache';
+import boardCacheDiag from '../../utils/board_cache_diag';
 
 export default Route.extend({
   store: service('store'),
@@ -78,7 +79,13 @@ export default Route.extend({
     // (folder / load_board targets), then fetch JSON for any missing children.
     runLater(function() {
       if(controller.isDestroyed || controller.isDestroying || controller.get('edit_mode')) { return; }
+      var warm_started = Date.now();
+      boardCacheDiag.mark('warm_images:start', { key: raw && raw.key });
       boardDetailCache.warm_images(raw, warm_opts);
+      boardCacheDiag.mark('warm_images:dispatched', {
+        key: raw && raw.key,
+        ms: Date.now() - warm_started
+      });
     }, 100);
     runLater(function() {
       if(controller.isDestroyed || controller.isDestroying || controller.get('edit_mode')) { return; }
@@ -91,6 +98,7 @@ export default Route.extend({
     var user = this.modelFor('user');
     user.set('subroute_name', i18n.t('board_detail', "Board Detail"));
     var board_key = user.get('user_name') + '/' + params.boardname;
+    boardCacheDiag.mark('model:start', { board_key: board_key });
 
     // Cache-first: try the in-memory raw cache + Ember Data identity map
     // before hitting the network. Mirrors the cache-first pattern in
@@ -122,25 +130,22 @@ export default Route.extend({
         var hit_normalized = this.store.normalize('board', JSON.parse(JSON.stringify(cached_raw)));
         this.store.push(hit_normalized);
       } catch (e) { /* best-effort; serializer edge cases shouldn't block nav */ }
+      boardCacheDiag.span('model:start', 'model:cache_hit', {
+        board_key: board_key,
+        button_count: (cached_raw.buttons && cached_raw.buttons.length) || 0
+      });
       return RSVP.resolve(cached_record);
     }
 
-    // Cache miss — fetch via /api/v1/boards/:id/tree (root + every
-    // reachable descendant in one response). NO loading overlay: the
-    // grid renders as soon as the root is ready; descendants are
-    // cached + pushed to the Ember Data store as background work so
-    // every subsequent folder tap is a synchronous cache HIT (instant,
-    // no overlay, no network). Images warm in the background too.
-    //
-    // Resolve the route the moment the ROOT board is ready — we do
-    // NOT block on descendant caching or image preloads. Descendant
-    // work continues after resolve(); by the time the user reads the
-    // board and taps a folder, it's done.
-    //
-    // Fallback: if /tree fails (older deploy, network) we retry with
-    // the single-board endpoint so the page still works.
+    // Cache miss — two-phase load so large vocab trees do not block paint:
+    //   1) GET /tree?root_only=1 (lite root JSON only) → resolve + paint
+    //   2) GET /tree (full) in background → ingest descendants into
+    //      boardDetailCache + Ember Data for instant folder taps
+    // Fallback: if root_only fails, try show, then still warm full /tree.
+    boardCacheDiag.mark('model:cache_miss', { board_key: board_key });
     return new RSVP.Promise(function(resolve) {
-      var handleRoot = function(boardData) {
+      var resolved = false;
+      var handleRoot = function(boardData, source) {
         var raw_copy = JSON.parse(JSON.stringify(boardData));
         _this.set('_raw_board_data', raw_copy);
         // force: network response is authoritative for this navigation.
@@ -148,26 +153,71 @@ export default Route.extend({
         var store = _this.store;
         var normalized = store.normalize('board', boardData);
         var record = store.push(normalized);
-        // Image warm runs in _finalize_board_display for the visible board.
-        // Resolve immediately — grid renders now, no overlay.
-        resolve(record);
+        boardCacheDiag.span('model:start', 'model:root_ready', {
+          board_key: board_key,
+          source: source || 'tree',
+          button_count: (boardData.buttons && boardData.buttons.length) || 0
+        });
+        if (!resolved) {
+          resolved = true;
+          // Image warm runs in _finalize_board_display for the visible board.
+          resolve(record);
+        }
+        return record;
       };
 
-      var fallbackSingleBoard = function() {
-        persistence.ajax('/api/v1/boards/' + board_key, { type: 'GET' }).then(function(data) {
-          var boardData = boardDetailCache.normalize_board_payload(data);
-          if(boardData) {
-            handleRoot(boardData);
-          } else {
-            resolve({ error: true, boardname: params.boardname });
-          }
+      var warmFullTreeInBackground = function() {
+        var tree_started = Date.now();
+        boardCacheDiag.mark('model:background_tree_start', { board_key: board_key });
+        persistence.ajax('/api/v1/boards/' + board_key + '/tree', { type: 'GET' }).then(function(data) {
+          boardCacheDiag.mark('model:background_tree_response', {
+            board_key: board_key,
+            ms: Date.now() - tree_started,
+            descendant_count: (data && data.descendants && data.descendants.length) || 0
+          });
+          if (!data || !data.root || !data.root.board) { return; }
+          // Root is already painted/cached; do not force-replace it or
+          // re-warm its images. Descendants still get cached + pushed.
+          boardDetailCache.ingest_tree(data, null, {
+            force: false,
+            warm_root_images: false
+          });
+          boardCacheDiag.mark('model:descendants_cached', {
+            board_key: board_key,
+            descendant_count: (data.descendants && data.descendants.length) || 0
+          });
         }, function() {
-          resolve({ error: true, boardname: params.boardname });
+          boardCacheDiag.mark('model:background_tree_fail', { board_key: board_key });
         });
       };
 
-      persistence.ajax('/api/v1/boards/' + board_key + '/tree', { type: 'GET' }).then(function(data) {
-        if(!data || !data.root || !data.root.board) {
+      var fallbackSingleBoard = function() {
+        boardCacheDiag.mark('model:tree_fallback_show', { board_key: board_key });
+        persistence.ajax('/api/v1/boards/' + board_key, { type: 'GET' }).then(function(data) {
+          var boardData = boardDetailCache.normalize_board_payload(data);
+          if (boardData) {
+            handleRoot(boardData, 'show');
+            warmFullTreeInBackground();
+          } else if (!resolved) {
+            resolved = true;
+            resolve({ error: true, boardname: params.boardname });
+          }
+        }, function() {
+          if (!resolved) {
+            resolved = true;
+            resolve({ error: true, boardname: params.boardname });
+          }
+        });
+      };
+
+      var root_started = Date.now();
+      persistence.ajax('/api/v1/boards/' + board_key + '/tree?root_only=1', { type: 'GET' }).then(function(data) {
+        boardCacheDiag.mark('model:root_only_response', {
+          board_key: board_key,
+          ms: Date.now() - root_started,
+          descendant_count: (data && data.descendants && data.descendants.length) || 0
+        });
+        if (!data || !data.root || !data.root.board) {
           fallbackSingleBoard();
           return;
         }
@@ -176,27 +226,8 @@ export default Route.extend({
           fallbackSingleBoard();
           return;
         }
-        // Resolve the route with the root FIRST so the user sees the
-        // board immediately — descendant caching happens after.
-        handleRoot(rootBoardData);
-
-        // Background: cache + Ember-Data-push every descendant so
-        // sub-board navigation is a true synchronous cache hit
-        // (boardDetailCache.get → raw AND store.peekAll → record).
-        // This is the work that makes folder taps instant.
-        var subStore = _this.store;
-        // JSON + Ember Data only — do not warm descendant images here.
-        // Warming every sub-board floods the browser queue (same rationale
-        // as prefetch_for_user). Images load when the user opens that board.
-        (data.descendants || []).forEach(function(wrapped) {
-          var sub_raw = boardDetailCache.normalize_board_payload(wrapped);
-          if (!sub_raw) { return; }
-          boardDetailCache.set(sub_raw);
-          try {
-            var sub_normalized = subStore.normalize('board', JSON.parse(JSON.stringify(sub_raw)));
-            subStore.push(sub_normalized);
-          } catch (e) { /* serializer edge cases shouldn't block prefetch */ }
-        });
+        handleRoot(rootBoardData, 'tree_root_only');
+        warmFullTreeInBackground();
       }, function() {
         fallbackSingleBoard();
       });
@@ -357,9 +388,21 @@ export default Route.extend({
     // Load button set for find-a-button functionality
     if(model.get('valid_id') && !model.get('integration')) {
       // Find-a-button support; failure must not surface as an unhandled rejection.
+      var bs_started = Date.now();
+      boardCacheDiag.mark('setup:buttonset_start', { board_key: board_key });
       var load_bs = model.load_button_set();
-      if(load_bs && typeof load_bs.catch === 'function') {
-        load_bs.catch(function() { /* optional offline path */ });
+      if(load_bs && typeof load_bs.then === 'function') {
+        load_bs.then(function() {
+          boardCacheDiag.mark('setup:buttonset_done', {
+            board_key: board_key,
+            ms: Date.now() - bs_started
+          });
+        }, function() {
+          boardCacheDiag.mark('setup:buttonset_fail', {
+            board_key: board_key,
+            ms: Date.now() - bs_started
+          });
+        });
       }
     }
 
@@ -422,9 +465,26 @@ export default Route.extend({
     // above; priming here does not extend overlay visibility.
     var raw = _this.get('_raw_board_data');
     if(raw) {
+      var primed_already = !!(this.persistence && this.persistence.get('primed'));
+      boardCacheDiag.mark('setup:prime_start', {
+        board_key: board_key,
+        primed_already: primed_already
+      });
+      var prime_started = Date.now();
       _this._maybe_prime_caches().then(function() {
         if(controller.isDestroyed || controller.isDestroying) { return; }
+        boardCacheDiag.mark('setup:prime_done', {
+          board_key: board_key,
+          ms: Date.now() - prime_started,
+          primed_already: primed_already
+        });
+        var build_started = Date.now();
         _this._finalize_board_display(controller, raw);
+        boardCacheDiag.mark('setup:grid_built', {
+          board_key: board_key,
+          ms: Date.now() - build_started,
+          rows: (controller.get('ordered_buttons') || []).length
+        });
       });
     }
 

--- a/app/frontend/app/utils/board_cache_diag.js
+++ b/app/frontend/app/utils/board_cache_diag.js
@@ -1,0 +1,61 @@
+// Opt-in speak-mode board open timings.
+// Enable: localStorage.setItem('ll_board_cache_diag', '1') then reload.
+// Or: window.__LL_BOARD_CACHE_DIAG = true
+// Logs land in console as [ll-board-cache] … and on window.__LL_BOARD_CACHE_LOG.
+
+function enabled() {
+  if (typeof window === 'undefined') { return false; }
+  if (window.__LL_BOARD_CACHE_DIAG === true) { return true; }
+  try {
+    return window.localStorage && window.localStorage.getItem('ll_board_cache_diag') === '1';
+  } catch (e) {
+    return false;
+  }
+}
+
+function mark(label, detail) {
+  if (!enabled()) { return; }
+  var entry = {
+    t: Date.now(),
+    label: label,
+    detail: detail || null
+  };
+  try {
+    window.__LL_BOARD_CACHE_LOG = window.__LL_BOARD_CACHE_LOG || [];
+    window.__LL_BOARD_CACHE_LOG.push(entry);
+  } catch (e) { /* ignore */ }
+  try {
+    // eslint-disable-next-line no-console
+    console.log('[ll-board-cache]', label, detail || '');
+  } catch (e2) { /* ignore */ }
+}
+
+function span(startLabel, endLabel, detail) {
+  if (!enabled()) { return; }
+  var log = null;
+  try { log = window.__LL_BOARD_CACHE_LOG; } catch (e) { log = null; }
+  if (!log || !log.length) {
+    mark(endLabel, detail);
+    return;
+  }
+  var start = null;
+  for (var i = log.length - 1; i >= 0; i--) {
+    if (log[i].label === startLabel) {
+      start = log[i];
+      break;
+    }
+  }
+  var ms = start ? (Date.now() - start.t) : null;
+  var merged = {};
+  var src = detail || {};
+  Object.keys(src).forEach(function(k) { merged[k] = src[k]; });
+  merged.ms_since = startLabel;
+  merged.ms = ms;
+  mark(endLabel, merged);
+}
+
+export default {
+  enabled: enabled,
+  mark: mark,
+  span: span
+};

--- a/app/frontend/tests/unit/utils/board-detail-cache-test.js
+++ b/app/frontend/tests/unit/utils/board-detail-cache-test.js
@@ -116,6 +116,34 @@ module('Unit | Utility | board-detail-cache', function(hooks) {
     assert.notOk(forced.ordered_buttons, 'force clears ordered_buttons');
   });
 
+  test('ingest_tree with warm_root_images false still caches descendants without replacing a fresh root', function(assert) {
+    var origStore = LingoLinq.store;
+    var pushed = [];
+    LingoLinq.store = {
+      normalize: function(type, data) { return { type: type, data: data }; },
+      push: function(payload) { pushed.push(payload); return payload; }
+    };
+
+    var rootRaw = { key: 'user/root', id: '1_100', buttons: [{ id: 1 }] };
+    var rootEntry = boardDetailCache.set(rootRaw, { force: true });
+    rootEntry.ordered_buttons = [[{ id: 1 }]];
+
+    var tree = {
+      root: { board: { key: 'user/root', id: '1_100', buttons: [{ id: 99 }] } },
+      descendants: [
+        { board: { key: 'user/child-a', id: '1_101', buttons: [] } },
+        { board: { key: 'user/child-b', id: '1_102', buttons: [] } }
+      ]
+    };
+    var ok = boardDetailCache.ingest_tree(tree, null, { force: false, warm_root_images: false });
+    assert.ok(ok, 'ingest succeeds');
+    assert.strictEqual(boardDetailCache.get('user/root'), rootEntry.raw, 'keeps painted root payload');
+    assert.ok(rootEntry.ordered_buttons, 'preserves ordered_buttons on painted root');
+    assert.ok(boardDetailCache.get('user/child-a'), 'caches first descendant');
+    assert.ok(boardDetailCache.get('user/child-b'), 'caches second descendant');
+    LingoLinq.store = origStore;
+  });
+
   test('warm_linked_images warms cached child boards without refetching', function(assert) {
     var url = 'https://example.com/child-symbol.png';
     var parent = {

--- a/docs/task-management/2026-07-23-speak-mode-board-cache-latency.md
+++ b/docs/task-management/2026-07-23-speak-mode-board-cache-latency.md
@@ -1,0 +1,105 @@
+# Speak-mode board cache latency — working log
+
+**Goal:** Map what/when is cached for speak-mode board opens, measure why opens still feel long, propose one verified fix.
+
+**Branch:** `docs/melissa-speak-mode-board-cache-diagnosis`
+
+## Confirmed UI / flags (local `lingolinq` user)
+
+| Item | Value | Evidence |
+|------|--------|----------|
+| `board_view_style` | `modern` (board-detail) | `User#preference_defaults` default `'modern'`; local user `settings.preferences.board_view_style` = `modern` |
+| `background_board_prefetch` | **ON** (global) | In `ENABLED_FRONTEND_FEATURES` ([`lib/feature_flags.rb`](../../lib/feature_flags.rb)); `FeatureFlags.feature_enabled_for?` → `true` for `lingolinq` |
+| Home board | `lingolinq/vocal-flair-84` (`1_635`) | 96 downstream boards |
+
+Default speak path: `user.board-detail` → session `boardDetailCache` (5 min TTL) → miss hits `GET /api/v1/boards/:key/tree`.
+
+## Caching map (brief)
+
+1. **Session** — [`board_detail_cache.js`](../../app/frontend/app/utils/board_detail_cache.js): raw JSON, 5 min TTL; warmed by open + `prefetch_for_user` (home always; liked/owned/public when flag on).
+2. **Offline** — IndexedDB/SQLite via persistence: boards, images, sounds, buttonsets, `dataCache`; sync stamp ~5 min; force sync >48h.
+3. **Server** — no HTTP/Redis body cache on board `show`/`tree`/`bulk`; lite serialize for tree; button-set S3/CDN separate.
+
+## Instrumentation
+
+Opt-in client timings (no console noise by default):
+
+- [`app/frontend/app/utils/board_cache_diag.js`](../../app/frontend/app/utils/board_cache_diag.js)
+- Wired into [`routes/user/board-detail.js`](../../app/frontend/app/routes/user/board-detail.js)
+
+Enable in browser:
+
+```js
+localStorage.setItem('ll_board_cache_diag', '1');
+// reload, open a board, then:
+window.__LL_BOARD_CACHE_LOG
+```
+
+Marks: `model:start` → `model:cache_hit` | `model:cache_miss` → `model:tree_response` → `model:root_ready` → `setup:prime_*` → `setup:grid_built` → `warm_images:*` / `setup:buttonset_*`.
+
+## Measurement (2026-07-23, local DB, user `lingolinq`)
+
+Rails runner mimicking `BoardsController#tree` (`as_lite: true`, `skip_subs: true`):
+
+| Step | Time | Size |
+|------|------|------|
+| Root only (`vocal-flair-84`, 142 buttons) | **0.048 s** | ~1.5 MB |
+| Full tree (root + **96** descendants) | **1.95 s** serialize | **~84 MB** JSON |
+| Sample descendant boards | — | 1.5–4.0 MB each |
+
+Earlier non-lite serialize was ~6.3 s / ~160 MB (wrong opts); lite path is what production uses.
+
+### Critical path verification
+
+[`routes/user/board-detail.js`](../../app/frontend/app/routes/user/board-detail.js) `model()`:
+
+- Comment says resolve when **root** is ready and cache descendants in background.
+- Implementation awaits the **full** `GET …/tree` response (root **and** all descendants) before `handleRoot` / `resolve`.
+- Therefore a cold open of this home board cannot paint until ~2s+ server work **plus** transferring/parsing ~84 MB — even though paint only needs the ~1.5 MB root (~50 ms server).
+
+Secondary (after model resolves):
+
+- `_maybe_prime_caches()` gates `_finalize_board_display` / grid build (can add IndexedDB latency if not already `primed`).
+- `load_button_set()` starts in parallel (find-a-button); not required for modern grid paint.
+- `warm_images` runs ~100 ms after grid build (symbols can still look “loading”).
+- Overlay: My Boards uses 150 ms min on cache hit / 700 ms otherwise; board-icon uses `paint_view_switch_overlay` (dismiss +150 ms after `routeDidChange`).
+
+Button-set lookup for this board returned no URL in the runner (`for_user(..., allow_slow=false)`); not on the modern paint path.
+
+## Root cause (verified)
+
+**Cold / TTL-miss speak opens for large vocab trees block on downloading and parsing the entire `/tree` payload before the root grid can paint.** Session cache and prefetch help *after* that expensive warm; they do not remove the first-cost cliff. Prefetch of home itself pays the same ~84 MB cost in the background.
+
+## Proposed fix (single, targeted) — IMPLEMENTED
+
+**Two-phase board-detail load:**
+
+1. On `boardDetailCache` miss: `GET /api/v1/boards/:key/tree?root_only=1` (lite root, empty descendants) → `handleRoot` → resolve → paint.
+2. In background: `GET …/tree` (full) → `boardDetailCache.ingest_tree(..., { force: false, warm_root_images: false })`.
+3. Fallback if root_only fails: `GET /boards/:key` (show), then the same background full tree.
+
+**Code:**
+- [`app/controllers/api/boards_controller.rb`](../../app/controllers/api/boards_controller.rb) `#tree` honors `root_only=1|true|yes`
+- [`app/frontend/app/routes/user/board-detail.js`](../../app/frontend/app/routes/user/board-detail.js) `model()` two-phase path
+- Spec: `spec/controllers/api/boards_controller_spec.rb` root_only example
+- QUnit: `ingest_tree` preserves fresh root while caching descendants
+
+Expected effect for this home board: time-to-grid ≈ root (~50 ms server + ~1.5 MB) instead of full tree (~2 s + ~84 MB). Folder taps stay cache-instant once background ingest finishes.
+
+## Not covered / follow-ups
+
+- Browser Network waterfall for this open (Rails/Ember HTTP stack was down during this pass; server serialize + payload size are the verified bottleneck via `rails runner` mirroring `#tree`).
+- Prefetch cost for this account: **1539** owned boards — phase-3 owned prefetch can amplify `/tree` work; orthogonal to time-to-first-paint.
+- Shrinking lite JSON per board (still 1.5–4 MB each) — separate payload-size work; related open remediations from tree-timeout RCA (#286 / punchlist #23).
+- Making `paint_view_switch_overlay` / board-icon honor cache-hit short mins like `user/index`.
+- Classic speak path soft-reload + button sets.
+
+## Status
+
+| Todo | Status |
+|------|--------|
+| Confirm UI + flags | Done |
+| Measure open path | Done (server tree timing + code path proof) |
+| Log findings | This file |
+| Propose fix | Done → implemented two-phase root-then-tree |
+| Implement two-phase | Done on `feat/melissa-speak-mode-two-phase-tree-load` |

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -27,6 +27,7 @@ file (see [README.md](README.md)).
 - [Gotcha: serialize rapid model saves — overlapping user.save() lose updates / trip "in flight"](#gotcha-serialize-rapid-model-saves--overlapping-usersave-lose-updates--trip-in-flight)
 - [Pattern: dedup an "already-owned copy" by parent lineage, never by slug convention](#pattern-dedup-an-already-owned-copy-by-parent-lineage-never-by-slug-convention)
 - [Pattern: phased board prefetch — shared planner, dual persistence files](#pattern-phased-board-prefetch--shared-planner-dual-persistence-files)
+- [Pattern: board-detail `/tree` blocks paint on the full descendant payload](#pattern-board-detail-tree-blocks-paint-on-the-full-descendant-payload)
 - [Pattern: board-preview latency is cold-cache, not the loading gate — warm on intent](#pattern-board-preview-latency-is-cold-cache-not-the-loading-gate--warm-on-intent)
 - [Gotcha: every route transition closes all modals (global_transition) — don't keep a modal "open behind" a routed page](#gotcha-every-route-transition-closes-all-modals-global_transition--dont-keep-a-modal-open-behind-a-routed-page)
 - [Gotcha: Shepherd modal overlay is VISUAL-ONLY; canClickTarget:false makes the target click "fall through"](#gotcha-shepherd-modal-overlay-is-visual-only-canclicktargetfalse-makes-the-target-click-fall-through)
@@ -270,6 +271,18 @@ Board-detail has `_auto_rename_board`, which POSTs `/rename` when `board.name` c
 **Flags:** Phase 1 (home) is unconditional; phases 2–4 run when `background_board_prefetch` is enabled (shipped in `ENABLED_FRONTEND_FEATURES`). Phase 4 also honors legacy `catalog_board_prefetch`.
 
 **First seen in:** [2026-05-30-phased-online-board-caching.md](./2026-05-30-phased-online-board-caching.md)
+
+## Pattern: board-detail `/tree` blocks paint on the full descendant payload
+
+**Surface:** cold / TTL-miss opens of modern speak (`user.board-detail` → `GET /api/v1/boards/:key/tree`).
+
+**Gotcha:** Route comments say “resolve when the root is ready; cache descendants in the background,” but `model()` only calls `handleRoot` / `resolve` inside the `/tree` AJAX success handler — after root **and** all descendants have been downloaded and parsed. For a large vocab (e.g. home with ~96 downstream boards) lite serialize alone was ~2s and ~84MB JSON locally; root-only was ~50ms / ~1.5MB. Session `boardDetailCache` (5 min) and `background_board_prefetch` only help *after* that warm; they do not remove the first-open cliff. Prefetch of the home root pays the same full-tree cost in the background.
+
+**Fix recipe:** Two-phase load — `GET …/tree?root_only=1` first (lite root), paint, then ingest full `/tree` in the background via `ingest_tree(..., { force: false, warm_root_images: false })`. Server skips descendant load when `root_only` is set. Do not “fix” slow opens by only extending TTL or prefetch coverage.
+
+**Diag:** `localStorage.ll_board_cache_diag=1` → [`board_cache_diag.js`](../../app/frontend/app/utils/board_cache_diag.js) marks on board-detail.
+
+**First seen in:** [2026-07-23-speak-mode-board-cache-latency.md](./2026-07-23-speak-mode-board-cache-latency.md)
 
 ## Pattern: supervisor caseload session prefetch reuses board_detail_cache, not offline sync
 

--- a/spec/controllers/api/boards_controller_spec.rb
+++ b/spec/controllers/api/boards_controller_spec.rb
@@ -3280,6 +3280,17 @@ describe Api::BoardsController, :type => :controller do
       expect(json['descendants'].map { |d| d['board']['id'] }.sort).to eq(children.map(&:global_id).sort)
     end
 
+    it "returns root only when root_only=1 (skips descendant serialize)" do
+      token_user
+      root, children = build_owned_tree(@user, 3)
+      expect(Board).to_not receive(:find_all_by_global_id)
+      get :tree, params: { board_id: root.global_id, root_only: '1' }
+      json = assert_success_json
+      expect(json['root']['board']['id']).to eq(root.global_id)
+      expect(json['descendants']).to eq([])
+      expect(children.length).to eq(3) # fixture guard; full tree covered by sibling examples
+    end
+
     it "404s when the board is missing" do
       token_user
       get :tree, params: { board_id: 'no/such-board' }


### PR DESCRIPTION
Large vocab trees were blocking speak-mode opens on the full descendant payload (~84MB / ~2s locally). Fetch lite root first, then ingest the full tree in the background; add opt-in open-path diag and document the finding.