### PR TITLE
compliance(program): realign the version header with the register as v1.2

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -519,13 +519,13 @@
       "attestation": {
         "attestedBy": "Scot Wahlquist",
         "attestedDate": "2026-08-04",
-        "attestedContentHash": "2c582b44be3910895be49b8eb969f0da8a1c867789eeb0b882daa757ce0aeac4",
+        "attestedContentHash": "72070eb8e84a9c68b48dd2b3a90120b5e74ec5464f2f5e6da43787b547b5abc3",
         "priorAttestations": [
           "2026-07-22"
         ],
-        "note": "Re-attested 2026-08-04 by Scot Wahlquist. Scope: the runtime-AI operational-status correction in PR #725. The prior corpus stated the Bedrock path was dormant and that no lingolinq-web revision carried a Bedrock credential; that was accurate when written and expired 2026-08-03T08:23:02Z when revision 00013-76w mounted BEDROCK_AWS_KEY/SECRET. The corpus now states a closed window: not operational to 2026-08-03T08:23Z, operational to 2026-08-04T06:31Z (one internal verification call, no user or student data), not operational since. Verified live: sts:GetCallerIdentity returned 239044785114 (user/lingolinq-bedrock-runtime)."
+        "note": "Re-attested 2026-08-04 by Scot Wahlquist as v1.2 (third pin, same day). The program described is unchanged from v1.1; this revision realigns the in-document version header with this register, which had pinned the document at 2026-08-04 while the header still read v1.1 / 2026-07-22. Scope of this pin: the version block, the attestation-statement date, the attestation-date row, and the added v1.2 scope paragraph. The substantive runtime-AI closed-window correction it describes was already present in the bytes pinned earlier the same day; no compliance claim changed in this revision."
       },
