### PR TITLE
fix(word_data): cache word-frequency ranks instead of downloading a 1.7MB list per record

### DIFF
--- a/app/models/word_data.rb
+++ b/app/models/word_data.rb
@@ -165,6 +165,11 @@ class WordData < ApplicationRecord
   FREQUENCY_RANK_TTL = 30.days.to_i
   FREQUENCY_RANK_LOCK_KEY = 'word_data/en/frequency_ranks/building'
   FREQUENCY_RANK_LOCK_TTL = 10.minutes.to_i
+  # The hash is written in slices, so it is built under a staging key and swapped
+  # in with an atomic RENAME. Readers therefore only ever observe the live key as
+  # absent or complete, never half-populated (a partially visible hash would hand
+  # back nil for words not yet written, and that nil gets persisted as a score).
+  FREQUENCY_RANK_BUILD_KEY = 'word_data/en/frequency_ranks/staging'
   # A truncated or failed download must never be cached, so a rebuild is only
   # accepted when it yields at least this many words.
   FREQUENCY_RANK_MIN_WORDS = 1000
@@ -230,12 +235,20 @@ class WordData < ApplicationRecord
         next if word.blank? || ranks.key?(word)
         ranks[word] = idx
       end
+      # Build under the staging key, then swap. A reader that arrives mid-build
+      # sees no live key, fails to take the lock, and falls back to an uncached
+      # lookup rather than reading a hash that is missing most of its words.
+      redis.del(FREQUENCY_RANK_BUILD_KEY)
       ranks.each_slice(5000) do |slice|
-        redis.mapped_hmset(FREQUENCY_RANK_KEY, slice.to_h)
+        redis.mapped_hmset(FREQUENCY_RANK_BUILD_KEY, slice.to_h)
       end
-      redis.expire(FREQUENCY_RANK_KEY, FREQUENCY_RANK_TTL)
+      # Set the TTL before the swap; RENAME carries it over, so the live key is
+      # never left without one.
+      redis.expire(FREQUENCY_RANK_BUILD_KEY, FREQUENCY_RANK_TTL)
+      redis.rename(FREQUENCY_RANK_BUILD_KEY, FREQUENCY_RANK_KEY)
       :ready
     ensure
+      redis.del(FREQUENCY_RANK_BUILD_KEY)
       redis.del(FREQUENCY_RANK_LOCK_KEY)
     end
   end

--- a/app/models/word_data.rb
+++ b/app/models/word_data.rb
@@ -154,6 +154,92 @@ class WordData < ApplicationRecord
     end
   end
 
