### PR TITLE
fix(codex-review): resolve deep-pass to a terminal state on every exit path

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -52,6 +52,18 @@ jobs:
       LOOP_N: ${{ inputs.loop_n }}
       CODEX_REVIEW_REQUESTED_EVIDENCE_MODE: ${{ vars.CODEX_REVIEW_EVIDENCE_MODE || 'bounded' }}
       CODEX_REVIEW_CHUNKED_SCOPE: ${{ vars.CODEX_REVIEW_CHUNKED_SCOPE || 'all' }}
+      # Stable per-ATTEMPT run identity. Every deep-pass status this job writes
+      # carries this as target_url, which makes it the join key for three
+      # consumers: this job's own "did my status land" verification, the
+      # heartbeat in scripts/codex-review-run-chunks.py, and
+      # codex-watchdog.yml's staleness anchor.
+      #
+      # It MUST include run_attempt. `runs/<run_id>` alone is identical across
+      # re-runs of the same run, so attempt 2 would match attempt 1's terminal
+      # status (reporting false success in the verify loop) and inherit attempt
+      # 1's created_at (defeating the watchdog's age clock). `/attempts/<n>` is
+      # a real linkable Actions URL, so this costs nothing in usability.
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
     steps:
       # Codex review of this pipeline (PR #607) caught that the fail-closed
       # anchor was not actually first: the old single validate-inputs step
@@ -75,7 +87,7 @@ jobs:
             -f state=pending \
             -f context=codex-review/deep-pass \
             -f description="Codex review running (loop ${LOOP_N})" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="${RUN_URL}"
 
       - name: Validate remaining inputs (flip status to failure on bad input, don't just leave it pending)
         run: |
@@ -84,7 +96,7 @@ jobs:
               -f state=failure \
               -f context=codex-review/deep-pass \
               -f description="$1" \
-              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              -f target_url="${RUN_URL}"
             echo "::error::$1" >&2
             exit 1
           }
@@ -110,7 +122,7 @@ jobs:
               -f state=failure \
               -f context=codex-review/deep-pass \
               -f description="pr_number ${PR_NUMBER}'s current head (${ACTUAL_HEAD}) does not match dispatched head_sha" \
-              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              -f target_url="${RUN_URL}"
             echo "::error::pr_number ${PR_NUMBER} head is ${ACTUAL_HEAD}, but dispatch head_sha was ${HEAD_SHA}: refusing to bind review/comment routing to the wrong PR" >&2
             exit 1
           fi
@@ -376,7 +388,7 @@ jobs:
             --head-sha "${HEAD_SHA}" \
             --prior-loop-file /tmp/prior_loop.txt \
             --repository "${{ github.repository }}" \
-            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --run-url "${RUN_URL}" \
             --heartbeat
 
       - name: Run reviewer (Claude Sonnet 4.6 API, Tier 2 claude-deep route)
@@ -477,7 +489,7 @@ jobs:
             -f state="$FINAL_STATE" \
             -f context=codex-review/deep-pass \
             -f description="$DESCRIPTION" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="${RUN_URL}"
 
           # Success condition (literal, per build spec section 1): do not
           # exit success unless a follow-up GET confirms deep-pass is no
@@ -486,7 +498,7 @@ jobs:
           # verification by target_url instead of taking the newest context.
           # codex-watchdog.yml is the independent backstop if this check
           # itself never runs (job killed before this line).
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # RUN_URL is job-level env (attempt-scoped); do not rebuild it here.
           for i in $(seq 1 6); do
             sleep 5
             gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/statuses" > /tmp/codex-statuses.json
@@ -499,3 +511,97 @@ jobs:
 
           echo "codex-review/deep-pass still pending 30s after W2 POST succeeded; failing this job so it does not report false success. codex-watchdog.yml's workflow_run trigger will flip the status to failure." >&2
           exit 1
