### PR TITLE
fix(extra-data): keep the only copy when a remote upload does not land

### DIFF
--- a/app/models/concerns/extra_data.rb
+++ b/app/models/concerns/extra_data.rb
@@ -45,17 +45,41 @@ module ExtraData
             res = upload_remote_data(public_extra_data, public_path, 'public')
           end
 
-          if res != :nothing && self.is_a?(BoardDownstreamButtonSet)
+          # Only :uploaded and :confirmed mean a remote copy actually exists.
+          # :throttled and :nothing both mean it does not, so neither may be
+          # treated as a stored revision or used to justify dropping the local
+          # copy -- for ANY record type. The old rule keyed off the record class
+          # instead, on the theory that a button set is always regenerable; the
+          # empty-button-set incident showed regeneration hits the same trap.
+          stored_remotely = (res == :uploaded || res == :confirmed)
+          if stored_remotely && self.is_a?(BoardDownstreamButtonSet)
             self.data['extra_data_revision'] = self.data['full_set_revision']
           end
-          if self.is_a?(LogSession) && (res == :nothing || res == :throttled)
-            # log sessions should save to the db if upload fails, as there's
-            # no way to regenerate the un-uploaded data
-          else
+          if stored_remotely
             self.data.delete(extra_data_attribute)
+          else
+            # This record now holds the only copy, so put it back inline before
+            # saving. Skipping the delete is NOT enough: for a button set over the
+            # stash threshold, generate_defaults has already moved the buttons out
+            # of self.data into @cached_extra_data (see
+            # BoardDownstreamButtonSet#generate_defaults), so the row would still
+            # persist with no buttons and a stale button_count.
+            self.data[extra_data_attribute] = extra_data
           end
           # persist the nonce and the url, remove the big-data attribute
           self.data['extra_data_version'] = extra_data_version
+          @skip_extra_data_update = true
+          self.save
+          @skip_extra_data_update = false
+        elsif self.data[extra_data_attribute] == nil
+          # Upload skipped because a retry is already scheduled (or the board is
+          # gone), but generate_defaults has already pulled the buttons out of
+          # self.data into @cached_extra_data. The caller's own save right after
+          # this -- update_for does exactly that -- would otherwise persist a row
+          # with no buttons. Write the only copy back and save it inline.
+          # @skip_extra_data_update brackets the save so the before_save
+          # generate_defaults cannot immediately re-stash and re-delete it.
+          self.data[extra_data_attribute] = extra_data
           @skip_extra_data_update = true
           self.save
           @skip_extra_data_update = false
@@ -113,6 +137,15 @@ module ExtraData
       end
       return res[:uploaded] ? :uploaded : :confirmed
     end
+    # remote_upload only hands back a path after it either uploaded the object or
+    # verified a byte-identical one already sits at that path
+    # (check_existing_upload matched on checksum, then touched it). Either way the
+    # remote copy is present, so this is a confirmed detach, not a no-op. The
+    # branch above is skipped here only because no bookkeeping changed -- same
+    # path, same checksum -- which is exactly why the CDN pointers are left alone.
+    # Reserve :nothing for "no upload happened at all" (res nil), since callers
+    # use it to decide whether it is safe to discard the only local copy.
+    return :confirmed if res && res[:path]
     return :nothing
   end
 

--- a/spec/models/concerns/extra_data_spec.rb
+++ b/spec/models/concerns/extra_data_spec.rb
@@ -367,7 +367,175 @@ describe ExtraData, :type => :model do
       expect(ra.path).to eq("#{s.global_id}")
       expect(ra.action).to eq("upload_log_session")
       expect(ra.act_at).to be > 4.minutes.from_now
