### PR TITLE
fix(button-sets): stop destroying button sets when remote extra data is off

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -120,7 +120,17 @@ jobs:
       # ARN). Uploader.fronted_url rewrites stored bucket URLs to this domain at serialization
       # time; stable (non-presigned) URLs are required by the Ember offline cache, which is
       # URL-keyed and does not strip X-Amz-* params.
-      APP_ENV_VARS_STATIC: AWS_REGION=us-west-2,SES_REGION=us-west-2,UPLOADS_S3_BUCKET=lingolinq-prod-uploads,STATIC_S3_BUCKET=lingolinq-prod-static,UPLOADS_S3_NO_ACL=1,UPLOADS_S3_CDN=https://d34sa6lc5jfe66.cloudfront.net,SENTRY_ENVIRONMENT=production,RAILS_LOG_TO_STDOUT=true,RAILS_SERVE_STATIC_FILES=true,RUBY_YJIT_ENABLE=1,WEB_CONCURRENCY=2
+      # REMOTE_EXTRA_DATA=1: gates the detach-to-S3 path for BoardDownstreamButtonSet
+      # buttons and LogSession events (ExtraData#extra_data_too_big?). This was a
+      # Render dashboard-only variable with no tracked-config representation, so the
+      # GCP migration dropped it silently. With it unset, BoardDownstreamButtonSet
+      # #generate_defaults still stripped data['buttons'] for any set over 200
+      # buttons while detach_extra_data no-op'd, destroying the set on the next save
+      # -- which zeroed 1754 of 2061 prod button sets (find-a-button and button-set
+      # loading broken library-wide, diagnosed 2026-08-01). The code now degrades to
+      # inline storage when this is unset, but prod wants the remote path: without it
+      # every button set is stored inline in Postgres.
+      APP_ENV_VARS_STATIC: AWS_REGION=us-west-2,SES_REGION=us-west-2,UPLOADS_S3_BUCKET=lingolinq-prod-uploads,STATIC_S3_BUCKET=lingolinq-prod-static,UPLOADS_S3_NO_ACL=1,UPLOADS_S3_CDN=https://d34sa6lc5jfe66.cloudfront.net,REMOTE_EXTRA_DATA=1,SENTRY_ENVIRONMENT=production,RAILS_LOG_TO_STDOUT=true,RAILS_SERVE_STATIC_FILES=true,RUBY_YJIT_ENABLE=1,WEB_CONCURRENCY=2
       # REDIS_TLS_VERIFY_HOSTNAME=false is set on every deploy below: Memorystore is reached by
       # private IP and its server cert is issued for the instance, not the IP, so hostname
       # matching cannot pass. CA-chain verification (VERIFY_PEER against REDIS_CA_CERT) stays on.

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -121,15 +121,19 @@ jobs:
       # time; stable (non-presigned) URLs are required by the Ember offline cache, which is
       # URL-keyed and does not strip X-Amz-* params.
       # REMOTE_EXTRA_DATA=1: gates the detach-to-S3 path for BoardDownstreamButtonSet
-      # buttons and LogSession events (ExtraData#extra_data_too_big?). This was a
-      # Render dashboard-only variable with no tracked-config representation, so the
-      # GCP migration dropped it silently. With it unset, BoardDownstreamButtonSet
-      # #generate_defaults still stripped data['buttons'] for any set over 200
-      # buttons while detach_extra_data no-op'd, destroying the set on the next save
-      # -- which zeroed 1754 of 2061 prod button sets (find-a-button and button-set
-      # loading broken library-wide, diagnosed 2026-08-01). The code now degrades to
-      # inline storage when this is unset, but prod wants the remote path: without it
-      # every button set is stored inline in Postgres.
+      # buttons and LogSession events (ExtraData#extra_data_too_big?). With it unset,
+      # BoardDownstreamButtonSet#generate_defaults still stripped data['buttons'] for
+      # any set over 200 buttons while detach_extra_data no-op'd, destroying the set on
+      # the next save -- which zeroed 1754 of 2061 prod button sets (find-a-button and
+      # button-set loading broken library-wide, diagnosed 2026-08-01, PR #724).
+      # PROVENANCE, do not restate this as a migration regression without checking:
+      # the variable is absent from tracked config everywhere in this repo AND from the
+      # 2026-06-30 45-var Render prod env accounting, so it was most likely never set on
+      # Render prod either. Vintage unknown; it was NOT confirmed to be a GCP cutover drop.
+      # Enabling it here is a deliberate production enablement decision (Scot, 2026-08-01),
+      # not a restoration: the code now degrades safely to inline storage when this is
+      # unset, but inline means every button set lives in Postgres and ships whole in the
+      # API response (~1MB for a 3717-button set), which is a bad steady state.
       APP_ENV_VARS_STATIC: AWS_REGION=us-west-2,SES_REGION=us-west-2,UPLOADS_S3_BUCKET=lingolinq-prod-uploads,STATIC_S3_BUCKET=lingolinq-prod-static,UPLOADS_S3_NO_ACL=1,UPLOADS_S3_CDN=https://d34sa6lc5jfe66.cloudfront.net,REMOTE_EXTRA_DATA=1,SENTRY_ENVIRONMENT=production,RAILS_LOG_TO_STDOUT=true,RAILS_SERVE_STATIC_FILES=true,RUBY_YJIT_ENABLE=1,WEB_CONCURRENCY=2
       # REDIS_TLS_VERIFY_HOSTNAME=false is set on every deploy below: Memorystore is reached by
       # private IP and its server cert is issued for the instance, not the IP, so hostname

