### PR TITLE
fix(codex-review): correct chunk-cap review docs

### DIFF
--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -72,8 +72,8 @@ structural retry (`run_model` re-invokes `codex exec` with a strict-JSON
 suffix), the worst-case count of actual `codex exec` invocations is 102, not
 51. Use 102 for any timeout or watchdog headroom analysis. This is a larger
 budget than the first canary's 27-logical/54-invocation ceiling, but it
-preserves the same convergence and
-fail-closed envelope checks. The raised cap is required for #686-class large
+preserves the same convergence and fail-closed envelope checks. The raised cap
+is required for #686-class large
 frontend PRs, where about 298 KB across 29 SCSS, template, and i18n-heavy files
 produced 8 chunks and then failed coverage as `(diff-wide): too_many_chunks`
 under the old cap. A PR that needs a 17th chunk still records
@@ -144,12 +144,14 @@ chunk findings are defanged before prompt assembly.
 
 ## Watchdog and heartbeat
 
-`codex-watchdog.yml` fails pending `codex-review/deep-pass` statuses that age
-past its threshold. Chunked reviews can legitimately take longer than the old
-2-3 model-call path, so `scripts/codex-review-run-chunks.py` reposts pending
-status before every model call and retry. Heartbeat failures are non-fatal; they
-are progress hints, not correctness gates. A real hang stops heartbeating and the
-watchdog still fails closed.
+`codex-watchdog.yml` is scheduled every 10 minutes and fails pending
+`codex-review/deep-pass` statuses once they are at least 30 minutes old. Treat
+that as the design target, not a precise service-level guarantee: GitHub can
+delay or skip scheduled workflows. Chunked reviews can legitimately take longer
+than the old 2-3 model-call path, so `scripts/codex-review-run-chunks.py`
+reposts pending status before every model call and retry. Heartbeat failures are
+non-fatal; they are progress hints, not correctness gates. A real hang stops
+heartbeating and the watchdog still fails closed when the scheduled sweep runs.
 
 Measured smoke timing:
 
@@ -163,22 +165,24 @@ Measured smoke timing:
   window.
 
 The 16-chunk worst case has not been live-smoked yet. Using the #685 timing as
-a rough lower-bound throughput check (75 s / 14 invocations = about 5.4 s per
-invocation), 51 logical calls would be about 4.5 minutes of reviewer-step time,
-and the 102-invocation retry-saturated worst case about 9 minutes, at the
-current `reasoning effort: none` setting and before ordinary GitHub runner and
-API variance. Both remain well inside the 90-minute job timeout, and each model
-call still posts a pending-status heartbeat before it starts. Treat 5.4 s as a
-floor, not an estimate: per-call latency scales with prompt size, and the
-manifest block embedded in every chunk prompt grows with chunk count.
+a rough lower-bound throughput check, assuming the smoke had no structural
+retries (75 s / 14 invocations = about 5.4 s per invocation), 51 logical calls
+would be about 4.5 minutes of reviewer-step time. A 102-invocation case would
+be about 9 minutes only if retries fail fast. A single hung `codex exec`
+dominates that estimate and is bounded only by the 90-minute job timeout, with
+the watchdog expected to fail the stale status when its scheduled sweep runs.
+Each model call still posts a pending-status heartbeat before it starts. Treat
+5.4 s as a floor, not an estimate: per-call latency scales with prompt size, and
+the manifest block embedded in every chunk prompt grows with chunk count.
 
 Two known limits this cap raise does not address, both unchanged from the
 8-chunk canary and both currently fail-closed rather than wrong:
 
 - `run_model` passes no `timeout=` to `subprocess.run`, so a single hung
   `codex exec` stops heartbeating and stalls the job until the 90-minute
-  ceiling. The watchdog flips the status to failure after 30 stale minutes, so
-  the merge gate still resolves, but the runner minutes are spent.
+  ceiling. The watchdog is designed to flip the status once a scheduled sweep
+  sees it at least 30 minutes stale, so the merge gate still resolves
+  fail-closed, but the runner minutes and operator wait time are spent.
 - The synthesis prompt embeds every chunk review verbatim
   (`chunk_result_group` keeps the full `review` object for each run), so its
   input scales with chunks times runs: up to 48 full review objects at this
@@ -190,6 +194,11 @@ Two known limits this cap raise does not address, both unchanged from the
 If real timings approach the watchdog threshold, keep the fail-closed
 status behavior and revisit chunk parallelism or job boundaries as a separate
 design.
+
+Chunked evidence is still opt-in through `CODEX_REVIEW_EVIDENCE_MODE=chunked`;
+the workflow defaults to bounded evidence. Do not make chunked evidence the
+default, or raise the 16-chunk ceiling, without a fresh large non-PII smoke and
+recorded wall-clock result.
 
 This timing is valid only for the current `reasoning effort: none` config. If
 production changes to a higher reasoning effort, re-run the controlled smoke and

