### PR TITLE
fix: open boards Folders accordion with (fn sendAction)

### DIFF
--- a/app/frontend/app/components/available-boards-section.js
+++ b/app/frontend/app/components/available-boards-section.js
@@ -93,16 +93,16 @@ export default Component.extend({
         if (ctrl) { ctrl.send.apply(ctrl, [actionName].concat(bound)); }
       };
     };
+    // Invokes immediately — templates bind with `(fn this.sendAction "name" …)`.
+    // Do NOT return a nested handler: `(fn factory "x")` would call the factory
+    // at event time and discard the returned function (accordion / drag / filter
+    // no-ops). Keep the Event arg; updateFolderFilter and drag/drop read it
+    // (unlike ctrlAction, which strips events for click-only controller actions).
+    // See LEARNINGS: `(fn this.ctrlAction …)` factory gotcha; task log
+    // 2026-08-05-boards-folder-accordion-fn-sendaction.md.
     this.sendAction = function(actionName) {
-      var bound = Array.prototype.slice.call(arguments, 1);
-      return function() {
-        var args = bound.concat(Array.prototype.slice.call(arguments));
-        var evt = args[args.length - 1];
-        if (evt && typeof evt.preventDefault === 'function' && (evt.type || evt.target)) {
-          args.pop();
-        }
-        self.send.apply(self, [actionName].concat(args));
-      };
+      var args = Array.prototype.slice.call(arguments, 1);
+      self.send.apply(self, [actionName].concat(args));
     };
     this.selfActionNoBubble = function(actionName) {
       var bound = Array.prototype.slice.call(arguments, 1);

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -8252,3 +8252,15 @@ Ref: PR #725; live-prod verification via a throwaway Cloud Run job on the servin
 
 Stop Masquerading controls (PR #714) signal masquerade without naming the acting admin. Operator identity is already stashed as `session.original_user_name` (set at masquerade start, restored every `session.restore()`). Expose a stash-safe computed (`masqueradeOperatorName` / `masqueradeStopLabel` on `controllers/application.js`) and bind every chrome path (AppNavbar desktop + menu + drawer, legacy `#identity`, brief). Do not rely on `application.hbs` alone when `useAppNavbarInHeader` is true. Finding LL-cde54765c6. Ref: [`2026-08-05-masquerade-operator-indicator.md`](./2026-08-05-masquerade-operator-indicator.md).
 
+
+## Gotcha: `(fn this.sendAction …)` with a factory helper never runs the action
+
+**Surface:** user boards page Folders accordion (`/u/:user/boards`, `available-boards-section`).
+
+**Symptom:** Clicking Folders header/chevron does nothing; folder filter / drag-drop wired the same way also no-op.
+
+**Root cause:** Same as the `(fn this.ctrlAction …)` factory gotcha. `sendAction` returned a handler function; template used `{{on "click" (fn this.sendAction "toggleFoldersExpanded")}}`, so click called the factory and discarded the returned handler.
+
+**Fix recipe:** Either bind at render (`(this.sendAction "x")`) **or** make `sendAction` invoke `self.send` immediately when used with `fn`. Prefer immediate-invoke here because every binding already uses `fn` and several handlers need the Event (`updateFolderFilter`, drag/drop) — do not strip the event the way `ctrlAction` does.
+
+**Evidence:** [`2026-08-05-boards-folder-accordion-fn-sendaction.md`](./2026-08-05-boards-folder-accordion-fn-sendaction.md); related LEARNINGS entry on `(fn this.ctrlAction …)`.


### PR DESCRIPTION
sendAction was a factory that returned a handler, but templates bind (fn this.sendAction …), so clicks discarded the handler and never toggled. Invoke immediately and keep the Event for filter/drag handlers.