### PR TITLE
ci: auto-deploy to Cloud Run on merge to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,12 @@
 <!--
-Delete any section that does not apply. The migration checklist is NOT optional
-on a PR targeting `main`: since 2026-08-06 a merge into `main` automatically
-builds, migrates the production database, and deploys, with no human between the
-merge button and prod. See .github/workflows/deploy-cloudrun.yml.
+Delete any section that does not apply.
+
+The migration checklist is NOT optional on a PR targeting `main`. Once the
+automatic pipeline is live on `main`, merging there creates a production
+deployment that builds, migrates the production database, and rolls out, gated
+only by an environment approval click. There is no other human step, and no
+opportunity to review the migration after the merge. See
+.github/workflows/deploy-cloudrun.yml.
 -->
 
 ## What
@@ -29,9 +33,11 @@ If it does contain a migration, confirm each of these before requesting review:
       column or table, no `NOT NULL` without a default, no in-place type change,
       and no removal of a job class that already-queued jobs may reference.
 - [ ] The **old** application code still works against the **new** schema. A
-      merge into `main` runs the migration BEFORE the new web revision exists,
-      and the worker pool is replaced LAST, so both old-code-new-schema and
-      new-web-old-worker states occur on every release.
+      merge into `main` runs the migration BEFORE the new web revision takes
+      traffic, and the worker pool is replaced LAST, so both old-code-new-schema
+      and new-web-old-worker states occur on every release. If the health gate
+      rejects the new revision, the migration stays applied while the OLD
+      revision keeps serving, so old-code-new-schema can persist indefinitely.
 - [ ] Anything destructive is deferred to a later release, after the code that
       used the old shape is gone from production.
 - [ ] If the migration is long-running or uses `disable_ddl_transaction!`,
@@ -46,6 +52,15 @@ someone watching, or schedule a maintenance window.
 - [ ] No new environment variable or secret is required. (Otherwise: seed it in
       GCP Secret Manager and add it to the relevant set in
       `deploy-cloudrun.yml` FIRST, or the deploy fails at boot.)
-- [ ] Rollback is understood. Traffic rollback is
-      `gcloud run services update-traffic lingolinq-web --to-revisions <prev>=100`,
-      which is only safe when the migration in this release is backward compatible.
+- [ ] Rollback is understood. Traffic rollback is:
+
+      gcloud run services update-traffic lingolinq-web \
+        --region us-central1 --to-revisions <prev>=100
+
+      Two caveats. It is only safe when the migration in this release is
+      backward compatible, since rolling code back does not roll the schema
+      back. And it PINS the service to that revision, clearing
+      `latestRevision`, so every later deploy will create a revision that takes
+      no traffic until someone runs `--to-latest`. The deploy workflow does that
+      un-pinning for you on its next successful run.
+      Neither command touches the worker pool; roll that back separately.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+<!--
+Delete any section that does not apply. The migration checklist is NOT optional
+on a PR targeting `main`: since 2026-08-06 a merge into `main` automatically
+builds, migrates the production database, and deploys, with no human between the
+merge button and prod. See .github/workflows/deploy-cloudrun.yml.
+-->
+
+## What
+
+<!-- One or two sentences. What changes for a user or an operator? -->
+
+## Why
+
+<!-- The problem this solves. Link the issue, incident, or finding. -->
+
+## Testing
+
+<!-- What you ran, and what you saw. "CI is green" is not testing. -->
+
+---
+
+## Database migrations
+
+- [ ] **This PR contains no migration.** (Skip the rest of this section.)
+
+If it does contain a migration, confirm each of these before requesting review:
+
+- [ ] The migration is **expand-contract**: it only adds. No dropped or renamed
+      column or table, no `NOT NULL` without a default, no in-place type change,
+      and no removal of a job class that already-queued jobs may reference.
+- [ ] The **old** application code still works against the **new** schema. A
+      merge into `main` runs the migration BEFORE the new web revision exists,
+      and the worker pool is replaced LAST, so both old-code-new-schema and
+      new-web-old-worker states occur on every release.
+- [ ] Anything destructive is deferred to a later release, after the code that
+      used the old shape is gone from production.
+- [ ] If the migration is long-running or uses `disable_ddl_transaction!`,
+      you have checked it completes inside the 3600s task timeout. The migrate
+      Job does not retry, by design.
+
+If you cannot satisfy these, **do not merge to `main`**. Deploy it by hand with
+someone watching, or schedule a maintenance window.
+
+## Production impact
+
+- [ ] No new environment variable or secret is required. (Otherwise: seed it in
+      GCP Secret Manager and add it to the relevant set in
+      `deploy-cloudrun.yml` FIRST, or the deploy fails at boot.)
+- [ ] Rollback is understood. Traffic rollback is
+      `gcloud run services update-traffic lingolinq-web --to-revisions <prev>=100`,
+      which is only safe when the migration in this release is backward compatible.

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -2,9 +2,15 @@ name: Deploy to Cloud Run
 
 # Production deploy pipeline for GCP Cloud Run.
 #