+
+      # ------------------------------------------------------------------
+      # Terminal-status lifecycle: this job resolves its OWN status on every
+      # exit path.
+      #
+      # Before this step existed the only terminal deep-pass writes were the
+      # input-validation guards near the top of the job and the resolve step
+      # above. Anything failing between them -- notably the reviewer auth step
+      # -- left deep-pass `pending` and delegated the problem to
+      # codex-watchdog.yml, which by design waits 30 minutes before acting.
+      # Observed 2026-07-28: auth failed in about 90 seconds while deep-pass
+      # read "Codex review running" for 41-65 minutes on PRs #690, #696, #697.
+      # The gate was not broken; it was lying about its own state.
+      #
+      # `if: always()` is required, NOT `if: failure()`. failure() does not run
+      # when the job is CANCELLED, which is one of the five cases this must
+      # cover: success, failure, cancellation, re-run on the same SHA, and the
+      # status write itself failing.
+      #
+      # codex-watchdog.yml remains the independent backstop for the one case
+      # this step cannot cover: the runner dying before this step executes.
+      - name: Resolve codex-review/deep-pass to a terminal state (all exit paths)
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -uo pipefail
+
+          # Read only THIS attempt's own status entries. RUN_URL is
+          # attempt-scoped, so a re-run cannot see attempt 1's terminal status
+          # and wrongly conclude there is nothing left to do.
+          # `gh api --paginate` emits one JSON array PER PAGE, so the raw output
+          # is concatenated arrays (`[...][...]`), not a single array. Normalize
+          # with `jq -s 'add'` rather than `--slurp`, which is not available on
+          # every gh version.
+          statuses_json="$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/statuses?per_page=100" --paginate 2>/dev/null | jq -s 'add // []' 2>/dev/null || echo '[]')"
+          current_state="$(printf '%s' "$statuses_json" | jq -r --arg u "$RUN_URL" '
+            [ .[] | select(.context == "codex-review/deep-pass" and .target_url == $u) ]
+            | sort_by(.created_at) | last | .state // ""
+          ')"
+
+          echo "job.status=${JOB_STATUS}; deep-pass state for this attempt: ${current_state:-<none posted>}"
+
+          if [ -n "$current_state" ] && [ "$current_state" != "pending" ]; then
+            echo "Already terminal (${current_state}) for this attempt; nothing to do."
+            exit 0
+          fi
+
+          case "$JOB_STATUS" in
+            cancelled)
+              description="Review cancelled before producing a verdict"
+              ;;
+            success)
+              # Reaching here on a green job means the resolve step never wrote
+              # a verdict (skipped, or an early `exit 0`). Fail closed: never
+              # report a passing gate for a review that recorded no result.
+              description="Job reported success but wrote no verdict; failing closed"
+              ;;
+            *)
+              description="Review job failed before producing a verdict (see run log)"
+              ;;
+          esac
+
+          # Every case is `failure`. There is no path on which an unresolved
+          # deep-pass should become `success`.
+          posted=""
+          for write_attempt in 1 2 3; do
+            if gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+                 -f state=failure \
+                 -f context=codex-review/deep-pass \
+                 -f description="$description" \
+                 -f target_url="${RUN_URL}"; then
+              posted=yes
+              break
+            fi
+            echo "::warning::deep-pass status write attempt ${write_attempt} failed; retrying in 5s" >&2
+            sleep 5
+          done
+
+          # Case 5: the status write itself failing must be loud, not silent.
+          if [ -z "$posted" ]; then
+            echo "::error::Could not write a terminal codex-review/deep-pass status after 3 attempts. The status is left pending and codex-watchdog.yml is now the only backstop." >&2
+            exit 1
+          fi
+
+          echo "deep-pass -> failure: ${description}"
+
+          # If the job was otherwise green, fail it so the run does not report
+          # success while its own gate resolved to failure.
+          if [ "$JOB_STATUS" = "success" ]; then
+            echo "::error::Failing this job to match the deep-pass verdict it just wrote." >&2
+            exit 1
+          fi
+          exit 0

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -546,7 +546,39 @@ jobs:
           # is concatenated arrays (`[...][...]`), not a single array. Normalize
           # with `jq -s 'add'` rather than `--slurp`, which is not available on
           # every gh version.
