### PR TITLE
fix(codex-review): raise chunk evidence cap

### DIFF
--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -58,13 +58,22 @@ objects (`git diff BASE...HEAD` and `git ls-tree HEAD_SHA`), not the index.
 
 Limits are intentionally explicit:
 
-- maximum chunks: 8
+- maximum chunks: 16
 - target raw bytes per chunk: 40 KB
 - synthesis calls: up to 3 successful model runs
 - approving chunk calls: up to 3 successful model runs per chunk
 - structural retry: one retry only for invalid JSON, schema failure, missing
   output, or transient CLI/API failure
 - current serial timeout: 90 minutes
+
+Worst-case model-call budget is 51 serial calls: up to 16 chunks times 3
+chunk-review runs, plus up to 3 synthesis runs. This is a larger budget than
+the first canary's 27-call ceiling, but it preserves the same convergence and
+fail-closed envelope checks. The raised cap is required for #686-class large
+frontend PRs, where about 298 KB across 29 SCSS, template, and i18n-heavy files
+produced 8 chunks and then failed coverage as `(diff-wide): too_many_chunks`
+under the old cap. A PR that needs a 17th chunk still records
+`too_many_chunks`, marks coverage incomplete, and cannot approve.
 
 A blocking chunk verdict is not rerun for confirmation, but the remaining
 chunks still run so the author receives complete findings and CI can attest
@@ -148,6 +157,15 @@ Measured smoke timing:
   `scripts/codex-review-run-chunks.py`.
 - Heartbeats fired about every 5-6 seconds, far inside the 30-minute watchdog
   window.
+
+The 16-chunk worst case has not been live-smoked yet. Using the #685 timing as
+a rough lower-bound throughput check, 51 calls would be about 4.5 minutes of
+reviewer-step time at the current `reasoning effort: none` setting, before
+ordinary GitHub runner and API variance. That remains well inside the 90-minute
+job timeout, and each model call still posts a pending-status heartbeat before
+it starts. If real timings approach the watchdog threshold, keep the fail-closed
+status behavior and revisit chunk parallelism or job boundaries as a separate
+design.
 
 This timing is valid only for the current `reasoning effort: none` config. If
 production changes to a higher reasoning effort, re-run the controlled smoke and

--- a/.github/codex/evidence-policy.json
+++ b/.github/codex/evidence-policy.json
@@ -1,5 +1,5 @@
 {
-  "max_chunks": 8,
+  "max_chunks": 16,
   "chunk_target_bytes": 40000,
   "excluded_paths": [
     {

--- a/scripts/codex-review-build-evidence.test.py
+++ b/scripts/codex-review-build-evidence.test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import importlib.util
+import json
 import pathlib
 import tempfile
 import unittest
@@ -13,6 +14,9 @@ SPEC.loader.exec_module(build_evidence)
 
 
 POLICY = [(build_evidence.re.compile(r"(^|/)db/schema\.rb$"), "generated schema")]
+TRUSTED_POLICY_MAX_CHUNKS = json.loads(
+    pathlib.Path(".github/codex/evidence-policy.json").read_text()
+)["max_chunks"]
 
 
 def section(path, body):
@@ -76,6 +80,39 @@ class EvidenceChunkingTest(unittest.TestCase):
         self.assertFalse(incomplete)
         covered = {item["path"] for chunk in chunks for item in chunk["coverage"]}
         self.assertEqual(covered, {f"app/models/file_{i}.rb" for i in range(5)})
+
+    def test_nine_chunk_diff_that_exceeded_old_cap_is_complete_under_trusted_cap(self):
+        sections = [
+            section(f"app/models/file_{i}.rb", "@@ -1,1 +1,1 @@\n-old\n+" + ("x" * 20) + "\n")
+            for i in range(9)
+        ]
+        chunks, _, incomplete, _ = build_evidence.build_chunks(
+            sections,
+            [],
+            260,
+            TRUSTED_POLICY_MAX_CHUNKS,
+        )
+        self.assertEqual(TRUSTED_POLICY_MAX_CHUNKS, 16)
+        self.assertEqual(len(chunks), 9)
+        self.assertFalse(incomplete)
+        covered = {item["path"] for chunk in chunks for item in chunk["coverage"]}
+        self.assertEqual(covered, {f"app/models/file_{i}.rb" for i in range(9)})
+
+    def test_diff_exceeding_trusted_cap_still_marks_too_many_chunks_incomplete(self):
+        sections = [
+            section(f"app/models/file_{i}.rb", "@@ -1,1 +1,1 @@\n-old\n+" + ("x" * 20) + "\n")
+            for i in range(TRUSTED_POLICY_MAX_CHUNKS + 1)
+        ]
+        chunks, _, incomplete, _ = build_evidence.build_chunks(
+            sections,
+            [],
+            260,
+            TRUSTED_POLICY_MAX_CHUNKS,
+        )
+        self.assertEqual(len(chunks), TRUSTED_POLICY_MAX_CHUNKS)
+        self.assertEqual(incomplete[-1]["reason"], "too_many_chunks")
+        self.assertEqual(incomplete[-1]["chunks"], TRUSTED_POLICY_MAX_CHUNKS + 1)
+        self.assertEqual(incomplete[-1]["max_chunks"], TRUSTED_POLICY_MAX_CHUNKS)
 
     def test_oversized_single_hunk_is_incomplete(self):
         giant = "@@ -1,1 +1,1 @@\n-old\n+" + ("x" * 500) + "\n"


### PR DESCRIPTION
## Summary
- raise trusted chunked evidence max from 8 to 16 chunks
- add regression coverage for a 9-chunk diff that now completes and a 17th chunk that still records too_many_chunks
- document the 51-call worst-case budget, watchdog implications, and #686-class PR need

## Verification
- python3 scripts/codex-review-build-evidence.test.py
- python3 scripts/codex-review-build-envelope.test.py
- python3 scripts/codex-review-run-chunks.test.py
- python3 -m py_compile scripts/codex-review-build-evidence.py scripts/codex-review-run-chunks.py scripts/codex-review-build-envelope.py scripts/codex-review-assemble-prompt.py
- git diff --check

## Notes
- python3 scripts/codex-review-chunk-diff.test.py was requested, but current origin/staging no longer has that file after #687 dropped the superseded first-gen diff chunker.
- Rollout remains governed by CODEX_REVIEW_EVIDENCE_MODE and CODEX_REVIEW_CHUNKED_SCOPE. This PR does not broaden scope or change branch protection.