### PR TITLE
fix: emit fail-closed AuditEvent on masquerade authorization (LL-522c1a6d13)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -179,6 +179,12 @@ class ApplicationController < ActionController::Base
         @linked_user = User.find_by_path(as_user)
         admin = Organization.admin
         if admin && admin.manager?(@api_user) && @linked_user
+          # Fail-closed disclosure: refuse impersonation if the accounting row
+          # cannot be written (FERPA/HIPAA). Deduped per operator/target for 30m.
+          if record_masquerade_audit!(operator: @api_user, target: @linked_user, branch: 'site_admin') != :ok
+            api_error 503, {error: 'Audit log write failed; masquerade refused'}
+            return false
+          end
           @true_user = @api_user
           @linked_user.permission_scopes = @api_user.permission_scopes
           @api_user = @linked_user
@@ -192,6 +198,10 @@ class ApplicationController < ActionController::Base
             masq_ok = ((managed_ids & attached_ids).length > 0) && 'store'
           end
           if masq_ok
+            if record_masquerade_audit!(operator: @api_user, target: @linked_user, branch: 'org_manager') != :ok
+              api_error 503, {error: 'Audit log write failed; masquerade refused'}
+              return false
+            end
             Permissions.setex(RedisInit.default, masq_key, 30.minutes.to_i, 'true') if masq_ok == 'store'
             @true_user = @api_user
             @linked_user.permission_scopes = @api_user.permission_scopes
@@ -397,5 +407,32 @@ class ApplicationController < ActionController::Base
       "#<#{raw_p.class.name}>"
     end
     Rails.logger.info("[INSTALLED_HEADER] #{source} val=#{h_log.inspect} effective=#{installed_app_header_effective.inspect} params=#{p_log.inspect} installed_app=#{installed_app?} browser_client=#{browser_client?}")
+  end
+
+  private
+
+  # FERPA/HIPAA accounting-of-disclosures for masquerade authorization.
+  # Deduped per operator/target for 30 minutes so per-request as_user_id does
+  # not flood the audit table. Returns :ok when a prior window is still open or
+  # a new row persisted; :failed when the write did not persist (caller must
+  # refuse the impersonation — fail-closed).
+  def record_masquerade_audit!(operator:, target:, branch:)
+    return :failed unless operator && target
+    audit_key = "masq_audit/#{operator.global_id}/#{target.global_id}"
+    return :ok if RedisInit.default.get(audit_key) == 'true'
+
+    event = AuditEvent.log_command(operator.global_id, {
+      'type' => 'masquerade',
+      'command' => 'authorize',
+      'acting_as' => target.global_id,
+      'branch' => branch.to_s
+    })
+    return :failed unless event&.persisted?
+
+    Permissions.setex(RedisInit.default, audit_key, 30.minutes.to_i, 'true')
+    :ok
+  rescue => e
+    Rails.logger.error('masquerade audit log failed: ' + e.class.to_s)
+    :failed
   end
 end

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -8234,3 +8234,13 @@ Ref: PR #725; live-prod verification via a throwaway Cloud Run job on the servin
 
 **Evidence:** [`2026-08-04-speak-bar-skips-button-sounds.md`](./2026-08-04-speak-bar-skips-button-sounds.md).
 
+## Pattern: masquerade authorization must emit a fail-closed AuditEvent
+
+**Surface:** `ApplicationController#check_api_token` `as_user_id` / `X-As-User-Id` impersonation (site-admin and org-manager branches).
+
+**Symptom:** FERPA/HIPAA accounting-of-disclosures had no record that an admin viewed or acted inside a student account. PaperTrail whodunnit (`user:<op>:as:<target>`) is not enough (destroy-only / pruned / missing on some models).
+
+**Fix recipe:** On successful authorization, **before** swapping `@api_user`, call a helper that (1) Redis-dedups per operator/target for 30 minutes (`masq_audit/<op>/<target>`, separate from the org auth `masq/...` key), (2) writes `AuditEvent.log_command` with `type=masquerade`, `acting_as`, and `branch`, (3) **fail-closes** (503, no swap) if the row does not persist — same posture as database_schema/contents disclosure reads. Attribute `user_key` to the operator (pre-swap `@api_user`), never the target. Do not emit on denied attempts.
+
+**Evidence:** finding `LL-522c1a6d13`; [`2026-08-05-masquerade-audit-event.md`](./2026-08-05-masquerade-audit-event.md); prior art `schema_explorer.rb` `audit_user_key` / `audit_acting_as`.
+