-      "contentHash": "2c582b44be3910895be49b8eb969f0da8a1c867789eeb0b882daa757ce0aeac4",
+      "contentHash": "72070eb8e84a9c68b48dd2b3a90120b5e74ec5464f2f5e6da43787b547b5abc3",
       "bundles": [
         "compliance-records-set-2026-06"
       ],

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -45,7 +45,7 @@
 | Compliance Posture Report | git | `docs/legal/COMPLIANCE_POSTURE_REPORT.md` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-07-23 | 2026-10-23 | 2026-07-23 | `b29b1cd0d5ca` | school-dpa-package, security-review, grant |
 | Compliance Posture Report (branded) | Drive | [open](https://docs.google.com/document/d/1A2cM0m6GvErHwpiMgns258NbN_M2krNB_HyedHJkqpk/edit) | superseded | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06 |
 | Compliance Posture Report (branded, 2026-07-16 re-attest) | Drive | [open](https://docs.google.com/document/d/1yx-jVYesJ0ZQM0myir6d0rRMMzGEoH5EL5_luicucYo/edit) | draft | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-07-22 | 2027-01-22 | no | (supplied) | school-dpa-package, security-review |
-| Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-08-04 | 2027-07-22 | 2026-08-04 | `2c582b44be39` | compliance-records-set-2026-06 |
+| Compliance Program | git | `docs/legal/COMPLIANCE_PROGRAM.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-08-04 | 2027-07-22 | 2026-08-04 | `72070eb8e84a` | compliance-records-set-2026-06 |
 | LingoLinq Security, Privacy & Compliance Overview | git | `docs/legal/COMPLIANCE_PROGRAM_OVERVIEW.md` | approved | FERPA, COPPA, HIPAA, GDPR, SOC2 | Scot Wahlquist | 2026-08-04 | 2027-07-22 | 2026-08-04 | `933d4863d95b` | security-review |
 | Records of Processing Activities (RoPA) and Data Map | Drive | [open](https://docs.google.com/document/d/1x6F8qiqR_7Ojc6-TQGYp2HYBMxjIUTzH0EGCQj8R-qg/edit) | published | GDPR | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, dsar |
 
@@ -266,7 +266,7 @@ green build. Verified for git rows only; Drive and Notion hashes are operator-su
 | AWS Business Associate Agreement (signed PDF) | 2026-02 | `55f28e00168c` | verified |
 | Compliance & Data Governance (COMPLIANCE.md) | 2026-08-04 | `72af832942c4` | verified |
 | Compliance Posture Report | 2026-07-23 | `b29b1cd0d5ca` | verified |
-| Compliance Program | 2026-08-04 | `2c582b44be39` | verified |
+| Compliance Program | 2026-08-04 | `72070eb8e84a` | verified |
 | COPPA Final-Rule Verification | 2026-07-23 | `35a6298e2df5` | verified |
 | Data Retention Schedule | 2026-07-23 | `0c748cadd744` | verified |
 | Google Cloud Platform BAA + CDPA + SCCs - Acceptance Record | 2026-07-23 | `3e8f43b12186` | verified |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,7 +11,7 @@
 **Audited commit:** `20953ab3d5a80c3a9cbb249f37a79357b7f1baf1`  
 **Audited ref:** `scot/compliance/audit-refresh-2026-07-07`  
 **Run date:** 2026-07-08  
-**Page generated:** 2026-08-04T21:41:08Z
+**Page generated:** 2026-08-05T05:17:17Z
 
 ## Headline - open findings
 

--- a/docs/legal/COMPLIANCE_PROGRAM.md
+++ b/docs/legal/COMPLIANCE_PROGRAM.md
@@ -9,10 +9,18 @@
 > request, or finding ID that can be verified against live code. Aspirational controls are confined
 > to Section 12 and are marked "not yet built" so nothing here reads as a promise we cannot keep.
 >
-> **Version:** 1.1 (re-attested) · **Date:** 2026-06-18 (v1.0); 2026-07-22 (v1.1) ·
-> **Attested by:** Scot Wahlquist, CEO (2026-06-18; 2026-07-22) · **Supersedes:** Master
-> Compliance & Security Program v1.0/v1.1 · **Source of
+> **Version:** 1.2 (re-attested) · **Date:** 2026-06-18 (v1.0); 2026-07-22 (v1.1); 2026-08-04
+> (v1.2) · **Attested by:** Scot Wahlquist, CEO (2026-06-18; 2026-07-22; 2026-08-04) ·
+> **Supersedes:** Master Compliance & Security Program v1.0/v1.1 · **Source of
 > truth for status:** `audit-reports/FINDINGS.json`
+>
+> **v1.2 scope (2026-08-04).** The program described here is unchanged from v1.1. This revision
+> records one correction, applied in Section 5 and in Section 15 point 3: the runtime AI vendor
+> status, previously stated as *active*, then over-corrected to never-operational, is now stated
+> as a closed operational window (2026-08-03T08:23Z to 2026-08-04T06:31Z, one internal
+> verification call carrying no user or student data; not operational as of 2026-08-04). The
+> version header is realigned with `audit-reports/DOCUMENT-REGISTER.json`, which pinned this
+> document at 2026-08-04 while the header still read 2026-07-22.
 
 ---
 
@@ -326,7 +334,7 @@ by code, configuration, or signed agreements with accurate citations; aspiration
 confined to Section 12; known residuals remain tracked rather than hidden, including LL-11db0dc848,
 LL-e573a39d2b, LL-6619cc1811, LL-aacae48768, and LL-7f7372e3eb; counsel-dependent claims remain
 internal; and no external sharing is authorized until explicitly released. I additionally attest
-that, to the best of my knowledge as of 2026-07-22:
+that, to the best of my knowledge as of 2026-08-04:
 
 1. This document is an honest, evidence-based description of the compliance and security program as
    it actually exists after the Gate 1 GCP DNS cutover, not as we aspire for it to be.
@@ -368,7 +376,7 @@ the attestation date. It is not a certification, a legal opinion, or a guarantee
 | Posture at that commit | 0 open Critical / 5 open High / 24 open Medium / 25 open Low, per `audit-reports/FINDINGS.json` |
 | Infrastructure state verified | 2026-07-22 Gate 1 DNS cutover: `app.lingolinq.com` live on GCP load balancer IP `136.68.41.122`; Redis PONG captured from Cloud Run execution `lingolinq-migrate-vl5d5` at 2026-07-22T05:00:46Z (`ping=PONG`, `scheme=rediss`, `ca_blocks=1`, `verify_hostname=false`). `ca_blocks=1` is the expected Memorystore instance-CA chain length for this endpoint; `verify_hostname=false` is the documented pinned-CA/private-IP hatch while CA-chain verification remains on. Render retained as write-frozen rollback fallback pending explicit decommission. |
 | Attested by | Scot Wahlquist, CEO |
-| Attestation date | 2026-06-18 (v1.0); 2026-07-22 (v1.1) |
+| Attestation date | 2026-06-18 (v1.0); 2026-07-22 (v1.1); 2026-08-04 (v1.2) |
 
 _Once attested, the canonical home for this document is the repository at
 `docs/legal/COMPLIANCE_PROGRAM.md`, alongside the evidence it indexes. Moving it there is a


### PR DESCRIPTION
The register pinned docs/legal/COMPLIANCE_PROGRAM.md at 2026-08-04 after the
Bedrock corpus sweep (#725), while the document's own header still read
"Version 1.1 ... 2026-07-22". Body and register disagreed on the document's
own identity, which audit-artifacts-integrity cannot catch: it proves bytes
match the pin, never that the prose is right.

No compliance claim changes here. The substantive runtime-AI correction (the
closed operational window) was already in the bytes pinned earlier the same
day. This revision only:

  - bumps the version block to 1.2 and adds 2026-08-04 to the date and
    attested-by lists
  - adds a v1.2 scope paragraph stating that the program itself is unchanged
  - moves the attestation-statement date from 2026-07-22 to 2026-08-04
  - adds "2026-08-04 (v1.2)" to the Attestation date row

Re-attested by Scot Wahlquist, CEO, on 2026-08-04 (third pin that day);
attestedContentHash moved 2c582b44be39 -> 72070eb8e84a.

Prompted by: the Drive mirror (doc 1bpmMrbcFZET...) is titled "Attested
2026-07-22" and predates the 2026-08-04 corrections, so it must be
republished and the current copy archived. That publish is a separate step.

## Fix status
| Item | Status | Evidence |
| Version header matches register | Fixed | docs/legal/COMPLIANCE_PROGRAM.md:12-22 |
| Attestation re-pinned to v1.2 bytes | Fixed | audit-reports/DOCUMENT-REGISTER.json |
| Five preflight checks green | Fixed | all --check PASS locally |

## Not covered by this PR
- Drive republish to 641.1 and archiving the 2026-07-22 mirror to
  x-Archive - Superseded (needs the Drive write, tracked separately)
- Registering the Drive mirror for this document: the register currently
  records mirrors: NONE for it even though the mirror has existed since
  2026-07-24
- COMPLIANCE.md (repo root, "Compliance & Data Governance") has no Drive
  counterpart at all; whether it should is undecided

## Author-Model: opus-5