+  # The English word-frequency list lives in S3 as a ~1.7MB file, ordered
+  # highest-frequency first. Scoring a word only needs that word's rank, but the
+  # per-record path (assert_missing_priority -> schedule(:assert_priority)) used
+  # to re-download the entire file for EVERY word saved. Resque forks per job, so
+  # an in-process memo would not survive between jobs; the rank map is cached in
+  # Redis instead, turning a 1.7MB download per word into a single HGET.
+  FREQUENCY_LIST_PATH = 'language/english_with_counts.txt'
+  FREQUENCY_RANK_KEY = 'word_data/en/frequency_ranks'
+  FREQUENCY_RANK_TTL = 30.days.to_i
+  FREQUENCY_RANK_LOCK_KEY = 'word_data/en/frequency_ranks/building'
+  FREQUENCY_RANK_LOCK_TTL = 10.minutes.to_i
+  # A truncated or failed download must never be cached, so a rebuild is only
+  # accepted when it yields at least this many words.
+  FREQUENCY_RANK_MIN_WORDS = 1000
+
+  def self.frequency_list_url
+    bucket = ENV['STATIC_S3_BUCKET'] || 'lingolinq'
+    "https://#{bucket}.s3.amazonaws.com/#{FREQUENCY_LIST_PATH}"
+  end
+
+  # Downloads and parses the full ordered list. Only the batch path
+  # (self.assert_priority) and a cache rebuild should call this; per-word callers
+  # want frequency_rank.
+  def self.frequency_counts
+    req = Typhoeus.get(frequency_list_url)
+    body = (req && req.body).to_s
+    return nil if body.empty?
+    body.split(/\n/).map{|s| s.split(/\t/)[0] }
+  end
+
+  # Rank of a word in the frequency list (0-based), or nil if absent. Mirrors
+  # what `counts.index(word)` returned before the cache existed, including
+  # first-occurrence semantics for any duplicated word.
+  def self.frequency_rank(word)
+    return nil if word.blank?
+    redis = RedisInit.default
+    return uncached_frequency_rank(word) if !redis
+
+    case assert_frequency_ranks(redis)
+    when :ready
+      rank = redis.hget(FREQUENCY_RANK_KEY, word)
+      rank && rank.to_i
+    when :busy
+      # Another process is building the cache; look it up directly rather than
+      # persisting an unscored priority.
+      uncached_frequency_rank(word)
+    else
+      # The list itself could not be fetched. Matches the pre-cache behavior of
+      # a failed download: no frequency component to the score, and no retry.
+      nil
+    end
+  end
+
+  def self.uncached_frequency_rank(word)
+    counts = frequency_counts
+    counts && counts.index(word)
+  end
+
+  # Builds the Redis word => rank hash if it is missing. A short lock keeps a
+  # burst of concurrent jobs to one download. Returns:
+  #   :ready       - the cache is populated and safe to read
+  #   :busy        - another process holds the build lock
+  #   :unavailable - the list could not be downloaded, so do not retry it here
+  def self.assert_frequency_ranks(redis)
+    return :ready if redis.hlen(FREQUENCY_RANK_KEY) > 0
+    return :busy unless redis.set(FREQUENCY_RANK_LOCK_KEY, '1', nx: true, ex: FREQUENCY_RANK_LOCK_TTL)
+
+    begin
+      counts = frequency_counts
+      return :unavailable if !counts || counts.length < FREQUENCY_RANK_MIN_WORDS
+
+      ranks = {}
+      counts.each_with_index do |word, idx|
+        next if word.blank? || ranks.key?(word)
+        ranks[word] = idx
+      end
+      ranks.each_slice(5000) do |slice|
+        redis.mapped_hmset(FREQUENCY_RANK_KEY, slice.to_h)
+      end
+      redis.expire(FREQUENCY_RANK_KEY, FREQUENCY_RANK_TTL)
+      :ready
+    ensure
+      redis.del(FREQUENCY_RANK_LOCK_KEY)
+    end
+  end
+
   def self.assert_priority(relation)
     bs = Board.find_by_path('example/core-112').board_downstream_button_set rescue nil
     buttons = nil
@@ -161,10 +247,7 @@ class WordData < ApplicationRecord
       bs.assert_extra_data
       buttons = bs.buttons
     end
-    bucket = ENV['STATIC_S3_BUCKET'] || 'lingolinq'
-    req = Typhoeus.get("https://#{bucket}.s3.amazonaws.com/language/english_with_counts.txt")
-    lines = req.body.split(/\n/)
-    counts = lines.map{|s| s.split(/\t/)[0] }
+    counts = frequency_counts
     cores = WordData.core_lists.select{|l| l['locale'] == 'en' }
     fringes = WordData.fringe_lists.select{|l| l['locale'] == 'en' }
     relation.find_in_batches(batch_size: 20) do |batch|
@@ -205,29 +288,22 @@ class WordData < ApplicationRecord
       scores << 7 if fringe_count > 0
     end
     if scores.empty?
-      # download word frequency list
+      # The batch path (self.assert_priority) passes the whole list in once and
+      # every record indexes into it. On the per-record path there is no list, so
+      # use the cached rank rather than downloading the file for this one word.
       counts = opts && opts['counts']