--- a/spec/controllers/api/database_contents_controller_spec.rb
+++ b/spec/controllers/api/database_contents_controller_spec.rb
@@ -220,6 +220,8 @@ describe Api::DatabaseContentsController, :type => :controller do
     # user: the read still succeeds because the real actor is an admin-org
     # manager, and the disclosure is attributed to that admin (not the target).
     # This would 403 if the gate evaluated the impersonated user.
+    # Masquerade authorization itself also writes one AuditEvent (type=masquerade),
+    # so the request produces two rows: authorize + contents disclosure.
     it 'should authorize and attribute to the real admin when masquerading as a non-admin' do
       admin_org = Organization.create(admin: true)
       token_user
@@ -229,10 +231,13 @@ describe Api::DatabaseContentsController, :type => :controller do
 
       expect {
         get :index, params: {table: 'organizations', as_user_id: target.global_id}
-      }.to change { AuditEvent.count }.by(1)
+      }.to change { AuditEvent.count }.by(2)
       expect(response.successful?).to eq(true)
-      event = AuditEvent.last
-      expect(event.user_key).to eq(@user.global_id)
+      masq = AuditEvent.where(user_key: @user.global_id).detect { |e| e.data['type'] == 'masquerade' }
+      expect(masq).to be_present
+      expect(masq.data['acting_as']).to eq(target.global_id)
+      event = AuditEvent.where(user_key: @user.global_id).detect { |e| e.data['type'] == 'database_contents' }
+      expect(event).to be_present
       expect(event.data['acting_as']).to eq(target.global_id)
     end
 

--- a/spec/controllers/api/database_schema_controller_spec.rb
+++ b/spec/controllers/api/database_schema_controller_spec.rb
@@ -156,6 +156,8 @@ describe Api::DatabaseSchemaController, :type => :controller do
     # user: the read still succeeds because the real actor is an admin-org
     # manager, and the disclosure is attributed to that admin (not the target).
     # This would 403 if the gate evaluated the impersonated user.
+    # Masquerade authorization itself also writes one AuditEvent (type=masquerade),
+    # so the request produces two rows: authorize + schema disclosure.
     it 'should authorize and attribute to the real admin when masquerading as a non-admin' do
       admin_org = Organization.create(admin: true)
       token_user
@@ -164,18 +166,23 @@ describe Api::DatabaseSchemaController, :type => :controller do
 
       expect {
         get :index, params: {as_user_id: target.global_id}
-      }.to change { AuditEvent.count }.by(1)
+      }.to change { AuditEvent.count }.by(2)
       expect(response.successful?).to eq(true)
-      event = AuditEvent.last
-      expect(event.user_key).to eq(@user.global_id)
+      masq = AuditEvent.where(user_key: @user.global_id).detect { |e| e.data['type'] == 'masquerade' }
+      expect(masq).to be_present
+      expect(masq.data['acting_as']).to eq(target.global_id)
+      event = AuditEvent.where(user_key: @user.global_id).detect { |e| e.data['type'] == 'database_schema' }
+      expect(event).to be_present
       expect(event.data['acting_as']).to eq(target.global_id)
     end
 
     # A non-admin who is merely able to masquerade (an org manager viewing as one
     # of their users) must NOT inherit schema-explorer access just because the
     # impersonated target happens to be privileged. The gate authorizes the
-    # acting non-admin (@true_user), who fails, so the read is denied and nothing
-    # is disclosed or logged. Guards the escalation direction of the same gate.
+    # acting non-admin (@true_user), who fails, so the read is denied and no
+    # schema disclosure is logged. Masquerade authorization still writes its
+    # own AuditEvent (type=masquerade). Guards the escalation direction of the
+    # same gate.
     it 'should deny a non-admin who masquerades as a privileged target' do
       token_user
       org = Organization.create