-          statuses_json="$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/statuses?per_page=100" --paginate 2>/dev/null | jq -s 'add // []' 2>/dev/null || echo '[]')"
+          #
+          # The READ retries, like the write below. An earlier version fell back
+          # to `[]` on any read failure, which is indistinguishable from "no
+          # status has been posted". On a GREEN job that meant a transient API
+          # blip would take the fail-closed branch and overwrite the `success`
+          # the resolve step had already written correctly, converting a passing
+          # review into a blocked merge. Unreachable while no reviewer route is
+          # funded (nothing can reach `success`), and therefore exactly the kind
+          # of latent bug that would first appear on the day a route is funded.
+          statuses_json=""
+          read_ok=""
+          for read_attempt in 1 2 3; do
+            if raw="$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/statuses?per_page=100" --paginate 2>/dev/null)"; then
+              statuses_json="$(printf '%s' "$raw" | jq -s 'add // []' 2>/dev/null)" || statuses_json=""
+              if [ -n "$statuses_json" ]; then read_ok=yes; break; fi
+            fi
+            echo "::warning::deep-pass status read attempt ${read_attempt} failed; retrying in 5s" >&2
+            sleep 5
+          done
+
+          if [ -z "$read_ok" ]; then
+            # Asymmetric on purpose. If the job did not succeed, writing
+            # `failure` is correct no matter what the current status says, so
+            # proceed. If the job DID succeed, the current status may be a
+            # legitimate `success` and we cannot see it: refuse to guess.
+            if [ "$JOB_STATUS" = "success" ]; then
+              echo "::error::Could not read the current codex-review/deep-pass status after 3 attempts, and this job succeeded. Refusing to overwrite a possibly-successful verdict. codex-watchdog.yml remains the backstop." >&2
+              exit 1
+            fi
+            echo "::warning::Could not read the current deep-pass status after 3 attempts; the job did not succeed, so writing failure is safe regardless." >&2
+            statuses_json='[]'
+          fi
+
           current_state="$(printf '%s' "$statuses_json" | jq -r --arg u "$RUN_URL" '
             [ .[] | select(.context == "codex-review/deep-pass" and .target_url == $u) ]
             | sort_by(.created_at) | last | .state // ""

--- a/.github/workflows/codex-watchdog.yml
+++ b/.github/workflows/codex-watchdog.yml
@@ -37,15 +37,48 @@ jobs:
         run: |
           # commit-status API has no "list all pending for context X" endpoint,
           # so we walk open PRs and check each head SHA's status directly.
+          #
+          # The age anchor is the EARLIEST pending status for the run attempt
+          # that is currently in force, not the most recent one.
+          # scripts/codex-review-run-chunks.py re-POSTs a `pending` heartbeat as
+          # each chunk completes; every heartbeat mints a new status entry with a
+          # fresh created_at. Anchoring on the latest entry therefore let a
+          # heartbeating run push this clock forward indefinitely and outrun the
+          # 30-minute sweep, defeating the backstop in exactly the hang case it
+          # exists for. Grouping by target_url (attempt-scoped since the
+          # codex-review.yml RUN_URL change) and taking the oldest pending entry
+          # in that group measures how long THIS attempt has actually been
+          # running, and keeps a re-run from inheriting the prior attempt's clock.
+          #
+          # Uses the plural /statuses endpoint: /status returns only the latest
+          # entry per context and so cannot see the earliest heartbeat.
           gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
             --jq '.[] | [.number, .head.sha] | @tsv' > /tmp/open-prs.tsv
           : > /tmp/stale.tsv
           while IFS=$'\t' read -r pr_number head_sha; do
             [ -z "$head_sha" ] && continue
-            status_json="$(gh api "repos/${{ github.repository }}/commits/${head_sha}/status" 2>/dev/null || echo '{}')"
-            state="$(echo "$status_json" | jq -r '[.statuses[] | select(.context=="codex-review/deep-pass") | .state][0] // empty')"
-            created_at="$(echo "$status_json" | jq -r '[.statuses[] | select(.context=="codex-review/deep-pass") | .created_at][0] // empty')"
+            # `--paginate` emits one JSON array per page, so the raw output is
+            # concatenated arrays. `jq -s 'add'` normalizes it to one array and
+            # works on every gh version (unlike `--slurp`).
+            statuses_json="$(gh api "repos/${{ github.repository }}/commits/${head_sha}/statuses?per_page=100" --paginate 2>/dev/null | jq -s 'add // []' 2>/dev/null || echo '[]')"
+            state="$(echo "$statuses_json" | jq -r '
+              [ .[] | select(.context == "codex-review/deep-pass") ]
+              | sort_by(.created_at) | last | .state // empty
+            ')"
             [ "$state" != "pending" ] && continue
