### PR TITLE
fix: avoid batch frequency re-fetch and untrusted school stamps

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -407,7 +407,10 @@ class User < ApplicationRecord
   # Persist settings['compliance'] from registration params (create only).
   # Accepts birth_month / birth_year / jurisdiction_declaration (and camelCase /
   # dasherized variants). Declared jurisdiction wins over registration country.
-  def stamp_compliance_profile_from_params!(params, country: nil)
+  # authored_organization_id must be the *validated* org id (org exists + author
+  # has edit). Passing the raw request param would let SegmentResolver classify
+  # the account as school / FERPA before authorization rejects the value.
+  def stamp_compliance_profile_from_params!(params, country: nil, authored_organization_id: nil)
     declaration = (
       params['jurisdiction_declaration'] ||
       params['jurisdiction-declaration'] ||
@@ -424,7 +427,7 @@ class User < ApplicationRecord
       birth_month: birth_month,
       birth_year: birth_year,
       segment_opts: {
-        authored_organization_id: params['authored_organization_id']
+        authored_organization_id: authored_organization_id
       }
     )
 
@@ -2086,8 +2089,14 @@ class User < ApplicationRecord
       }
       # Compliance Kernel: persist birth month/year + jurisdiction declaration when
       # the flag is ON. Flag OFF ⇒ this block is skipped (byte-identical to prior).
+      # Pass only a validated authored org id so segment classification cannot
+      # stamp school/FERPA from an untrusted or unauthorized request param.
       if FeatureFlags.compliance_workflow_kernel_enabled?
-        stamp_compliance_profile_from_params!(params, country: country)
+        stamp_compliance_profile_from_params!(
+          params,
+          country: country,
+          authored_organization_id: (org_authorized ? authoring_org.global_id : nil)
+        )
       end
     end
     self.settings['referrer'] ||= params['referrer'] if params['referrer']

--- a/app/models/word_data.rb
+++ b/app/models/word_data.rb
@@ -301,11 +301,17 @@ class WordData < ApplicationRecord
       scores << 7 if fringe_count > 0
     end
     if scores.empty?
-      # The batch path (self.assert_priority) passes the whole list in once and
-      # every record indexes into it. On the per-record path there is no list, so
-      # use the cached rank rather than downloading the file for this one word.
-      counts = opts && opts['counts']
-      idx = counts ? counts.index(self.word) : WordData.frequency_rank(self.word)
+      # The batch path (self.assert_priority) always passes a 'counts' key — the
+      # list when the download succeeded, or nil when it failed. A failed batch
+      # must NOT fall through to frequency_rank: that would re-download once per
+      # record (assert_frequency_ranks releases its lock on failure). Only the
+      # per-record path (no opts, or opts without 'counts') should look up rank.
+      if opts && opts.key?('counts')
+        counts = opts['counts']
+        idx = counts && counts.index(self.word)
+      else
+        idx = WordData.frequency_rank(self.word)
+      end
       # top 5,000 - 5 points
       # top 10,000 - 4 points
       # top 25,000 - 3 points

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -20,6 +20,8 @@ file (see [README.md](README.md)).
 
 ## Index
 
