### PR TITLE
Paint boards page from a short-lived Mine list cache.

### DIFF
--- a/app/frontend/app/controllers/user/index.js
+++ b/app/frontend/app/controllers/user/index.js
@@ -25,6 +25,7 @@ import {
 } from '../../utils/board-roots';
 import { filterBrandRoots } from '../../utils/board-brands';
 import boardDetailCache from '../../utils/board_detail_cache';
+import boardsPageListCache from '../../utils/boards_page_list_cache';
 
 function invertBoardTagMap(map) {
   var inv = {};
@@ -1035,45 +1036,97 @@ export default Controller.extend({
     if(!args.per_page) { args.per_page = 50; }
     var prior = _this.get(list_name) || [];
     if(prior.error || prior.loading) { prior = []; }
-    if(!append && !prior.length) {
+    /* When a usable completed list is already on screen (SPA re-entry or
+       localStorage hydrate), keep it painted and accumulate pages in a
+       side buffer. Assigning partial pages onto list_name would clear
+       `.done` and re-trigger the boards-page overlay. */
+    var backgroundRefresh = boardsPageListCache.isUsableList(prior);
+    var bufferKey = list_name + ':' + list_id;
+    /* Do not clobber a usable empty list (`[].done`) with {loading:true}. */
+    if(!append && !backgroundRefresh && !prior.length) {
       _this.set(list_name, {loading: true});
     }
+    if(!append && backgroundRefresh) {
+      _this._boards_list_refresh_buffers = _this._boards_list_refresh_buffers || {};
+      _this._boards_list_refresh_buffers[bufferKey] = [];
+    }
     _this.store.query('board', args).then(function(boards) {
-      if(_this.get('list_id') == list_id) {
-        if(!append && prior.length) {
-          prior = [];
-        }
+      if(_this.get('list_id') != list_id) { return; }
 
-        var chunk = boards.slice();
-        if (append && prior.length) {
-          prior = prior.concat(chunk);
+      var chunk = boards.slice();
+      var meta = _this.persistence.meta('board', boards); //_this.store.metadataFor('board');
+
+      if(backgroundRefresh) {
+        var buf = (_this._boards_list_refresh_buffers && _this._boards_list_refresh_buffers[bufferKey]) || [];
+        if(append && buf.length) {
+          buf = buf.concat(chunk);
         } else {
-          prior = chunk;
+          buf = chunk;
         }
-        prior.user_id = _this.get('model.id');
-        _this.set(list_name, prior);
-        var meta = _this.persistence.meta('board', boards); //_this.store.metadataFor('board');
+        buf.user_id = _this.get('model.id');
+        _this._boards_list_refresh_buffers = _this._boards_list_refresh_buffers || {};
+        _this._boards_list_refresh_buffers[bufferKey] = buf;
         if(meta && meta.more) {
           args.per_page = meta.per_page;
           args.offset = meta.next_offset;
-          /* Throttle subsequent pages so a 5-page sweep doesn't fire as
-             a single back-to-back burst (which read as a network
-             "flood" in the dev tools, and competed with foreground
-             traffic like board-preview image loads). 200ms is small
-             enough that the full list still finishes streaming in ~1s
-             for typical cases, and large enough that the requests
-             interleave cleanly with user-initiated work. The list_id
-             check at the top of the function still guards against tab
-             changes during the gap. */
           runLater(function() {
             if(_this.isDestroyed || _this.isDestroying) { return; }
             _this.generate_or_append_to_list(args, list_name, list_id, true);
           }, 200);
         } else {
-          _this.set(list_name + '.done', true);
+          buf.done = true;
+          buf.user_id = _this.get('model.id');
+          _this.set(list_name, buf);
+          if(_this._boards_list_refresh_buffers) {
+            delete _this._boards_list_refresh_buffers[bufferKey];
+          }
+          if(list_name === 'model.my_boards') {
+            boardsPageListCache.write(_this.get('model.id'), buf);
+          }
+        }
+        return;
+      }
+
+      if(!append && prior.length) {
+        prior = [];
+      }
+
+      if (append && prior.length) {
+        prior = prior.concat(chunk);
+      } else {
+        prior = chunk;
+      }
+      prior.user_id = _this.get('model.id');
+      _this.set(list_name, prior);
+      if(meta && meta.more) {
+        args.per_page = meta.per_page;
+        args.offset = meta.next_offset;
+        /* Throttle subsequent pages so a 5-page sweep doesn't fire as
+           a single back-to-back burst (which read as a network
+           "flood" in the dev tools, and competed with foreground
+           traffic like board-preview image loads). 200ms is small
+           enough that the full list still finishes streaming in ~1s
+           for typical cases, and large enough that the requests
+           interleave cleanly with user-initiated work. The list_id
+           check at the top of the function still guards against tab
+           changes during the gap. */
+        runLater(function() {
+          if(_this.isDestroyed || _this.isDestroying) { return; }
+          _this.generate_or_append_to_list(args, list_name, list_id, true);
+        }, 200);
+      } else {
+        _this.set(list_name + '.done', true);
+        if(list_name === 'model.my_boards') {
+          boardsPageListCache.write(_this.get('model.id'), _this.get(list_name));
         }
       }
     }, function() {
+      if(backgroundRefresh) {
+        if(_this._boards_list_refresh_buffers) {
+          delete _this._boards_list_refresh_buffers[bufferKey];
+        }
+        return;
+      }
       if(_this.get('list_id') == list_id && !prior.length) {
         _this.set(list_name, {error: true});
       }

--- a/app/frontend/app/routes/user/boards.js
+++ b/app/frontend/app/routes/user/boards.js
@@ -2,9 +2,11 @@ import Route from '@ember/routing/route';
 import modal from '../../utils/modal';
 import i18n from '../../utils/i18n';
 import { inject as service } from '@ember/service';
+import boardsPageListCache from '../../utils/boards_page_list_cache';
 
 export default Route.extend({
   appState: service('app-state'),
+  store: service('store'),
   controllerName: 'user/index',
 
   activate: function() {
@@ -17,13 +19,36 @@ export default Route.extend({
     return model;
   },
   setupController: function(controller, model) {
-    if(model) { model.reload(); }
+    /* Parent `user` route already resolves currentUser cache-first and
+       background-reloads. An eager model.reload() here raced the Mine-list
+       query and did not help the overlay gate. Only refresh when stale. */
+    if(model && !model.get('really_fresh')) {
+      var reloadPromise = model.reload();
+      if(reloadPromise && reloadPromise.catch) {
+        reloadPromise.catch(function() { });
+      }
+    }
     controller.set('model', model);
     controller.set('parent_object', null);
     controller.set('password', null);
     controller.set('new_user_name', null);
     controller.set('filterString', '');
     controller.set('filterStringDebounced', '');
+
+    /* Hard-refresh hydrate: if Mine list is not already usable in memory,
+       restore a short-lived localStorage snapshot so the overlay gate
+       (`my_boards.done`) can pass immediately while update_selected
+       background-refreshes. */
+    if(model && !boardsPageListCache.isUsableList(model.get('my_boards'))) {
+      var snapshot = boardsPageListCache.read(model.get('id'));
+      if(snapshot && Array.isArray(snapshot.boards)) {
+        var records = boardsPageListCache.hydrate(this.store, snapshot.boards);
+        records.done = true;
+        records.user_id = model.get('id');
+        model.set('my_boards', records);
+      }
+    }
+
     controller.update_selected();
     controller.reload_logs();
     controller.load_badges();

--- a/app/frontend/app/services/app-state.js
+++ b/app/frontend/app/services/app-state.js
@@ -27,6 +27,7 @@ import LingoLinq from '../app';
 import editManager from '../utils/edit_manager';
 import word_suggestions from '../utils/word_suggestions';
 import boardDetailCache from '../utils/board_detail_cache';
+import boardsPageListCache from '../utils/boards_page_list_cache';
 import buttonTracker from '../utils/raw_events';
 import capabilities from '../utils/capabilities';
 import scanner from '../utils/scanner';
@@ -2077,6 +2078,9 @@ export default Service.extend({
     // In-memory board JSON / ordered_buttons / image-warm state must not
     // leak across users on SPA sign-out (full reload clears module state).
     try { boardDetailCache.clear(); } catch(e) { /* non-critical */ }
+    // Boards-page Mine list snapshots are per-user localStorage; drop them
+    // on sign-out so a shared device never shows another user's tiles.
+    try { boardsPageListCache.clearAll(); } catch(e) { /* non-critical */ }
     this.set('last_keepalive', null);
     this.set('refresh_stamp', null);
     this.set('short_refresh_stamp', null);

--- a/app/frontend/app/utils/boards_page_list_cache.js
+++ b/app/frontend/app/utils/boards_page_list_cache.js
@@ -1,0 +1,187 @@
+// Short-lived Mine-tab list snapshot for the boards page overlay gate.
+//
+// Distinct from board_detail_cache (speak-mode /tree JSON). This only stores
+// compact list-tile attributes so /:user/boards can paint immediately after a
+// hard refresh within TTL while a background store.query refreshes the list.
+
+import { get as emberGet } from '@ember/object';
+
+var TTL_MS = 10 * 60 * 1000;
+var MAX_BOARDS = 500;
+var KEY_PREFIX = 'll_boards_page_mine_v1:';
+
+var SNAPSHOT_ATTRS = [
+  'id',
+  'key',
+  'name',
+  'user_name',
+  'public',
+  'copy_id',
+  'image_url',
+  'locale',
+  'translated_locales',
+  'grid',
+  'home_board',
+  'stars'
+];
+
+function _now() {
+  return Date.now();
+}
+
+function _storage() {
+  try {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage;
+    }
+  } catch (e) { /* private mode / blocked */ }
+  return null;
+}
+
+function _storage_key(userId) {
+  if (!userId) { return null; }
+  return KEY_PREFIX + String(userId);
+}
+
+function _attr(board, name) {
+  if (!board) { return undefined; }
+  if (typeof board.get === 'function') {
+    return board.get(name);
+  }
+  return emberGet(board, name);
+}
+
+function serializeBoard(board) {
+  if (!board) { return null; }
+  var id = _attr(board, 'id');
+  if (!id) { return null; }
+  var out = { id: String(id) };
+  for (var i = 0; i < SNAPSHOT_ATTRS.length; i++) {
+    var key = SNAPSHOT_ATTRS[i];
+    if (key === 'id') { continue; }
+    var val = _attr(board, key);
+    if (val !== undefined && val !== null) {
+      out[key] = val;
+    }
+  }
+  return out;
+}
+
+function write(userId, boards) {
+  var storage = _storage();
+  var key = _storage_key(userId);
+  if (!storage || !key || !boards || !Array.isArray(boards)) { return false; }
+  var serialized = [];
+  var limit = Math.min(boards.length, MAX_BOARDS);
+  for (var i = 0; i < limit; i++) {
+    var row = serializeBoard(boards[i]);
+    if (row) { serialized.push(row); }
+  }
+  try {
+    storage.setItem(key, JSON.stringify({
+      saved_at: _now(),
+      user_id: String(userId),
+      boards: serialized
+    }));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function read(userId) {
+  var storage = _storage();
+  var key = _storage_key(userId);
+  if (!storage || !key) { return null; }
+  var raw = null;
+  try {
+    raw = storage.getItem(key);
+  } catch (e) {
+    return null;
+  }
+  if (!raw) { return null; }
+  try {
+    var parsed = JSON.parse(raw);
+    if (!parsed || parsed.user_id !== String(userId)) { return null; }
+    if (!parsed.saved_at || (_now() - parsed.saved_at) > TTL_MS) {
+      try { storage.removeItem(key); } catch (e2) { /* ignore */ }
+      return null;
+    }
+    if (!Array.isArray(parsed.boards)) { return null; }
+    return parsed;
+  } catch (e) {
+    try { storage.removeItem(key); } catch (e2) { /* ignore */ }
+    return null;
+  }
+}
+
+function clear(userId) {
+  var storage = _storage();
+  var key = _storage_key(userId);
+  if (!storage || !key) { return; }
+  try { storage.removeItem(key); } catch (e) { /* ignore */ }
+}
+
+function clearAll() {
+  var storage = _storage();
+  if (!storage) { return; }
+  var toRemove = [];
+  try {
+    for (var i = 0; i < storage.length; i++) {
+      var k = storage.key(i);
+      if (k && k.indexOf(KEY_PREFIX) === 0) {
+        toRemove.push(k);
+      }
+    }
+  } catch (e) { return; }
+  toRemove.forEach(function(k) {
+    try { storage.removeItem(k); } catch (e2) { /* ignore */ }
+  });
+}
+
+function hydrate(store, boards) {
+  if (!store || !boards || !boards.length) { return []; }
+  var records = [];
+  for (var i = 0; i < boards.length; i++) {
+    var board = boards[i];
+    if (!board || !board.id) { continue; }
+    var attrs = {};
+    for (var j = 0; j < SNAPSHOT_ATTRS.length; j++) {
+      var key = SNAPSHOT_ATTRS[j];
+      if (key === 'id') { continue; }
+      if (board[key] !== undefined) {
+        attrs[key] = board[key];
+      }
+    }
+    try {
+      records.push(store.push({
+        data: {
+          id: String(board.id),
+          type: 'board',
+          attributes: attrs
+        }
+      }));
+    } catch (e) { /* skip bad rows */ }
+  }
+  return records;
+}
+
+function isUsableList(list) {
+  /* Array-shaped completed lists only — including length 0 (empty library)
+     so a finished Mine fetch does not re-trigger the boards overlay. */
+  return !!(list && list.done && !list.loading && !list.error && Array.isArray(list));
+}
+
+export default {
+  TTL_MS: TTL_MS,
+  MAX_BOARDS: MAX_BOARDS,
+  KEY_PREFIX: KEY_PREFIX,
+  SNAPSHOT_ATTRS: SNAPSHOT_ATTRS,
+  serializeBoard: serializeBoard,
+  write: write,
+  read: read,
+  clear: clear,
+  clearAll: clearAll,
+  hydrate: hydrate,
+  isUsableList: isUsableList
+};

--- a/app/frontend/tests/unit/utils/boards-page-list-cache-test.js
+++ b/app/frontend/tests/unit/utils/boards-page-list-cache-test.js
@@ -1,0 +1,102 @@
+import { module, test } from 'qunit';
+import boardsPageListCache from 'frontend/utils/boards_page_list_cache';
+
+module('Unit | Utility | boards-page-list-cache', function(hooks) {
+  hooks.beforeEach(function() {
+    boardsPageListCache.clearAll();
+  });
+
+  hooks.afterEach(function() {
+    boardsPageListCache.clearAll();
+  });
+
+  test('write/read round-trips compact board attrs for matching user', function(assert) {
+    var boards = [
+      { id: '1_10', key: 'alice/home', name: 'Home', user_name: 'alice', public: false, copy_id: '1_1', image_url: 'https://example.com/a.png', locale: 'en', stars: 2 },
+      { id: '1_11', key: 'alice/food', name: 'Food', user_name: 'alice', public: true }
+    ];
+    assert.ok(boardsPageListCache.write('1_99', boards), 'write succeeds');
+    var snapshot = boardsPageListCache.read('1_99');
+    assert.ok(snapshot, 'read returns snapshot');
+    assert.equal(snapshot.user_id, '1_99');
+    assert.equal(snapshot.boards.length, 2);
+    assert.equal(snapshot.boards[0].key, 'alice/home');
+    assert.equal(snapshot.boards[0].image_url, 'https://example.com/a.png');
+    assert.equal(snapshot.boards[1].name, 'Food');
+    assert.strictEqual(snapshot.boards[0].buttons, undefined, 'does not persist buttons');
+  });
+
+  test('read returns null for wrong user or expired TTL', function(assert) {
+    boardsPageListCache.write('1_1', [{ id: '1_2', key: 'u/b', name: 'B' }]);
+    assert.strictEqual(boardsPageListCache.read('1_2'), null, 'wrong user id misses');
+
+    var key = boardsPageListCache.KEY_PREFIX + '1_1';
+    var stale = {
+      saved_at: Date.now() - boardsPageListCache.TTL_MS - 1000,
+      user_id: '1_1',
+      boards: [{ id: '1_2', key: 'u/b', name: 'B' }]
+    };
+    window.localStorage.setItem(key, JSON.stringify(stale));
+    assert.strictEqual(boardsPageListCache.read('1_1'), null, 'expired snapshot is dropped');
+    assert.strictEqual(window.localStorage.getItem(key), null, 'expired key removed');
+  });
+
+  test('write caps at MAX_BOARDS', function(assert) {
+    var many = [];
+    for (var i = 0; i < boardsPageListCache.MAX_BOARDS + 25; i++) {
+      many.push({ id: '1_' + i, key: 'u/b' + i, name: 'Board ' + i });
+    }
+    boardsPageListCache.write('1_50', many);
+    var snapshot = boardsPageListCache.read('1_50');
+    assert.equal(snapshot.boards.length, boardsPageListCache.MAX_BOARDS);
+  });
+
+  test('isUsableList requires an array with done', function(assert) {
+    assert.notOk(boardsPageListCache.isUsableList(null));
+    assert.notOk(boardsPageListCache.isUsableList({ loading: true }));
+    assert.notOk(boardsPageListCache.isUsableList({ error: true }));
+    var partial = [{ id: '1_1' }];
+    assert.notOk(boardsPageListCache.isUsableList(partial), 'length without done is not usable');
+    partial.done = true;
+    assert.ok(boardsPageListCache.isUsableList(partial));
+    var empty = [];
+    empty.done = true;
+    assert.ok(boardsPageListCache.isUsableList(empty), 'empty completed Mine list is usable');
+  });
+
+  test('write persists empty completed Mine lists', function(assert) {
+    assert.ok(boardsPageListCache.write('1_9', []));
+    var snapshot = boardsPageListCache.read('1_9');
+    assert.ok(snapshot);
+    assert.deepEqual(snapshot.boards, []);
+  });
+
+  test('hydrate pushes board records into the store', function(assert) {
+    var pushed = [];
+    var store = {
+      push: function(payload) {
+        pushed.push(payload);
+        return { id: payload.data.id, get: function(k) { return payload.data.attributes[k] || payload.data.id; } };
+      }
+    };
+    var records = boardsPageListCache.hydrate(store, [
+      { id: '1_7', key: 'u/home', name: 'Home', public: false },
+      { id: null, key: 'bad' }
+    ]);
+    assert.equal(records.length, 1);
+    assert.equal(pushed.length, 1);
+    assert.equal(pushed[0].data.type, 'board');
+    assert.equal(pushed[0].data.attributes.key, 'u/home');
+  });
+
+  test('clearAll removes all boards-page mine keys', function(assert) {
+    boardsPageListCache.write('1_1', [{ id: '1_2', key: 'a/b', name: 'A' }]);
+    boardsPageListCache.write('1_3', [{ id: '1_4', key: 'c/d', name: 'C' }]);
+    window.localStorage.setItem('unrelated_key', 'keep');
+    boardsPageListCache.clearAll();
+    assert.strictEqual(boardsPageListCache.read('1_1'), null);
+    assert.strictEqual(boardsPageListCache.read('1_3'), null);
+    assert.equal(window.localStorage.getItem('unrelated_key'), 'keep');
+    window.localStorage.removeItem('unrelated_key');
+  });
+});

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -36,6 +36,7 @@ file (see [README.md](README.md)).
 - [Pattern: phased board prefetch — shared planner, dual persistence files](#pattern-phased-board-prefetch--shared-planner-dual-persistence-files)
 - [Pattern: board-detail `/tree` blocks paint on the full descendant payload](#pattern-board-detail-tree-blocks-paint-on-the-full-descendant-payload)
 - [Pattern: board-preview latency is cold-cache, not the loading gate — warm on intent](#pattern-board-preview-latency-is-cold-cache-not-the-loading-gate--warm-on-intent)
+- [Pattern: boards-page Mine list — cache-first paint, atomic background refresh](#pattern-boards-page-mine-list--cache-first-paint-atomic-background-refresh)
 - [Gotcha: every route transition closes all modals (global_transition) — don't keep a modal "open behind" a routed page](#gotcha-every-route-transition-closes-all-modals-global_transition--dont-keep-a-modal-open-behind-a-routed-page)
 - [Gotcha: sync double `modal.open` — the *second* template wins; do not invent write-loss on the winner](#gotcha-sync-double-modalopen--the-second-template-wins-do-not-invent-write-loss-on-the-winner)
 - [Gotcha: Shepherd modal overlay is VISUAL-ONLY; canClickTarget:false makes the target click "fall through"](#gotcha-shepherd-modal-overlay-is-visual-only-canclicktargetfalse-makes-the-target-click-fall-through)
@@ -297,6 +298,16 @@ Board-detail has `_auto_rename_board`, which POSTs `/rename` when `board.name` c
 **Diag:** `localStorage.ll_board_cache_diag=1` → [`board_cache_diag.js`](../../app/frontend/app/utils/board_cache_diag.js) marks on board-detail.
 
 **First seen in:** [2026-07-23-speak-mode-board-cache-latency.md](./2026-07-23-speak-mode-board-cache-latency.md)
+
+## Pattern: boards-page Mine list — cache-first paint, atomic background refresh
+
+**Surface:** `/:user/boards` overlay gated on `model.my_boards.done` ([`user/boards.hbs`](../../app/frontend/app/templates/user/boards.hbs)); list load in [`generate_or_append_to_list`](../../app/frontend/app/controllers/user/index.js).
+
+**Gotcha:** Re-entering the boards page always re-queried `store.query('board', { user_id })`. Streaming partial pages onto `model.my_boards` cleared `.done` until the last page, so a background refetch re-showed “Preparing your workspace.” Server Redis on boards index only caches public search, not Mine `user_id` lists.
+
+**Fix recipe:** (1) Persist a compact Mine snapshot in localStorage ([`boards_page_list_cache.js`](../../app/frontend/app/utils/boards_page_list_cache.js), 10m TTL). (2) Hydrate in [`routes/user/boards.js`](../../app/frontend/app/routes/user/boards.js) before `update_selected`. (3) When the visible list is already usable (`Array` + `.done`), accumulate pages in a side buffer and atomically swap only on the final page; never set `{loading:true}` over a usable empty list. (4) Clear snapshots in `appState.clear_user_state`. Distinct from `board_detail_cache` (speak `/tree`).
+
+**First seen in:** [2026-08-03-boards-page-cache-first.md](./2026-08-03-boards-page-cache-first.md)
 
 ## Pattern: supervisor caseload session prefetch reuses board_detail_cache, not offline sync
 


### PR DESCRIPTION
Skip the full-viewport loading overlay on SPA re-entry and hard refresh by hydrating the last Mine snapshot, refreshing in the background with an atomic swap so pagination never clears .done mid-fetch.