--- a/app/models/board_downstream_button_set.rb
+++ b/app/models/board_downstream_button_set.rb
@@ -37,7 +37,14 @@ class BoardDownstreamButtonSet < ApplicationRecord
       self.data['linked_board_ids'] = buttons.map{|b| b['linked_board_id'] }.compact.uniq
       self.data['button_count'] = buttons.length
       self.data['board_count'] = buttons.map{|b| b['board_id'] }.uniq.length
-      if (self.data['buttons'] || []).length > 200
+      # Only hand the buttons off to the detach-to-S3 path when that path can
+      # actually store them. Without REMOTE_EXTRA_DATA, detach_extra_data is a
+      # no-op (extra_data_too_big? short-circuits), so stashing them here would
+      # move the only copy into memory, and the next save re-enters this method,
+      # clears @cached_extra_data, and writes button_count = 0 -- silently
+      # destroying the set. Keeping them inline is the correct degraded mode; it
+      # is already how every set under the 200-button threshold is stored.
+      if remote_extra_data_enabled? && (self.data['buttons'] || []).length > 200
         @cached_extra_data = self.data['buttons']
         self.data.delete('buttons')
       end

--- a/app/models/concerns/extra_data.rb
+++ b/app/models/concerns/extra_data.rb
@@ -183,8 +183,15 @@ module ExtraData
     false
   end
 
+  # Whether detached (S3-backed) extra data is available in this environment.
+  # When it is not, nothing can ever be uploaded, so callers must keep their data
+  # inline rather than stashing it somewhere that will never be persisted.
+  def remote_extra_data_enabled?
+    !!ENV['REMOTE_EXTRA_DATA']
+  end
+
   def extra_data_too_big?
-    return false unless ENV['REMOTE_EXTRA_DATA']
+    return false unless remote_extra_data_enabled?
     if self.is_a?(LogSession) && self.log_type == 'session'
       user = self.user
       if self.data && self.data['events'] && self.data['events'].length > 5

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -8012,8 +8012,13 @@ detach is a **silent no-op** that still returns `true`. Meanwhile
 `@cached_extra_data` for any set over 200 buttons. Nothing got uploaded, so that was the only
 copy, and because `generate_defaults` is a `before_save` callback that begins by nilling
 `@cached_extra_data`, the very next save recomputed `button_count = 0` and wrote the record
-empty. This zeroed 1754 of 2061 prod button sets after the Render to GCP migration dropped the
-variable (it was dashboard-only, with no tracked-config representation).
+empty. This zeroed 1754 of 2061 prod button sets. The variable appears in no tracked config
+anywhere in the repo, and does not appear in the 2026-06-30 45-var Render prod env
+accounting either, so its absence is a long-standing misconfiguration of unknown
+vintage rather than a cutover regression. (Do not assume "the migration dropped it"
+without checking the Render side; the 10 prod sets that carry a nonce come from
+`url_for`'s `detach_extra_data('force')` path, which bypasses the env gate at
+`extra_data.rb:28`, and are not evidence the var was ever set.)
 
 **Rule:** never move the only copy of data into a transient stash unless the destination is
 known to be writable. Gate the strip on the same predicate that gates the write. `LogSession`

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -7999,3 +7999,37 @@ After the Ember 5 modal migration, `utils/modal.open` only drives `service:modal
 ## Gotcha: authenticated chrome is AppNavbar, not application.hbs #identity
 
 When `useAppNavbarInHeader` is true (dashboard, org, most user routes), `application.hbs` renders `<AppNavbar>` and **skips** the legacy `#identity` block. Header controls added only under `#identity` in `application.hbs` are invisible on those pages. Put authenticated-nav affordances (e.g. Stop Masquerading next to Upgrade) in `app-navbar-authenticated-inner.hbs` (and the mobile drawer). Ref: [`2026-07-30-org-directory-find-user-masquerade.md`](./2026-07-30-org-directory-find-user-masquerade.md).