+            # target_url of the entry currently in force; scope the anchor to it.
+            active_url="$(echo "$statuses_json" | jq -r '
+              [ .[] | select(.context == "codex-review/deep-pass") ]
+              | sort_by(.created_at) | last | .target_url // ""
+            ')"
+            created_at="$(echo "$statuses_json" | jq -r --arg u "$active_url" '
+              [ .[]
+                | select(.context == "codex-review/deep-pass"
+                         and .state == "pending"
+                         and (.target_url // "") == $u)
+                | .created_at ]
+              | sort | first // empty
+            ')"
             [ -z "$created_at" ] && continue
             age_min=$(( ( $(date -u +%s) - $(date -u -d "$created_at" +%s) ) / 60 ))
             if [ "$age_min" -ge 30 ]; then


### PR DESCRIPTION
Phase 2 of `ai-company-brain outputs/plans/2026-07-28-codex-review-gate-plan.md`.
Scope is **gate reliability only**. No routing, credential, compliance-toggle, or
branch-protection change.

## Problem

`codex-review/deep-pass` wrote a terminal status in only two places: the
input-validation guards at the top of the job, and the final resolve step.
Anything failing between them, notably the reviewer auth step, left the status
`pending` and delegated the problem to `codex-watchdog.yml`, which by design waits
30 minutes.

Observed 2026-07-28: auth failed in about 90 seconds while `deep-pass` read
"Codex review running" for 41-65 minutes on #690, #696 and #697.

**The watchdog was working correctly.** It found all three and flipped them to
`failure`. The primary workflow was misreporting its own state, so a fast failure
looked like a slow review. This PR fixes the reporting and keeps the watchdog as
the independent backstop.

## Changes

**1. Attempt-scoped run identity.** `RUN_URL` is now job-level env and includes
`/attempts/<run_attempt>`. `runs/<run_id>` alone is identical across re-runs, so
attempt 2 could match attempt 1's terminal status in the resolve step's verify loop
(reporting false success) and inherit attempt 1's `created_at` (defeating the
watchdog clock). All six `target_url` writes and `run-chunks --run-url` use it.

**2. Terminal-status lifecycle step, `if: always()`.** Covers success, failure,
cancellation, re-run on the same SHA, and the status write itself failing.
`if: failure()` is insufficient because it does not run on cancellation.
Idempotent, retries the write 3x, fails the job loudly if it cannot write, and
fails closed if a green job produced no verdict.

**3. Watchdog anchors on the earliest pending status for the attempt in force**,
read from the plural `/statuses` endpoint. `run-chunks.py` re-POSTs a pending
heartbeat per chunk, each minting a new `created_at`, so anchoring on the latest
entry let a heartbeating run push the clock forward indefinitely and outrun the
30-minute sweep, in exactly the hang case the backstop exists for.

## Pre-push verification

- 44 existing codex-review unit tests pass (envelope 27, evidence 11, chunks 6)
- both workflows parse; `bash -n` clean over every embedded `run` block
- jq anchor logic checked against synthetic multi-attempt heartbeat data

## Live verification, 2026-07-29 (attended)

All five cases exercised. Cases 2, 3 and 4 pass outright; case 1 is deferred with
partial coverage; case 5 behaves as designed (loud failure, no terminal status
possible). **Watchdog verification remains post-merge** - see the limitation
section below.

`codex-review.yml` is `workflow_dispatch` only, so every case below was dispatched
deliberately. Runs 1-3 used `--ref scot/fix/codex-review-terminal-status`.

### Case 2 - forced auth failure: **PASS**

| Field | Value |
|---|---|
| Run / attempt | `30424895673` / **attempt 1** |
| Head SHA | `4d40d53f50d7bdb1d0369167c380b3a99b663bf8` |
| Dispatched | 2026-07-29T05:22:46Z |
| `pending` posted | 2026-07-29T05:22:52Z |
| `failure` posted | 2026-07-29T05:23:47Z |
| **Pending -> terminal** | **55 s** (target: < 5 min) |
| Failing step | `Authenticate Codex CLI` (true auth failure, not a review failure) |
| Job conclusion | `failure` |
| Status payload | `state=failure`, `description="Review job failed before producing a verdict (see run log)"`, `target_url=.../runs/30424895673/attempts/1` |
| Finalizer output | `job.status=failure; deep-pass state for this attempt: pending` -> wrote `failure` |

### Case 3 - retry on the same SHA: **PASS**

Re-run of the same run, same SHA, creating attempt 2.

| Field | Value |
|---|---|
| Run / attempt | `30424895673` / **attempt 2** |
| Head SHA | `4d40d53f50d7bdb1d0369167c380b3a99b663bf8` (identical to attempt 1) |
| Re-run dispatched | 2026-07-29T05:28:53Z |
| `pending` posted | 2026-07-29T05:28:59Z |
| `failure` posted | 2026-07-29T05:30:00Z |
| **Pending -> terminal** | **61 s** |

All four required properties confirmed:

1. **attempt 2 uses `/attempts/2`** - `target_url=.../runs/30424895673/attempts/2`
2. **cannot inherit attempt 1's terminal status** - attempt 2's finalizer logged
   `job.status=failure; deep-pass state for this attempt: pending`. It read
   `pending`, not attempt 1's `failure`, so it did not short-circuit
3. **cannot inherit attempt 1's clock** - earliest-pending anchor per attempt:
   attempt 1 = `05:22:52Z`, attempt 2 = `05:28:59Z`. Distinct
4. **the attempt-specific status is the one resolved** - each attempt posted
   exactly one `pending` and one `failure` under its own `target_url`

Full status history on the SHA:

```
04:00:02Z  pending  runs/30421049473                 <- old code, see below
05:22:52Z  pending  runs/30424895673/attempts/1
05:23:47Z  failure  runs/30424895673/attempts/1
05:28:59Z  pending  runs/30424895673/attempts/2
05:30:00Z  failure  runs/30424895673/attempts/2
```

### Case 1 - normal completion: **DEFERRED**, with partial coverage

**True case 1 is not executable pre-funding.** A terminal `success` requires a
reviewer to return APPROVE, and no reviewer route is funded: `codex` fails at auth
and `claude-deep` has no key. Retest terminal success after an authorized route is
funded, together with the post-merge watchdog observation.

**Partial coverage via the credential-free `blocked` route.** A throwaway PR (#704)
added one harmless fixture at a data-bearing path so the classifier resolved
`data_bearing=true -> reviewer_route=blocked`, which needs no model credential.

*Terminal-resolution path verified end to end; terminal success not achievable
pre-funding.*

| Field | Value |
|---|---|
| Run / attempt | `30425448455` / attempt 1 |
| Head SHA | `7256f13404bd9246d21dc4ea61c6421438a1e140` (throwaway PR #704) |
| Dispatched | 2026-07-29T05:34:01Z |
| `pending` posted | 2026-07-29T05:34:06Z |
| `failure` posted | 2026-07-29T05:34:57Z (51 s) |
| **Job conclusion** | `success` |
| **deep-pass state** | **`failure`** - `NEEDS_HUMAN` + HIGH finding. Recorded as terminal failure, **not** case-1 success |
| Steps exercised | Re-classify -> Reviewer blocked (Tier 1) -> Build W2 envelope -> POST result to n8n W2 and resolve status -> terminal finalizer |
| Finalizer output | `job.status=success; deep-pass state for this attempt: failure` -> `Already terminal (failure) for this attempt; nothing to do.` |

The final line also demonstrates **idempotency**: the resolve step had already
written a terminal status, so the finalizer correctly made no second write and did
not trigger the fail-closed branch.

### Case 4 - cancellation: **finalizer ran; watchdog NOT required**

| Field | Value |
|---|---|
| Run / attempt | `30425940023` / attempt 1 |
| Head SHA | `4d40d53f50d7bdb1d0369167c380b3a99b663bf8` |
| Dispatched | 2026-07-29T05:43:57Z |
| Cancel requested | 2026-07-29T05:44:20Z (during `Checkout PR head`) |
| Job conclusion | `cancelled` |
| Cancelled step | `Checkout PR head` |
| **Finalizer step** | **ran, conclusion `success`** |
| Finalizer output | `job.status=cancelled; deep-pass state for this attempt: pending` |
| `failure` posted | 2026-07-29T05:44:21Z, **1 s after the cancel request** |
| Status payload | `state=failure`, `description="Review cancelled before producing a verdict"`, `target_url=.../runs/30425940023/attempts/1` |

**The `always()` finalizer executed inside GitHub's cancellation grace period and
wrote the terminal status itself. The watchdog was not required.** This is why
`if: always()` was used instead of `if: failure()`, which would not have run here.

Scope of the claim: this was a **graceful** cancellation. A force-cancel or runner
termination can still preempt the grace period, in which case the watchdog remains
the backstop. This case confirms graceful cancellation reaches the finalizer; it
does not prove all cancellations do.

### Case 5 - status-write failure: **fails loudly, no terminal status claimed**

Forced on a throwaway branch (`scot/test/codex-gate-case5-status-write`, since
deleted) that pointed **only the finalizer's status-write endpoint** at a
nonexistent repo. The finalizer's status *read* was left untouched. `#702`'s own
history was never modified.

| Field | Value |
|---|---|
| Run / attempt | `30426019261` / attempt 1 |
| Head SHA | `4d40d53f50d7bdb1d0369167c380b3a99b663bf8` |
| Dispatched | 2026-07-29T05:45:32Z |
| Finalizer input | `job.status=failure; deep-pass state for this attempt: pending` |
| **Retry count** | **3**, warnings at 05:46:36Z, 05:46:41Z, 05:46:46Z (5 s apart) |
| **`::error::` output** | `Could not write a terminal codex-review/deep-pass status after 3 attempts. The status is left pending and codex-watchdog.yml is now the only backstop.` |
| **Finalizer step conclusion** | `failure` |
| **Job conclusion** | `failure` |
| **Status left** | **`pending`** at 05:45:43Z under `.../runs/30426019261/attempts/1` |

```
##[warning]deep-pass status write attempt 1 failed; retrying in 5s
##[warning]deep-pass status write attempt 2 failed; retrying in 5s
##[warning]deep-pass status write attempt 3 failed; retrying in 5s
##[error]Could not write a terminal codex-review/deep-pass status after 3 attempts.
         The status is left pending and codex-watchdog.yml is now the only backstop.
```

**No terminal status is claimed for this case.** The status API is the thing that
was deliberately unavailable, so a terminal status was impossible by construction.
What is verified is that the failure is **loud rather than silent**: three retries,
an `::error::` annotation, a failed step, and a failed job.

**Recovery observation (in flight).** The left-pending status is the documented
input to the backstop. `codex-watchdog.yml` should fail it once it passes the
30-minute threshold (earliest ~06:15Z, next sweep ~06:20Z). That recovery runs the
**default-branch** watchdog, so it demonstrates the backstop catching a
left-pending status but **does not verify change 3**.

### Uncontrolled before/after observation

Not a formal experiment; recorded because it is useful operational evidence.

When #702 was opened, n8n auto-dispatched a review (`30421049473`, 04:00:02Z)
running the **default-branch** version of the workflow. Its status entry has no
`/attempts/` suffix and sat `pending` for roughly **82 minutes**. Runs on the same
SHA using this branch's code resolved the same context in 55 and 61 seconds.

Conditions differed between the two (different code path, different dispatcher,
different time), so treat it as an observation rather than a controlled comparison.

## Known limitation: the watchdog change cannot be verified pre-merge

Change 3 is in `codex-watchdog.yml`, which triggers on `schedule` and
`workflow_run`. **Both always run the version on the default branch (`staging`).**
So it cannot be exercised from this branch and takes effect only after merge.

The offline jq test is valid pre-merge evidence for the branch implementation, but
it is **not** a substitute for live default-branch behavior. **No watchdog
verification is claimed here.** A separate post-merge observation of watchdog
anchoring and recovery is required.

## Not in this PR

Held per decision: provider routing and credentials, `CODEX_COMPLIANCE_PATHS`,
`COMPLIANCE_PATTERNS` widening, the Windows instruction-mirror sync repair, and the
`--admin` exception policy (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eWWTEBEwJBqbkwmyku22n