-# LIVE AND AUTOMATIC: every push to `main` deploys to production, including running DB
-# migrations against prod Cloud SQL. `workflow_dispatch` is retained for manual redeploys and
+# LIVE: a push to `main` CREATES a production deployment, which then proceeds once a reviewer
+# approves it in the `production` environment. That deployment runs DB migrations against prod
+# Cloud SQL, rolls out a new web revision with no traffic, health-checks it, shifts traffic,
+# and replaces the worker pool. `workflow_dispatch` is retained for manual redeploys and
 # rollforwards, but only on `main` (see the ref guard on the deploy job).
+#
+# Do not read "every push deploys" too literally. Two documented cases break it: a queued run
+# can be cancelled while pending (see CONCURRENCY below), and a run whose approval arrives
+# after `main` has moved on refuses to deploy stale code (see the staleness guard).
 #
 # DO NOT assume `main` only receives vetted, staging-tested code. It does not. Release PRs from
 # `staging` are the common case, but hotfix branches merge DIRECTLY into `main` and that is the
@@ -13,12 +19,19 @@ name: Deploy to Cloud Run
 # branch of a PR into `main`. What makes automatic deploy acceptable is therefore NOT
 # provenance, it is the three gates below, and removing any of them removes the safety:
 #   1. Required status checks on `main` (rspec, build-and-test, audit-artifacts-integrity,
-#      codex-review-tests, security-scan, secret-detection) with enforce_admins on, so nothing
-#      reaches `main` red, whatever branch it came from.
-#   2. The `production` environment on the deploy job: `main`-only branch policy plus a
-#      required reviewer, which is the authorization boundary and the audit record.
+#      codex-review-tests, security-scan, secret-detection) with enforce_admins on, so no PR
+#      merges red against the base it was tested against, whatever branch it came from.
+#      Note `strict` is FALSE, deliberately: requiring every PR to be up to date with `main`
+#      before merging would block a hotfix behind a merge-back. The residual risk is real --
+#      a PR green against base X can merge after `main` has advanced to Y, so `main` can be
+#      red while every individual merge was green. The health gate below is the backstop.
+#   2. The `production` environment on the deploy job: `main`-only branch policy plus required
+#      reviewers. A pause, an audit record, and a kill switch. NOT a two-person control; see
+#      the note on the `environment:` key below for what actually enforces that.
 #   3. The ref guard + the WIF provider's `assertion.ref` condition, so no other ref can
 #      deploy or even mint a deploy token.
+#   4. The candidate rollout: the new revision takes NO user traffic until it has answered
+#      two consecutive health probes on its own tagged URL.
 #
 # MIGRATIONS MUST BE EXPAND-CONTRACT. This is a hard rule for anything that reaches `main`,
 # and it is a consequence of the step order below, which no amount of care in this file can
@@ -62,6 +75,11 @@ name: Deploy to Cloud Run
 #     run queues, regardless of `cancel-in-progress`. Three merges in quick succession deploy
 #     the 1st and 3rd; the 2nd shows `cancelled`. On a linear `main` that is benign, since the
 #     3rd contains the 2nd, but it means "every push deploys" is not literally true.
+#   - A run AWAITING ENVIRONMENT APPROVAL counts as in-progress and holds this group for as
+#     long as the approval sits unactioned, which can be days. Every merge behind it queues,
+#     and each new one cancels the previously pending one. Approve or reject promptly; an
+#     ignored approval quietly stops all production deploys. The staleness guard is what stops
+#     a late approval from shipping the stale commit it was created for.
 # `cancel-in-progress: false` is still right: cancelling a run partway through the migration
 # Job is the one thing guaranteed to hurt.
 #
@@ -147,11 +165,21 @@ jobs:
     # `assertion.ref` condition, so a non-main ref cannot mint a deploy token either.
     if: needs.guard.outputs.enabled == 'true' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    # Protected environment: `main`-only deployment branch policy plus a required reviewer.
-    # This is the authorization boundary AND the audit record for every production change
-    # (Deployments API), and disabling it halts auto-deploy without touching this file.
+    # Protected environment: `main`-only deployment branch policy plus required reviewers.
+    # What this actually gives you, stated precisely so nobody over-trusts it: a PAUSE before
+    # anything touches prod, a Deployments API AUDIT RECORD of who released what, and a KILL
+    # SWITCH (disable the environment and auto-deploy stops without editing this file).
+    # It is NOT a two-person control: `prevent_self_review` is false, so whoever merges can
+    # approve their own deployment. That is deliberate, so a single on-call engineer can ship
+    # a hotfix at 2am. The actual two-person control is upstream and stronger: CODEOWNERS
+    # (`* @swahlquist @MelissaOneil`) plus `require_code_owner_reviews` plus a required
+    # approving review on `main`, which forces a second human onto every PR that gets here.
     environment: production
-    timeout-minutes: 45
+    # 90, not 45. The migrate Job is allowed --task-timeout 3600s (60 min), so a 45 minute job
+    # ceiling could cancel the workflow WHILE a valid long migration is still running
+    # server-side: GitHub would release the concurrency slot and report failure while prod is
+    # mid-DDL. This ceiling must stay strictly greater than build + 3600s + deploys + probes.
+    timeout-minutes: 90
     permissions:
       contents: read
       id-token: write
