### PR TITLE
chore(deploy): mount BEDROCK_AWS_KEY/SECRET on Cloud Run

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -104,7 +104,21 @@ jobs:
       # MAPS_KEY is intentionally NOT here: it is a client-public key emitted at asset-precompile
       # (globals.js.erb), not read at runtime, so it is passed as a Docker build ARG in the
       # "Build and push image" step (alongside DEFAULT_HOST), not mounted at runtime.
-      NON_BOOT_SECRETS: AWS_KEY=AWS_KEY:latest,AWS_SECRET=AWS_SECRET:latest,GOOGLE_TTS_TOKEN=GOOGLE_TTS_TOKEN:latest,GOOGLE_PLACES_TOKEN=GOOGLE_PLACES_TOKEN:latest,GOOGLE_TRANSLATE_TOKEN=GOOGLE_TRANSLATE_TOKEN:latest,GOOGLE_OAUTH_CLIENT_ID=GOOGLE_OAUTH_CLIENT_ID:latest,GOOGLE_OAUTH_CLIENT_SECRET=GOOGLE_OAUTH_CLIENT_SECRET:latest,STRIPE_SECRET_KEY=STRIPE_SECRET_KEY:latest,ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,SENTRY_DSN=SENTRY_DSN:latest,SMS_ENCRYPTION_KEY=SMS_ENCRYPTION_KEY:latest,INTERNAL_API_TOKEN=INTERNAL_API_TOKEN:latest,CACHE_TOKEN=CACHE_TOKEN:latest,OPENSYMBOLS_SECRET=OPENSYMBOLS_SECRET:latest,IPLOCATE_API_KEY=IPLOCATE_API_KEY:latest,YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest
+      #
+      # BEDROCK_AWS_KEY / BEDROCK_AWS_SECRET are the Tier 1 runtime AI credentials read by
+      # lib/ai_client.rb (board generation, word prediction, prediction seeding, eval narration).
+      # They are SEPARATE from AWS_KEY/AWS_SECRET on purpose: those are the least-privilege S3/SES
+      # IAM user (scripts/gcp/iam/lingolinq-cloudrun-s3-ses-policy.json) and have no Bedrock invoke
+      # permission. ai_client.rb deliberately refuses to fall back to them, because doing so once
+      # made `configured?` true while every request returned AccessDenied. Both halves are required;
+      # a partial pair is ignored atomically. No BEDROCK_AWS_REGION entry is needed while Bedrock
+      # runs in the same region as S3: bedrock_region falls back to AWS_REGION, already set to
+      # us-west-2 in APP_ENV_VARS_STATIC. If Bedrock moves region, add BEDROCK_AWS_REGION there
+      # (a region string is not a secret and does not belong in this list).
+      #
+      # ANTHROPIC_API_KEY remains listed but is now INERT: no code under app/ lib/ config/ reads it
+      # since the Bedrock cutover. Removing it is deliberately out of scope here (see PR body).
+      NON_BOOT_SECRETS: AWS_KEY=AWS_KEY:latest,AWS_SECRET=AWS_SECRET:latest,BEDROCK_AWS_KEY=BEDROCK_AWS_KEY:latest,BEDROCK_AWS_SECRET=BEDROCK_AWS_SECRET:latest,GOOGLE_TTS_TOKEN=GOOGLE_TTS_TOKEN:latest,GOOGLE_PLACES_TOKEN=GOOGLE_PLACES_TOKEN:latest,GOOGLE_TRANSLATE_TOKEN=GOOGLE_TRANSLATE_TOKEN:latest,GOOGLE_OAUTH_CLIENT_ID=GOOGLE_OAUTH_CLIENT_ID:latest,GOOGLE_OAUTH_CLIENT_SECRET=GOOGLE_OAUTH_CLIENT_SECRET:latest,STRIPE_SECRET_KEY=STRIPE_SECRET_KEY:latest,ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,SENTRY_DSN=SENTRY_DSN:latest,SMS_ENCRYPTION_KEY=SMS_ENCRYPTION_KEY:latest,INTERNAL_API_TOKEN=INTERNAL_API_TOKEN:latest,CACHE_TOKEN=CACHE_TOKEN:latest,OPENSYMBOLS_SECRET=OPENSYMBOLS_SECRET:latest,IPLOCATE_API_KEY=IPLOCATE_API_KEY:latest,YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest
       # Non-secret runtime config (Group B) + perf tuning (Group C), web + worker only. S3 bucket
       # names + AWS/SES regions are not secret. Stripe PUBLISHABLE key, registration email, and the
       # Redis namespace come from repo Variables (assembled below) so no env-specific value is


### PR DESCRIPTION
> **Updated 2026-08-02.** The original body described the Mantle plane and a Mantle-only IAM action. Both are superseded by #727. The blocking prerequisites are now **done**; see Sequencing.

## Problem