-    end    
+    end
+
+    describe "preserving the only copy when the upload does not land" do
+      # Regression for #732. A throttled (or otherwise unsuccessful) upload used
+      # to delete data['buttons'] anyway, on the theory that a button set is
+      # always regenerable. The empty-button-set incident showed regeneration
+      # hits the same trap. Nothing may drop the local copy unless a remote copy
+      # is confirmed present.
+      let(:many_buttons) do
+        (0...250).map{|i| {'id' => i, 'board_id' => '1_1', 'label' => "b#{i}"} }
+      end
+
+      def with_remote_extra_data
+        prior = ENV['REMOTE_EXTRA_DATA']
+        ENV['REMOTE_EXTRA_DATA'] = '1'
+        yield
+      ensure
+        ENV['REMOTE_EXTRA_DATA'] = prior
+      end
+
+      it "should keep a small button set inline when the upload is throttled" do
+        with_remote_extra_data do
+          u = User.create
+          b = Board.create(user: u)
+          bs = BoardDownstreamButtonSet.create(board: b)
+          bs.data['buttons'] = many_buttons[0, 10]
+          bs.generate_defaults(true)
+          # under the stash threshold, so the buttons are still inline
+          expect(bs.data['buttons'].length).to eq(10)
+          expect(Uploader).to receive(:remote_upload).at_least(1).times.and_raise("throttled upload")
+
+          bs.detach_extra_data(true)
+
+          expect(bs.data['buttons']).to_not eq(nil)
+          expect(bs.data['buttons'].length).to eq(10)
+          expect(bs.reload.data['buttons'].length).to eq(10)
+          expect(bs.data['button_count']).to eq(10)
+        end
+      end
+
+      it "should restore a stashed large button set when the upload is throttled" do
+        # The case that actually matters: generate_defaults has already moved the
+        # buttons out of self.data into @cached_extra_data, so merely skipping the
+        # delete would still persist a row with no buttons at all.
+        with_remote_extra_data do
+          u = User.create
+          b = Board.create(user: u)
+          bs = BoardDownstreamButtonSet.create(board: b)
+          bs.data['buttons'] = many_buttons
+          bs.generate_defaults(true)
+          expect(bs.data['buttons']).to eq(nil)
+          expect(bs.instance_variable_get('@cached_extra_data').length).to eq(250)
+          expect(Uploader).to receive(:remote_upload).at_least(1).times.and_raise("throttled upload")
+
+          bs.detach_extra_data(true)
+
+          expect(bs.reload.data['buttons']).to_not eq(nil)
+          expect(bs.data['buttons'].length).to eq(250)
+          expect(bs.data['button_count']).to eq(250)
+          expect(bs.buttons.length).to eq(250)
+        end
+      end
+
+      it "should not record the revision as stored when the upload is throttled" do
+        with_remote_extra_data do
+          u = User.create
+          b = Board.create(user: u)
+          bs = BoardDownstreamButtonSet.create(board: b)
+          bs.data['full_set_revision'] = 'rev-abc'
+          bs.data['buttons'] = many_buttons[0, 10]
+          bs.generate_defaults(true)
+          expect(Uploader).to receive(:remote_upload).at_least(1).times.and_raise("throttled upload")
+
+          bs.detach_extra_data(true)
+
+          expect(bs.data['extra_data_revision']).to_not eq('rev-abc')
+        end
+      end
+
+      it "should restore the stashed copy when the upload is skipped for an already-scheduled retry" do
+        # Path C: the guard skips the upload entirely, but generate_defaults has
+        # already emptied self.data. The caller's own save would then persist a
+        # row with no buttons.
+        with_remote_extra_data do
+          u = User.create
+          b = Board.create(user: u)
+          bs = BoardDownstreamButtonSet.create(board: b)
+          RemoteAction.create(path: b.global_id, act_at: 5.minutes.from_now, action: 'upload_button_set')
+          bs.data['buttons'] = many_buttons
+          bs.generate_defaults(true)
+          expect(bs.data['buttons']).to eq(nil)
+          expect(Uploader).to_not receive(:remote_upload)
+
+          bs.detach_extra_data(true)
+
+          expect(bs.reload.data['buttons']).to_not eq(nil)
+          expect(bs.data['buttons'].length).to eq(250)
+          expect(bs.data['button_count']).to eq(250)
+        end
+      end
+
+      it "should survive a full update_for rebuild whose upload is throttled" do
+        # The real-world path: update_for calls generate_defaults(true), then
+        # detach_extra_data(true), then set.save. That final save runs OUTSIDE
+        # @skip_extra_data_update, so before_save generate_defaults re-stashes and
+        # re-deletes -- which is how a row ends up with no buttons and a stale
+        # button_count.
+        with_remote_extra_data do
+          u = User.create
+          b = Board.create(user: u)
+          buttons = (0...250).map{|i| {'id' => i + 1, 'label' => "b#{i}"} }
+          order = (0...25).map{|r| (0...10).map{|c| (r * 10) + c + 1 } }
+          b.process({'buttons' => buttons, 'grid' => {'rows' => 25, 'columns' => 10, 'order' => order}})
+          Worker.process_queues
+          BoardDownstreamButtonSet.last_scheduled_stamp = nil
+          expect(Uploader).to receive(:remote_upload).at_least(1).times.and_raise("throttled upload")
+
+          set = BoardDownstreamButtonSet.update_for(b.global_id, true)
+          expect(set).to_not eq(nil)
+
+          set.reload
+          expect(set.data['buttons']).to_not eq(nil)
+          expect(set.data['buttons'].length).to eq(250)
+          expect(set.data['button_count']).to eq(250)
+          expect(set.buttons.length).to eq(250)
+        end
+      end
+
+      it "should still drop the local copy once the upload succeeds" do
+        with_remote_extra_data do
+          u = User.create
+          b = Board.create(user: u)
+          bs = BoardDownstreamButtonSet.create(board: b)
+          bs.data['full_set_revision'] = 'rev-abc'
+          bs.data['buttons'] = many_buttons
+          bs.generate_defaults(true)
+          expect(Uploader).to receive(:remote_upload).at_least(1).times.and_return({path: 'c/d/e.json', uploaded: true})
+
+          bs.detach_extra_data(true)
+
+          expect(bs.reload.data['buttons']).to eq(nil)
+          expect(bs.data['extra_data_revision']).to eq('rev-abc')
+        end
+      end
+
+      it "should drop a log session's events when an identical remote copy is confirmed" do
+        # Behavior change approved with #732: upload_remote_data used to return
+        # :nothing when S3 already held a byte-identical object at the same path,
+        # which is indistinguishable from "no upload happened". That case is now
+        # :confirmed, so the remote copy is verified and the local one may go.
+        u = User.create
+        d = Device.create(user: u)
+        s = LogSession.create(user: u, device: d, author: u, data: {'extra_data_nonce' => 'qwwqtqw'})
+        s.data['events'] = [{'id' => 1}, {'id' => 2}]
+        private_path, public_path = LogSession.extra_data_remote_paths(s.data['extra_data_nonce'], s, 2, true)
+        s.data['extra_data_private_path'] = private_path
+        s.data['extra_data_public_path'] = public_path
+        expect(s).to receive(:extra_data_too_big?).and_return(false).at_least(1).times
+        # same path back, no :uploaded flag -- remote_upload only does this after
+        # check_existing_upload matched on checksum
+        expect(Uploader).to receive(:remote_upload).at_least(1).times { |path, local, type, digest|
+          {url: "https://example.com/#{path}", path: path}
+        }
+
+        s.detach_extra_data('force')
+
+        expect(s.reload.data['events']).to eq(nil)
+      end
+    end
   end
 
   describe "extra_data_attribute" do