@@ -230,6 +258,32 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # Staleness guard. The environment approval can sit for days, and the job resumes with
+      # the ORIGINAL github.sha. Approving a forgotten deployment would then ship stale code,
+      # and its migrations, onto a schema that has since moved -- a worse version of the drift
+      # this workflow exists to prevent. A push-triggered run must still be the tip of `main`
+      # by the time a human approves it; if it is not, a newer run already covers this commit.
+      # workflow_dispatch is exempt: redeploying an older ref by hand is a legitimate rollforward.
+      - name: Assert this run is still the tip of main
+        if: github.event_name == 'push'
+        env:
+          RUN_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          TIP="$(git rev-parse origin/main 2>/dev/null || echo "")"
+          if [ -z "$TIP" ]; then
+            git fetch --quiet origin main
+            TIP="$(git rev-parse FETCH_HEAD)"
+          fi
+          echo "run sha: $RUN_SHA"
+          echo "main tip: $TIP"
+          if [ "$RUN_SHA" != "$TIP" ]; then
+            echo "::error::This run is for $RUN_SHA but main is now at $TIP."
+            echo "::error::Refusing to deploy stale code after a delayed approval. A newer run"
+            echo "::error::already covers this commit; approve that one instead."
+            exit 1
+          fi
 
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@v3
@@ -349,9 +403,30 @@ jobs:
             --region "${{ vars.GCP_REGION }}" \
             --wait
 
-      - name: Deploy web service
+      # Record the revision that is actually SERVING, before anything changes it. Do not derive
+      # the rollback target later from "second newest revision": revision lists are ordered by
+      # creation, include revisions that never took traffic, and a previous failed deploy would
+      # otherwise become the recommended rollback target during an incident.
+      - name: Record current serving revision
+        run: |
+          set -euo pipefail
+          PREV="$(gcloud run services describe lingolinq-web \
+            --region "${{ vars.GCP_REGION }}" --format=json \
+            | jq -r '[.status.traffic[] | select(.percent == 100) | .revisionName][0] // empty')"
+          if [ -z "$PREV" ]; then
+            echo "::warning::Could not determine a single 100% traffic revision; rollback hints will be omitted."
+          fi
+          echo "PREV_REVISION=$PREV" >> "$GITHUB_ENV"
+          echo "Currently serving: ${PREV:-<none>}"
+
+      # --no-traffic --tag candidate: the new revision is created and reachable at its own
+      # candidate URL, but users stay on the current revision until the health gate passes.
+      # This is what makes the probe a real pre-traffic gate rather than a post-mortem.
+      - name: Deploy web service (no traffic)
         run: |
           gcloud run deploy lingolinq-web \
+            --no-traffic \
+            --tag candidate \
             --image "$IMAGE" \
             --region "${{ vars.GCP_REGION }}" \
             --service-account "lingolinq-run@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com" \
@@ -367,41 +442,67 @@ jobs:
             --set-secrets "$BOOT_SECRETS,$NON_BOOT_SECRETS" \
             --allow-unauthenticated
 
-      # Gate the worker on the web service actually serving. Cloud Run's own readiness check
-      # only proves the container started; this proves the app boots against the migrated
-      # schema and can answer a request. If it fails we stop BEFORE replacing the worker pool,
-      # so the old workers keep draining the queue against code that was working.
+      # Probe the CANDIDATE revision by its own tagged URL, before it takes any user traffic.
+      # Probing the main service URL would be worthless here and actively dangerous: it would
+      # answer from the CURRENT revision and pass regardless of whether the new one works.
       #
-      # This does NOT roll back. Traffic has already shifted (the service is
-      # `latestRevision: true`, 100%), so a failure here is an alert, not a repair. The
-      # rollback command is printed below rather than run automatically, because choosing
-      # between rolling traffic back and rolling forward depends on whether the migration that
-      # just ran is backward compatible -- which is a human call, and exactly why the
-      # expand-contract rule in the header exists.
-      - name: Verify web service health
+      # What this proves and what it does not: /api/v1/health runs a `SELECT 1` and a Redis
+      # PING. It proves the new image boots, reaches Cloud SQL through the socket, reaches
+      # Memorystore over TLS, and can answer an HTTP request against the migrated schema. It
+      # does NOT prove schema-code compatibility in general, because Rails loads column
+      # metadata lazily per model, so a migration that breaks one model can still pass. The
+      # expand-contract rule in the header is the control for that; this is a boot smoke test.
+      #
+      # Two consecutive 200s, not one: a single 200 can come from an instance that is about to
+      # crash-loop on a later request.
+      - name: Verify candidate revision health
         run: |
