### PR TITLE
feat: org off-switch for third-party AI processing (translation + transcription)

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1102,6 +1102,16 @@ class Api::UsersController < ApplicationController
     user = User.find_by_path(params['user_id'])
     return unless exists?(user, params['user_id'])
     return unless allowed?(user, 'delete')
+    unless Organization.external_ai_processing_allowed_for_user?(user)
+      Organization.log_external_ai_processing_skip(user, 'translation')
+      # Neutral skip (not an error): empty translations, callers tolerate zero results.
+      return render json: {
+        source: params['source_lang'],
+        dest: params['destination_lang'],
+        translations: {},
+        external_ai_processing: false
+      }
+    end
     res = WordData.translate_batch(params['words'].map{|w| {:text => w } }, params['source_lang'], params['destination_lang'])
     render json: res
   end

--- a/app/frontend/app/components/button-set.hbs
+++ b/app/frontend/app/components/button-set.hbs
@@ -20,6 +20,8 @@
           {{else}}
             <p class="md-translate-hero__caption md-translate-status--error">{{t "Error loading translations, you can enter the translations by hand." key="error_loading_translations"}}</p>
           {{/if}}
+        {{else if this.translating.not_enabled}}
+          <p class="md-translate-hero__caption">{{t "Automatic translation is not enabled for this account. You can still enter translations by hand." key="translation_not_enabled_for_account"}}</p>
         {{else}}
           <p class="md-translate-hero__caption">
             {{t "The translations below are auto-generated. Please review them to make sure they are correct for your communicator's language." key="please_review_translations"}}