+- [Gotcha: batch-path nil is not “missing opts” — key presence vs value](#gotcha-batch-path-nil-is-not-missing-opts--key-presence-vs-value)
+- [Gotcha: compliance segment stamps must use validated org ids, not raw params](#gotcha-compliance-segment-stamps-must-use-validated-org-ids-not-raw-params)
 - [Gotcha: board translation Google egress is users#translate / WordData, not Board#translate_set](#gotcha-board-translation-google-egress-is-userstranslate--worddata-not-boardtranslate_set)
 - [Pattern: before adding a guard, grep the canonical path for one that already exists — with the exact flag name, in that file alone](#pattern-before-adding-a-guard-grep-the-canonical-path-for-one-that-already-exists--with-the-exact-flag-name-in-that-file-alone)
 - [Pattern: deleting dead CSS is a text-surgery problem — `:not()` and multi-line selector lists are the two ways to silently break live styling](#pattern-deleting-dead-css-is-a-text-surgery-problem---not-and-multi-line-selector-lists-are-the-two-ways-to-silently-break-live-styling)
@@ -7835,6 +7837,14 @@ feature reports "configured" then fails AccessDenied at invoke time.
 
 Evidence: `lib/ai_client.rb`, `spec/lib/ai_client_spec.rb`,
 `docs/task-management/2026-07-27-ai-client-bedrock-credential-review.md`.
+
+## Gotcha: batch-path nil is not “missing opts” — key presence vs value
+
+When a batch helper downloads once and fans out (`self.assert_priority` → `wd.assert_priority(opts)`), a failed download still passes the key (`'counts' => nil`). Treating `counts ? … : fallback` as “no list, so fetch per record” turns one S3 failure into N retries — especially when a Redis build lock is released on failure. Distinguish `opts.key?('counts')` (batch: use or skip) from absent key / no opts (per-record path). Ref: `app/models/word_data.rb`, [`2026-07-29-codex-release-review-fixes.md`](./2026-07-29-codex-release-review-fixes.md).
+
+## Gotcha: compliance segment stamps must use validated org ids, not raw params
+
+`Compliance::SegmentResolver.school_path?` treats any present `authored_organization_id` as school (FERPA / `school_authorization_allowed`). Signup authorization may reject a bogus or unauthorized id later, but a compliance stamp that reads the raw request param has already persisted the wrong segment. Pass only the validated org global_id (`org_authorized ? authoring_org.global_id : nil`). Ref: `User#stamp_compliance_profile_from_params!`, [`2026-07-29-codex-release-review-fixes.md`](./2026-07-29-codex-release-review-fixes.md).
 
 ## Gotcha: board translation Google egress is users#translate / WordData, not Board#translate_set
 

--- a/spec/models/user_compliance_kernel_spec.rb
+++ b/spec/models/user_compliance_kernel_spec.rb
@@ -59,4 +59,45 @@ describe 'User compliance kernel stamp' do
     expect(u.settings['compliance']['digital_consent_age']).to eq(14)
     expect(u.settings['compliance']['frameworks']).to include('LAW_25')
   end
+
+  it 'does not classify as school from an unvalidated authored_organization_id' do
+    stub_const('FeatureFlags::ENABLED_FRONTEND_FEATURES',
+               FeatureFlags::ENABLED_FRONTEND_FEATURES + ['compliance_workflow_kernel'])
+    u = create_user(
+      'country' => 'US',
+      'authored_organization_id' => 'invalid_org_999',
+      'birth_month' => 3,
+      'birth_year' => 2015
+    )
+    expect(u.errored?).to eq(false)
+    expect(u.settings['authored_organization_id']).to be_nil
+    c = u.settings['compliance']
+    expect(c['segment']).to eq('b2c')
+    expect(c['frameworks']).to include('COPPA')
+    expect(c['frameworks']).not_to include('FERPA')
+  end
+
+  it 'classifies as school only after the authoring org is authorized' do
+    stub_const('FeatureFlags::ENABLED_FRONTEND_FEATURES',
+               FeatureFlags::ENABLED_FRONTEND_FEATURES + ['compliance_workflow_kernel'])
+    o = Organization.create
+    manager = User.create
+    o.add_manager(manager.user_name, true)
+    u = User.process_new({
+      'user_name' => "comp_#{SecureRandom.hex(4)}",
+      'email' => "comp_#{SecureRandom.hex(4)}@example.com",
+      'password' => 'password1',
+      'terms_agree' => true,
+      'preferences' => { 'registration_type' => 'communicator' },
+      'country' => 'US',
+      'authored_organization_id' => o.global_id,
+      'birth_month' => 3,
+      'birth_year' => 2015
+    }, { pending: true, author: manager.reload })
+    expect(u.errored?).to eq(false)
+    expect(u.settings['authored_organization_id']).to eq(o.global_id)
+    c = u.settings['compliance']
+    expect(c['segment']).to eq('school')
+    expect(c['frameworks']).to include('FERPA')
+  end
 end

--- a/spec/models/word_data_spec.rb
+++ b/spec/models/word_data_spec.rb
@@ -1973,5 +1973,16 @@ RSpec.describe WordData, :type => :model do
       wd.assert_priority({'counts' => ['troixlet'], 'cores' => [], 'fringes' => []})
       expect(wd.reload.priority).to eq(5)
     end
+
+    it "should not re-fetch when the batch path passes counts: nil" do
+      # A failed frequency_counts in self.assert_priority still passes the key
+      # with a nil value. Falling through to frequency_rank would download once
+      # per record (the build lock is released on failure).
+      expect(Typhoeus).to_not receive(:get)
+      expect(WordData).to_not receive(:frequency_rank)
+      wd = WordData.create(:word => 'troixlet', :locale => 'en')
+      wd.assert_priority({'counts' => nil, 'cores' => [], 'fringes' => []})
+      expect(wd.reload.priority).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
Distinguish batch counts:nil from the per-record path so a failed frequency list download does not re-hit S3 per word, and stamp compliance segments only from a validated authored organization id.