-          URL="$(gcloud run services describe lingolinq-web \
-            --region "${{ vars.GCP_REGION }}" --format='value(status.url)')"
-          echo "Probing $URL/api/v1/health"
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$URL/api/v1/health" || echo 000)"
-            echo "  attempt $i: HTTP $CODE"
-            if [ "$CODE" = "200" ]; then
-              echo "Web service healthy on the new revision."
+          set -euo pipefail
+          TAG_URL="$(gcloud run services describe lingolinq-web \
+            --region "${{ vars.GCP_REGION }}" --format=json \
+            | jq -r '[.status.traffic[] | select(.tag == "candidate") | .url][0] // empty')"
+          if [ -z "$TAG_URL" ]; then
+            echo "::error::No candidate-tagged URL on lingolinq-web. The --tag candidate deploy did not take."
+            exit 1
+          fi
+          echo "Probing candidate at $TAG_URL/api/v1/health"
+          OK=0
+          for i in $(seq 1 12); do
+            if ! CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$TAG_URL/api/v1/health")"; then
+              CODE=000
+            fi
+            case "$CODE" in
+              200) OK=$((OK + 1)); echo "  attempt $i: HTTP 200 (consecutive: $OK)" ;;
+              *)   OK=0;          echo "  attempt $i: HTTP $CODE" ;;
+            esac
+            if [ "$OK" -ge 2 ]; then
+              echo "Candidate healthy on two consecutive probes."
               exit 0
             fi
             sleep 15
           done
-          PREV="$(gcloud run revisions list --service lingolinq-web \
-            --region "${{ vars.GCP_REGION }}" --format='value(metadata.name)' \
-            --sort-by=~metadata.creationTimestamp --limit=2 | tail -n1)"
-          echo "::error::lingolinq-web did not return 200 from /api/v1/health after 10 attempts."
-          echo "::error::Worker pool NOT replaced; it is still running the previous image."
-          echo "::error::To roll traffic back to the previous revision:"
-          echo "::error::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --to-revisions ${PREV}=100"
-          echo "::error::If this release contained a migration, check whether it is backward"
-          echo "::error::compatible BEFORE rolling back. If it is not, roll FORWARD instead."
+          echo "::error::Candidate revision never returned two consecutive 200s from /api/v1/health."
+          echo "::error::NO user traffic was shifted. Production is untouched and still serving ${PREV_REVISION:-the previous revision}."
+          echo "::error::The worker pool was NOT replaced."
+          echo "::error::The database migration for this release HAS already been applied. If it is not"
+          echo "::error::backward compatible, the currently-serving revision may now be broken too --"
+          echo "::error::check before assuming production is fine."
           exit 1
+
+      # Traffic shift is its own step, gated on the probe above. --to-latest (not
+      # --to-revisions) is deliberate: it restores `latestRevision: true`, so a service left
+      # pinned by an earlier manual rollback is un-pinned here rather than silently keeping
+      # users on an old revision while every subsequent deploy reports success.
+      - name: Shift traffic to the verified revision
+        run: |
+          set -euo pipefail
+          gcloud run services update-traffic lingolinq-web \
+            --region "${{ vars.GCP_REGION }}" \
+            --to-latest
+          SERVING="$(gcloud run services describe lingolinq-web \
+            --region "${{ vars.GCP_REGION }}" --format=json \
+            | jq -r '[.status.traffic[] | select(.percent == 100) | .revisionName][0] // empty')"
+          echo "Now serving: $SERVING (was: ${PREV_REVISION:-<unknown>})"
 
       - name: Deploy worker pool
         run: |

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -20,6 +20,23 @@ name: Deploy to Cloud Run
 #   3. The ref guard + the WIF provider's `assertion.ref` condition, so no other ref can
 #      deploy or even mint a deploy token.
 #
+# MIGRATIONS MUST BE EXPAND-CONTRACT. This is a hard rule for anything that reaches `main`,
+# and it is a consequence of the step order below, which no amount of care in this file can
+# remove: migrate -> web -> worker. That order leaves two windows where schema and code
+# disagree, and automation means nobody is watching them:
+#   * Between the migrate Job and the web deploy, the NEW schema serves the OLD web code.
+#   * Between the web deploy and the worker deploy, the NEW web code enqueues onto workers
+#     still running the OLD image.
+# So, in the release that changes the code:
+#   ALLOWED  -- add a column/table/index, add a nullable field, backfill, add a new job class,
+#               start dual-writing.
+#   FORBIDDEN -- drop or rename a column/table, add a NOT NULL constraint without a default,
+#               change a column type in place, or remove a job class that old workers may
+#               still dequeue.
+# Destructive changes ship in a LATER release, after the code that depended on the old shape
+# is gone from production. If you cannot make a change expand-contract, do not put it through
+# the automatic path: take the site down, or deploy it by hand with someone watching.
+#
 # The `guard` job still no-ops the whole run when vars.GCP_PROJECT_ID is empty, so the
 # workflow stays inert in a fork or a repo where the migration vars were never set.
 # Authentication is keyless via Workload Identity Federation -- no long-lived JSON
@@ -349,6 +366,42 @@ jobs:
             --set-env-vars "RACK_ENV=production,RAILS_ENV=production,REDIS_TLS_VERIFY_HOSTNAME=false,$APP_ENV_VARS" \
             --set-secrets "$BOOT_SECRETS,$NON_BOOT_SECRETS" \
             --allow-unauthenticated