@@ -187,8 +194,13 @@ describe Api::DatabaseSchemaController, :type => :controller do
 
       expect {
         get :index, params: {as_user_id: target.global_id}
-      }.not_to change { AuditEvent.count }
+      }.to change { AuditEvent.count }.by(1)
       expect(response.status).to eq(403)
+      event = AuditEvent.last
+      expect(event.user_key).to eq(@user.global_id)
+      expect(event.data['type']).to eq('masquerade')
+      expect(event.data['acting_as']).to eq(target.global_id)
+      expect(AuditEvent.where(user_key: @user.global_id).none? { |e| e.data['type'] == 'database_schema' }).to eq(true)
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -170,6 +170,119 @@ describe ApplicationController, :type => :controller do
       expect(assigns[:true_user]).to eq(u)
       expect(response).to be_successful
     end
+
+    describe "masquerade AuditEvent disclosure" do
+      after(:each) { AuditEvent.delete_all }
+
+      it "writes an AuditEvent for a site-admin masquerade" do
+        o = Organization.create(:admin => true)
+        u = User.create
+        u2 = User.create
+        o.add_manager(u.user_name, true)
+        d = Device.create(:user => u)
+        request.headers['Authorization'] = "Bearer #{d.tokens[0]}"
+
+        expect {
+          get :index, params: {:check_token => true, :as_user_id => u2.global_id}
+        }.to change { AuditEvent.count }.by(1)
+        expect(response).to be_successful
+        event = AuditEvent.last
+        expect(event.user_key).to eq(u.global_id)
+        expect(event.data['type']).to eq('masquerade')
+        expect(event.data['command']).to eq('authorize')
+        expect(event.data['acting_as']).to eq(u2.global_id)
+        expect(event.data['branch']).to eq('site_admin')
+      end
+
+      it "writes an AuditEvent for an org-manager masquerade" do
+        o = Organization.create()
+        u = User.create
+        u2 = User.create
+        o.add_manager(u.user_name, true)
+        o.add_user(u2.user_name, false, false)
+        d = Device.create(:user => u)
+        request.headers['Authorization'] = "Bearer #{d.tokens[0]}"
+
+        expect {
+          get :index, params: {:check_token => true, :as_user_id => u2.global_id}
+        }.to change { AuditEvent.count }.by(1)
+        expect(response).to be_successful
+        event = AuditEvent.last
+        expect(event.user_key).to eq(u.global_id)
+        expect(event.data['acting_as']).to eq(u2.global_id)
+        expect(event.data['branch']).to eq('org_manager')
+      end
+
+      it "writes an AuditEvent when masquerading via X-As-User-Id" do
+        o = Organization.create(:admin => true)
+        u = User.create
+        u2 = User.create
+        o.add_manager(u.user_name, true)
+        d = Device.create(:user => u)
+        request.headers['Authorization'] = "Bearer #{d.tokens[0]}"
+        request.headers['X-As-User-Id'] = u2.global_id
+
+        expect {
+          get :index, params: {:check_token => true}
+        }.to change { AuditEvent.count }.by(1)
+        expect(response).to be_successful
+        event = AuditEvent.last
+        expect(event.user_key).to eq(u.global_id)
+        expect(event.data['acting_as']).to eq(u2.global_id)
+        expect(event.data['branch']).to eq('site_admin')
+      end
+
+      it "deduplicates AuditEvents per operator/target within the Redis window" do
+        o = Organization.create(:admin => true)
+        u = User.create
+        u2 = User.create
+        o.add_manager(u.user_name, true)
+        d = Device.create(:user => u)
+        request.headers['Authorization'] = "Bearer #{d.tokens[0]}"
+
+        get :index, params: {:check_token => true, :as_user_id => u2.global_id}
+        expect(response).to be_successful
+        expect(AuditEvent.count).to eq(1)
+
+        expect {
+          get :index, params: {:check_token => true, :as_user_id => u2.global_id}
+        }.not_to change { AuditEvent.count }
+        expect(response).to be_successful
+        expect(assigns[:true_user]).to eq(u)
+        expect(assigns[:api_user]).to eq(u2)
+      end
+
+      it "does not write an AuditEvent for a denied org-manager masquerade" do
+        o = Organization.create()
+        u = User.create
+        u2 = User.create
+        o.add_manager(u.user_name, true)
+        d = Device.create(:user => u)
+        request.headers['Authorization'] = "Bearer #{d.tokens[0]}"
+
+        expect {
+          get :index, params: {:check_token => true, :as_user_id => u2.global_id}
+        }.not_to change { AuditEvent.count }
+        assert_error("Invalid masquerade attempt")
+      end
+
+      it "refuses masquerade when the audit write does not persist (fail-closed)" do
+        o = Organization.create(:admin => true)
+        u = User.create
+        u2 = User.create
+        o.add_manager(u.user_name, true)
+        d = Device.create(:user => u)
+        request.headers['Authorization'] = "Bearer #{d.tokens[0]}"
+        allow(AuditEvent).to receive(:log_command).and_return(AuditEvent.new)
+
+        get :index, params: {:check_token => true, :as_user_id => u2.global_id}
+        expect(response.status).to eq(503)
+        json = JSON.parse(response.body)
+        expect(json['error']).to eq('Audit log write failed; masquerade refused')
+        expect(assigns[:true_user]).to eq(nil)
+        expect(assigns[:api_user]).to eq(u)
+      end
+    end
     
     it "should not allow disabled tokens" do
       u = User.create