-      if !opts
-        bucket = ENV['STATIC_S3_BUCKET'] || 'lingolinq'
-        req = Typhoeus.get("https://#{bucket}.s3.amazonaws.com/language/english_with_counts.txt")
-        lines = req.body.split(/\n/)
-        counts = lines.map{|s| s.split(/\t/)[0] }
-      end
-      if counts
-        hash = {}
-        # top 5,000 - 5 points
-        # top 10,000 - 4 points
-        # top 25,000 - 3 points
-        # top 50,000 - 2 points
-        # any        - 1 point
-        idx = counts.index(self.word)
-        # score it from 0-5 based on word frequency
-        scores << 5 if idx && idx < 5000
-        scores << 4 if idx && idx < 10000
-        scores << 3 if idx && idx < 25000
-        scores << 2 if idx && idx < 50000
-        scores << 1 if idx
-      end
+      idx = counts ? counts.index(self.word) : WordData.frequency_rank(self.word)
+      # top 5,000 - 5 points
+      # top 10,000 - 4 points
+      # top 25,000 - 3 points
+      # top 50,000 - 2 points
+      # any        - 1 point
+      # score it from 0-5 based on word frequency
+      scores << 5 if idx && idx < 5000
+      scores << 4 if idx && idx < 10000
+      scores << 3 if idx && idx < 25000
+      scores << 2 if idx && idx < 50000
+      scores << 1 if idx
     end
     score = scores.max || 0
     if score

--- a/spec/models/word_data_spec.rb
+++ b/spec/models/word_data_spec.rb
@@ -1825,4 +1825,113 @@ RSpec.describe WordData, :type => :model do
       })
     end
   end