+
+      # Gate the worker on the web service actually serving. Cloud Run's own readiness check
+      # only proves the container started; this proves the app boots against the migrated
+      # schema and can answer a request. If it fails we stop BEFORE replacing the worker pool,
+      # so the old workers keep draining the queue against code that was working.
+      #
+      # This does NOT roll back. Traffic has already shifted (the service is
+      # `latestRevision: true`, 100%), so a failure here is an alert, not a repair. The
+      # rollback command is printed below rather than run automatically, because choosing
+      # between rolling traffic back and rolling forward depends on whether the migration that
+      # just ran is backward compatible -- which is a human call, and exactly why the
+      # expand-contract rule in the header exists.
+      - name: Verify web service health
+        run: |
+          URL="$(gcloud run services describe lingolinq-web \
+            --region "${{ vars.GCP_REGION }}" --format='value(status.url)')"
+          echo "Probing $URL/api/v1/health"
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$URL/api/v1/health" || echo 000)"
+            echo "  attempt $i: HTTP $CODE"
+            if [ "$CODE" = "200" ]; then
+              echo "Web service healthy on the new revision."
+              exit 0
+            fi
+            sleep 15
+          done
+          PREV="$(gcloud run revisions list --service lingolinq-web \
+            --region "${{ vars.GCP_REGION }}" --format='value(metadata.name)' \
+            --sort-by=~metadata.creationTimestamp --limit=2 | tail -n1)"
+          echo "::error::lingolinq-web did not return 200 from /api/v1/health after 10 attempts."
+          echo "::error::Worker pool NOT replaced; it is still running the previous image."
+          echo "::error::To roll traffic back to the previous revision:"
+          echo "::error::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --to-revisions ${PREV}=100"
+          echo "::error::If this release contained a migration, check whether it is backward"
+          echo "::error::compatible BEFORE rolling back. If it is not, roll FORWARD instead."
+          exit 1
 
       - name: Deploy worker pool
         run: |

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -1,12 +1,28 @@
 name: Deploy to Cloud Run
 
-# GATED / INERT scaffold for the Render -> GCP Cloud Run migration (Phase 2 groundwork).
+# Production deploy pipeline for GCP Cloud Run.
 #
-# This workflow does NOTHING until migration Phase 1 provisions the GCP project and sets
-# the repository variables below. It is workflow_dispatch-only (never runs on push/PR) and
-# the `guard` job no-ops the whole run when vars.GCP_PROJECT_ID is empty. Authentication is
-# keyless via Workload Identity Federation -- no long-lived JSON service-account key is ever
-# stored in GitHub.
+# LIVE AND AUTOMATIC: every push to `main` deploys to production, including running DB
+# migrations against prod Cloud SQL. `main` only receives merges from `staging` release PRs,
+# so the code has already run on staging before it lands here. `workflow_dispatch` is retained
+# for manual redeploys and rollforwards.
+#
+# The `guard` job still no-ops the whole run when vars.GCP_PROJECT_ID is empty, so the
+# workflow stays inert in a fork or a repo where the migration vars were never set.
+# Authentication is keyless via Workload Identity Federation -- no long-lived JSON
+# service-account key is ever stored in GitHub.
+#
+# WHY `on: push` AND NOT `on: workflow_run` (CI-gated): a workflow_run trigger only fires when
+# the workflow file is on the repo's DEFAULT branch, and this repo's default branch is
+# `staging`, not `main`. A workflow_run-triggered run also resolves github.ref and GITHUB_SHA
+# to the default branch, so it would build `staging` code and deploy it as prod unless every
+# checkout and image tag were rewritten to workflow_run.head_sha. The CI gate belongs on the
+# merge instead: require the CI checks on `main` in branch protection, so nothing reaches
+# `main` red in the first place.
+#
+# CONCURRENCY: deploys are serialized and NEVER cancelled mid-flight. Two merges landing close
+# together must not run `rails db:migrate` against prod concurrently, and cancelling a run
+# partway through the migration Job could leave the schema half-applied.
 #
 # Pipeline (when enabled): build image -> push to Artifact Registry -> run DB migration as a
 # dedicated Cloud Run Job (gen2 + Cloud SQL) -> deploy web service -> deploy worker pool.
@@ -45,12 +61,20 @@ name: Deploy to Cloud Run
 #   per-instance CA, fetched from the live instance) -- the app's Redis client loads it to
 #   verify the rediss:// TLS chain.
 #
-# MANUAL TRIGGER (only meaningful after Phase 1):
-#   gh workflow run deploy-cloudrun.yml
+# MANUAL TRIGGER (redeploy without a new commit, or deploy a specific ref):
+#   gh workflow run deploy-cloudrun.yml --ref main
 # ---------------------------------------------------------------------------------------
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
+
+# Serialize deploys across BOTH triggers. cancel-in-progress is deliberately false: see the
+# CONCURRENCY note above.
+concurrency:
+  group: deploy-cloudrun
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -67,10 +67,12 @@ name: Deploy to Cloud Run
 # and ONE shared `lingolinq-migrate` Job. Do not scope the group by ref. Two known limits, so
 # nobody reads more safety into this than it provides:
 #   - It is NOT a distributed lock. `gcloud run jobs execute --wait` is a client-side poll;
