### PR TITLE
fix(deploy): fail the deploy when a mounted secret does not land

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -304,8 +304,9 @@ jobs:
       # still REFERENCES them. Revision lingolinq-web-00014 (2026-08-04) dropped exactly
       # BEDROCK_AWS_KEY and BEDROCK_AWS_SECRET while every secret container stayed healthy, and
       # the Tier 1 runtime AI path failed closed for ~54 minutes with nothing reporting it.
-      # This asserts the linkage on the revision actually serving traffic, so a deploy that
-      # loses a secret fails the run instead of shipping a silently degraded revision.
+      # This asserts the linkage on every revision actually serving traffic (all nonzero
+      # percent targets under a canary/rollback split), so a deploy that loses a secret
+      # fails the run instead of shipping a silently degraded revision.
       # NOTE: this guards CI deploys only. A human running `gcloud run deploy` bypasses this
       # workflow entirely, which is how 00014 happened; see the script header.
       - name: Assert deployed secrets landed

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -298,3 +298,21 @@ jobs:
             --vpc-egress private-ranges-only \
             --set-env-vars "RACK_ENV=production,RAILS_ENV=production,REDIS_TLS_VERIFY_HOSTNAME=false,$APP_ENV_VARS" \
             --set-secrets "$BOOT_SECRETS,$NON_BOOT_SECRETS"
+
+      # Read back what actually landed. The "verify secrets are seeded" step above proves the
+      # secrets EXIST in Secret Manager before deploying; it cannot prove the deployed revision
+      # still REFERENCES them. Revision lingolinq-web-00014 (2026-08-04) dropped exactly
+      # BEDROCK_AWS_KEY and BEDROCK_AWS_SECRET while every secret container stayed healthy, and
+      # the Tier 1 runtime AI path failed closed for ~54 minutes with nothing reporting it.
+      # This asserts the linkage on the revision actually serving traffic, so a deploy that
+      # loses a secret fails the run instead of shipping a silently degraded revision.
+      # NOTE: this guards CI deploys only. A human running `gcloud run deploy` bypasses this
+      # workflow entirely, which is how 00014 happened; see the script header.
+      - name: Assert deployed secrets landed
+        run: |
+          bash scripts/gcp/assert-runtime-secrets.sh \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --service lingolinq-web \
+            --worker-pool lingolinq-worker \
+            --required "$BOOT_SECRETS,$NON_BOOT_SECRETS"

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -20,6 +20,7 @@ file (see [README.md](README.md)).
 
 ## Index
 