+
+  describe "frequency_rank" do
+    # The list is ordered highest-frequency first; rank is the 0-based index.
+    def frequency_body(words)
+      words.each_with_index.map{|w, i| "#{w}\t#{1000 - i}" }.join("\n")
+    end
+
+    def stub_frequency_list(words, times: 1)
+      response = double(body: frequency_body(words))
+      expect(Typhoeus).to receive(:get).exactly(times).times.and_return(response)
+    end
+
+    def long_list(*leading)
+      leading + (0...WordData::FREQUENCY_RANK_MIN_WORDS).map{|i| "filler#{i}" }
+    end
+
+    before(:each) do
+      RedisInit.default.del(WordData::FREQUENCY_RANK_KEY)
+      RedisInit.default.del(WordData::FREQUENCY_RANK_LOCK_KEY)
+    end
+
+    it "should return the rank of a word in the frequency list" do
+      stub_frequency_list(long_list('the', 'and', 'troixlet'))
+      expect(WordData.frequency_rank('the')).to eq(0)
+      expect(WordData.frequency_rank('and')).to eq(1)
+      expect(WordData.frequency_rank('troixlet')).to eq(2)
+    end
+
+    it "should return nil for a word that is not in the list" do
+      stub_frequency_list(long_list('the', 'and'))
+      expect(WordData.frequency_rank('chuckxflem')).to eq(nil)
+    end
+
+    it "should return nil for a blank word without downloading" do
+      expect(Typhoeus).to_not receive(:get)
+      expect(WordData.frequency_rank(nil)).to eq(nil)
+      expect(WordData.frequency_rank('')).to eq(nil)
+    end
+
+    it "should download the list only once across many lookups" do
+      # The regression this guards: the per-record path re-downloaded a ~1.7MB
+      # file for every word, which produced ~160GB/day of S3 egress.
+      stub_frequency_list(long_list('the', 'and', 'troixlet'), times: 1)
+      50.times do
+        expect(WordData.frequency_rank('troixlet')).to eq(2)
+      end
+    end
+
+    it "should use the first occurrence of a duplicated word" do
+      stub_frequency_list(long_list('the', 'troixlet', 'and', 'troixlet'))
+      expect(WordData.frequency_rank('troixlet')).to eq(1)
+    end
+
+    it "should not cache a failed or truncated download" do
+      empty = double(body: '')
+      expect(Typhoeus).to receive(:get).and_return(empty)
+      expect(WordData.frequency_rank('troixlet')).to eq(nil)
+      expect(RedisInit.default.hlen(WordData::FREQUENCY_RANK_KEY)).to eq(0)
+
+      # A later, healthy download is still allowed to populate the cache.
+      stub_frequency_list(long_list('troixlet'))
+      expect(WordData.frequency_rank('troixlet')).to eq(0)
+      expect(RedisInit.default.hlen(WordData::FREQUENCY_RANK_KEY)).to be > 0
+    end
+
+    it "should fall back to an uncached lookup when redis is unavailable" do
+      expect(RedisInit).to receive(:default).and_return(nil).at_least(1).times
+      stub_frequency_list(long_list('the', 'troixlet'))
+      expect(WordData.frequency_rank('troixlet')).to eq(1)
+    end
+
+    it "should fall back to an uncached lookup while another process is building" do
+      RedisInit.default.set(WordData::FREQUENCY_RANK_LOCK_KEY, '1')
+      stub_frequency_list(long_list('the', 'troixlet'))
+      expect(WordData.frequency_rank('troixlet')).to eq(1)
+      # The loser of the lock must not persist a half-built cache.
+      expect(RedisInit.default.hlen(WordData::FREQUENCY_RANK_KEY)).to eq(0)
+    end
+  end
+
+  describe "assert_priority" do
+    it "should score a word by frequency, downloading the list only once" do
+      # Deliberately nonsense words: anything in the core/fringe lists scores on
+      # that basis and never reaches the frequency branch.
+      words = ['troixlet'] + (0...WordData::FREQUENCY_RANK_MIN_WORDS).map{|i| "filler#{i}" }
+      body = words.each_with_index.map{|w, i| "#{w}\t#{1000 - i}" }.join("\n")
+      RedisInit.default.del(WordData::FREQUENCY_RANK_KEY)
+      RedisInit.default.del(WordData::FREQUENCY_RANK_LOCK_KEY)
+      expect(Typhoeus).to receive(:get).exactly(1).times.and_return(double(body: body))
+
+      wd = WordData.create(:word => 'troixlet', :locale => 'en')
+      wd.assert_priority
+      # top 5,000 -> 5 points
+      expect(wd.reload.priority).to eq(5)
+
+      # A second record must reuse the cache rather than download again.
+      wd2 = WordData.create(:word => 'chuckxflem', :locale => 'en')
+      wd2.assert_priority
+      # absent from the list entirely -> no score
+      expect(wd2.reload.priority).to eq(0)
+    end
+
+    it "should use the counts passed in by the batch path" do
+      expect(Typhoeus).to_not receive(:get)
+      wd = WordData.create(:word => 'troixlet', :locale => 'en')
+      wd.assert_priority({'counts' => ['troixlet'], 'cores' => [], 'fringes' => []})
+      expect(wd.reload.priority).to eq(5)
+    end
+  end
 end

--- a/spec/models/word_data_spec.rb
+++ b/spec/models/word_data_spec.rb
@@ -1844,6 +1844,7 @@ RSpec.describe WordData, :type => :model do
     before(:each) do
       RedisInit.default.del(WordData::FREQUENCY_RANK_KEY)
       RedisInit.default.del(WordData::FREQUENCY_RANK_LOCK_KEY)
+      RedisInit.default.del(WordData::FREQUENCY_RANK_BUILD_KEY)
     end
 
     it "should return the rank of a word in the frequency list" do
@@ -1902,6 +1903,45 @@ RSpec.describe WordData, :type => :model do
       expect(WordData.frequency_rank('troixlet')).to eq(1)
       # The loser of the lock must not persist a half-built cache.
       expect(RedisInit.default.hlen(WordData::FREQUENCY_RANK_KEY)).to eq(0)