-#     killing the GitHub job does not stop the server-side execution. If a run hits
-#     `timeout-minutes: 45`, is cancelled, or its runner dies, the lock releases while the
-#     execution may still be writing to prod. A real mutex would need a Postgres advisory lock
-#     inside the migration task. Tracked as follow-up, not solved here.
+#     killing the GitHub job does not stop the server-side execution. If a run hits the job's
+#     `timeout-minutes` ceiling, is cancelled, or its runner dies, the lock releases while the
+#     execution may still be writing to prod. That ceiling is set above the migrate Job's own
+#     `--task-timeout` precisely so a valid long migration cannot trip it, but a cancel or a
+#     dead runner still can. A real mutex would need a Postgres advisory lock inside the
+#     migration task. Tracked as follow-up, not solved here.
 #   - GitHub keeps only ONE pending run per group and cancels the older pending one when a new
 #     run queues, regardless of `cancel-in-progress`. Three merges in quick succession deploy
 #     the 1st and 3rd; the 2nd shows `cancelled`. On a linear `main` that is benign, since the

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -3,9 +3,22 @@ name: Deploy to Cloud Run
 # Production deploy pipeline for GCP Cloud Run.
 #
 # LIVE AND AUTOMATIC: every push to `main` deploys to production, including running DB
-# migrations against prod Cloud SQL. `main` only receives merges from `staging` release PRs,
-# so the code has already run on staging before it lands here. `workflow_dispatch` is retained
-# for manual redeploys and rollforwards.
+# migrations against prod Cloud SQL. `workflow_dispatch` is retained for manual redeploys and
+# rollforwards, but only on `main` (see the ref guard on the deploy job).
+#
+# DO NOT assume `main` only receives vetted, staging-tested code. It does not. Release PRs from
+# `staging` are the common case, but hotfix branches merge DIRECTLY into `main` and that is the
+# intended workflow for urgent fixes (e.g. #734 scot/fix/bedrock-runtime-main-hotfix and #726
+# scot/fix/empty-button-sets-prod-hotfix, both 2026-08-02/03). Nothing restricts the source
+# branch of a PR into `main`. What makes automatic deploy acceptable is therefore NOT
+# provenance, it is the three gates below, and removing any of them removes the safety:
+#   1. Required status checks on `main` (rspec, build-and-test, audit-artifacts-integrity,
+#      codex-review-tests, security-scan, secret-detection) with enforce_admins on, so nothing
+#      reaches `main` red, whatever branch it came from.
+#   2. The `production` environment on the deploy job: `main`-only branch policy plus a
+#      required reviewer, which is the authorization boundary and the audit record.
+#   3. The ref guard + the WIF provider's `assertion.ref` condition, so no other ref can
+#      deploy or even mint a deploy token.
 #
 # The `guard` job still no-ops the whole run when vars.GCP_PROJECT_ID is empty, so the
 # workflow stays inert in a fork or a repo where the migration vars were never set.
@@ -20,9 +33,20 @@ name: Deploy to Cloud Run
 # merge instead: require the CI checks on `main` in branch protection, so nothing reaches
 # `main` red in the first place.
 #
-# CONCURRENCY: deploys are serialized and NEVER cancelled mid-flight. Two merges landing close
-# together must not run `rails db:migrate` against prod concurrently, and cancelling a run
-# partway through the migration Job could leave the schema half-applied.
+# CONCURRENCY: one fixed group across BOTH triggers, because there is ONE production database
+# and ONE shared `lingolinq-migrate` Job. Do not scope the group by ref. Two known limits, so
+# nobody reads more safety into this than it provides:
+#   - It is NOT a distributed lock. `gcloud run jobs execute --wait` is a client-side poll;
+#     killing the GitHub job does not stop the server-side execution. If a run hits
+#     `timeout-minutes: 45`, is cancelled, or its runner dies, the lock releases while the
+#     execution may still be writing to prod. A real mutex would need a Postgres advisory lock
+#     inside the migration task. Tracked as follow-up, not solved here.
+#   - GitHub keeps only ONE pending run per group and cancels the older pending one when a new
+#     run queues, regardless of `cancel-in-progress`. Three merges in quick succession deploy
+#     the 1st and 3rd; the 2nd shows `cancelled`. On a linear `main` that is benign, since the
+#     3rd contains the 2nd, but it means "every push deploys" is not literally true.
+# `cancel-in-progress: false` is still right: cancelling a run partway through the migration
+# Job is the one thing guaranteed to hurt.
 #
 # Pipeline (when enabled): build image -> push to Artifact Registry -> run DB migration as a
 # dedicated Cloud Run Job (gen2 + Cloud SQL) -> deploy web service -> deploy worker pool.
@@ -99,8 +123,17 @@ jobs:
   deploy:
     name: Build and deploy
     needs: guard