--- a/app/frontend/app/components/button-set.js
+++ b/app/frontend/app/components/button-set.js
@@ -234,6 +234,11 @@ export default Component.extend({
             }
           }).then(function(data) {
             if (_this.isDestroyed || _this.isDestroying) { resolve(); return; }
+            if (data && data.external_ai_processing === false) {
+              _this.set('translating', { done: true, not_enabled: true });
+              resolve(data);
+              return;
+            }
             var trans = _this.get('translations');
             for (var key in (data && data.translations) || {}) {
               if (data.translations[key] && data.translations[key] !== key) {
@@ -251,7 +256,11 @@ export default Component.extend({
 
     RSVP.all_wait(promises).then(function() {
       if (_this.isDestroyed || _this.isDestroying) { return; }
-      _this.set('translating', { done: true });
+      if (_this.get('translating.not_enabled')) {
+        _this.set('translating', { done: true, not_enabled: true });
+      } else {
+        _this.set('translating', { done: true });
+      }
     }, function() {
       if (_this.isDestroyed || _this.isDestroying) { return; }
       _this.set('translating', { error: true });

--- a/app/frontend/app/controllers/button-set.js
+++ b/app/frontend/app/controllers/button-set.js
@@ -66,6 +66,11 @@ export default modal.ModalController.extend({
                 source_lang: _this.get('model.board.locale') || 'en'
               }
             }).then(function(data) {
+              if (data && data.external_ai_processing === false) {
+                _this.set('translating', { done: true, not_enabled: true });
+                res(data);
+                return;
+              }
               var trans = _this.get('translations');
               for(var key in data.translations) {
                 trans[key] = data.translations[key];
@@ -79,7 +84,11 @@ export default modal.ModalController.extend({
         }));
       });
       RSVP.all_wait(promises).then(function(res) {
-        _this.set('translating', {done: true});
+        if (_this.get('translating.not_enabled')) {
+          _this.set('translating', {done: true, not_enabled: true});
+        } else {
+          _this.set('translating', {done: true});
+        }
       }, function(err) {
         _this.set('translating', {error: true});
       });

--- a/app/frontend/app/models/organization.js
+++ b/app/frontend/app/models/organization.js
@@ -66,6 +66,7 @@ LingoLinq.Organization = BaseModel.extend({
   default_locale: attr('string'),
   jurisdiction: attr('string'),
   default_beta_program_access: attr('boolean'),
+  external_ai_processing: attr('boolean'),
   preferred_symbols: attr('string'),
   start_codes: attr('raw'),
   custom_domain: attr('boolean'),

--- a/app/frontend/app/templates/organization/settings.hbs
+++ b/app/frontend/app/templates/organization/settings.hbs
@@ -52,6 +52,17 @@
     </div>
 
     <div class="md-org-settings-field">
+      <label class="md-org-settings-field__label">{{t "Third-party AI processing" key="org_external_ai_processing_label"}}</label>
+      <label class="md-org-settings-toggle">
+        <input type="checkbox" checked={{this.model.external_ai_processing}} class="md-org-settings-toggle__input" {{on "change" (set-field this "model.external_ai_processing" "checkbox")}} />
+        <span class="md-org-settings-toggle__label">{{t "Allow third-party AI processing (translation, voice transcription)" key="org_external_ai_processing_toggle"}}</span>
+      </label>
+      <span class="md-org-settings-field__hint">
+        {{t "When off, board auto-translation and voice-recording transcription will not send data to Google. Recordings still work without a transcript. Turn this off if your contract forbids third-party processing." key="org_external_ai_processing_hint"}}
+      </span>
+    </div>
+
+    <div class="md-org-settings-field">
       <label for="board" class="md-org-settings-field__label">{{t "Home Boards" key="home_boards"}}</label>
       <textarea class="md-org-settings-textarea" id="board" placeholder={{this.board_keys_placeholder}} {{on "input" (set-field this "home_board_key_lines")}}>{{this.home_board_key_lines}}</textarea>
       <span class="md-org-settings-field__hint">

--- a/app/frontend/tests/models/organization-test.js
+++ b/app/frontend/tests/models/organization-test.js
@@ -67,4 +67,15 @@ describe('Organization', function() {
       expect(o.get('processed_org_subscriptions')).toEqual([]);
     });
   });
+
+  describe("external_ai_processing", function() {
+    it("should expose the external_ai_processing attr", function() {
+      var o = LingoLinq.store.createRecord('organization');
+      expect(o.get('external_ai_processing')).toEqual(undefined);
+      o.set('external_ai_processing', false);
+      expect(o.get('external_ai_processing')).toEqual(false);
+      o.set('external_ai_processing', true);
+      expect(o.get('external_ai_processing')).toEqual(true);
+    });
+  });
 });

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2580,6 +2580,13 @@ class Board < ApplicationRecord
     vocalization_lang = dest_lang
     return {done: true, translated: false, reason: 'mismatched user'} if user_local_id != self.user_id
     raise "can't translate for a shallow clone" if @sub_id
+    # Org off-switch for third-party AI: skip applying translations when the
+    # board owner's org has disabled external processing. (Google egress is
+    # also gated in users#translate; this is the board-side fail-closed check.)
+    unless Organization.external_ai_processing_allowed_for_user?(self.user)
+      Organization.log_external_ai_processing_skip(self.user, 'translation')
+      return {done: true, translated: false, reason: 'external_ai_processing_disabled'}
+    end
     set_as_default_here = !!set_as_default
     # Default behavior: a same-locale re-translation skips reapplying
     # the labels (set_as_default_here = false), preserving any prior

--- a/app/models/button_sound.rb
+++ b/app/models/button_sound.rb
@@ -42,6 +42,12 @@ class ButtonSound < ApplicationRecord
   
   def schedule_transcription(frd=false)
     if self.secondary_url && (!self.settings['transcription'] || self.settings['transcription'] == '') && (self.settings['transcription_errors'] || 0) < 2
+      # Org off-switch: do not call Google Speech-to-Text when disabled.
+      # Gate-skip is "not permitted," not a failure — do not bump transcription_errors.
+      unless Organization.external_ai_processing_allowed_for_user?(self.user)
+        Organization.log_external_ai_processing_skip(self.user, 'transcription')
+        return
+      end
       if frd
         # https://cloud.google.com/speech/reference/rest/
         ref = self.settings['secondary_output']

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1524,6 +1524,34 @@ class Organization < ApplicationRecord
     self.settings['default_beta_program_access'] != false
   end
 
+  # Opt-out off-switch for Google Translation / Speech-to-Text egress.
+  # Unset => allowed (preserve existing orgs). Explicit false => denied.
+  def external_ai_processing_allowed?
+    self.settings ||= {}
+    self.settings['external_ai_processing'] != false
+  end
+
+  # True when the user may send content to third-party AI processors.
+  # Unmanaged users are allowed (account-level COPPA gate covers minors).
+  # If the user is attached to any org that has disabled processing, deny
+  # (fail closed across multi-org attachments).
+  def self.external_ai_processing_allowed_for_user?(user)
+    return true unless user
+    orgs = attached_orgs(user, true).map { |e| e['org'] }.compact
+    return true if orgs.empty?
+    orgs.all?(&:external_ai_processing_allowed?)
+  end
+
+  # PII-free audit of a gate-skip. Never raises into the feature path.
+  def self.log_external_ai_processing_skip(user, flow)
+    org_ids = user ? attached_orgs(user).map { |e| e['id'] }.compact.uniq : []
+    AuditEvent.log_command(user&.global_id || 'unknown', {
+      'type' => 'external_ai_processing_skipped',
+      'flow' => flow.to_s,
+      'organization_ids' => org_ids
+    })
+  end
+
   def process_params(params, non_user_params)
     self.settings ||= {}
     self.settings['name'] = process_string(params['name']) if params['name']
@@ -1531,6 +1559,9 @@ class Organization < ApplicationRecord
     self.settings['org_access'] = process_boolean(params['org_access']) if params['org_access'] != nil
     if params.key?('default_beta_program_access') || params.key?(:default_beta_program_access)
       self.settings['default_beta_program_access'] = process_boolean(params['default_beta_program_access'])
+    end
+    if params.key?('external_ai_processing') || params.key?(:external_ai_processing)
+      self.settings['external_ai_processing'] = process_boolean(params['external_ai_processing'])
     end
     self.settings['inactivity_timeout'] = params['inactivity_timeout'].to_i if params['inactivity_timeout']
     self.settings.delete('inactivity_timeout') if (self.settings['inactivity_timeout'] || 0) < 10

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -20,6 +20,7 @@ file (see [README.md](README.md)).
 
 ## Index
 
+- [Gotcha: board translation Google egress is users#translate / WordData, not Board#translate_set](#gotcha-board-translation-google-egress-is-userstranslate--worddata-not-boardtranslate_set)
 - [Pattern: before adding a guard, grep the canonical path for one that already exists — with the exact flag name, in that file alone](#pattern-before-adding-a-guard-grep-the-canonical-path-for-one-that-already-exists--with-the-exact-flag-name-in-that-file-alone)
 - [Pattern: deleting dead CSS is a text-surgery problem — `:not()` and multi-line selector lists are the two ways to silently break live styling](#pattern-deleting-dead-css-is-a-text-surgery-problem---not-and-multi-line-selector-lists-are-the-two-ways-to-silently-break-live-styling)
 - [Pattern: a "protected" flag on a media record is an ENTITLEMENT boundary — never relax its predicate to fix a rendering bug](#pattern-a-protected-flag-on-a-media-record-is-an-entitlement-boundary--never-relax-its-predicate-to-fix-a-rendering-bug)
@@ -7799,3 +7800,7 @@ feature reports "configured" then fails AccessDenied at invoke time.
 
 Evidence: `lib/ai_client.rb`, `spec/lib/ai_client_spec.rb`,
 `docs/task-management/2026-07-27-ai-client-bedrock-credential-review.md`.
+
+## Gotcha: board translation Google egress is users#translate / WordData, not Board#translate_set
+
+`Board#translate_set` only applies a client-supplied translation hash — it does not call Google. The frontend first POSTs words to `/api/v1/users/:id/translate` → `WordData.translate_batch` → `query_translations` (Typhoeus to `translation.googleapis.com`), then posts the result to boards#translate → `translate_set`. An org off-switch that only gates `translate_set` still lets labels leave to Google. Gate the users translate action (and optionally `translate_set` as belt-and-suspenders); do **not** gate `WordData.query_translations` globally because `translate_locale_batch` uses it for library locale files. Org toggles for this live as top-level `settings['external_ai_processing']` (same shape as `default_beta_program_access`), not under `settings['permissions']` (ACL). Check all attached orgs (managers/supervisors), not only `managing_organization` / org_user. Ref: [#691](https://github.com/lingolinq/LingoLinq-AAC/issues/691), [`2026-07-28-org-external-ai-processing-off-switch.md`](./2026-07-28-org-external-ai-processing-off-switch.md).

--- a/lib/json_api/organization.rb
+++ b/lib/json_api/organization.rb
@@ -55,6 +55,7 @@ module JsonApi::Organization
       json['default_locale'] = org.settings['default_locale'] || 'en'
       json['jurisdiction'] = org.jurisdiction
       json['default_beta_program_access'] = org.default_beta_program_access?
+      json['external_ai_processing'] = org.external_ai_processing_allowed?
       if org.settings['activation_settings']
         json['start_codes'] = Organization.start_codes(org)
       end

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -2782,6 +2782,22 @@ describe Api::UsersController, :type => :controller do
       json = JSON.parse(response.body)
       expect(json).to eq({'a' => 'a'})
     end
+
+    it "should skip Google and return empty translations when org disables external AI processing" do
+      token_user
+      o = Organization.create(settings: {'total_licenses' => 1, 'external_ai_processing' => false})
+      o.add_user(@user.user_name, false, true)
+      @user.reload
+      words = ['a', 'b', 'c']
+      expect(WordData).not_to receive(:translate_batch)
+      expect(Typhoeus).not_to receive(:get)
+      expect(Organization).to receive(:log_external_ai_processing_skip).with(@user, 'translation')
+      post 'translate', params: {:user_id => @user.global_id, :words => words, :source_lang => 'en', :destination_lang => 'es'}
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+      expect(json['translations']).to eq({})
+      expect(json['external_ai_processing']).to eq(false)
+    end
   end
   
   describe "board_revisions" do

--- a/spec/lib/json_api/organization_spec.rb
+++ b/spec/lib/json_api/organization_spec.rb
@@ -51,6 +51,19 @@ describe JsonApi::Organization do
       expect(res['default_beta_program_access']).to eq(false)
     end
 
+    it "should include external_ai_processing when edit permissions are allowed" do
+      o = Organization.create
+      u = User.create
+      o.add_manager(u.user_name, true)
+      u.reload
+      res = JsonApi::Organization.build_json(o, :permissions => u)
+      expect(res['external_ai_processing']).to eq(true)
+      o.settings['external_ai_processing'] = false
+      o.save!
+      res = JsonApi::Organization.build_json(o.reload, :permissions => u)
+      expect(res['external_ai_processing']).to eq(false)
+    end
+
     it "should include jurisdiction when edit permissions are allowed" do
       o = Organization.create(settings: {'jurisdiction' => 'EU'})
       u = User.create

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -3476,6 +3476,28 @@ describe Board, :type => :model do
       })
       expect(res).to eq({done: true, translated: false, reason: 'mismatched user'})
     end
+
+    it "should skip when the board owner's org disables external AI processing" do
+      o = Organization.create(settings: {'total_licenses' => 1, 'external_ai_processing' => false})
+      u = User.create
+      o.add_user(u.user_name, false, true)
+      u.reload
+      b = Board.create(:user => u)
+      b.settings['buttons'] = [
+        {'id' => 1, 'label' => 'hat'},
+        {'id' => 2, 'label' => 'cat'}
+      ]
+      b.save
+      expect(Organization).to receive(:log_external_ai_processing_skip).with(u, 'translation')
+      res = b.translate_set({'hat' => 'sombrero', 'cat' => 'gato'}, {
+        'source' => 'en',
+        'dest' => 'es',
+        'board_ids' => [b.global_id]
+      })
+      expect(res).to eq({done: true, translated: false, reason: 'external_ai_processing_disabled'})
+      b.reload
+      expect(b.settings['buttons'][0]['label']).to eq('hat')
+    end
     
     it "should do nothing if the board's locale already matches the desired locale" do
       u = User.create

--- a/spec/models/button_sound_spec.rb
+++ b/spec/models/button_sound_spec.rb
@@ -496,6 +496,32 @@ describe ButtonSound, :type => :model do
       bs.schedule_transcription(true)
       expect(Typhoeus).to_not receive(:get)
     end
+
+    it "should skip Google and not increment transcription_errors when org disables external AI processing" do
+      o = Organization.create(settings: {'total_licenses' => 1, 'external_ai_processing' => false})
+      u = User.create
+      o.add_user(u.user_name, false, true)
+      u.reload
+      bs = ButtonSound.new(:user => u, :settings => {})
+      expect(bs).to receive(:secondary_url).and_return("http://www.example.com/sound.wav").at_least(1).times
+      expect(Typhoeus).not_to receive(:get)
+      expect(Typhoeus).not_to receive(:post)
+      expect(Organization).to receive(:log_external_ai_processing_skip).with(u, 'transcription')
+      bs.schedule_transcription(true)
+      expect(bs.settings['transcription_errors']).to eq(nil)
+    end
+
+    it "should not schedule transcription when org disables external AI processing" do
+      o = Organization.create(settings: {'total_licenses' => 1, 'external_ai_processing' => false})
+      u = User.create
+      o.add_user(u.user_name, false, true)
+      u.reload
+      bs = ButtonSound.create(:user => u, :settings => {})
+      expect(bs).to receive(:secondary_url).and_return("http://www.example.com/sound.wav")
+      expect(Organization).to receive(:log_external_ai_processing_skip).with(u, 'transcription')
+      bs.schedule_transcription
+      expect(Worker.scheduled?(ButtonSound, :perform_action, {:id => bs.id, :method => 'schedule_transcription', :arguments => [true]})).to eq(false)
+    end
   end
   
   describe "schedule_missing_transcodings" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -3697,4 +3697,61 @@ describe Organization, :type => :model do
       expect(o.data_policy_version).to eq(1)
     end
   end
+
+  describe "external_ai_processing_allowed?" do
+    it "should default to allowed when unset" do
+      o = Organization.create
+      expect(o.external_ai_processing_allowed?).to eq(true)
+    end
+
+    it "should return false when explicitly disabled" do
+      o = Organization.create
+      o.settings['external_ai_processing'] = false
+      o.save
+      expect(o.external_ai_processing_allowed?).to eq(false)
+    end
+
+    it "should persist via process_params" do
+      o = Organization.create
+      u = User.create
+      o.process({'external_ai_processing' => false}, {'updater' => u})
+      o.save
+      expect(o.reload.external_ai_processing_allowed?).to eq(false)
+      o.process({'external_ai_processing' => true}, {'updater' => u})
+      o.save
+      expect(o.reload.external_ai_processing_allowed?).to eq(true)
+    end
+
+    it "should allow unmanaged users" do
+      u = User.create
+      expect(Organization.external_ai_processing_allowed_for_user?(u)).to eq(true)
+      expect(Organization.external_ai_processing_allowed_for_user?(nil)).to eq(true)
+    end
+
+    it "should deny when the user's attached org has disabled processing" do
+      o = Organization.create(settings: {'total_licenses' => 1, 'external_ai_processing' => false})
+      u = User.create
+      o.add_user(u.user_name, false, true)
+      u.reload
+      expect(Organization.external_ai_processing_allowed_for_user?(u)).to eq(false)
+    end
+
+    it "should allow when the user's attached org leaves processing enabled" do
+      o = Organization.create(settings: {'total_licenses' => 1})
+      u = User.create
+      o.add_user(u.user_name, false, true)
+      u.reload
+      expect(Organization.external_ai_processing_allowed_for_user?(u)).to eq(true)
+    end
+
+    it "should deny managers when their org has disabled processing" do
+      o = Organization.create
+      o.settings['external_ai_processing'] = false
+      o.save
+      u = User.create
+      o.add_manager(u.user_name, true)
+      u.reload
+      expect(Organization.external_ai_processing_allowed_for_user?(u)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds a per-org opt-out (`settings['external_ai_processing']`) so districts whose contracts forbid third-party processing can disable Google Cloud Translation and Speech-to-Text egress.
- Fail-closed gates at the real call sites: `users#translate` (Google Translation), `ButtonSound#schedule_transcription` (Speech-to-Text), plus `Board#translate_set` as belt-and-suspenders. Skips are not errors (`transcription_errors` not incremented; translate returns empty with a neutral flag).
- Org Settings checkbox for self-serve; translate UI shows a neutral "not enabled for this account" state. PII-free `AuditEvent` on gate-skip.

Closes #691

## Fix status
| Item | Status | Evidence |
|---|---|---|
| Org setting + helper + JsonApi | Fixed | `organization.rb` (`external_ai_processing_allowed?` / `external_ai_processing_allowed_for_user?`); `lib/json_api/organization.rb` |
| Translation egress gated | Fixed | `users_controller.rb#translate`; empty `{ translations: {}, external_ai_processing: false }` when off |
| Transcription egress gated | Fixed | `button_sound.rb#schedule_transcription`; no Typhoeus, no `transcription_errors` bump |
| Board apply path gated | Fixed | `board.rb#translate_set` returns `reason: 'external_ai_processing_disabled'` |
| Org Settings checkbox | Fixed | `organization/settings.hbs` + Ember `organization.js` attr |
| Translate UX when off | Fixed | `button-set.hbs` / `.js` `not_enabled` state |
| RSpec | Fixed | 12 examples for org helper, JsonApi, users#translate, translate_set, schedule_transcription |

## Not covered by this PR
- Optional COPPA-at-egress belt (issue B) — account parental-consent gate already live in prod
- Finding register status move for LL-c38e7da48e / LL-1eb9a2435b (Scot post-merge)
- Parent-facing consent copy disclosure review (legal/copy, not code)

## Test plan
- [ ] RSpec: `bundle exec rspec` filtered to `external_ai_processing` / org-disables examples (12 green locally)
- [ ] Console: set `org.settings['external_ai_processing'] = false; org.save`, confirm translate returns empty and recordings skip transcription without error toast
- [ ] Org Settings: toggle checkbox, save, reload — value persists
- [ ] With toggle off: open translate flow → neutral "not enabled" copy (not an error)
- [ ] With toggle on (default): translation and transcription still work as before
- [ ] Unmanaged (non-org) users unaffected

## Author-Model: grok-4.5


Made with [Cursor](https://cursor.com)