### PR DESCRIPTION
## Summary
- Emit a Redis-deduped `AuditEvent` when masquerade is authorized via `as_user_id` / `X-As-User-Id` (site-admin and org-manager branches), recording operator, target (`acting_as`), and authorizing `branch`.
- Fail-closed: refuse impersonation with 503 if the disclosure row does not persist (same posture as database_schema/contents reads).
- Addresses register finding **LL-522c1a6d13** (high, FERPA/HIPAA). Finding left `open` for Scot to close.

## Entry points (P2)
| Entry point | Enforced at | Test |
| --- | --- | --- |
| API request with `as_user_id` (site-admin) | `ApplicationController#check_api_token` → `record_masquerade_audit!` before `@api_user` swap | `spec/controllers/application_controller_spec.rb` "writes an AuditEvent for a site-admin masquerade" |
| API request with `as_user_id` (org-manager) | same | "writes an AuditEvent for an org-manager masquerade" |
| API request with `X-As-User-Id` header | same | "writes an AuditEvent when masquerading via X-As-User-Id" |
| Denied org-manager attempt | no audit write | "does not write an AuditEvent for a denied org-manager masquerade" |
| Audit persist failure | 503, no swap | "refuses masquerade when the audit write does not persist (fail-closed)" |

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| Site-admin branch writes AuditEvent | Fixed | `application_controller.rb:184-186`; event `type=masquerade`, `branch=site_admin` |
| Org-manager branch writes AuditEvent | Fixed | `application_controller.rb:201-203`; `branch=org_manager` |
| Operator attributed (not target) | Fixed | `record_masquerade_audit!` uses pre-swap operator `global_id` as `user_key` (`:419-429`) |
| Dedup per operator/target (30m) | Fixed | Redis `masq_audit/<op>/<target>`; spec "deduplicates AuditEvents…" |
| Fail-closed on audit write failure | Fixed | 503 + no `@true_user` / no swap; spec "refuses masquerade…" |
| Denied attempts silent | Fixed | no event on 400 path |
| Register finding closed | Not fixed | Scot-owned; left `open` / `untriaged` |

## Not covered by this PR
- `LL-cde54765c6` (UI / whose-account indicator)
- Closing or triaging `LL-522c1a6d13` in `FINDINGS.json`
- Changing who may masquerade

## Test plan
- [x] `DB_USER=melis bundle exec rspec spec/controllers/application_controller_spec.rb -e "check_api_token"` (23 examples, 0 failures)
- [ ] Manual: site-admin masquerade → one `AuditEvent` with `user_key`=admin, `data.acting_as`=target, `data.branch`=`site_admin`
- [ ] Manual: repeat within 30m → no second event; impersonation still works
- [ ] Manual: org-manager masquerade of in-org user → event with `branch`=`org_manager`
- [ ] Manual: org-manager attempt outside org → 400, no event

## Author-Model: grok-4.5

Made with [Cursor](https://cursor.com)