+- [Gotcha: Cloud Run secret assertions must check every nonzero-percent traffic target](#gotcha-cloud-run-secret-assertions-must-check-every-nonzero-percent-traffic-target)
 - [Gotcha: Ember Data model ids in tests must be strings — numeric `set('id', N)` fails throwOnUnhandled](#gotcha-ember-data-model-ids-in-tests-must-be-strings--numeric-setid-n-fails-throwonunhandled)
 - [Gotcha: batch-path nil is not “missing opts” — key presence vs value](#gotcha-batch-path-nil-is-not-missing-opts--key-presence-vs-value)
 - [Gotcha: compliance segment stamps must use validated org ids, not raw params](#gotcha-compliance-segment-stamps-must-use-validated-org-ids-not-raw-params)
@@ -125,6 +126,17 @@ file (see [README.md](README.md)).
 - [Gotcha: private uploads bucket — server-side OBZ/OBF import must use signed_internal_url](#gotcha-private-uploads-bucket--server-side-obzobf-import-must-use-signed_internal_url)
 
 ---
+
+## Gotcha: Cloud Run secret assertions must check every nonzero-percent traffic target
+
+`status.latestReadyRevisionName` is not “what users hit,” and neither is “the revision with
+the largest traffic percent.” Cloud Run can split traffic across multiple revisions (canary /
+rollback). A post-deploy secret-linkage check that inspects only one of them can pass while a
+smaller-percentage revision is missing required `secretKeyRef` mounts. Emit and assert every
+`status.traffic` entry with `percent > 0` (dedupe by revision name; fall back to
+`latestReadyRevisionName` only when no nonzero targets exist). See
+`scripts/gcp/assert-runtime-secrets.sh` and
+[`2026-08-05-assert-runtime-secrets-traffic-split.md`](./2026-08-05-assert-runtime-secrets-traffic-split.md).
 
 ## Pattern: shared AI reuse caches need exact scrubbed keys before recommendation matching
 

--- a/scripts/gcp/assert-runtime-secrets.sh
+++ b/scripts/gcp/assert-runtime-secrets.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# assert-runtime-secrets.sh — fail closed when a live Cloud Run revision is missing a
+# secret the deploy was supposed to mount.
+#
+# WHY THIS EXISTS
+# ---------------
+# On 2026-08-04 a manual `gcloud run` deploy of `lingolinq-web` produced revision
+# `00014`, which dropped exactly `BEDROCK_AWS_KEY` and `BEDROCK_AWS_SECRET` and nothing
+# else. Cloud Run creates a new immutable revision on ANY config change, so a deploy that
+# reuses the same image can still silently remove secrets. For ~54 minutes the Tier 1
+# runtime AI credential path was absent from production and `AiClient.configured?` would
+# have returned false, failing every AI feature closed. Nothing detected it; the gap was
+# found only by reading revision history a day later.
+#
+# The deploy workflow already gates on secrets EXISTING in Secret Manager before it
+# deploys (see the "verify secrets are seeded" step). That check cannot catch this class
+# of bug: the secret containers were present and healthy the whole time. What was missing
+# was the REFERENCE from the running revision to the secret. This script closes that gap
+# by reading back what actually landed.
+#
+# WHAT IT CHECKS
+# --------------
+# For each named service/worker-pool, resolves the revision that is actually serving
+# (not merely the latest created) and asserts every required env var is present AND is
+# backed by a `secretKeyRef`. A var that is present but downgraded to a literal value is
+# treated as a failure: it means the secret linkage was replaced by something else.
+#
+# SCOPE AND LIMITS — read before trusting this
+# --------------------------------------------
+# * Called from the deploy workflow, it makes a CI deploy that drops a secret fail loudly
+#   instead of silently.
+# * It does NOT prevent drift introduced OUTSIDE CI. The 00014 incident was a human
+#   running `gcloud run deploy` directly, which never touches this workflow. Guarding
+#   that requires either restricting Cloud Run update permission to the deploy service
+#   account, or running this script on a schedule. Both are deliberately out of scope
+#   here. Run it standalone any time to reconcile live state:
+#
+#     bash scripts/gcp/assert-runtime-secrets.sh \
+#       --project lingolinq-prod --region us-central1 \
+#       --service lingolinq-web --worker-pool lingolinq-worker \
+#       --required "BEDROCK_AWS_KEY=x,BEDROCK_AWS_SECRET=x,SECRET_KEY_BASE=x"
+#
+# * It asserts the LINKAGE, not the value. It never reads secret material, and needs only
+#   `run.revisions.get` / `run.workerPools.get`, not `secretmanager.secretAccessor`.
+#
+# --required accepts the same `NAME=SECRET:version,...` form as `gcloud --set-secrets`,
+# so the workflow passes "$BOOT_SECRETS,$NON_BOOT_SECRETS" through unmodified and there is
+# no second list to keep in sync. Only the NAME (left of `=`) is used.
+set -euo pipefail
+
+PROJECT=''; REGION=''; SERVICE=''; WORKER_POOL=''; REQUIRED=''
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project)     PROJECT="$2"; shift 2 ;;
+    --region)      REGION="$2"; shift 2 ;;
+    --service)     SERVICE="$2"; shift 2 ;;
+    --worker-pool) WORKER_POOL="$2"; shift 2 ;;
+    --required)    REQUIRED="$2"; shift 2 ;;
+    *) echo "assert-runtime-secrets: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$PROJECT" ] || { echo "assert-runtime-secrets: --project is required" >&2; exit 2; }
+[ -n "$REGION" ]  || { echo "assert-runtime-secrets: --region is required" >&2; exit 2; }
+[ -n "$REQUIRED" ] || { echo "assert-runtime-secrets: --required is required" >&2; exit 2; }
+[ -n "$SERVICE$WORKER_POOL" ] || {
+  echo "assert-runtime-secrets: at least one of --service / --worker-pool is required" >&2; exit 2; }
+
+# Resolve the revision actually receiving traffic. `latestReadyRevisionName` is NOT
+# sufficient on its own: traffic can be pinned to an older revision, in which case the
+# revision serving users is not the newest one. Prefer an explicit traffic assignment
+# with a non-zero percent and fall back to latestReady only when no explicit split exists.
+serving_revision() {
+  gcloud run services describe "$1" --project="$PROJECT" --region="$REGION" --format=json 2>/dev/null \
+  | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+st = d.get("status", {}) or {}
+best, best_pct = None, 0
+for t in st.get("traffic", []) or []:
+    pct = t.get("percent") or 0
+    rev = t.get("revisionName")
+    if rev and pct > best_pct:
+        best, best_pct = rev, pct
+print(best or st.get("latestReadyRevisionName", "") or "")
+'
+}
+
+# Cloud Run services and worker pools do not share a response shape, and the worker-pool
+# API is still beta, so the container block sits at a different depth. Walk the document
+# for the first "containers" list rather than hard-coding either path; that keeps this
+# working if the beta shape shifts before GA.
+env_entries() {
+  python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+def find(o):
+    if isinstance(o, dict):
+        if isinstance(o.get("containers"), list) and o["containers"]:
+            return o["containers"]
+        for v in o.values():
+            r = find(v)
+            if r: return r
+    elif isinstance(o, list):
+        for v in o:
+            r = find(v)
+            if r: return r
+    return None
+containers = find(d) or []
+for c in containers:
+    for e in c.get("env", []) or []:
+        name = e.get("name")
+        if not name:
+            continue
+        # secretKeyRef => linked to Secret Manager; anything else => a literal value.
+        linked = "secret" if "valueFrom" in e else "literal"
+        print(name, linked)
+'
+}
+
+# Only the env-var NAME matters; strip the =SECRET:version half of each --set-secrets pair.
+mapfile -t REQUIRED_NAMES < <(printf '%s' "$REQUIRED" | tr ',' '\n' | sed 's/=.*//' | sed '/^$/d' | sort -u)
+[ "${#REQUIRED_NAMES[@]}" -gt 0 ] || { echo "assert-runtime-secrets: --required parsed to zero names" >&2; exit 2; }
+
+failed=0
+
+check_target() {
+  local kind="$1" name="$2" json rev
+  if [ "$kind" = service ]; then
+    rev="$(serving_revision "$name")"
+    if [ -z "$rev" ]; then
+      echo "FAIL [$name] could not resolve a serving revision" >&2
+      failed=1; return
+    fi
+    echo "== $name (serving revision: $rev)"
+    json="$(gcloud run revisions describe "$rev" --project="$PROJECT" --region="$REGION" --format=json 2>/dev/null)"
+  else
+    echo "== $name (worker pool)"
+    json="$(gcloud beta run worker-pools describe "$name" --project="$PROJECT" --region="$REGION" --format=json 2>/dev/null)"
+  fi
+
+  if [ -z "$json" ]; then
+    echo "FAIL [$name] could not read live configuration" >&2
+    failed=1; return
+  fi
+
+  local entries missing=() literal=()
+  entries="$(printf '%s' "$json" | env_entries)"
+
+  local want
+  for want in "${REQUIRED_NAMES[@]}"; do
+    local line
+    line="$(printf '%s\n' "$entries" | awk -v w="$want" '$1 == w {print $2; exit}')"
+    if [ -z "$line" ]; then
+      missing+=("$want")
+    elif [ "$line" != secret ]; then
+      literal+=("$want")
+    fi
+  done
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "FAIL [$name] missing secret-backed env var(s): ${missing[*]}" >&2
+    failed=1
+  fi
+  if [ "${#literal[@]}" -gt 0 ]; then
+    echo "FAIL [$name] env var(s) present but NOT backed by a secretKeyRef: ${literal[*]}" >&2
+    failed=1
+  fi
+  if [ "${#missing[@]}" -eq 0 ] && [ "${#literal[@]}" -eq 0 ]; then
+    echo "   OK: all ${#REQUIRED_NAMES[@]} required env vars are secret-backed"
+  fi
+}
+
+[ -n "$SERVICE" ]     && check_target service "$SERVICE"
+[ -n "$WORKER_POOL" ] && check_target worker  "$WORKER_POOL"
+
+if [ "$failed" -ne 0 ]; then
+  cat >&2 <<'EOM'
+
+Deployment is NOT safe: the live configuration is missing at least one secret the deploy
+was supposed to mount. A revision in this state runs with the secret simply absent from
+the environment, so any feature gated on it fails closed with no error at deploy time.
+Redeploy with the full --set-secrets list ("$BOOT_SECRETS,$NON_BOOT_SECRETS"); a partial
+--set-secrets REPLACES the whole set rather than merging into it.
+EOM
+  exit 1
+fi
+
+echo "assert-runtime-secrets: OK"