--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -66,9 +66,13 @@ Limits are intentionally explicit:
   output, or transient CLI/API failure
 - current serial timeout: 90 minutes
 
-Worst-case model-call budget is 51 serial calls: up to 16 chunks times 3
-chunk-review runs, plus up to 3 synthesis runs. This is a larger budget than
-the first canary's 27-call ceiling, but it preserves the same convergence and
+Worst-case budget is 51 *logical* calls: up to 16 chunks times 3 chunk-review
+runs, plus up to 3 synthesis runs. Because every logical call may fire one
+structural retry (`run_model` re-invokes `codex exec` with a strict-JSON
+suffix), the worst-case count of actual `codex exec` invocations is 102, not
+51. Use 102 for any timeout or watchdog headroom analysis. This is a larger
+budget than the first canary's 27-logical/54-invocation ceiling, but it
+preserves the same convergence and
 fail-closed envelope checks. The raised cap is required for #686-class large
 frontend PRs, where about 298 KB across 29 SCSS, template, and i18n-heavy files
 produced 8 chunks and then failed coverage as `(diff-wide): too_many_chunks`
@@ -159,11 +163,31 @@ Measured smoke timing:
   window.
 
 The 16-chunk worst case has not been live-smoked yet. Using the #685 timing as
-a rough lower-bound throughput check, 51 calls would be about 4.5 minutes of
-reviewer-step time at the current `reasoning effort: none` setting, before
-ordinary GitHub runner and API variance. That remains well inside the 90-minute
-job timeout, and each model call still posts a pending-status heartbeat before
-it starts. If real timings approach the watchdog threshold, keep the fail-closed
+a rough lower-bound throughput check (75 s / 14 invocations = about 5.4 s per
+invocation), 51 logical calls would be about 4.5 minutes of reviewer-step time,
+and the 102-invocation retry-saturated worst case about 9 minutes, at the
+current `reasoning effort: none` setting and before ordinary GitHub runner and
+API variance. Both remain well inside the 90-minute job timeout, and each model
+call still posts a pending-status heartbeat before it starts. Treat 5.4 s as a
+floor, not an estimate: per-call latency scales with prompt size, and the
+manifest block embedded in every chunk prompt grows with chunk count.
+
+Two known limits this cap raise does not address, both unchanged from the
+8-chunk canary and both currently fail-closed rather than wrong:
+
+- `run_model` passes no `timeout=` to `subprocess.run`, so a single hung
+  `codex exec` stops heartbeating and stalls the job until the 90-minute
+  ceiling. The watchdog flips the status to failure after 30 stale minutes, so
+  the merge gate still resolves, but the runner minutes are spent.
+- The synthesis prompt embeds every chunk review verbatim
+  (`chunk_result_group` keeps the full `review` object for each run), so its
+  input scales with chunks times runs: up to 48 full review objects at this
+  cap, versus 24 before. Neither `chunk-review-schema.json` nor
+  `synthesis-prompt.md` bounds finding count or description length. A synthesis
+  prompt too large to answer degrades to an invalid review and blocks, which is
+  correct but moves the failure from chunking to synthesis.
+
+If real timings approach the watchdog threshold, keep the fail-closed
 status behavior and revisit chunk parallelism or job boundaries as a separate
 design.
 

--- a/scripts/codex-review-build-evidence.test.py
+++ b/scripts/codex-review-build-evidence.test.py
@@ -116,15 +116,25 @@ class EvidenceChunkingTest(unittest.TestCase):
         self.assertEqual(incomplete[-1]["max_chunks"], TRUSTED_POLICY_MAX_CHUNKS)
 
     def test_readme_documents_the_same_cap_as_the_trusted_policy(self):
