### PR TITLE
Fix OBZ/OBF import fetch against private uploads bucket.

### DIFF
--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -121,6 +121,8 @@ file (see [README.md](README.md)).
 - [Gotcha: dual-key tag reads — check each key independently, never `a || b` before coercion](#gotcha-dual-key-tag-reads--check-each-key-independently-never-a--b-before-coercion)
 - [Gotcha: set-field on nested model fields needs nested observer deps (videoChanged pattern)](#gotcha-set-field-on-nested-model-fields-needs-nested-observer-deps-videochanged-pattern)
 - [Gotcha: embed-frame `data-user_token` is UserIntegration#user_token, not User#user_token](#gotcha-embed-frame-data-user_token-is-userintegrationuser_token-not-useruser_token)
+- [Gotcha: private uploads bucket — server-side OBZ/OBF import must use signed_internal_url](#gotcha-private-uploads-bucket--server-side-obzobf-import-must-use-signed_internal_url)
+- [Gotcha: private uploads bucket — server-side OBZ/OBF import must use signed_internal_url](#gotcha-private-uploads-bucket--server-side-obzobf-import-must-use-signed_internal_url)
 
 ---
 
@@ -8116,3 +8118,7 @@ the 2026-07-22 persistence-sync epoch-fencing entry.
 ## Gotcha: embed-frame `data-user_token` is UserIntegration#user_token, not User#user_token
 
 Two different credentials share the name `user_token`. `User#user_token` is a permanent HMAC of `global_id` (login-serialized via `lib/json_api/user.rb`). Embed-frame's `data-user_token` is **not** that: `board.js` reads `tool.get('user_token')` from the integration serializer, which mints `UserIntegration#user_token` (integration-scoped, obfuscated user id + integration id + sig). When scoping permanent-token findings (e.g. LL-90045bb29c residual), do not fold embed-frame into `User#user_token` blast radius without verifying the mint site. Ref: [`2026-08-03-ll-90045bb29c-narrow-close.md`](./2026-08-03-ll-90045bb29c-narrow-close.md).
+
+## Gotcha: private uploads bucket — server-side OBZ/OBF import must use signed_internal_url
+
+`lingolinq-prod-uploads` blocks public access. Browser upload (SigV4 POST) can succeed while the worker-side import still fails: `Converters::Utils.remote_to_boards` used to `SafeHttp.get` the raw `https://bucket.s3.amazonaws.com/...` URL, get a 403 XML body, then feed it to rubyzip → misleading `Zip end of central directory signature not found` at progress ~0.22 / `processing_file`. JSON bundle import already signed via `Uploader.signed_internal_url` (`lib/converters/api_json_bundle.rb`); OBF/OBZ import and `Uploader.remote_zip` must do the same, and raise on non-success HTTP before parsing. Ref: [`2026-08-04-obz-import-signed-fetch.md`](./2026-08-04-obz-import-signed-fetch.md).

--- a/lib/converters/utils.rb
+++ b/lib/converters/utils.rb
@@ -111,7 +111,12 @@ module Converters::Utils
   def self.remote_to_boards(user, url)
     result = []
     Progress.update_current_progress(0.1, :downloading_file)
-    response = SafeHttp.get(url)
+    # Uploads bucket blocks public access; unsigned GETs return 403 XML which
+    # rubyzip misreports as "Zip end of central directory signature not found".
+    # Same signing path as Converters::ApiJsonBundle (JSON board import).
+    fetch_url = Uploader.signed_internal_url(url).presence || url
+    response = SafeHttp.get(fetch_url)
+    raise "failed to download board file (#{response.code})" unless response.success?
     file = Tempfile.new('stash')
     file.binmode
     file.write response.body

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -416,7 +416,11 @@ module Uploader
   def self.remote_zip(url, &block)
     result = []
     Progress.update_current_progress(0.1, :downloading_file)
-    response = SafeHttp.get(url)
+    # Private uploads bucket: unsigned GET 403s; sign before fetch (see
+    # Converters::Utils.remote_to_boards / signed_internal_url).
+    fetch_url = signed_internal_url(url).presence || url
+    response = SafeHttp.get(fetch_url)
+    raise "failed to download zip (#{response.code})" unless response.success?
     Progress.update_current_progress(0.2, :processing_file)
     file = Tempfile.new('stash')
     file.binmode

--- a/spec/lib/converters/utils_spec.rb
+++ b/spec/lib/converters/utils_spec.rb
@@ -88,15 +88,34 @@ describe Converters::Utils do
 
   describe "remote_to_boards" do
     it "should make a request to the specified url" do
-      res = OpenStruct.new(:body => "bacon", :headers => {'Content-Type' => 'image/png'})
+      res = OpenStruct.new(:body => "bacon", :headers => {'Content-Type' => 'image/png'}, :success? => true, :code => 200)
       expect(SafeHttp).to receive(:get).with("http://example.com/board").and_return(res)
       expect { Converters::Utils.remote_to_boards(nil, "http://example.com/board") }.to raise_error("Unrecognized file type: image/png")
     end
     
     it "should error on unrecognized file type" do
-      res = OpenStruct.new(:body => "bacon", :headers => {'Content-Type' => 'image/png'})
+      res = OpenStruct.new(:body => "bacon", :headers => {'Content-Type' => 'image/png'}, :success? => true, :code => 200)
       expect(SafeHttp).to receive(:get).with("http://example.com/board").and_return(res)
       expect { Converters::Utils.remote_to_boards(nil, "http://example.com/board") }.to raise_error("Unrecognized file type: image/png")
+    end
+
+    it "should fetch uploads-bucket URLs via signed_internal_url" do
+      uploads_bucket = ENV['UPLOADS_S3_BUCKET'] || 'lingolinq-dev-uploads'
+      # No .obf/.obz suffix so type detection uses Content-Type only (signing is under test).
+      raw = "https://#{uploads_bucket}.s3.amazonaws.com/imports/boards/1_1/upload-abc"
+      signed = "https://#{uploads_bucket}.s3.us-west-2.amazonaws.com/imports/boards/1_1/upload-abc?X-Amz-Signature=test"
+      expect(Uploader).to receive(:signed_internal_url).with(raw).and_return(signed)
+      res = OpenStruct.new(:body => "bacon", :headers => {'Content-Type' => 'image/png'}, :success? => true, :code => 200)
+      expect(SafeHttp).to receive(:get).with(signed).and_return(res)
+      expect { Converters::Utils.remote_to_boards(nil, raw) }.to raise_error("Unrecognized file type: image/png")
+    end
+
+    it "should raise when the download is not successful" do
+      res = OpenStruct.new(:body => "AccessDenied", :headers => {}, :success? => false, :code => 403)
+      expect(SafeHttp).to receive(:get).with("http://example.com/board.obz").and_return(res)
+      expect {
+        Converters::Utils.remote_to_boards(nil, "http://example.com/board.obz")
+      }.to raise_error("failed to download board file (403)")
     end
     
     it "should download and process an obf file" do
@@ -104,7 +123,7 @@ describe Converters::Utils do
       shell['id'] = '1234'
       shell['name'] = "Cool Board"
 
-      res = OpenStruct.new(:body => shell.to_json, :headers => {'Content-Type' => 'application/obf'})
+      res = OpenStruct.new(:body => shell.to_json, :headers => {'Content-Type' => 'application/obf'}, :success? => true, :code => 200)
       expect(SafeHttp).to receive(:get).with("http://example.com/board").and_return(res)
       b = Board.new
       expect(Converters::LingoLinq).to receive(:from_obf).and_return(b)
@@ -117,7 +136,7 @@ describe Converters::Utils do
       shell['id'] = '1234'
       shell['name'] = "Cool Board"
 
-      res = OpenStruct.new(:body => shell.to_json, :headers => {'Content-Type' => 'application/obz'})
+      res = OpenStruct.new(:body => shell.to_json, :headers => {'Content-Type' => 'application/obz'}, :success? => true, :code => 200)
       expect(SafeHttp).to receive(:get).with("http://example.com/board").and_return(res)
       b = Board.new
       expect(Converters::LingoLinq).to receive(:from_obz).and_return([b])

--- a/spec/lib/uploader_spec.rb
+++ b/spec/lib/uploader_spec.rb
@@ -1691,11 +1691,30 @@ describe Uploader do
   describe "remote_zip" do
     it "should call the block with the loaded zip" do
       expect(OBF::Utils).to receive(:load_zip).and_yield({zipper: true})
-      res = OpenStruct.new(body: 'abc')
+      res = OpenStruct.new(body: 'abc', success?: true, code: 200)
       expect(SafeHttp).to receive(:get).with('http://www.example.com/import.zip').and_return(res)
       Uploader.remote_zip('http://www.example.com/import.zip') do |zipper|
         expect(zipper).to eq({zipper: true})
       end
+    end
+
+    it "should fetch uploads-bucket URLs via signed_internal_url" do
+      uploads_bucket = ENV['UPLOADS_S3_BUCKET'] || 'lingolinq-dev-uploads'
+      raw = "https://#{uploads_bucket}.s3.amazonaws.com/imports/sounds/bank.zip"
+      signed = "#{raw}?X-Amz-Signature=test"
+      expect(Uploader).to receive(:signed_internal_url).with(raw).and_return(signed)
+      expect(OBF::Utils).to receive(:load_zip).and_yield({zipper: true})
+      res = OpenStruct.new(body: 'abc', success?: true, code: 200)
+      expect(SafeHttp).to receive(:get).with(signed).and_return(res)
+      Uploader.remote_zip(raw) { |zipper| expect(zipper).to eq({zipper: true}) }
+    end
+
+    it "should raise when the download is not successful" do
+      res = OpenStruct.new(body: 'AccessDenied', success?: false, code: 403)
+      expect(SafeHttp).to receive(:get).with('http://www.example.com/import.zip').and_return(res)
+      expect {
+        Uploader.remote_zip('http://www.example.com/import.zip') { }
+      }.to raise_error('failed to download zip (403)')
     end
   end
  


### PR DESCRIPTION
Sign server-side downloads with signed_internal_url and fail on non-success HTTP so a 403 body is not misread as a corrupt zip.