### PR DESCRIPTION
Closes #732.

`detach_extra_data` decided whether to discard a record's extra data by record **class** rather than by upload **outcome**. Anything that was not a `LogSession` had `data[attr]` deleted even when the upload was throttled. The reasoning in the comment was that a button set is always regenerable; #724 showed regeneration hits the same trap, which is how prod button sets ended up at `button_count = 0` with no buttons anywhere.

## Three loss paths, only the first of which the issue described

**A. Small sets.** Buttons are inline in `data['buttons']`, and `extra_data_too_big?` is `.length > 0` (not `> 200`), so this ran for any non-empty set with `REMOTE_EXTRA_DATA` on. Throttle deleted the only copy.

**B. Large sets (> 200 buttons).** `generate_defaults` has already moved the buttons into `@cached_extra_data` and deleted `data['buttons']` in `before_save` (`board_downstream_button_set.rb:47-50`). On throttle the delete is a no-op and the row is already empty. **Skipping the delete does not fix this**; the copy has to be written back. This is the case the S3 detach exists for.

**C. Upload skipped for an already-scheduled retry.** The guard at `extra_data.rb:41` short-circuits the whole block while `generate_defaults` has already emptied `self.data`, so the caller's own save persists a row with no buttons. This is the path `update_for` takes:

```ruby
# board_downstream_button_set.rb:662-668
set.data['buttons'] = all_buttons
set.generate_defaults(true)   # > 200: stash to @cached_extra_data, delete from data
set.detach_extra_data(true)   # throttled
set.save                      # <-- runs OUTSIDE @skip_extra_data_update
```

That final `set.save` re-enters `before_save generate_defaults` unguarded: it nils `@cached_extra_data`, then `skip_extra_data_processing?` returns true (nonce present, no buttons) and skips the recompute. Row with no buttons, stale non-zero `button_count`, last in-memory copy destroyed in the same breath. That is the prod signature.

## Changes

