### PR TITLE
Fix speak-mode blank images when protected is the string "false".

### DIFF
--- a/app/frontend/app/components/create-board-new.js
+++ b/app/frontend/app/components/create-board-new.js
@@ -125,6 +125,10 @@ export default Component.extend({
     this.set('_label_images', {});
     this._label_images_debounce = null;
     this.set('_label_images_lookup_promise', null);
+    // In-flight manual image drops (file/URL onto a tile). Create must wait
+    // for these the same way it waits for OpenSymbols lookups — otherwise a
+    // drop that finished uploading after Create was clicked is never baked.
+    this._pending_label_image_uploads = [];
     // Paint feature — mirrors the board-detail edit toolbar's paint flow.
     // `_painted_colors` is the user's manual overrides keyed by label so
     // the color follows the label through drag-reorder; baked into
@@ -1224,6 +1228,8 @@ export default Component.extend({
 
   /** Waits for any in-flight or debounced symbol lookups before save.
    *  Applies to manual (non-AI) and AI board create — same preview path.
+   *  Also waits for manual image drops still uploading so Create cannot
+   *  bake before the hosted URL lands in `_label_images`.
    *  Waits for an in-flight lookup to finish before flushing so save
    *  does not fire duplicate /api/v1/search/symbols requests. */
   _ensure_label_images_before_save() {
@@ -1232,12 +1238,18 @@ export default Component.extend({
       cancel(this._label_images_debounce);
       this._label_images_debounce = null;
     }
+    var pending_uploads = (this._pending_label_image_uploads || []).slice();
+    var wait_uploads = pending_uploads.length
+      ? RSVP.allSettled(pending_uploads)
+      : RSVP.resolve();
     var pending = this.get('_label_images_lookup_promise');
     var wait = pending ? RSVP.resolve(pending) : RSVP.resolve();
-    return wait.then(function() {
-      return _this._lookup_label_images();
-    }, function() {
-      return _this._lookup_label_images();
+    return wait_uploads.then(function() {
+      return wait.then(function() {
+        return _this._lookup_label_images();
+      }, function() {
+        return _this._lookup_label_images();
+      });
     });
   },
 
@@ -1704,7 +1716,7 @@ export default Component.extend({
     } else {
       url_promise = this._dropped_image_url(dataTransfer);
     }
-    return url_promise.then(function(url) {
+    var upload_promise = url_promise.then(function(url) {
       if(!url) { return RSVP.reject(); }
       var content_type = url.match(/^data:/) ? url.split(/;/)[0].split(/:/)[1] : null;
       // Defense-in-depth: only accept image payloads. Reject a data: URI whose
@@ -1749,6 +1761,16 @@ export default Component.extend({
         return image;
       });
     });
+    // Track so Create can wait for the hosted URL before baking buttons.
+    if(!this._pending_label_image_uploads) { this._pending_label_image_uploads = []; }
+    this._pending_label_image_uploads.push(upload_promise);
+    var clear_pending = function() {
+      var list = _this._pending_label_image_uploads || [];
+      var idx = list.indexOf(upload_promise);
+      if(idx >= 0) { list.splice(idx, 1); }
+    };
+    upload_promise.then(clear_pending, clear_pending);
+    return upload_promise;
   },
 
   /** Remove the image drag-over highlight from a cell element. */

--- a/app/frontend/app/controllers/user/board-detail.js
+++ b/app/frontend/app/controllers/user/board-detail.js
@@ -1852,6 +1852,10 @@ export default Controller.extend(prefClasses, {
   },
 
   processButtons: function() {
+    // Rebuild display from _last_raw. Callers that just wrote a save
+    // payload onto model.buttons MUST sync that payload into _last_raw
+    // first (see saveButtonChanges) — otherwise this clobbers the save
+    // with a pre-edit snapshot (notably newly assigned image_ids).
     if(this._last_raw) {
       this._build_from_raw(this._last_raw);
     }
@@ -4380,6 +4384,36 @@ export default Controller.extend(prefClasses, {
 
     board.set('buttons', state.buttons);
     board.set('grid', state.grid);
+    // Keep _last_raw in sync with the serialized save payload BEFORE any
+    // rebuild. processButtons() → _build_from_raw(_last_raw) does
+    // board.set('buttons', raw.buttons); if _last_raw still held the
+    // pre-edit snapshot, that clobber would undo process_for_saving and
+    // drop newly assigned image_ids (and other button edits) from the
+    // Ember Data save. Legacy board/index processButtons only refreshed
+    // display and never overwrote model.buttons from a stale raw cache.
+    // Also merge in-session image_urls so the rebuild can resolve the
+    // new image_ids (select_image_preview updates board.image_urls but
+    // not _last_raw.image_urls).
+    var imageUrlsForRaw = board.get('image_urls') ? Object.assign({}, board.get('image_urls')) : {};
+    (orderedButtons || []).forEach(function(btnRow) {
+      (btnRow || []).forEach(function(btn) {
+        var imgId = btn && (btn.get ? btn.get('image_id') : null);
+        if(imgId && !imageUrlsForRaw[imgId]) {
+          var url = btn.get ? (btn.get('local_image_url') || btn.get('image_url')) : null;
+          if(url) { imageUrlsForRaw[imgId] = url; }
+        }
+      });
+    });
+    if(Object.keys(imageUrlsForRaw).length) {
+      board.set('image_urls', imageUrlsForRaw);
+    }
+    if(this._last_raw) {
+      this._last_raw.buttons = state.buttons;
+      this._last_raw.grid = state.grid;
+      if(Object.keys(imageUrlsForRaw).length) {
+        this._last_raw.image_urls = Object.assign({}, this._last_raw.image_urls || {}, imageUrlsForRaw);
+      }
+    }
     this.processButtons();
 
     // Handle copy-on-save

--- a/app/frontend/tests/components/create-board-new-test.js
+++ b/app/frontend/tests/components/create-board-new-test.js
@@ -1,6 +1,7 @@
 import {
   describe,
   it,
+  itAsync,
   expect,
   beforeEach
 } from 'frontend/tests/helpers/jasmine';
@@ -161,23 +162,21 @@ describe('CreateBoardNewComponent', 'component:create-board-new', function() {
   });
 
   describe('_ensure_label_images_before_save waits for manual image drops', function() {
-    it('resolves only after pending drop uploads settle', function(done) {
+    // Jasmine helper has no mocha-style `done` callback — use itAsync + await.
+    itAsync('resolves only after pending drop uploads settle', async function() {
       var c = makeComponent();
       var settled = false;
       var deferredResolve;
       var pending = new Promise(function(resolve) { deferredResolve = resolve; });
       c._pending_label_image_uploads = [pending];
       c._lookup_label_images = function() { return Promise.resolve(); };
-      c._ensure_label_images_before_save().then(function() {
-        expect(settled).toEqual(true);
-        done();
-      }, function(err) {
-        done.fail(err);
-      });
+      var ensurePromise = c._ensure_label_images_before_save();
       // Not settled yet — drop still in flight.
       expect(settled).toEqual(false);
       settled = true;
       deferredResolve();
+      await ensurePromise;
+      expect(settled).toEqual(true);
     });
   });
 });

--- a/app/frontend/tests/components/create-board-new-test.js
+++ b/app/frontend/tests/components/create-board-new-test.js
@@ -159,4 +159,25 @@ describe('CreateBoardNewComponent', 'component:create-board-new', function() {
       expect(c.get('ai_generate_disabled')).toEqual(false);
     });
   });
+
+  describe('_ensure_label_images_before_save waits for manual image drops', function() {
+    it('resolves only after pending drop uploads settle', function(done) {
+      var c = makeComponent();
+      var settled = false;
+      var deferredResolve;
+      var pending = new Promise(function(resolve) { deferredResolve = resolve; });
+      c._pending_label_image_uploads = [pending];
+      c._lookup_label_images = function() { return Promise.resolve(); };
+      c._ensure_label_images_before_save().then(function() {
+        expect(settled).toEqual(true);
+        done();
+      }, function(err) {
+        done.fail(err);
+      });
+      // Not settled yet — drop still in flight.
+      expect(settled).toEqual(false);
+      settled = true;
+      deferredResolve();
+    });
+  });
 });

--- a/app/frontend/tests/unit/controllers/user-board-detail-save-image-persist-test.js
+++ b/app/frontend/tests/unit/controllers/user-board-detail-save-image-persist-test.js
@@ -7,6 +7,16 @@ module('Unit | Controller | user/board-detail save image persist', function(hook
 
   hooks.beforeEach(function() {
     this.controller = this.owner.factoryFor('controller:user/board-detail').create();
+    // Isolate the save-path contract: processButtons → _build_from_raw(_last_raw)
+    // restores model.buttons from _last_raw. Stub the rebuild to only that assignment
+    // so we don't need a full Board model (contextualized_buttons, Button.create, etc.).
+    var ctrl = this.controller;
+    ctrl._build_from_raw = function(raw) {
+      var board = this.get('model');
+      if(board && board.set && raw && raw.buttons !== undefined) {
+        board.set('buttons', raw.buttons);
+      }
+    };
   });
 
   hooks.afterEach(function() {
@@ -19,23 +29,9 @@ module('Unit | Controller | user/board-detail save image persist', function(hook
   test('processButtons without syncing _last_raw clobbers a newly assigned image_id', function(assert) {
     var stale = [{ id: 1, label: 'cannonball' }];
     var saved = [{ id: 1, label: 'cannonball', image_id: 'img_new' }];
-    var grid = { rows: 1, columns: 1, order: [[1]] };
-    var board = EmberObject.create({
-      buttons: stale.slice(),
-      grid: grid,
-      image_urls: {},
-      locale: 'en'
-    });
+    var board = EmberObject.create({ buttons: stale.slice() });
     this.controller.set('model', board);
-    this.controller.set('edit_mode', true);
-    this.controller._last_raw = {
-      id: '1_1',
-      key: 'user/board',
-      buttons: stale,
-      grid: grid,
-      image_urls: {},
-      locale: 'en'
-    };
+    this.controller._last_raw = { buttons: stale };
 
     board.set('buttons', saved);
     // Intentionally do NOT sync _last_raw — this is the pre-fix save path.
@@ -50,30 +46,13 @@ module('Unit | Controller | user/board-detail save image persist', function(hook
   test('syncing _last_raw before processButtons preserves newly assigned image_id', function(assert) {
     var stale = [{ id: 1, label: 'cannonball' }];
     var saved = [{ id: 1, label: 'cannonball', image_id: 'img_new' }];
-    var grid = { rows: 1, columns: 1, order: [[1]] };
-    var board = EmberObject.create({
-      buttons: stale.slice(),
-      grid: grid,
-      image_urls: {},
-      locale: 'en'
-    });
+    var board = EmberObject.create({ buttons: stale.slice() });
     this.controller.set('model', board);
-    this.controller.set('edit_mode', true);
-    this.controller._last_raw = {
-      id: '1_1',
-      key: 'user/board',
-      buttons: stale,
-      grid: grid,
-      image_urls: {},
-      locale: 'en'
-    };
+    this.controller._last_raw = { buttons: stale };
 
     board.set('buttons', saved);
-    board.set('image_urls', { img_new: 'https://cdn.example.com/cannonball.png' });
     // Fixed save path: sync serialized payload into _last_raw before rebuild.
     this.controller._last_raw.buttons = saved;
-    this.controller._last_raw.grid = grid;
-    this.controller._last_raw.image_urls = { img_new: 'https://cdn.example.com/cannonball.png' };
     this.controller.processButtons();
 
     assert.equal(

--- a/app/frontend/tests/unit/controllers/user-board-detail-save-image-persist-test.js
+++ b/app/frontend/tests/unit/controllers/user-board-detail-save-image-persist-test.js
@@ -1,0 +1,85 @@
+import { module, test } from 'qunit';
+import { setupTest } from '../../helpers';
+import EmberObject from '@ember/object';
+
+module('Unit | Controller | user/board-detail save image persist', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.controller = this.owner.factoryFor('controller:user/board-detail').create();
+  });
+
+  hooks.afterEach(function() {
+    if(this.controller) {
+      this.controller.destroy();
+      this.controller = null;
+    }
+  });
+
+  test('processButtons without syncing _last_raw clobbers a newly assigned image_id', function(assert) {
+    var stale = [{ id: 1, label: 'cannonball' }];
+    var saved = [{ id: 1, label: 'cannonball', image_id: 'img_new' }];
+    var grid = { rows: 1, columns: 1, order: [[1]] };
+    var board = EmberObject.create({
+      buttons: stale.slice(),
+      grid: grid,
+      image_urls: {},
+      locale: 'en'
+    });
+    this.controller.set('model', board);
+    this.controller.set('edit_mode', true);
+    this.controller._last_raw = {
+      id: '1_1',
+      key: 'user/board',
+      buttons: stale,
+      grid: grid,
+      image_urls: {},
+      locale: 'en'
+    };
+
+    board.set('buttons', saved);
+    // Intentionally do NOT sync _last_raw — this is the pre-fix save path.
+    this.controller.processButtons();
+
+    assert.notOk(
+      board.get('buttons')[0].image_id,
+      'documents the bug: processButtons restores stale _last_raw.buttons and drops image_id'
+    );
+  });
+
+  test('syncing _last_raw before processButtons preserves newly assigned image_id', function(assert) {
+    var stale = [{ id: 1, label: 'cannonball' }];
+    var saved = [{ id: 1, label: 'cannonball', image_id: 'img_new' }];
+    var grid = { rows: 1, columns: 1, order: [[1]] };
+    var board = EmberObject.create({
+      buttons: stale.slice(),
+      grid: grid,
+      image_urls: {},
+      locale: 'en'
+    });
+    this.controller.set('model', board);
+    this.controller.set('edit_mode', true);
+    this.controller._last_raw = {
+      id: '1_1',
+      key: 'user/board',
+      buttons: stale,
+      grid: grid,
+      image_urls: {},
+      locale: 'en'
+    };
+
+    board.set('buttons', saved);
+    board.set('image_urls', { img_new: 'https://cdn.example.com/cannonball.png' });
+    // Fixed save path: sync serialized payload into _last_raw before rebuild.
+    this.controller._last_raw.buttons = saved;
+    this.controller._last_raw.grid = grid;
+    this.controller._last_raw.image_urls = { img_new: 'https://cdn.example.com/cannonball.png' };
+    this.controller.processButtons();
+
+    assert.equal(
+      board.get('buttons')[0].image_id,
+      'img_new',
+      'save payload image_id survives processButtons when _last_raw was synced'
+    );
+  });
+});

--- a/app/models/button_image.rb
+++ b/app/models/button_image.rb
@@ -37,7 +37,10 @@ class ButtonImage < ApplicationRecord
   end
   
   def protected?
-    !!self.settings['protected']
+    # Must use process_boolean — clients (and some legacy writes) can store the
+    # string "false". `!!"false"` is true in Ruby, which made JsonApi::Image treat
+    # ordinary symbol picks / uploads as gated and blank their URL in speak mode.
+    process_boolean(self.settings && self.settings['protected'])
   end
   
   def track_image_use_later
@@ -57,7 +60,7 @@ class ButtonImage < ApplicationRecord
         self.user.schedule(:track_protected_source,self.settings['protected_source'])
       end
     end
-    if self.settings && self.settings['protected'] && !self.settings['fallback']
+    if self.settings && self.protected? && !self.settings['fallback']
       if self.settings['button_label'] || self.settings['search_term']
         Worker.schedule_for(:slow, ButtonImage, :perform_action, {
           'id' => self.id,
@@ -72,8 +75,8 @@ class ButtonImage < ApplicationRecord
   def assert_fallback(button_image)
     # When swapping images, user the fallback image after the swap if one wasn't already defined
     changed = false
-    if button_image && !button_image.settings['protected']
-      if self.settings['protected'] && !self.settings['fallback']
+    if button_image && !button_image.protected?
+      if self.protected? && !self.settings['fallback']
         self.settings['fallback'] = button_image.settings.slice('pending', 'content_type', 'width', 'height', 'source_url', 'hc', 'license')
         self.settings['fallback']['url'] = button_image.url
         changed = true
@@ -92,7 +95,7 @@ class ButtonImage < ApplicationRecord
   end
 
   def generate_fallback(force=false)
-    if self.settings['protected'] && (!self.settings['fallback'] || force)
+    if self.protected? && (!self.settings['fallback'] || force)
       term = self.settings['button_label'] || self.settings['search_term']
       if !term
         # fallback for legacy button images
@@ -235,9 +238,11 @@ class ButtonImage < ApplicationRecord
       self.settings['authorless'] = true if non_user_params[:no_author]
 
       process_license(params['license']) if params['license']
-      self.settings['protected'] = params['protected'] if params['protected'] != nil
+      # Cast through process_boolean so string "false" / "true" from form-encoded
+      # or legacy clients never land in settings (see protected?).
+      self.settings['protected'] = process_boolean(params['protected']) if params['protected'] != nil
       self.settings['protected_source'] = params['protected_source'] if params['protected_source'] != nil
-      self.settings['protected'] = params['ext_lingolinq_protected'] if params['ext_lingolinq_protected'] != nil
+      self.settings['protected'] = process_boolean(params['ext_lingolinq_protected']) if params['ext_lingolinq_protected'] != nil
       self.settings['protected_source'] = params['ext_lingolinq_protected_source'] if params['ext_lingolinq_protected_source'] != nil
       self.settings['finding_user_name'] = params['finding_user_name'] if params['finding_user_name']
       self.settings['suggestion'] = params['suggestion'] if params['suggestion']

--- a/app/models/button_sound.rb
+++ b/app/models/button_sound.rb
@@ -37,7 +37,8 @@ class ButtonSound < ApplicationRecord
   end
   
   def protected?
-    !!self.settings['protected']
+    # Same string-"false" pitfall as ButtonImage — see that model's protected?.
+    process_boolean(self.settings && self.settings['protected'])
   end
   
   def schedule_transcription(frd=false)
@@ -259,9 +260,9 @@ class ButtonSound < ApplicationRecord
       self.settings['content_type'] = params['content_type'] if params['content_type']
       self.settings['duration'] = params['duration'].to_i if params['duration']
       process_license(params['license']) if params['license']
-      self.settings['protected'] = params['protected'] if params['protected'] != nil
+      self.settings['protected'] = process_boolean(params['protected']) if params['protected'] != nil
       self.settings['protected_source'] = params['protected_source'] if params['protected_source'] != nil
-      self.settings['protected'] = params['ext_lingolinq_protected'] if params['ext_lingolinq_protected'] != nil
+      self.settings['protected'] = process_boolean(params['ext_lingolinq_protected']) if params['ext_lingolinq_protected'] != nil
       self.settings['protected_source'] = params['ext_lingolinq_protected_source'] if params['ext_lingolinq_protected_source'] != nil
       self.settings['suggestion'] = params['suggestion'] if params['suggestion']
       self.public = params['public'] if params['public'] != nil

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -2608,6 +2608,24 @@ rendering + caching. (Burned once 2026-06-12 by an image_id "efficiency fix"; re
 
 ---
 
+## Pattern: board-detail `processButtons` in save path clobbers new `image_id`
+
+**Surface:** Board-detail edit mode → Button Settings / drop image → Save → reopen from My Boards → image gone.
+
+**Symptom:** Tile shows the new picture while editing; after Save (and especially after leaving and reopening), the button has no image again.
+
+**Root cause:** `saveButtonChanges` sets `model.buttons` from `process_for_saving()`, then calls `processButtons()`. On board-detail, `processButtons` is NOT the legacy no-op / display refresh — it runs `_build_from_raw(this._last_raw)`, which does `board.set('buttons', raw.buttons)`. If `_last_raw` still holds the pre-edit snapshot (change_button did not mutate the same array ref), the just-serialized `image_id` is overwritten before `board.save()`.
+
+Originally `processButtons` was an intentional no-op (`8c277037d`) precisely because board-detail owns display via `_build_from_raw`. Rebuilding from stale raw inside the save path undoes that contract.
+
+**Fix:** Before `processButtons()`, sync `state.buttons` / `state.grid` / in-session `image_urls` into `_last_raw`. Also document the contract on `processButtons`.
+
+**Related (create-board-new):** Create must also wait for in-flight `_applyDroppedImageToLabel` uploads (not only OpenSymbols lookups) before baking `_label_images` into `model.buttons`.
+
+**Evidence:** `controllers/user/board-detail.js` `saveButtonChanges`; tests `user-board-detail-save-image-persist-test.js`. Task log: [2026-07-30-ai-board-manual-image-not-persisting.md](./2026-07-30-ai-board-manual-image-not-persisting.md).
+
+---
+
 ## Pattern: OpenSymbols search returns nested license objects — pick_preview must normalize
 
 **Surface:** Button-settings Picture tab → search symbols → pick thumbnail → "Use This".
@@ -7912,3 +7930,27 @@ With `throwOnUnhandled: true` in test (`app/deprecation-workflow.js`), `store.cr
 ## Gotcha: Ember 5.12 orphan-template deletion can drop live UI that lived only in the orphan
 
 The Ember 5.12 upgrade deleted "legacy orphan" button-settings partials (`button-settings-picture.hbs`, etc.) that still held controls never ported into the component-based `button-settings.hbs`. Example: per-button `text_only` / `stretch_text_only` ("Show only text (as large as fits) for this button") — runtime attribute + render/save paths stayed wired; only the Picture-tab checkbox disappeared. When removing orphan templates, diff each orphan against the surviving component/controller template for unbound controls before deleting. Ref: [`2026-07-30-button-settings-text-only-checkbox.md`](./2026-07-30-button-settings-text-only-checkbox.md).
+
+## Gotcha: `settings['protected']` stored as the string `"false"` blanks speak-mode images
+
+**Surface:** Button image create/update (`ButtonImage#process_params`) + speak-mode display (`JsonApi::Image` → board `image_urls` → board-detail `_make_btn`).
+
+**Symptom:** Edit mode / Button Settings show the picture; after Save, speak mode shows the label as a text symbol only. DB has a real `image_id` and S3 URL.
+
+**Root cause:** `protected?` was `!!self.settings['protected']`. In Ruby `!!"false"` is **true**. JsonApi then treats the image as gated (blank `protected_source` fails the allowed-sources check), replaces `url` with a missing fallback → `image_urls[id] = nil` → `_make_btn` sets `text_symbol`. Edit mode still looks fine because it uses the in-session `_picked_display_url` / Ember image record, not the blanked API map.
+
+Do **not** “fix” this by relaxing the JsonApi protected-source gate (entitlement boundary — see pattern above). Cast on write and on read:
+
+```ruby
+def protected?
+  process_boolean(self.settings && self.settings['protected'])
+end
+# process_params:
+self.settings['protected'] = process_boolean(params['protected']) if params['protected'] != nil
+```
+
+Same pitfall exists on `ButtonSound`. Related: settings-backed API flags + string `'false'` (beta feedback pattern earlier in this file).
+
+**Evidence:** `lingolinq_admin/animals` shark `1_41045_…` had `protected: "false"` (String), `protected?=true` pre-fix, `url: nil` in `images_and_sounds_for`.
+
+**First seen in:** [`2026-07-30-ai-board-manual-image-not-persisting.md`](./2026-07-30-ai-board-manual-image-not-persisting.md)

--- a/spec/lib/json_api/image_spec.rb
+++ b/spec/lib/json_api/image_spec.rb
@@ -82,6 +82,45 @@ describe JsonApi::Image do
       expect(hash['fallback']).to eq(nil)
     end
 
+    # Regression: form-encoded / legacy clients store protected as the string "false".
+    # `!!"false"` is true in Ruby, which blanked the speak-mode URL for a real symbol
+    # (lingolinq_admin/animals shark, 2026-07-30). protected? and process must cast.
+    it 'should serve the real url when settings protected is the string false' do
+      i = ButtonImage.new(url: 'http://www.example.com/shark.svg', settings: {
+        'protected' => 'false',
+        'protected_source' => '',
+        'content_type' => 'image/svg+xml'
+      })
+      expect(i.protected?).to eq(false)
+      hash = JsonApi::Image.build_json(i, :allowed_sources => [])
+      expect(hash['url']).to eq('http://www.example.com/shark.svg')
+      expect(hash['fallback']).to eq(nil)
+      expect(hash['protected']).to eq(false)
+    end
+
+    it 'should cast string false to boolean false on process_new' do
+      u = User.create
+      i = ButtonImage.process_new({
+        'url' => 'http://www.example.com/shark2.svg',
+        'content_type' => 'image/svg+xml',
+        'protected' => 'false',
+        'protected_source' => ''
+      }, {:user => u})
+      expect(i.settings['protected']).to eq(false)
+      expect(i.protected?).to eq(false)
+    end
+
+    it 'should still treat string true as protected' do
+      i = ButtonImage.new(url: 'http://www.example.com/pic.png', settings: {
+        'protected' => 'true',
+        'protected_source' => 'lessonpix'
+      })
+      expect(i.protected?).to eq(true)
+      hash = JsonApi::Image.build_json(i, :allowed_sources => [])
+      expect(hash['url']).to eq(nil)
+      expect(hash['fallback']).to eq(true)
+    end
+
     it 'should revert to a fallback image if no list provided and the user does not have access to the protected_source' do
       u = User.create
       User.purchase_extras({'premium_symbols' => true, 'user_id' => u.global_id})


### PR DESCRIPTION
Cast ButtonImage/ButtonSound protected flags through process_boolean so form-encoded or legacy "false" values are not treated as gated, and harden board-detail/create-board-new save paths so newly assigned images are not clobbered or raced before persist.