### PR TITLE
Fix Speak bar replay to use button vocalization, not label.

### DIFF
--- a/app/frontend/app/controllers/user/board-detail.js
+++ b/app/frontend/app/controllers/user/board-detail.js
@@ -803,9 +803,22 @@ export default Controller.extend(prefClasses, {
     return this.get('model.image_url') || null;
   }),
 
-  sentence_text: computed('sentence_parts.[]', function() {
+  // Display text for the speak-bar strip (chip labels / text-only mode).
+  // Intentionally uses label, not vocalization — AAC buttons often show a
+  // short label while speaking a longer distinct vocalization.
+  sentence_text: computed('sentence_parts.[]', 'sentence_parts.@each.label', function() {
     var parts = this.get('sentence_parts') || [];
-    return parts.map(function(p) { return p.label; }).join(' ');
+    return parts.map(function(p) { return p && p.label; }).filter(Boolean).join(' ');
+  }),
+
+  // Text spoken when the user taps the Speak bar or mic. Prefer vocalization
+  // (same convention as utterance.speak_button / vocalize_list / demo speak).
+  sentence_speak_text: computed('sentence_parts.[]', 'sentence_parts.@each.label', 'sentence_parts.@each.vocalization', function() {
+    var parts = this.get('sentence_parts') || [];
+    return parts.map(function(p) {
+      if(!p) { return ''; }
+      return p.vocalization || p.label || '';
+    }).filter(Boolean).join(' ');
   }),
 
   has_sentence: computed('sentence_parts.[]', function() {
@@ -1091,10 +1104,14 @@ export default Controller.extend(prefClasses, {
           image_url = label_images[_this._chip_image_key(emberGet(b, 'button_id'), label)] || null;
         }
       }
+      // Keep vocalization on the chip mirror so Speak-bar / mic replay can
+      // speak the button's spoken text, not only the display label.
+      var vocalization = (emberGet(b, 'vocalization') || '').replace(/\s+$/, '');
       parts.push({
         id: emberGet(b, 'button_id') || ('utt-' + raw_index),
         raw_index: raw_index,
         label: label,
+        vocalization: vocalization || null,
         in_progress: in_progress,
         image_url: image_url
       });
@@ -1119,6 +1136,7 @@ export default Controller.extend(prefClasses, {
     for(var i = 0; i < a.length; i++) {
       var x = a[i] || {}, y = b[i] || {};
       if(x.raw_index !== y.raw_index || x.label !== y.label || x.id !== y.id ||
+         x.vocalization !== y.vocalization ||
          x.image_url !== y.image_url || !!x.in_progress !== !!y.in_progress) { return false; }
     }
     return true;
@@ -6774,7 +6792,8 @@ export default Controller.extend(prefClasses, {
     },
 
     speak_sentence: function() {
-      var text = this.get('sentence_text');
+      // Speak vocalization when present (label is display-only on chips).
+      var text = this.get('sentence_speak_text');
       if(text) {
         speecher.speak_text(text);
         var phrases = (this.get('app_state.board_detail_recent_phrases') || []).slice();
@@ -7000,20 +7019,23 @@ export default Controller.extend(prefClasses, {
         if(!button || button.is_match === false) { return; }
         var label = button.label;
         var image_url = button.image || button.image_url || button.local_image_url;
+        var vocalization = button.vocalization || null;
         var btn_id = button.id;
         // Prefer the already-cached local image URL when available
         var local = find_local(btn_id);
         if(local) {
           var local_img = _get(local, 'local_image_url') || _get(local, 'image_url');
           if(local_img) { image_url = local_img; }
+          if(!vocalization) { vocalization = _get(local, 'vocalization') || null; }
         }
-        parts.push({ id: btn_id, label: label, image_url: image_url });
+        parts.push({ id: btn_id, label: label, vocalization: vocalization, image_url: image_url });
       });
       this.set('sentence_parts', parts);
       // Speak the full sentence (mirrors the speak_sentence action so the
       // user hears the whole phrase, not just the first word). Also pushes
-      // it onto the recent-phrases history.
-      var text = this.get('sentence_text');
+      // it onto the recent-phrases history. Use speak text (vocalization ||
+      // label) so distinct button vocalizations are not replaced by labels.
+      var text = this.get('sentence_speak_text');
       if(text) {
         speecher.stop('text');
         speecher.speak_text(text);
@@ -7056,7 +7078,7 @@ export default Controller.extend(prefClasses, {
         }
       }
       var parts = (this.get('sentence_parts') || []).slice();
-      parts.push({ id: btn_id, label: label, image_url: image_url });
+      parts.push({ id: btn_id, label: label, vocalization: vocalization || null, image_url: image_url });
       this.set('sentence_parts', parts);
       // Speak the button immediately
       speecher.stop('text');

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -152,6 +152,7 @@ For user-entered AI prompts that become reusable data, scrub PII first, normaliz
 - [Pattern: auth-page (login/register) "content cut off / bg not full height" — page-bg must be a transparent box; mesh goes on the fixed full-viewport `#within_ember`](#pattern-auth-page-loginregister-content-cut-off--bg-not-full-height--page-bg-must-be-a-transparent-box-mesh-goes-on-the-fixed-full-viewport-within_ember)
 - [Pattern: blank username suggestions must be discarded before `clean_path`](#pattern-blank-username-suggestions-must-be-discarded-before-clean_path)
 - [Pattern: keyboard control vocalizations must survive translation overlay](#pattern-keyboard-control-vocalizations-must-survive-translation-overlay)
+- [Pattern: board-detail Speak bar must speak vocalization, not just label](#pattern-board-detail-speak-bar-must-speak-vocalization-not-just-label)
 - [Pattern: per-user UI prefs must be read from `currentUser`, not the board-detail route's URL user](#pattern-per-user-ui-prefs-must-be-read-from-currentuser-not-the-board-detail-routes-url-user)
 - [Pattern: `.md-board-collection__*` is a light-base panel reusable on any page; dark theme is ancestor-scoped](#pattern-md-board-collection-is-a-light-base-panel-reusable-on-any-page-dark-theme-is-ancestor-scoped)
 - [Pattern: a new user preference is a 3-touch change — whitelist + default + dirty-bit save](#pattern-a-new-user-preference-is-a-3-touch-change--whitelist--default--dirty-bit-save)
@@ -8122,3 +8123,15 @@ Two different credentials share the name `user_token`. `User#user_token` is a pe
 ## Gotcha: private uploads bucket — server-side OBZ/OBF import must use signed_internal_url
 
 `lingolinq-prod-uploads` blocks public access. Browser upload (SigV4 POST) can succeed while the worker-side import still fails: `Converters::Utils.remote_to_boards` used to `SafeHttp.get` the raw `https://bucket.s3.amazonaws.com/...` URL, get a 403 XML body, then feed it to rubyzip → misleading `Zip end of central directory signature not found` at progress ~0.22 / `processing_file`. JSON bundle import already signed via `Uploader.signed_internal_url` (`lib/converters/api_json_bundle.rb`); OBF/OBZ import and `Uploader.remote_zip` must do the same, and raise on non-success HTTP before parsing. Ref: [`2026-08-04-obz-import-signed-fetch.md`](./2026-08-04-obz-import-signed-fetch.md).
+
+## Pattern: board-detail Speak bar must speak vocalization, not just label
+
+**Surface:** board-detail Speak Mode — button with distinct `label` vs `vocalization` (e.g. joke boards: label "Money joke", vocalization = the joke text).
+
+**Symptom:** Button tap speaks the joke correctly; tapping the Speak bar text or mic speaks only the short label.
+
+**Root cause:** Two speak paths. Button tap uses `utterance.speak_button` (`vocalization || label`). Classic `#button_list` uses `utterance.vocalize_list` (same). Board-detail's `speak_sentence` was speaking local `sentence_text`, which joined **labels only**, and `sync_sentence_from_button_list` never copied `vocalization` onto `sentence_parts` chips. Demo speak already had the correct helper (`sentence_text_for` → `vocalization || label`).
+
+**Fix recipe:** Persist `vocalization` on each `sentence_parts` chip when mirroring `app_state.button_list`. Keep display `sentence_text` as labels (chip / text-strip UX). Speak via a separate `sentence_speak_text` (`vocalization || label`) from `speak_sentence` / phrase-builder speak. Do not silently switch board-detail mic to `vocalize_list` without checking `list_vocalized` / `clear_on_vocalize` side effects.
+
+**Evidence:** task log [`2026-08-04-speak-bar-label-not-vocalization.md`](./2026-08-04-speak-bar-label-not-vocalization.md); `board-detail.js` `sentence_speak_text` / `sync_sentence_from_button_list`; contrast `utterance.js` `speak_button` / `vocalize_list` and `demo/speak.js` `sentence_text_for`.


### PR DESCRIPTION
Board-detail sentence chips kept only labels, so mic/bar replay said "Money joke" instead of the joke text after a correct button tap.