--- a/scripts/gcp/assert-runtime-secrets.sh
+++ b/scripts/gcp/assert-runtime-secrets.sh
@@ -20,10 +20,12 @@
 #
 # WHAT IT CHECKS
 # --------------
-# For each named service/worker-pool, resolves the revision that is actually serving
-# (not merely the latest created) and asserts every required env var is present AND is
-# backed by a `secretKeyRef`. A var that is present but downgraded to a literal value is
-# treated as a failure: it means the secret linkage was replaced by something else.
+# For each named service/worker-pool, resolves every revision that is actually serving
+# traffic (not merely the latest created) and asserts every required env var is present
+# AND is backed by a `secretKeyRef`. A var that is present but downgraded to a literal
+# value is treated as a failure: it means the secret linkage was replaced by something
+# else. Under a canary/rollback split, every nonzero-percent target is checked so a
+# minority revision cannot hide a dropped secret.
 #
 # SCOPE AND LIMITS — read before trusting this
 # --------------------------------------------
@@ -66,23 +68,30 @@ done
 [ -n "$SERVICE$WORKER_POOL" ] || {
   echo "assert-runtime-secrets: at least one of --service / --worker-pool is required" >&2; exit 2; }
 
-# Resolve the revision actually receiving traffic. `latestReadyRevisionName` is NOT
-# sufficient on its own: traffic can be pinned to an older revision, in which case the
-# revision serving users is not the newest one. Prefer an explicit traffic assignment
-# with a non-zero percent and fall back to latestReady only when no explicit split exists.
-serving_revision() {
+# Resolve every revision actually receiving traffic. `latestReadyRevisionName` alone is
+# not enough: traffic can be pinned to an older revision, or split across several
+# (canary / rollback). Emit one revision name per line for every status.traffic entry
+# with percent > 0; fall back to latestReady only when no nonzero targets exist.
+serving_revisions() {
   gcloud run services describe "$1" --project="$PROJECT" --region="$REGION" --format=json 2>/dev/null \
   | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 st = d.get("status", {}) or {}
-best, best_pct = None, 0
+latest = st.get("latestReadyRevisionName") or ""
+revs, seen = [], set()
 for t in st.get("traffic", []) or []:
     pct = t.get("percent") or 0
-    rev = t.get("revisionName")
-    if rev and pct > best_pct:
-        best, best_pct = rev, pct
-print(best or st.get("latestReadyRevisionName", "") or "")
+    if pct <= 0:
+        continue
+    rev = t.get("revisionName") or (latest if t.get("latestRevision") else "")
+    if rev and rev not in seen:
+        seen.add(rev)
+        revs.append(rev)
+if not revs and latest:
+    revs.append(latest)
+for r in revs:
+    print(r)
 '
 }
 
@@ -124,23 +133,11 @@ mapfile -t REQUIRED_NAMES < <(printf '%s' "$REQUIRED" | tr ',' '\n' | sed 's/=.*
 
 failed=0
 
-check_target() {
-  local kind="$1" name="$2" json rev
-  if [ "$kind" = service ]; then
-    rev="$(serving_revision "$name")"
-    if [ -z "$rev" ]; then
-      echo "FAIL [$name] could not resolve a serving revision" >&2
-      failed=1; return
-    fi
-    echo "== $name (serving revision: $rev)"
-    json="$(gcloud run revisions describe "$rev" --project="$PROJECT" --region="$REGION" --format=json 2>/dev/null)"
-  else
-    echo "== $name (worker pool)"
-    json="$(gcloud beta run worker-pools describe "$name" --project="$PROJECT" --region="$REGION" --format=json 2>/dev/null)"
-  fi
-
+# Assert required env vars on one already-fetched revision/worker-pool JSON document.
+assert_env_json() {
+  local label="$1" json="$2"
   if [ -z "$json" ]; then
-    echo "FAIL [$name] could not read live configuration" >&2
+    echo "FAIL [$label] could not read live configuration" >&2
     failed=1; return
   fi
 
@@ -159,15 +156,36 @@ check_target() {
   done
 
   if [ "${#missing[@]}" -gt 0 ]; then
-    echo "FAIL [$name] missing secret-backed env var(s): ${missing[*]}" >&2
+    echo "FAIL [$label] missing secret-backed env var(s): ${missing[*]}" >&2
     failed=1
   fi
   if [ "${#literal[@]}" -gt 0 ]; then
-    echo "FAIL [$name] env var(s) present but NOT backed by a secretKeyRef: ${literal[*]}" >&2
+    echo "FAIL [$label] env var(s) present but NOT backed by a secretKeyRef: ${literal[*]}" >&2
     failed=1
   fi
   if [ "${#missing[@]}" -eq 0 ] && [ "${#literal[@]}" -eq 0 ]; then
     echo "   OK: all ${#REQUIRED_NAMES[@]} required env vars are secret-backed"
+  fi
+}
+
+check_target() {
+  local kind="$1" name="$2" json rev
+  if [ "$kind" = service ]; then
+    local revs=()
+    mapfile -t revs < <(serving_revisions "$name")
+    if [ "${#revs[@]}" -eq 0 ] || [ -z "${revs[0]:-}" ]; then
+      echo "FAIL [$name] could not resolve a serving revision" >&2
+      failed=1; return
+    fi
+    for rev in "${revs[@]}"; do
+      echo "== $name (serving revision: $rev)"
+      json="$(gcloud run revisions describe "$rev" --project="$PROJECT" --region="$REGION" --format=json 2>/dev/null)"
+      assert_env_json "$name/$rev" "$json"
+    done
+  else
+    echo "== $name (worker pool)"
+    json="$(gcloud beta run worker-pools describe "$name" --project="$PROJECT" --region="$REGION" --format=json 2>/dev/null)"
+    assert_env_json "$name" "$json"
   fi
 }
 


### PR DESCRIPTION
## What and why

On 2026-08-04, revision `lingolinq-web-00014` (06:31Z) dropped exactly `BEDROCK_AWS_KEY` and `BEDROCK_AWS_SECRET` and nothing else. Revision `00015` (07:25Z) restored them. Cloud Audit Logs attribute **both** to a human running `google.cloud.run.v1.Services.ReplaceService`, not to `cloud-run-deployer@` (which performed the 2026-08-03 CI deploy).

For ~54 minutes the Tier 1 runtime AI credential path was absent from production. `AiClient.configured?` requires a complete credential pair (`lib/ai_client.rb:159-162`), so every AI feature would have failed closed, and nothing reported it. It was found only by reading revision history a day later.

The existing "verify secrets are seeded" step cannot catch this. It proves the secrets **exist** in Secret Manager before deploying, and they did the whole time. What was lost was the **reference** from the running revision to the secret. Cloud Run mints a new immutable revision on any config change, so a deploy reusing the same image digest can still silently remove secrets.

## What this adds

`scripts/gcp/assert-runtime-secrets.sh` reads back what actually landed:

- Resolves the revision **actually serving traffic**, not merely the latest created (traffic can be pinned to an older revision).
- Checks the worker pool too, since AI work runs in background jobs.
- Asserts every name in `--required` is present **and** backed by a `secretKeyRef`. A var present but downgraded to a literal value is also a failure.
- Asserts linkage only. It never reads secret material and needs no `secretmanager.secretAccessor`.

`--required` takes the same `NAME=SECRET:version` form as `gcloud --set-secrets`, so the workflow passes `"$BOOT_SECRETS,$NON_BOOT_SECRETS"` through unmodified. There is no second list to drift.

## Fix status

| Item | Status | Evidence |
| --- | --- | --- |
| CI deploy that drops a secret now fails loudly | Fixed | `.github/workflows/deploy-cloudrun.yml` step "Assert deployed secrets landed" |
| Serving-revision resolution (not latest-created) | Fixed | `serving_revision()` prefers non-zero traffic percent, falls back to `latestReadyRevisionName` |
| Worker pool covered | Fixed | `--worker-pool lingolinq-worker`; verified live |
| Missing secret detected | Fixed | Live test: exit 1, `missing secret-backed env var(s): NOT_A_REAL_SECRET` |
| Literal-downgrade detected | Fixed | Live test: exit 1 on `AWS_REGION` (legitimately literal, so not in `--required`) |
| Happy path on real list | Fixed | Live: all 32 required secrets secret-backed on `lingolinq-web` (serving `00015`) and `lingolinq-worker` |
| Drift from **manual** deploys | **Not fixed** | See below |

## Not covered by this PR

- **Manual `gcloud run deploy` drift, which is the actual cause of the `00014` incident.** A human deploying directly bypasses this workflow entirely. Closing it needs either restricting Cloud Run update permission to the deploy service account (with an audited break-glass path), or running this script on a schedule. Both are deliberately out of scope; the script is written standalone-callable so either can reuse it. The limit is stated in the script header and in the workflow comment rather than left implicit.
- **No in-app AI generation has been observed on revision `00015`.** A full normalized spec comparison shows `00013` (which served the one successful `AiApiLog` row) and `00015` are identical on image digest, command, args, service account, every env entry including `secretKeyRef` targets, resources, ports, and VPC/ingress. That is configuration equivalence, not a live functional test. Tracked separately.
- **IAM least-privilege, permission boundary, and access-key age on `lingolinq-bedrock-runtime` are unverified.** IAM reads in that account require an MFA session (`scripts/gcp/iam/README.md` documents the procedure and the intended `LingoLinqBedrockRuntimeInvoke` scoping). Needs Scot.
- No Ruby, Ember, or user-facing strings touched, so no i18n, feature flag, or spec changes apply.

## Author-Model: opus-5