-        # The README's chunk cap, worst-case call budget, and watchdog timing
-        # analysis are what a maintainer reads before tuning the policy, so a
-        # silent drift between the two is a documentation bug with operational
-        # consequences. Keep them mechanically pinned to each other.
-        documented = re.search(
-            r"^- maximum chunks: (\d+)$", TRUSTED_POLICY_README.read_text(), re.MULTILINE
+        readme = TRUSTED_POLICY_README.read_text()
+        documented_cap = re.search(r"^- maximum chunks: (\d+)$", readme, re.MULTILINE)
+        logical_budget = re.search(
+            r"Worst-case budget is (\d+) \*logical\* calls", readme
         )
-        self.assertIsNotNone(documented, "README must state '- maximum chunks: N'")
-        self.assertEqual(int(documented.group(1)), TRUSTED_POLICY_MAX_CHUNKS)
+        invocation_budget = re.search(
+            r"actual `codex exec` invocations is (\d+)", readme
+        )
+        self.assertIsNotNone(documented_cap, "README must state '- maximum chunks: N'")
+        self.assertIsNotNone(logical_budget, "README must state the logical call budget")
+        self.assertIsNotNone(invocation_budget, "README must state the invocation budget")
+        self.assertEqual(int(documented_cap.group(1)), TRUSTED_POLICY_MAX_CHUNKS)
+        self.assertEqual(int(logical_budget.group(1)), TRUSTED_POLICY_MAX_CHUNKS * 3 + 3)
+        self.assertEqual(int(invocation_budget.group(1)), (TRUSTED_POLICY_MAX_CHUNKS * 3 + 3) * 2)
+        self.assertLessEqual(
+            TRUSTED_POLICY_MAX_CHUNKS,
+            16,
+            "Raising the chunk cap above 16 needs a fresh large-PR smoke and budget review.",
+        )
 
     def test_oversized_single_hunk_is_incomplete(self):
         giant = "@@ -1,1 +1,1 @@\n-old\n+" + ("x" * 500) + "\n"

--- a/scripts/codex-review-build-evidence.test.py
+++ b/scripts/codex-review-build-evidence.test.py
@@ -2,6 +2,7 @@
 import importlib.util
 import json
 import pathlib
+import re
 import tempfile
 import unittest
 import unittest.mock
@@ -14,9 +15,10 @@ SPEC.loader.exec_module(build_evidence)
 
 
 POLICY = [(build_evidence.re.compile(r"(^|/)db/schema\.rb$"), "generated schema")]
-TRUSTED_POLICY_MAX_CHUNKS = json.loads(
-    pathlib.Path(".github/codex/evidence-policy.json").read_text()
-)["max_chunks"]
+REPO_ROOT = MODULE_PATH.parents[1]
+TRUSTED_POLICY_PATH = REPO_ROOT / ".github/codex/evidence-policy.json"
+TRUSTED_POLICY_README = REPO_ROOT / ".github/codex/README.md"
+TRUSTED_POLICY_MAX_CHUNKS = json.loads(TRUSTED_POLICY_PATH.read_text())["max_chunks"]
 
 
 def section(path, body):
@@ -92,7 +94,6 @@ class EvidenceChunkingTest(unittest.TestCase):
             260,
             TRUSTED_POLICY_MAX_CHUNKS,
         )
-        self.assertEqual(TRUSTED_POLICY_MAX_CHUNKS, 16)
         self.assertEqual(len(chunks), 9)
         self.assertFalse(incomplete)
         covered = {item["path"] for chunk in chunks for item in chunk["coverage"]}
@@ -113,6 +114,17 @@ class EvidenceChunkingTest(unittest.TestCase):
         self.assertEqual(incomplete[-1]["reason"], "too_many_chunks")
         self.assertEqual(incomplete[-1]["chunks"], TRUSTED_POLICY_MAX_CHUNKS + 1)
         self.assertEqual(incomplete[-1]["max_chunks"], TRUSTED_POLICY_MAX_CHUNKS)
+
+    def test_readme_documents_the_same_cap_as_the_trusted_policy(self):
+        # The README's chunk cap, worst-case call budget, and watchdog timing
+        # analysis are what a maintainer reads before tuning the policy, so a
+        # silent drift between the two is a documentation bug with operational
+        # consequences. Keep them mechanically pinned to each other.
+        documented = re.search(
+            r"^- maximum chunks: (\d+)$", TRUSTED_POLICY_README.read_text(), re.MULTILINE
+        )
+        self.assertIsNotNone(documented, "README must state '- maximum chunks: N'")
+        self.assertEqual(int(documented.group(1)), TRUSTED_POLICY_MAX_CHUNKS)
 
     def test_oversized_single_hunk_is_incomplete(self):
         giant = "@@ -1,1 +1,1 @@\n-old\n+" + ("x" * 500) + "\n"


### PR DESCRIPTION
## Summary
- correct the chunked review budget from 51 actual invocations to 51 logical calls and up to 102 codex exec invocations with retries
- document the synthesis payload and subprocess timeout limits that remain fail-closed but not fixed here
- make the evidence-builder tests CWD-independent and pin the README chunk cap to the trusted policy JSON

## Fix status
Fixed the senior-review findings that were documentation or test hygiene issues in merged PR #688.

## Not covered by this PR
- No runtime synthesis payload bound is added.
- No subprocess timeout is added to run_model.
- No rollout variable, branch protection, workflow boundary, or chunk cap change is made.

## Verification
- python3 scripts/codex-review-build-evidence.test.py
- python3 scripts/codex-review-build-envelope.test.py
- python3 scripts/codex-review-run-chunks.test.py
- git diff --check

## Author-Model:
Claude Code follow-up branch reviewed and opened by Codex.