+    end
+
+    it "should never expose a partially populated cache to a concurrent reader" do
+      # The hash is written in slices. A reader arriving between slices must not
+      # see the live key as ready and get nil for a word that has not been
+      # written yet, because that nil is persisted as the word's score.
+      words = long_list('troixlet') + (0...6000).map{|i| "tail#{i}" }
+      expect(words.length).to be > 5000
+      stub_frequency_list(words)
+
+      seen_mid_build = []
+      allow(RedisInit.default).to receive(:mapped_hmset).and_wrap_original do |orig, *args|
+        seen_mid_build << RedisInit.default.hlen(WordData::FREQUENCY_RANK_KEY)
+        orig.call(*args)
+      end
+
+      expect(WordData.frequency_rank('tail5999')).to eq(words.index('tail5999'))
+      # More than one slice was written, and the live key was empty throughout.
+      expect(seen_mid_build.length).to be > 1
+      expect(seen_mid_build.uniq).to eq([0])
+      # After the swap the live key holds the whole list, not just the last slice.
+      expect(RedisInit.default.hlen(WordData::FREQUENCY_RANK_KEY)).to eq(words.uniq.length)
+    end
+
+    it "should leave no live cache behind if the build fails partway" do
+      words = long_list('troixlet') + (0...6000).map{|i| "tail#{i}" }
+      stub_frequency_list(words)
+      calls = 0
+      allow(RedisInit.default).to receive(:mapped_hmset).and_wrap_original do |orig, *args|
+        calls += 1
+        raise Redis::BaseError, 'boom' if calls > 1
+        orig.call(*args)
+      end
+
+      expect { WordData.frequency_rank('troixlet') }.to raise_error(Redis::BaseError)
+      expect(RedisInit.default.hlen(WordData::FREQUENCY_RANK_KEY)).to eq(0)
+      expect(RedisInit.default.hlen(WordData::FREQUENCY_RANK_BUILD_KEY)).to eq(0)
+      # The lock must not be orphaned, or the cache could never be rebuilt.
+      expect(RedisInit.default.get(WordData::FREQUENCY_RANK_LOCK_KEY)).to eq(nil)
     end
   end
 


### PR DESCRIPTION
## What and why

`WordData#assert_missing_priority` (`app/models/word_data.rb:15`) schedules the **instance** `assert_priority` for every record saved without a priority. With no `opts`, that path downloaded the entire ~1.7MB `language/english_with_counts.txt` from S3 to resolve a **single word's** rank.

Measured from CloudTrail S3 data events for 2026-07-07: **97,103 fetches of that one object = 159.7 GB of egress in a single day**, sustained at ~1.1 req/sec around the clock. It was the dominant line item on the AWS bill (S3 went $0.78 in April to $57.02 for Jul 1-26; storage itself is only ~$0.23/mo). Three separate bursts: Jun 8-9, Jun 30-Jul 3, Jul 6-8.

Attribution by burst (CloudTrail S3 data events, all anonymous `Typhoeus` GETs of the same key):

| Date | Source | Signed identity also seen on IP | Bucket | Volume |
| --- | --- | --- | --- | --- |
| Jun 8 | `107.3.91.150` | `lingolinq-dev-app` | `lingolinq-dev-static` | 97.9 GB |
| Jun 30 | `136.124.34.18` | **`lingolinq-cloudrun-prod`** | **`lingolinq-prod-static`** | 121.2 GB |
| Jul 2 | `34.96.47.200` | **`lingolinq-cloudrun-prod`** | **`lingolinq-prod-static`** | 100.0 GB |
| Jul 7 | `67.186.242.78` | local dev machine | `lingolinq-dev-static` | 159.7 GB |

