### PR TITLE
fix(art50): use AA token for disclosure link

### DIFF
--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -39315,7 +39315,8 @@ body.md-ds-active .app-navbar__beta-feedback-link {
   min-width: 0;
 }
 .la-terms-agree-link {
-  color: var(--md-teal);
+  /* WCAG AA: this link sits on the near-white terms/AI disclosure modal surface. */
+  color: $brand-verdigris-aa;
   font-weight: 600;
   text-decoration: none;
 


### PR DESCRIPTION
## Summary

Fixes the Article 50 pre-enable contrast blocker `LL-a9d6d5a46b` by moving the shared `.la-terms-agree-link` text color from the low-contrast `var(--md-teal)` token to the AA-safe `$brand-verdigris-aa` token.

This shared class is used by the Article 50 AI disclosure modal's "Read the Full AI Transparency Notice" link and the terms-agree flow, so the fix benefits both surfaces without introducing a one-off hex override.

## Why

`var(--md-teal)` resolves to the brand verdigris token used for accents. On the near-white modal surface, that color is too light for normal-size link text and was recorded as high-severity finding `LL-a9d6d5a46b`, a pre-enable blocker for the EU AI Act Article 50 transparency flag.

## Fix status

| Item | Status | Evidence |
| --- | --- | --- |
| `LL-a9d6d5a46b` low-contrast link text | Fixed | `.la-terms-agree-link` now uses `$brand-verdigris-aa` in `app/frontend/app/styles/app.scss` |
| No inline hex / token drift | Fixed | Uses existing `$brand-verdigris-aa` design token from `_variables.scss` |
| Article 50 flag enablement | Not changed | This PR does not touch `ENABLED_FRONTEND_FEATURES` or production flag state |
| Finding closure | Not changed | Scot closes/verifies findings separately after merge/deploy verification |

## Verification

- `git diff --check` passed.
- Contrast calculation:
  - Old `#2A9D8F` on `#FFFFFF`: `3.32:1` — fails WCAG AA for normal text.
  - New `#1A7B7A` on `#FFFFFF`: `5.05:1` — passes.
  - New `#1A7B7A` on near-white `#F8F9FA`: `4.79:1` — passes.
- Claude Code deep review verdict: Approve. It independently recomputed the contrast math, checked the finding remediation, confirmed no current dark-mode/theming regression from replacing `var(--md-teal)`, and found the blast radius limited to the terms-agree and AI disclosure modal links.

## Not covered by this PR

- Does not enable `article_50_disclosure`.
- Does not deploy anything to production.
- Does not update or close the Notion finding record; keep `LL-a9d6d5a46b` as verification-gated until merge/deploy evidence is attached.
- Does not clean up the pre-existing `_variables.scss` comment that annotates `$brand-verdigris-aa` as `4.73:1` on white; current recomputation shows `5.05:1`, so that can be handled in a separate housekeeping PR.
- Does not consolidate older AA teal idioms such as `var(--fs-dark-teal, $brand-verdigris-aa)`.

## Rollout note

This PR only removes the contrast blocker that must land before the production artifact is deployed and the Article 50 transparency flag is enabled with Scot's sign-off.

## Author-Model

Codex GPT-5