-    if: needs.guard.outputs.enabled == 'true'
+    # Ref guard: production is `main` and only `main`. Without this, ANY collaborator with
+    # Actions write could `workflow_dispatch` this workflow on any branch or tag and deploy it
+    # to prod, migrations included. That is not hypothetical -- run 28881107723 (2026-07-07)
+    # deployed `--ref staging` to production. The WIF provider carries the matching
+    # `assertion.ref` condition, so a non-main ref cannot mint a deploy token either.
+    if: needs.guard.outputs.enabled == 'true' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Protected environment: `main`-only deployment branch policy plus a required reviewer.
+    # This is the authorization boundary AND the audit record for every production change
+    # (Deployments API), and disabling it halts auto-deploy without touching this file.
+    environment: production
     timeout-minutes: 45
     permissions:
       contents: read
@@ -271,6 +304,14 @@ jobs:
         # hanging against an unreachable address. `private-ranges-only` routes ONLY RFC1918 /
         # Google ranges through the VPC; public egress (S3/SES/etc.) still uses the default
         # path, so this does not force all traffic through the VPC. (Phase 3.)
+        # --max-retries 0 is MANDATORY, not tuning. The Job default is 3 retries at a 600s task
+        # timeout. 13 migrations use `disable_ddl_transaction!`, including
+        # 20260702120000_add_retention_cleanup_indexes.rb, which builds indexes with
+        # `algorithm: :concurrently` on log_session_boards / progresses / board_button_sounds.
+        # A CREATE INDEX CONCURRENTLY killed at the timeout leaves an INVALID index behind; the
+        # automatic retry then dies on PG::DuplicateTable, and the migration never records in
+        # schema_migrations -- a partially advanced prod schema needing manual DBA repair.
+        # Retrying a Rails migration is never correct. Fail once, loudly, and stop.
         run: |
           gcloud run jobs deploy lingolinq-migrate \
             --image "$IMAGE" \
@@ -283,6 +324,8 @@ jobs:
             --vpc-egress private-ranges-only \
             --command bundle \
             --args "exec,rake,db:migrate" \
+            --max-retries 0 \
+            --task-timeout 3600s \
             --set-env-vars "RACK_ENV=production,RAILS_ENV=production,REDIS_TLS_VERIFY_HOSTNAME=false" \
             --set-secrets "$BOOT_SECRETS"
           gcloud run jobs execute lingolinq-migrate \

--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -419,7 +419,7 @@ reconciliation.
 Restore the dump whole into `lingolinq_production` on `lingolinq-prod-pg` (private IP
 `10.160.0.3`). Reconcile row counts, extensions, and schema against the baseline. The migrate Job
 later applies only **incremental** `db:migrate` on top; it never runs `db:prepare` (which could
-load `schema.rb` and drop tables; see `deploy-cloudrun.yml:118-124`).
+load `schema.rb` and drop tables; see `deploy-cloudrun.yml:259-266`).
 
 ### 4. S1 - reset and verify sequences  (built, #424)
 
@@ -473,7 +473,10 @@ script, and is NOT in the deploy workflow `BOOT_SECRETS`. Decide before cutover:
 > workflow no-ops while `vars.GCP_PROJECT_ID` is empty, so dispatching first just no-ops. Steps 6
 > and 7 were swapped in the first draft; this is the corrected order.
 
-The deploy workflow no-ops while `vars.GCP_PROJECT_ID` is empty (`deploy-cloudrun.yml:65-71`).
+The deploy workflow no-ops while `vars.GCP_PROJECT_ID` is empty (`deploy-cloudrun.yml:87-97`).
+Note: since 2026-08-05 the workflow also deploys automatically on every push to `main`, so a
+release merge into `main` is itself a production deploy; `gh workflow run` below is now the
+manual redeploy path rather than the only path.
 "Un-inert" = set the deferred repo variables (Settings > Secrets and variables > Actions >
 Variables). Three are already set (`GCP_REGION=us-central1`, `GCP_WIF_PROVIDER`, `GCP_DEPLOY_SA`,
 per tracker 1.10). Set the remaining four:

--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -419,7 +419,8 @@ reconciliation.
 Restore the dump whole into `lingolinq_production` on `lingolinq-prod-pg` (private IP
 `10.160.0.3`). Reconcile row counts, extensions, and schema against the baseline. The migrate Job
 later applies only **incremental** `db:migrate` on top; it never runs `db:prepare` (which could
-load `schema.rb` and drop tables; see `deploy-cloudrun.yml:259-266`).
+load `schema.rb` and drop tables; see the "Strictly incremental" comment on the
+"Run database migration (Cloud Run Job)" step in `deploy-cloudrun.yml`).
 
 ### 4. S1 - reset and verify sequences  (built, #424)
 
@@ -473,10 +474,12 @@ script, and is NOT in the deploy workflow `BOOT_SECRETS`. Decide before cutover:
 > workflow no-ops while `vars.GCP_PROJECT_ID` is empty, so dispatching first just no-ops. Steps 6
 > and 7 were swapped in the first draft; this is the corrected order.
 
