### PR TITLE
chore(codex-review): retire gpt-5.5, split the gate across the approved 5.6 tiers

### DIFF
--- a/.github/codex/REVIEW-MEMORY.md
+++ b/.github/codex/REVIEW-MEMORY.md
@@ -25,7 +25,7 @@ into an unrelated PR.
 
 - **Stale provider-version wording is a real finding, not pedantry.**
   Compliance and infra docs that name a specific model/CLI version
-  (`gpt-5.5`, `codex-cli 0.144.1`, etc.) drift silently. If a PR touches a
+  (`gpt-5.6-terra`, `codex-cli 0.146.0`, etc.) drift silently. If a PR touches a
   doc naming a provider/version, confirm the version claim against the live
   tool (`codex --version`, vendor changelog) rather than assuming the doc is
   current.

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -345,9 +345,14 @@ jobs:
         run: |
           run_codex() {
             # $1 = output path for this run's review JSON
+            # gpt-5.6-terra per the approved-reviewer registry (CLAUDE.md, CI
+            # `codex-review` gate row: terra default, luna A/B). This is the
+            # whole-diff pass that produces the verdict directly, so it takes
+            # the balanced tier; the chunked path splits luna/terra by leg in
+            # scripts/codex-review-run-chunks.py.
             codex exec \
               --sandbox read-only \
-              -m gpt-5.5 \
+              -m gpt-5.6-terra \
               --output-schema .github/codex/review-schema.json \
               --output-last-message "$1" \
               < /tmp/prompt.md
@@ -357,7 +362,7 @@ jobs:
             if ! python3 -c "import json, sys; json.load(open(sys.argv[1]))" "$1" 2>/dev/null; then
               echo "Run produced invalid JSON; retrying with stricter instruction." >&2
               { cat /tmp/prompt.md; echo ""; echo "Output ONLY the JSON object. No prose, no markdown fences."; } \
-                | codex exec --sandbox read-only -m gpt-5.5 \
+                | codex exec --sandbox read-only -m gpt-5.6-terra \
                     --output-schema .github/codex/review-schema.json \
                     --output-last-message "$1"
             fi

--- a/scripts/codex-review-run-chunks.py
+++ b/scripts/codex-review-run-chunks.py
@@ -11,6 +11,20 @@ import sys
 
 CI_MARKER_RE = re.compile(r"<!--\s*/?\s*CI_INJECT:[A-Z_]+\s*-->")
 
+# Reviewer models, per the approved-reviewer registry (CLAUDE.md "Approved
+# reviewers", CI `codex-review` gate row: terra default, luna A/B). Only those
+# two ids are approved for this gate; do NOT introduce gpt-5.6-sol here, which
+# is approved only for the interactive/local Codex row.
+#
+# Split by what each tier is for. Chunk passes are the high-volume leg: one
+# prompt per diff slice, up to three convergence runs each, and the bulk of a
+# run's invocations. Synthesis is the decisive leg: it reads every chunk result
+# and produces the verdict that becomes the commit status, over at most three
+# calls. Cost follows the same shape, so the cheap tier carries the volume and
+# the balanced tier carries the judgment.
+CHUNK_MODEL = "gpt-5.6-luna"
+SYNTHESIS_MODEL = "gpt-5.6-terra"
+
 
 def defang_ci_markers(body):
     return CI_MARKER_RE.sub(
@@ -119,14 +133,14 @@ def heartbeat(args, description):
     )
 
 
-def run_model(args, prompt_path, schema_path, output_path, heartbeat_description=None):
+def run_model(args, prompt_path, schema_path, output_path, heartbeat_description=None, model=CHUNK_MODEL):
     command = [
         "codex",
         "exec",
         "--sandbox",
         "read-only",
         "-m",
-        "gpt-5.5",
+        model,
         "--output-schema",
         str(schema_path),
         "--output-last-message",
@@ -298,17 +312,17 @@ def main():
     build_synthesis_prompt(synthesis_template, live_state, manifest_md, prior_loop, chunk_result_groups, synthesis_prompt)
     synthesis_paths = []
     synthesis_1 = out_dir / "synthesis-1.json"
-    if not run_model(args, synthesis_prompt, ".github/codex/synthesis-schema.json", synthesis_1, "Codex review running synthesis run 1"):
+    if not run_model(args, synthesis_prompt, ".github/codex/synthesis-schema.json", synthesis_1, "Codex review running synthesis run 1", model=SYNTHESIS_MODEL):
         write_invalid_review(synthesis_1, args.head_sha)
     synthesis_paths.append(synthesis_1)
     if review_kind(load_json(synthesis_1)) == "approved":
         synthesis_2 = out_dir / "synthesis-2.json"
-        if not run_model(args, synthesis_prompt, ".github/codex/synthesis-schema.json", synthesis_2, "Codex review running synthesis run 2"):
+        if not run_model(args, synthesis_prompt, ".github/codex/synthesis-schema.json", synthesis_2, "Codex review running synthesis run 2", model=SYNTHESIS_MODEL):
             write_invalid_review(synthesis_2, args.head_sha)
         synthesis_paths.append(synthesis_2)
         if needs_tiebreak(synthesis_paths):
             synthesis_3 = out_dir / "synthesis-3.json"
-            if not run_model(args, synthesis_prompt, ".github/codex/synthesis-schema.json", synthesis_3, "Codex review running synthesis run 3"):
+            if not run_model(args, synthesis_prompt, ".github/codex/synthesis-schema.json", synthesis_3, "Codex review running synthesis run 3", model=SYNTHESIS_MODEL):
                 write_invalid_review(synthesis_3, args.head_sha)
             synthesis_paths.append(synthesis_3)
 

--- a/spec/lib/eval_narrator_spec.rb
+++ b/spec/lib/eval_narrator_spec.rb
@@ -81,7 +81,7 @@ describe EvalNarrator do
       it 'rejects Covered Models (Fable / Mythos), unknown, and non-string ids' do
         expect(described_class.allowed_model?('anthropic.claude-fable-5')).to eq(false)
         expect(described_class.allowed_model?('anthropic.claude-mythos-5')).to eq(false)
-        expect(described_class.allowed_model?('gpt-5.5')).to eq(false)
+        expect(described_class.allowed_model?('gpt-5.6-luna')).to eq(false)
         expect(described_class.allowed_model?('')).to eq(false)
         expect(described_class.allowed_model?(nil)).to eq(false)
       end


### PR DESCRIPTION
Moves the `codex-review` gate off `gpt-5.5` and onto the two models the approved-reviewer registry actually authorizes for it, assigning each leg by what that leg does.

## Why now

The registry's CI `codex-review` gate row moved to `gpt-5.6-terra` (default) / `gpt-5.6-luna` (A/B) on 2026-08-03. The pipeline was still pinned to `gpt-5.5` in three places. That was latent while the gate was dead (12 consecutive runs failed at "Authenticate Codex CLI" because `CODEX_OPENAI_API_KEY` was never set, and nothing ran after 2026-07-31), but the secret was added on 2026-08-04, so the stale pin would now actually run an unapproved model.

## Assignment

| Leg | Model | Why |
|---|---|---|
| Chunk passes (`run-chunks.py`) | `gpt-5.6-luna` | Volume leg: one prompt per diff slice, up to 3 convergence runs each, and where the 102-invocation worst case lives. Narrow per-call scope; reliability comes from convergence, not single-pass strength. Vendor tier: "fast and affordable". |
| Synthesis (`run-chunks.py`) | `gpt-5.6-terra` | Decisive leg: reads every chunk result, produces the verdict that becomes the commit status, at most 3 calls. Vendor tier: "balanced, for everyday work". |
| Non-chunked whole-diff pass (`codex-review.yml`) | `gpt-5.6-terra` | Produces the verdict directly, same stakes as synthesis. |

`gpt-5.6-sol` is deliberately not used. It is approved for the interactive/local Codex row, not this gate.

The model is threaded through a `run_model` kwarg with one named constant per leg, so there is a single authoritative value instead of scattered literals.

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| Chunk/synthesis model split | Fixed | `scripts/codex-review-run-chunks.py:25-26`, `:136`, `:315`, `:320`, `:325` |
| Workflow reviewer model | Fixed | `.github/workflows/codex-review.yml:355`, `:365` |
| Stale version example in review memory | Fixed | `.github/codex/REVIEW-MEMORY.md:28` |
| Stale negative-assertion input | Fixed | `spec/lib/eval_narrator_spec.rb:84` |
| No `gpt-5.5` anywhere in tree | Fixed | `grep -rn 'gpt-5\.5'` returns nothing |

## Verification
- `python3 -m py_compile scripts/codex-review-run-chunks.py` passes
- Workflow YAML parses
- Both `gpt-5.6-terra` and `gpt-5.6-luna` confirmed present in the CI key's OpenAI project model list
- `git diff --check` clean

`bundle exec rspec spec/lib/eval_narrator_spec.rb` was **not** run locally (no Postgres in the worktree). `EvalNarrator.allowed_model?` is `model.is_a?(String) && ALLOWED_MODELS.include?(model)` against a two-element Anthropic-only array, so neither the old nor the new input is in it and the assertion value is unchanged. That is read-verified, not executed. CI covers it.

## Not covered by this PR
- `codex-review/deep-pass` is still absent from staging's required status checks, so the fail-closed anchor described in `codex-review.yml`'s header remains documented but unenforced. That is a branch-protection decision, not a code change.
- `CLAUDE_REVIEW_API_KEY` is still unset. It is only reachable when `CODEX_COMPLIANCE_PATHS=block`, and that repo variable is unset (defaults to `allow`), so the claude-deep leg cannot currently fire.
- No `LEARNINGS.md` entry: #725 and #744 both have concurrent edits to that file, and a third would collide. Follow-up once those land.
- Historical artifacts outside this repo still name `gpt-5.5`; those are dated records and were left alone.

## Author-Model: opus-5