+
+## Pattern: a missing env var can turn a storage optimization into silent data destruction
+
+**Surface:** `ExtraData` concern (`app/models/concerns/extra_data.rb`) plus any caller that
+stashes data into `@cached_extra_data` before calling `detach_extra_data`.
+
+**Gotcha:** `extra_data_too_big?` hard-returns false unless `ENV['REMOTE_EXTRA_DATA']` is set,
+and the upload block in `detach_extra_data` is gated on it. With the var unset the entire
+detach is a **silent no-op** that still returns `true`. Meanwhile
+`BoardDownstreamButtonSet#generate_defaults` was stripping `data['buttons']` into the in-memory
+`@cached_extra_data` for any set over 200 buttons. Nothing got uploaded, so that was the only
+copy, and because `generate_defaults` is a `before_save` callback that begins by nilling
+`@cached_extra_data`, the very next save recomputed `button_count = 0` and wrote the record
+empty. This zeroed 1754 of 2061 prod button sets after the Render to GCP migration dropped the
+variable (it was dashboard-only, with no tracked-config representation).
+
+**Rule:** never move the only copy of data into a transient stash unless the destination is
+known to be writable. Gate the strip on the same predicate that gates the write. `LogSession`
+already did this correctly (`extra_data.rb:51-53` keeps events in the DB when upload fails);
+`BoardDownstreamButtonSet` did not, on the reasoning that button sets are regenerable, but
+regeneration hits the identical trap.
+
+**Diagnostic technique that cracked it:** look at the *distribution*, not one record. Every
+prod button set was under the 200-button threshold (`bc_max=194`, `bc_gt200=0`) in a library
+whose root boards legitimately produce 3717-button sets. A hard ceiling exactly at a constant
+in the code is a fingerprint pointing straight at the branch guarded by that constant. One
+broken record looks like corruption; the histogram names the line.
+
+**Also:** `extras:rebuild_button_sets` reported success while writing empty sets, which sent a
+prior triage session chasing S3 KMS and ImageMagick ghosts. A repair task that cannot detect
+its own no-op is worse than no task. It now preflights the storage config and reports roots
+that rebuild to zero.
+
+**First seen in:** `2026-08-01-prod-empty-button-sets.md` (PR #724)

--- a/lib/tasks/extras.rake
+++ b/lib/tasks/extras.rake
@@ -396,11 +396,16 @@ task "extras:rebuild_button_sets" => :environment do
   end
   puts "\nRebuilt #{processed} root boards (#{errored} errors)."
   puts "Sub-boards reference their root's set via source_id, so the whole tree is covered."
-  if empty.any?
-    puts "\nWARNING: #{empty.length} root board(s) rebuilt to button_count=0:"
+  if empty.any? || errored > 0
+    puts "\nFAILED: #{empty.length} root board(s) rebuilt to button_count=0, #{errored} raised:"
     empty.first(20).each { |k| puts "  #{k}" }
     puts "  ...and #{empty.length - 20} more" if empty.length > 20
+    puts "A root board with children that rebuilds to zero buttons is a failure, not a success."
     puts "This usually means extra-data storage is not persisting. Check REMOTE_EXTRA_DATA and S3 credentials."
+    # Exit nonzero so an automated caller cannot read this as a clean run. Silently
+    # "succeeding" while writing empty sets is what sent a prior triage session
+    # chasing S3 KMS and ImageMagick ghosts for two days.
+    exit 1
   end
 end
 

--- a/lib/tasks/extras.rake
+++ b/lib/tasks/extras.rake
@@ -335,6 +335,23 @@ end
 # and can produce empty sets. One board at a time is the correct, prod-proven mode
 # (this mirrors the button-set half of extras:fix_prod_setup).
 task "extras:rebuild_button_sets" => :environment do
+  # Preflight. Without REMOTE_EXTRA_DATA the detach-to-S3 path is a no-op, and this
+  # task used to run to "completion" while writing button_count=0 for every set over
+  # 200 buttons (1754 of 2061 prod sets, 2026-08-01). Refuse rather than silently
+  # rebuild the library into empty sets. Set REBUILD_BUTTON_SETS_ALLOW_INLINE=1 to
+  # proceed anyway and store every set inline in Postgres.
+  if !ENV['REMOTE_EXTRA_DATA'] && !ENV['REBUILD_BUTTON_SETS_ALLOW_INLINE']
+    abort <<~MSG
+      REFUSING TO RUN: REMOTE_EXTRA_DATA is not set.
+      Button sets over 200 buttons cannot be persisted to S3 in this environment and
+      would be stored inline in Postgres instead. Set REMOTE_EXTRA_DATA=1 (with working
+      S3 credentials), or set REBUILD_BUTTON_SETS_ALLOW_INLINE=1 to accept inline storage.
+    MSG
+  end
+  if ENV['REMOTE_EXTRA_DATA'] && ENV['UPLOADS_S3_BUCKET'].blank?
+    abort 'REFUSING TO RUN: REMOTE_EXTRA_DATA is set but UPLOADS_S3_BUCKET is empty.'
+  end
+
   # Clear the per-board traversal coordination cache so every root gets a clean rebuild.
   cache_keys = RedisInit.default.keys('traversed/button_set/*')
   cache_keys.each { |k| RedisInit.default.del(k) }
@@ -357,7 +374,7 @@ task "extras:rebuild_button_sets" => :environment do
   end
 
   puts "  Root boards to rebuild: #{root_boards.length}"
-  processed = 0; errored = 0
+  processed = 0; errored = 0; empty = []
   root_boards.each_with_index do |board, i|
     children = (board.settings['immediately_downstream_board_ids'] || []).length
     print "  [#{i + 1}/#{root_boards.length}] #{board.key} (#{children} children)..."
@@ -368,6 +385,9 @@ task "extras:rebuild_button_sets" => :environment do
       cnt = bs && bs.data['button_count']
       inc = bs && (bs.data['included_board_ids'] || []).length
       puts " done (boards=#{inc} buttons=#{cnt})"
+      # A root board with children that rebuilds to zero buttons is a failure, not a
+      # success. Track it so the summary cannot read as green when the library is empty.
+      empty << board.key if cnt.to_i == 0
       processed += 1
     rescue => e
       puts " ERROR: #{e.class}: #{e.message}"
@@ -376,6 +396,12 @@ task "extras:rebuild_button_sets" => :environment do
   end
   puts "\nRebuilt #{processed} root boards (#{errored} errors)."
   puts "Sub-boards reference their root's set via source_id, so the whole tree is covered."
+  if empty.any?
+    puts "\nWARNING: #{empty.length} root board(s) rebuilt to button_count=0:"
+    empty.first(20).each { |k| puts "  #{k}" }
+    puts "  ...and #{empty.length - 20} more" if empty.length > 20
+    puts "This usually means extra-data storage is not persisting. Check REMOTE_EXTRA_DATA and S3 credentials."
+  end
 end
 
 task "extras:reindex_public_boards" => :environment do

--- a/spec/models/board_downstream_button_set_spec.rb
+++ b/spec/models/board_downstream_button_set_spec.rb
@@ -8,7 +8,54 @@ describe BoardDownstreamButtonSet, :type => :model do
     expect(bs.data['button_count']).to eq(0)
     expect(bs.data['board_count']).to eq(0)
   end
-  
+
+  describe "large button sets without remote extra data" do
+    # Regression: with REMOTE_EXTRA_DATA unset, detach_extra_data is a no-op, so
+    # stripping data['buttons'] moved the only copy into memory and the next save
+    # re-entered generate_defaults, cleared it, and wrote button_count = 0. That
+    # zeroed 1754 of 2061 prod button sets (2026-08-01).
+    let(:many_buttons) do
+      (0...250).map{|i| {'id' => i, 'board_id' => '1_1', 'label' => "b#{i}"} }
+    end
+
+    it "should keep buttons inline and preserve button_count across saves" do
+      ENV['REMOTE_EXTRA_DATA'] = nil
+      bs = BoardDownstreamButtonSet.create
+      bs.data['buttons'] = many_buttons
+      bs.generate_defaults(true)
+      expect(bs.data['button_count']).to eq(250)
+      expect(bs.data['buttons']).to_not eq(nil)
+
+      bs.save
+      bs.reload
+      expect(bs.data['button_count']).to eq(250)
+      expect(bs.buttons.length).to eq(250)
+    end
+
+    it "should still detach to remote storage when remote extra data is enabled" do
+      ENV['REMOTE_EXTRA_DATA'] = '1'
+      bs = BoardDownstreamButtonSet.create
+      bs.data['buttons'] = many_buttons
+      bs.generate_defaults(true)
+      expect(bs.data['button_count']).to eq(250)
+      # handed off to the detach path rather than left inline
+      expect(bs.data['buttons']).to eq(nil)
+      expect(bs.instance_variable_get('@cached_extra_data').length).to eq(250)
+      ENV['REMOTE_EXTRA_DATA'] = nil
+    end
+
+    it "should leave small button sets inline either way" do
+      ENV['REMOTE_EXTRA_DATA'] = '1'
+      bs = BoardDownstreamButtonSet.create
+      bs.data['buttons'] = many_buttons[0, 10]
+      bs.generate_defaults(true)
+      expect(bs.data['button_count']).to eq(10)
+      expect(bs.data['buttons']).to_not eq(nil)
+      ENV['REMOTE_EXTRA_DATA'] = nil
+    end
+  end
+
+
   describe "update_for" do
     it "should not create a buttonset and should re-enqueue a bounded retry if a matching board is not yet visible" do
       # The board may not be visible yet because the deferred job can run before the


### PR DESCRIPTION
## Problem

1754 of 2061 `BoardDownstreamButtonSet` records in GCP prod have `button_count = 0`,
so find-a-button and button-set loading are broken across the board library.

## Root cause (confirmed, not hypothesized)

`REMOTE_EXTRA_DATA` is unset in GCP prod (verified live: `gcloud run services
describe lingolinq-web` returns 44 env vars, and a prod runner confirmed
`env_remote_extra_data=nil`). It appears in no tracked config anywhere in the repo.

**Correction / open question on provenance.** An earlier draft of this PR claimed the
GCP migration dropped it. I could not verify that and it is probably wrong: the
2026-06-30 env-reconciliation accounting enumerated all 45 Render prod env vars and
`REMOTE_EXTRA_DATA` is not among them, so it was likely never set on Render prod
either. (The 10 prod sets that do carry a nonce are explained by `url_for`'s
`detach_extra_data('force')` path, which bypasses the env gate at `extra_data.rb:28`,
not by the var having been set.) Treat this as a long-standing misconfiguration of
unknown vintage, not a cutover regression. I had no Render API key available to check
directly; that check is still owed.

With it unset, `ExtraData#extra_data_too_big?` hard-returns false
(`extra_data.rb:187`), which gates the upload block in `detach_extra_data`
(`extra_data.rb:28`) and makes the whole detach a **silent no-op**.

But `BoardDownstreamButtonSet#generate_defaults` still stripped `data['buttons']`
into the in-memory `@cached_extra_data` for any set over 200 buttons
(`board_downstream_button_set.rb:40-43`). Nothing was uploaded, so that was the
only remaining copy. The next `save` fires `before_save :generate_defaults`, which
nils `@cached_extra_data` at line 29, finds no buttons anywhere, and writes
`button_count = 0`. The set is destroyed.

Normally the `@skip_extra_data_update` guard set inside a *successful* detach
(`extra_data.rb:59-61`) protects the count on that follow-up save. When detach
no-ops, that guard is never set.

### Evidence

Live env: `gcloud run services describe lingolinq-web` returns 44 env vars,
`REMOTE_EXTRA_DATA` absent. A prod runner confirmed `env_remote_extra_data=nil`.

Distribution across all 2061 prod sets:

```
bc_zero=1754   bc_1_200=307   bc_gt200=0   bc_max=194
with_nonce=10  with_inline_buttons=237     with_source_id=71
```

**No button set in the entire production database exceeds 200 buttons**, in a
library where one root board (`vocal-flair-84`) carries 142 buttons across 98
downstream boards. Its true set is 3717 buttons. Every set that would have crossed
the threshold was zeroed; the 307 survivors are exactly those below it. That
distribution is the fingerprint of the >200 branch.

### Ruled out

- **Not `BoardContent` / copy-by-reference.** `Board#grid_buttons` (`board.rb:1765`)
  calls `self.buttons`, which resolves through `BoardContent.load_content`
  (`board.rb:1744`).
- **Not the Step-1 `source_id` early return** (`board_downstream_button_set.rb:517`);
  only 71 of 2061 sets carry a `source_id`.
- **Not the Redis traversal cache**; `update_for:421` deletes the key it reads.
- **Not S3 KMS/SigV4 or ImageMagick** (already fixed; re-confirmed by probe below).

## Changes

- `ExtraData#remote_extra_data_enabled?` extracted as the single gate for
  "can detached storage actually persist anything," reused by `extra_data_too_big?`.
- `generate_defaults` only strips `data['buttons']` when that gate is open. Inline
  storage is the correct degraded mode and is already how every sub-200 set is stored.
- `REMOTE_EXTRA_DATA=1` set in the Cloud Run deploy env, so prod uses the intended
  S3-backed path instead of storing every set inline in Postgres. **This one is a
  judgment call and wants sign-off** (see "Decision needed" below), because I could
  not confirm prod has ever run with it on.
- `extras:rebuild_button_sets` refuses to run when extra-data storage cannot persist,
  and now reports roots that rebuild to zero buttons. It previously reported success
  while writing empty sets, which misled a prior triage session.
- Regression specs for the degraded path and the remote-enabled path.

## Verification

S3 round-trip in prod (proving the remote path is healthy and merely never invoked):
```
upload_result={... uploaded: true}
readback={found: true, url: "https://d34sa6lc5jfe66.cloudfront.net/..."}
```

End-to-end rebuild of the representative root in prod with the gate open:
```
VERIFY board=1_815 root_buttons=142
VERIFY set=1_771 bc=3717 incl=98 nonce=true
VERIFY s3_object_exists=true
```
`button_count` 0 -> 3717, nonce assigned, S3 object present and fetchable.

Specs: `board_downstream_button_set_spec.rb` + `extra_data_spec.rb` = 121 examples,
0 failures. `button_sets_controller_spec.rb` + `json_api/button_set_spec.rb` = 19
examples, 0 failures. The new degraded-path spec was confirmed to fail without the
code change.

## Fix status

| Item | Status | Evidence |
|---|---|---|
| Root cause identified | Fixed | `extra_data.rb:187`, `board_downstream_button_set.rb:40-43` |
| Data destruction on save | Fixed | `board_downstream_button_set.rb:47`; spec "should keep buttons inline and preserve button_count across saves" |
| Prod env restored | Fixed (takes effect on next Cloud Run deploy) | `deploy-cloudrun.yml` `APP_ENV_VARS_STATIC` |
| Rebuild path silently reporting success | Fixed | `lib/tasks/extras.rake` preflight + empty-root summary |
| Representative root has non-zero count + fetchable url | Fixed | `VERIFY set=1_771 bc=3717 ... s3_object_exists=true` |
| Remaining ~1753 empty sets | Not fixed in this PR | Requires running `extras:rebuild_button_sets` in prod AFTER this merges and deploys |

## Decision: remote mode ENABLED (approved)

`REMOTE_EXTRA_DATA=1` stays. Approved by Scot 2026-08-01, concurred by the Codex
review pass. Recorded here because this is a deliberate production enablement, not a
restoration of a known-prior state.

Rationale: prod already serves remote `/extras/` URLs for the sets that have them
(that is the 404 in the original report), so remote mode is partially live regardless.
S3 write and CloudFront readback were both verified working in prod. The inline
alternative is not a safe status quo but a different untested state that ships roughly
a megabyte of JSON per board-set fetch, which is a meaningful regression for offline
sync on an AAC client.

Residual risk accepted: this prod was not confirmed to have ever run *fully* in remote
mode, and the Render-side env could not be checked directly (no API key available).

## Not covered by this PR

- **The bulk rebuild has not been run.** Only `vocal-flair-84` was rebuilt, as
  verification. The other ~1753 sets stay empty until `extras:rebuild_button_sets`
  runs in prod, which should happen after this deploys so regenerated sets are not
  destroyed again. That is a bulk prod write and wants explicit sign-off.
- **The `scotw` / `home_board=nil` open question** from the handoff was not traced.
- **A second latent data-loss path**: when an upload is throttled,
  `upload_remote_data` returns `:throttled` but `detach_extra_data:55` still deletes
  the attribute. Not touched here to keep this change surgical.
- **`lingolinq-seed` Cloud Run job still exists.** It is a standing privileged
  surface and the handoff asks for it to be deleted; it is being kept only because
  the bulk rebuild needs it. Delete after the rebuild:
  `gcloud run jobs delete lingolinq-seed --region us-central1`.

## Author-Model: opus-5