-The deploy workflow no-ops while `vars.GCP_PROJECT_ID` is empty (`deploy-cloudrun.yml:87-97`).
-Note: since 2026-08-05 the workflow also deploys automatically on every push to `main`, so a
-release merge into `main` is itself a production deploy; `gh workflow run` below is now the
-manual redeploy path rather than the only path.
+The deploy workflow no-ops while `vars.GCP_PROJECT_ID` is empty (the `guard` job, "Check
+migration readiness", in `deploy-cloudrun.yml`).
+Note: once PR #758 reaches `main`, a push to `main` also CREATES a production deployment
+automatically, which proceeds after a reviewer approves it in the `production` environment. A
+release merge into `main` is therefore itself a production deploy, and `gh workflow run` below
+becomes the manual redeploy path rather than the only path.
 "Un-inert" = set the deferred repo variables (Settings > Secrets and variables > Actions >
 Variables). Three are already set (`GCP_REGION=us-central1`, `GCP_WIF_PROVIDER`, `GCP_DEPLOY_SA`,
 per tracker 1.10). Set the remaining four:


### PR DESCRIPTION
## What

Turns the Cloud Run deploy workflow from manual-dispatch-only into an automatic production deploy on every push to `main`, behind three gates.

```yaml
on:
  push:
    branches: [main]
  workflow_dispatch:

concurrency:
  group: deploy-cloudrun
  cancel-in-progress: false
```

## Why

Prod releases currently require someone to remember `gh workflow run deploy-cloudrun.yml --ref main` after merging the release PR. That gap is why Cloud Run sat two days behind `main` on 2026-08-05 (serving `420aada8` while `main` was at `abc1f28a`).

## Correction to the original justification

The first version of this PR claimed "`main` only receives merges from `staging` release PRs, so anything landing there has already run on staging." **That was false.** Four of the last ten merges into `main` came from elsewhere, including two production hotfixes in the three days before this PR was opened:

```
734  scot/fix/bedrock-runtime-main-hotfix    2026-08-03
726  scot/fix/empty-button-sets-prod-hotfix  2026-08-02
```

Hotfix-direct-to-`main` is the intended workflow for urgent fixes, and nothing restricts PR source branches into `main`. So automatic deploy on push to `main` cannot rest on provenance. It rests on the three gates below instead.

## The three gates

1. **Required status checks on `main`** (applied outside this diff): `rspec`, `build-and-test`, `audit-artifacts-integrity`, `codex-review-tests`, `security-scan`, `secret-detection`, with `enforce_admins: true`. Nothing reaches `main` red, whatever branch it came from.
2. **`environment: production`** on the deploy job: `main`-only deployment branch policy plus required reviewers. This is the authorization boundary and the audit record for every production change, and disabling it halts auto-deploy without a code change.
3. **Ref guard**: `if: github.ref == 'refs/heads/main'` on the deploy job, plus `assertion.ref == 'refs/heads/main' && assertion.ref_type == 'branch'` on the WIF provider, so no other ref can deploy or even mint a deploy token. Previously any collaborator could dispatch this on any ref: run `28881107723` shipped `--ref staging` to production on 2026-07-07.

## Migration safety

`--max-retries 0` and `--task-timeout 3600s` on the migrate Job. The Job default was 3 retries at 600s. 13 migrations use `disable_ddl_transaction!`, including `20260702120000_add_retention_cleanup_indexes.rb`, which builds indexes with `algorithm: :concurrently` on `log_session_boards`, `progresses`, and `board_button_sounds`. A `CREATE INDEX CONCURRENTLY` killed at the timeout leaves an INVALID index behind, the automatic retry then dies on `PG::DuplicateTable`, and the migration never records in `schema_migrations`. Retrying a Rails migration is never correct. The live Job has been updated to match.

## Concurrency, honestly described

One fixed group across both triggers, because there is one production database and one shared migrate Job. Two limits are now documented in the header rather than glossed:

- It is **not** a distributed lock. `gcloud run jobs execute --wait` is a client-side poll, so killing the GitHub job does not stop the server-side execution.
- GitHub keeps only **one** pending run per group and cancels the older pending one when a new run queues, regardless of `cancel-in-progress`. Three merges in quick succession deploy the 1st and 3rd.

## Why not `on: workflow_run` to gate on CI

- `workflow_run` only fires when the workflow file is on the repository's **default branch**, and this repo's default branch is `staging`, not `main`.
- A `workflow_run`-triggered run resolves `github.ref` and `GITHUB_SHA` to the default branch, so it would build `staging` code and deploy it as production unless every checkout and the image tag were rewritten to `workflow_run.head_sha`.

## Review

Dual review (Codex senior-dev + Claude adversary, run in parallel) returned request-changes on the first commit; both flagged the missing CI gate and the false provenance claim. All five blocking items are applied. Findings artifact: `outputs/docs/2026-08-06-pr758-dual-review-findings.md`.

Known follow-ups, deliberately not in this PR: a real migration mutex (Postgres advisory lock), `queue: max` on the concurrency group, a pre-migration backup step plus documented image-rollback command, Cloud SQL deletion protection, moving `GCP_*` repo Variables to environment scope, SHA-pinning the three third-party actions, and correcting the `COMPLIANCE.md:519` attestation about pre-deploy security scanning.

## Blast radius

Merging this to `staging` changes nothing. It takes effect only once `staging` reaches `main`, and the first automatic deploy will be that release merge.