**Two of the four bursts ran in production on Cloud Run**, not just on dev machines. `Async#schedule` enqueues to the **`default`** queue (`boy_band` `AsyncInstanceMethods#schedule` -> `schedule_for('default', ...)`), which is the same queue `BoardDownstreamButtonSet.schedule_once(:update_for, ...)` uses, and every worker type in the Procfile consumes `default`. So ~74k (Jun 30) and ~61k (Jul 2) slow jobs sat ahead of user-facing button-set regeneration for most of a day. This is not migration egress and it will recur on any bulk WordData import.

## Approach

Resque forks per job (v3.0.0 default, `boy_band` does not disable it, no `FORK_PER_JOB=false` in the Procfile), so a class-level in-process memo would be discarded between jobs and fix nothing. The ordered list is cached instead as a Redis `word => rank` hash, making a per-record lookup one `HGET`.

Three correctness details:

- **First-occurrence ranks preserved.** `counts.index(word)` returns the first match; a naive `hmset` loop would let a duplicated word overwrite with its later index and silently change scores. The builder skips words it has already ranked.
- **Lock losers get a correct answer.** A burst of concurrent jobs all miss at once. One wins the build lock; the rest fall back to an uncached lookup rather than reading an empty cache and persisting an unscored priority.
- **Failed downloads are never cached.** An empty or truncated response would poison the cache for the full TTL. A rebuild is only accepted at >= `FREQUENCY_RANK_MIN_WORDS` (1000), and that case returns `nil`, matching pre-cache behavior on a failed download.

## Fix status

| Item | Status | Evidence |
| --- | --- | --- |
| Per-record S3 download removed | Fixed | `app/models/word_data.rb:291` uses `WordData.frequency_rank` |
| Rank cached across forked jobs | Fixed | `assert_frequency_ranks` Redis hash, `word_data.rb:210-238` |
| Concurrent-build stampede | Fixed | `SET NX EX` lock, `word_data.rb:216`; `:busy` falls back |
| Failed download not cached | Fixed | `word_data.rb:220`; spec "should not cache a failed or truncated download" |
| First-occurrence rank semantics | Fixed | `word_data.rb:223-226`; spec "should use the first occurrence of a duplicated word" |
| Duplicate download code in two places | Fixed | both now call `self.frequency_counts` |
| `assert_priority` test coverage | Fixed (was zero) | 10 new specs, `spec/models/word_data_spec.rb` |

Scoring behavior is otherwise unchanged: the batch path still indexes into the list it already passes via `opts['counts']`, thresholds are untouched, and a failed download still contributes no frequency score.

One intentional edge-case change: previously, `opts` present but without a `'counts'` key produced no frequency score at all. It now resolves through the cache. No caller does this (the only caller, `self.assert_priority:172`, always supplies `'counts'`), so this is dead-path cleanup rather than a behavior change in practice.

## Verification

```
bundle exec rspec spec/models/word_data_spec.rb
62 examples, 0 failures, 1 pending
```

The pending example is pre-existing (`update_activities_for`, "Not yet implemented"). The regression guard is "should download the list only once across many lookups": 50 lookups, exactly one `Typhoeus.get`.

## Not covered by this PR

- **No backfill.** Records already written with a too-low priority during the affected runs are not corrected. `WordData.assert_priority(relation)` (the batch path) can re-score them and was already efficient; running it is a separate operational decision.
- **The `after_save` fan-out itself is unchanged.** One job per record is still enqueued; this PR makes each job cheap rather than removing the N-jobs-for-N-records pattern.
- **No feature flag.** Outward behavior is identical and there is no UI surface; this is a background-job performance fix.
- **Unrelated, found while investigating:** `lingolinq-logs-prod` has never received a log. S3 server access logging is configured on both prod buckets but the target bucket has `ObjectOwnership: BucketOwnerEnforced` (ACLs disabled) and no bucket policy granting `logging.s3.amazonaws.com`, so neither delivery mechanism is available. Worth a separate fix if any compliance doc claims S3 access logging is in place.

## Author-Model: opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FGBa9VbPW3FeF5xwyfF2V