### PR TITLE
chore: update GitHub Actions Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       SYSTEM_ERROR_EMAIL: ${{ secrets.SYSTEM_ERROR_EMAIL }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -67,19 +67,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
+          package-manager-cache: false
 
       # The cache key MUST carry the Node major. node_modules holds native
       # bindings (sqlite3) compiled against a specific Node ABI; restoring a
       # Node-20-built tree into a Node 22 runner loads a binding built for the
       # wrong ABI. Bump this suffix on every Node major bump.
       - name: Cache node_modules and Puppeteer Chrome
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             app/frontend/node_modules
@@ -129,7 +130,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -159,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Guards the codex-review envelope logic: status fail-closed mapping,
       # the prompt-injection guard, the per-chunk convergence policy, and the
@@ -185,7 +186,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -202,7 +203,7 @@ jobs:
 
       - name: Upload Brakeman results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: brakeman-results
           path: brakeman-results.json
@@ -213,9 +214,10 @@ jobs:
           bundle-audit check --update
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Run npm audit (frontend CVE check)
         working-directory: app/frontend
@@ -234,7 +236,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -67,7 +67,7 @@ jobs:
           python3 -c "import json; json.load(open('/tmp/findings.json'))"
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -158,7 +158,7 @@ jobs:
           echo "effective evidence mode: ${effective}"
 
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.head_sha }}
           fetch-depth: 0

--- a/.github/workflows/codex-watchdog.yml
+++ b/.github/workflows/codex-watchdog.yml
@@ -30,7 +30,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout (for the labeling helper script only)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Find open PRs with a pending codex-review/deep-pass status
         id: find_pending

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -127,7 +127,7 @@ jobs:
       # See config/initializers/resque.rb.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@v3

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Comment preview URL on PR
         if: steps.find-pr.outputs.pr_number
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = parseInt("${{ steps.find-pr.outputs.pr_number }}");

--- a/.github/workflows/sync-document-register-to-notion.yml
+++ b/.github/workflows/sync-document-register-to-notion.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ vars.NOTION_DOCS_DB_ID != '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4.3'

--- a/.github/workflows/sync-findings-to-notion.yml
+++ b/.github/workflows/sync-findings-to-notion.yml
@@ -21,7 +21,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4.3'

--- a/.github/workflows/sync-render-secrets.yml
+++ b/.github/workflows/sync-render-secrets.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout LingoLinq-AAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install 1Password CLI
         run: |

--- a/.github/workflows/weekly-release-pr.yml
+++ b/.github/workflows/weekly-release-pr.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repo (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Fixes the recurring GitHub Actions warning shown during codex-review runs:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24.

This is a workflow action-runtime cleanup only. It does not change the application Node version.

## Changes

- Updated first-party GitHub JavaScript actions to Node 24-runtime versions:
  - actions/checkout@v4 -> actions/checkout@v6
  - actions/setup-node@v4 -> actions/setup-node@v6
  - actions/cache@v4 -> actions/cache@v5
  - actions/upload-artifact@v4 -> actions/upload-artifact@v6
  - actions/github-script@v7 -> actions/github-script@v8
- Kept LingoLinq-AAC application/frontend Node pinned at 22.
- Added package-manager-cache: false to setup-node@v6 steps so caching behavior stays explicit through the existing actions/cache step.

## Verification

- rg check found no remaining old first-party Node 20-runtime action refs in .github/workflows.
- git diff --check passed.
- Ruby YAML parser loaded every .github/workflows/*.yml file successfully.
- actionlint was not installed locally, so not run.

## Notes

This should remove the codex-review warning without moving the app from Node 22 to Node 24.