1. Gate the delete on `stored_remotely` (`res == :uploaded || res == :confirmed`) instead of on record class, and restore `data[attr]` inline when the upload did not land.
2. Gate the `extra_data_revision` stamp on the same condition. It previously fired on `res != :nothing`, which includes `:throttled`, recording a never-uploaded revision as stored.
3. `upload_remote_data` returns `:confirmed` when `remote_upload` handed back a path, reserving `:nothing` for "no upload happened at all". `remote_upload` only returns a path after uploading or after `check_existing_upload` matched on checksum, so the remote copy is verified present either way. Callers use `:nothing` to decide whether it is safe to drop the only local copy, so the two had to be separated. CDN bookkeeping is deliberately left alone on that path since nothing changed (same path, same checksum), and invalidating it would be a gratuitous cache miss on every steady-state re-detach.
4. New `elsif` on the pending-`RemoteAction` guard restores the stashed copy and saves, bracketed by `@skip_extra_data_update = true` so `before_save generate_defaults` cannot immediately re-stash and re-delete it. **Required, not defensive**: without it, path C still loses the data even with changes 1-3 in place.

Change 1 is a truth-table no-op for `LogSession` on every outcome except the one covered by change 3.

## Approved behavior change

A `LogSession` whose identical events are already confirmed on S3 now drops its local copy instead of keeping it. Previously that case returned `:nothing` (indistinguishable from "no upload happened") and the events were preserved. Pinned by its own test.

## Fix status

| Item | Status | Evidence |
| --- | --- | --- |
| Path A: small set, throttled upload keeps buttons | Fixed | `extra_data.rb:57-66`; spec "should keep a small button set inline when the upload is throttled" |
| Path B: large stashed set, throttled upload restores buttons | Fixed | `extra_data.rb:59-66`; spec "should restore a stashed large button set when the upload is throttled" |
| Path C: upload skipped for scheduled retry | Fixed | `extra_data.rb:73-85`; specs "should restore the stashed copy when the upload is skipped for an already-scheduled retry" and "should survive a full update_for rebuild whose upload is throttled" |
| `extra_data_revision` no longer stamped on a throttled upload | Fixed | `extra_data.rb:54-56`; spec "should not record the revision as stored when the upload is throttled" |
| `:nothing` vs `:confirmed` disambiguated | Fixed | `extra_data.rb:140-148`; spec "should drop a log session's events when an identical remote copy is confirmed" |
| Successful upload still detaches | No regression | spec "should still drop the local copy once the upload succeeds" |
| `LogSession` throttled still preserves events | No regression | pre-existing specs at `extra_data_spec.rb:306`, `:336` |

## Not covered by this PR

- `generate_defaults` still stashes buttons into `@cached_extra_data` without knowing whether detach will be able to store them. Changes 1 and 4 close the loss, but the stash-then-restore round trip is a latent smell worth a follow-up.
- No prod deploy, prod mutation, or button-set rebuild. Staging only; prod receives this via a later release PR.
- P2 entry-point enumeration is not applicable: no auth, access-control, or visibility surface is touched.
- P3/P4 generated-artifact and cross-doc checks are not applicable: no files under `docs/legal/`, `audit-reports/`, or the document register are touched.

## Tests

New describe block in `spec/models/concerns/extra_data_spec.rb`. **6 of the 7 new examples fail against the unfixed concern**, verified by stashing the app change and re-running; the 7th is the no-regression pin and correctly passes both ways.

The `update_for` regression builds a real 250-button board with an explicit 25x10 grid, throttles `remote_upload`, then reloads the row and asserts `data['buttons'].length == 250` and `button_count == 250`. It is the only test that covers the line-668 save.

| Run | Result |
| --- | --- |
| `extra_data_spec.rb` | 50 examples, 0 failures |
| extra_data + button_set + log_session + remote_action + uploader | 415 examples, 0 failures, 7 pending (pre-existing) |
| New examples vs unfixed concern | 6 of 7 fail as intended |
| Full suite, this branch | 6623 examples, 17 failures |
| Full suite, base `57bd9f729` | 6616 examples, 16 failures |

The suite is **not green at base**. The stable failure set is **15 examples, identical on both**: `word_suggestions_controller:29`, `throttling_spec:87`, `stats_spec:710`, `subscription_spec:1642`, and 11 `user_spec` `add_premium_voice` / `track_protected_source` examples (the known `AuditEvent`-escapes-rollback family).

Three further examples churn between runs and are order/state-dependent, not branch-dependent: base surfaced `board_spec:5089`; this branch surfaced `exporter_spec:80` and `relinking_spec:786` on one run and neither on another. All three pass in isolation (388 examples, 0 failures for `exporter` + `relinking` + `board` together on this branch).

An earlier full run on this branch showed 27 failures including 10 in `stats_spec` and 2 in `user_mailer_spec`. Those were test-DB residue from prior targeted runs in the same session, not a regression: `.rspec` is `--order defined`, and `stats_spec` (file #131) and `user_mailer_spec` (#152) both load **before** `extra_data_spec` (#172), so the added examples cannot reach them. Both files also pass alone on this branch, and a clean re-run reproduced none of the 12.

## Author-Model: opus-5