`lib/ai_client.rb` reads `BEDROCK_AWS_KEY` and `BEDROCK_AWS_SECRET` for every Tier 1 runtime AI path. Neither was ever added to `NON_BOOT_SECRETS`, so neither is mounted on Cloud Run.

Verified against the live service on 2026-08-02: `lingolinq-web` (us-central1) has **no** `BEDROCK_AWS_KEY`, `BEDROCK_AWS_SECRET`, `AWS_ACCESS_KEY_ID`, or `AWS_SECRET_ACCESS_KEY`. `AiClient.configured?` is therefore **false in production**, and every runtime AI feature degrades to "AI is not configured".

This is the second half of the fix. **#727 alone does not turn AI on in production** and neither does this PR alone. Both are required.

## Change

Adds two entries to `NON_BOOT_SECRETS`, plus a comment block recording why they are distinct from `AWS_KEY`/`AWS_SECRET`.

```
BEDROCK_AWS_KEY=BEDROCK_AWS_KEY:latest
BEDROCK_AWS_SECRET=BEDROCK_AWS_SECRET:latest
```

Non-boot is correct: these are lazy-loaded at use time, so they land on the web service and worker pool and not on the migration Job. This PR touches one file and mounts two secrets. Nothing else.

## Corrected: which plane, and which IAM action

The original body said the IAM user needs **`bedrock-mantle:CreateInference`** and explicitly *not* `bedrock:InvokeModel`. That is now **inverted**, per #727:

AWS exposes two Bedrock planes with **different model catalogs and separate entitlements**.

| Plane | Status in account `239044785114` |
| --- | --- |
| classic `bedrock-runtime` | **Entitled and working.** The default as of #727. |
| `bedrock-mantle` | **Not entitled.** 403 `not available for this account` on every model, even with admin credentials and `bedrock-mantle:CreateInference` on `Resource: "*"`. Access request open with AWS. |

Because Mantle fails with full admin credentials, the earlier 403 was an **entitlement** fact, not the missing-IAM-action diagnosis recorded above.

So the required grant is `bedrock:InvokeModel` / `InvokeModelWithResponseStream` on Anthropic **inference-profile** ARNs. The managed policy `LingoLinqBedrockRuntimeInvoke` was updated 2026-08-01 to add exactly that; it previously covered foundation-model ARNs only, which is why every call failed. Classic rejects bare foundation-model ids (`on-demand throughput isn't supported`) and requires the `us.` cross-region profile form, which `AiClient.bedrock_model` supplies.

## No `BEDROCK_AWS_REGION`

`bedrock_region` falls back to `AWS_REGION`, confirmed `us-west-2` on the live service. Haiku 4.5 via the `us.` profile was verified working in `us-west-2` (and in `us-east-1` / `us-east-2`). A region string is not a secret and does not belong in this list.

## Sequencing: prerequisites are DONE

Verified 2026-08-02:

- [x] Classic Bedrock model access active for Claude Haiku 4.5 (live invoke returned a completion).
- [x] IAM: `LingoLinqBedrockRuntimeInvoke` updated with inference-profile ARNs. The runtime user `lingolinq-bedrock-runtime` invokes successfully.
- [x] Credentials stored in 1Password, vault **LingoLinq Prod**.
- [x] `BEDROCK_AWS_KEY` and `BEDROCK_AWS_SECRET` exist in Secret Manager (`lingolinq-prod`), each with an **enabled** version 1. Values confirmed by SHA-256 comparison to be the same credentials verified against Bedrock. No plaintext was printed.
- [x] `roles/secretmanager.secretAccessor` granted on both secrets to `serviceAccount:lingolinq-run@lingolinq-prod.iam.gserviceaccount.com`, which is the Cloud Run runtime service account for `lingolinq-web`.

The "Assert referenced secrets exist" step will therefore pass. **This PR is no longer blocked.**

## Merge and deploy order

1. **#727 first** (dual-plane client). Merging this one first would mount credentials for a client that still targets an unentitled plane.
2. **#719 second** (this PR).
3. Deploy once, then verify: Cloud Run env shows both variables, `AiClient.configured?` is true, `sts get-caller-identity` resolves to account `239044785114`, a board generation succeeds, and the `AiApiLog` row is written.

## Known limitation after merge

**Eval narration will still not be operational.** It requests Claude Opus 4.7, which is absent from the classic Bedrock catalog entirely (`ValidationException` in all three regions tested, a different error from a permissions failure). It falls back to its deterministic local template and egresses nothing. Making it operational requires either routing it to Haiku 4.5, which changes the model named in the Article 50 and consent disclosures, or Mantle entitlement landing.

Board generation, word prediction, and prediction seeding are unaffected and will work.

## Out of scope

**Removing the inert `ANTHROPIC_API_KEY`** (and `GEMINI_API_KEY`), both still mounted but unread since the Bedrock cutover. Cleanup rather than a fix; flagged so it is not forgotten.