### PR TITLE
security(ai): gate focus_generate_words with ai_feature_enabled_for? on cache hit (#762)

### DIFF
--- a/app/controllers/api/integrations_controller.rb
+++ b/app/controllers/api/integrations_controller.rb
@@ -92,8 +92,22 @@ class Api::IntegrationsController < ApplicationController
   end
 
   def focus_generate_words
-    unless FeatureFlags.feature_enabled_for?('ai_board_generation', @api_user)
+    # Gate on the AI-specific check so org disable_ai_features, COPPA, EU under-16,
+    # and user prefs are enforced at the endpoint — including on an AiFocusWordSet
+    # cache hit, which returns before AiBoardGenerator.generate_focus_words runs.
+    unless FeatureFlags.ai_feature_enabled_for?('ai_board_generation', @api_user)
       return api_error(403, { error: 'Feature not available' })
+    end
+    # EU AI Act Article 50(1) server-side backstop: a client that skips the
+    # ai-disclosure modal and calls this endpoint directly must still be refused.
+    # 'article_50_disclosure' is AVAILABLE-only (not in ENABLED_FRONTEND_FEATURES),
+    # so feature_enabled_for? returns false and this guard is inert until the flag
+    # is enabled. Do not enable it here. Distinct error code from the AI refusal
+    # above so the client and the register can tell the two apart.
+    if FeatureFlags.feature_enabled_for?('article_50_disclosure', @api_user) &&
+       EuJurisdiction.disclosure_required?(@api_user) &&
+       !@api_user.article_50_disclosure_shown?
+      return api_error(403, { error: 'article_50_disclosure_required' })
     end
 
     processed_params, json_body_source = integration_json_body_params_source

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -5767,6 +5767,18 @@ decrypt). Local fix (test DB only, regenerates on boot):
 `psql -U scotw -d lingolinq-test -c "delete from settings where key='encryption_hash'"`. Do not
 "fix" it by editing the dotenv load order in spec_helper.
 
+## Gotcha: controller AI endpoints must call `ai_feature_enabled_for?` before any shared-cache short-circuit (#762)
+
+`feature_enabled_for?` is rollout only. `ai_feature_enabled_for?` also enforces org
+`disable_ai_features`, COPPA, EU under-16, and user prefs. A controller that gates with the plain
+flag and then returns a warmed `AiFocusWordSet` (keyed only on scrubbed prompt + locale + core
+flag — no user/org scope) skips every consent check on a cache HIT; the generator's own
+`ai_feature_enabled_for?` only runs on MISS. Specs that only exercise the miss path pass against
+the broken code. Mutation-test cache-hit 403 examples: revert the controller gate, confirm red
+(200 + cached words), restore, confirm green. Mirror `boards_controller#generate_labels` for the
+gate + Article 50 backstop (`article_50_disclosure` is AVAILABLE-only — do not enable it just to
+exercise the backstop). See `docs/task-management/2026-08-07-focus-words-consent-gate.md`.
+
 ## Pattern: every external-model call site must gate the same way (COPPA + org opt-out + PiiScrubber + AiApiLog)
 
 The canonical AI egress shape is fixed across call sites (`lib/ai_word_predictor.rb`,

--- a/spec/controllers/api/integrations_controller_spec.rb
+++ b/spec/controllers/api/integrations_controller_spec.rb
@@ -308,11 +308,12 @@ describe Api::IntegrationsController, :type => :controller do
       assert_missing_token
     end
 
-    it 'should reject when the feature flag is off' do
+    it 'should reject when the AI feature gate is off' do
       token_user
-      expect(FeatureFlags).to receive(:feature_enabled_for?).with('ai_board_generation', @user).and_return(false)
+      expect(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_board_generation', anything).and_return(false)
       post 'focus_generate_words', params: { prompt: 'grinch lesson' }
       expect(response).to have_http_status(403)
+      expect(JSON.parse(response.body)['error']).to eq('Feature not available')
     end
 
     it 'should require a prompt' do
@@ -449,6 +450,135 @@ describe Api::IntegrationsController, :type => :controller do
       expect(response).to have_http_status(503)
       json = JSON.parse(response.body)
       expect(json['error']).to eq('AI service unavailable')
+    end
+
+    # Cache-hit consent gate (issue #762): AiFocusWordSet.find_for is global by
+    # scrubbed prompt/locale/core flag, so a warmed row can serve any requester.
+    # On a hit the controller used to return before AiBoardGenerator ran, skipping
+    # ai_feature_enabled_for?. These examples assert 403 ON A CACHE HIT. A
+    # cache-miss-only example passes against the broken code and proves nothing.
+    # Stub surrounding layers; leave real ai_feature_enabled_for? running (except
+    # where the Article 50 block stubs it true to isolate that backstop).
+    describe "AI consent gate on cache hit" do
+      def warm_focus_cache!
+        AiFocusWordSet.create!(
+          scrubbed_prompt: 'grinch lesson',
+          locale: 'en',
+          include_core_words: true,
+          title: 'Grinch Words',
+          words: %w[go stop more help read]
+        )
+      end
+
+      def post_cached_focus
+        post 'focus_generate_words', params: {
+          prompt: 'grinch lesson', word_count: 5, locale: 'en', include_core_words: true
+        }
+      end
+
+      # Drive real ai_feature_enabled_for?; stub only the layers around the
+      # preference check (matches boards_controller "user preference gate").
+      def stub_ai_layers_except_prefs
+        allow(FeatureFlags).to receive(:ai_enabled_for?).and_return(true)
+        allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).and_return(false)
+        allow(FeatureFlags).to receive(:eu_under16_blocks_ai_for?).and_return(false)
+        allow(FeatureFlags).to receive(:feature_enabled_for?).and_call_original
+        allow(FeatureFlags).to receive(:feature_enabled_for?)
+          .with('ai_board_generation', anything).and_return(true)
+      end
+
+      it "should 403 for an opted-out user even when the library is already warmed" do
+        token_user
+        focus_set = warm_focus_cache!
+        stub_ai_layers_except_prefs
+        @user.settings['preferences']['ai_features_enabled'] = false
+        @user.save!
+        expect(AiBoardGenerator).not_to receive(:generate_focus_words)
+        post_cached_focus
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['error']).to eq('Feature not available')
+        expect(focus_set.reload.cache_hit_count).to eq(0)
+      end
+
+      it "should 403 when the org has disable_ai_features even on a cache hit" do
+        token_user
+        focus_set = warm_focus_cache!
+        allow(FeatureFlags).to receive(:ai_enabled_for?).and_return(false)
+        allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).and_return(false)
+        allow(FeatureFlags).to receive(:eu_under16_blocks_ai_for?).and_return(false)
+        allow(FeatureFlags).to receive(:feature_enabled_for?).and_call_original
+        allow(FeatureFlags).to receive(:feature_enabled_for?)
+          .with('ai_board_generation', anything).and_return(true)
+        expect(AiBoardGenerator).not_to receive(:generate_focus_words)
+        post_cached_focus
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['error']).to eq('Feature not available')
+        expect(focus_set.reload.cache_hit_count).to eq(0)
+      end
+
+      it "should 403 for a COPPA-blocked account even on a cache hit" do
+        token_user
+        focus_set = warm_focus_cache!
+        allow(FeatureFlags).to receive(:ai_enabled_for?).and_return(true)
+        allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).and_return(true)
+        allow(FeatureFlags).to receive(:eu_under16_blocks_ai_for?).and_return(false)
+        allow(FeatureFlags).to receive(:feature_enabled_for?).and_call_original
+        allow(FeatureFlags).to receive(:feature_enabled_for?)
+          .with('ai_board_generation', anything).and_return(true)
+        expect(AiBoardGenerator).not_to receive(:generate_focus_words)
+        post_cached_focus
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['error']).to eq('Feature not available')
+        expect(focus_set.reload.cache_hit_count).to eq(0)
+      end
+
+      it "should 403 for an EU under-16 account without parental consent even on a cache hit" do
+        token_user
+        focus_set = warm_focus_cache!
+        allow(FeatureFlags).to receive(:ai_enabled_for?).and_return(true)
+        allow(FeatureFlags).to receive(:coppa_blocks_ai_for?).and_return(false)
+        allow(FeatureFlags).to receive(:eu_under16_blocks_ai_for?).and_return(true)
+        allow(FeatureFlags).to receive(:feature_enabled_for?).and_call_original
+        allow(FeatureFlags).to receive(:feature_enabled_for?)
+          .with('ai_board_generation', anything).and_return(true)
+        expect(AiBoardGenerator).not_to receive(:generate_focus_words)
+        post_cached_focus
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['error']).to eq('Feature not available')
+        expect(focus_set.reload.cache_hit_count).to eq(0)
+      end
+
+      describe "article_50_disclosure backstop" do
+        it "should proceed on a cache hit with the flag NOT enabled (AVAILABLE-only shipping state)" do
+          token_user
+          focus_set = warm_focus_cache!
+          expect(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_board_generation', anything).and_return(true)
+          # article_50_disclosure is AVAILABLE-only; feature_enabled_for? returns
+          # false for real (no stub). Jurisdiction/ack must not affect the response.
+          allow(EuJurisdiction).to receive(:disclosure_required?).and_return(true)
+          allow_any_instance_of(User).to receive(:article_50_disclosure_shown?).and_return(false)
+          expect(AiBoardGenerator).not_to receive(:generate_focus_words)
+          post_cached_focus
+          json = assert_success_json
+          expect(json['cached']).to eq(true)
+          expect(focus_set.reload.cache_hit_count).to eq(1)
+        end
+
+        it "should return 403 with article_50_disclosure_required on a cache hit when the flag is on, in scope, and unacknowledged" do
+          token_user
+          focus_set = warm_focus_cache!
+          expect(FeatureFlags).to receive(:ai_feature_enabled_for?).with('ai_board_generation', anything).and_return(true)
+          allow(FeatureFlags).to receive(:feature_enabled_for?).and_call_original
+          allow(FeatureFlags).to receive(:feature_enabled_for?).with('article_50_disclosure', anything).and_return(true)
+          allow(EuJurisdiction).to receive(:disclosure_required?).and_return(true)
+          allow_any_instance_of(User).to receive(:article_50_disclosure_shown?).and_return(false)
+          expect(AiBoardGenerator).not_to receive(:generate_focus_words)
+          post_cached_focus
+          expect(response).to have_http_status(:forbidden)
+          expect(JSON.parse(response.body)['error']).to eq('article_50_disclosure_required')
+          expect(focus_set.reload.cache_hit_count).to eq(0)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Closes #762.

## Summary
- Swap `focus_generate_words` from `FeatureFlags.feature_enabled_for?` to `ai_feature_enabled_for?`, matching `boards_controller#generate_labels`, so org `disable_ai_features`, COPPA, EU under-16, and user AI prefs refuse **before** any `AiFocusWordSet` cache hit.
- Add the Article 50(1) server-side backstop with distinct error code `article_50_disclosure_required`. Flag stays AVAILABLE-only — **not enabled**.
- Request specs assert **403 on a cache hit** for opted-out, org-disabled, COPPA-blocked, and EU under-16 accounts; Art50 flag-off shipping path still succeeds.

## Fix status
| Item | Status | Evidence |
|------|--------|----------|
| Consent gate on cache hit | Fixed | `app/controllers/api/integrations_controller.rb` `focus_generate_words` uses `ai_feature_enabled_for?` before `find_for` |
| Article 50 backstop (symmetric with generate_labels) | Fixed | same action; `403` + `article_50_disclosure_required` |
| Error-code distinction AI vs Art50 | Fixed | `'Feature not available'` vs `'article_50_disclosure_required'` |
| `article_50_disclosure` enabled | Not done (intentional) | AVAILABLE-only in `lib/feature_flags.rb`; do not enable |
| Cross-family cache keying | Not fixed (Scot call) | see below |
| Hotfix to `main` | Not done (Scot call) | see below |

## Entry points
| Entry point | Enforced at | Test |
|-------------|-------------|------|
| Direct API `POST focus_generate_words` (cache hit) | Rails controller `ai_feature_enabled_for?` + Art50 backstop | `spec/controllers/api/integrations_controller_spec.rb` `"AI consent gate on cache hit"` |
| Direct API (cache miss) | Same controller gate (also generator) | covered by new gate + existing generator-error examples |
| Ember client | UX only — not the security boundary | n/a |

## Not covered by this PR
- `focus_generated_words_usage` still uses plain `feature_enabled_for?` (does not serve cached AI words)
- Stale boards_controller comment claiming `article_50_disclosure` is unregistered (flag is AVAILABLE-only; left untouched)
- Changing `AiFocusWordSet` global cache keying
- Enabling `article_50_disclosure` or hotfixing `main`

## Mutation test (required)
Filter: `bundle exec rspec spec/controllers/api/integrations_controller_spec.rb -e 'AI consent gate on cache hit'`

**Against broken gate** (`feature_enabled_for?` only, Art50 block removed): **6 examples, 6 failures**
- opted-out / org disable / COPPA / EU under-16: expected `403`, got `200`
- Art50 required: expected `403`, got `200`
- Art50 flag-off example: `ai_feature_enabled_for?` expected 1 time, received 0

**With fix restored**: **6 examples, 0 failures** (full `focus_generate_words` describe: **17 examples, 0 failures**)

## Scot calls (evidence only — do not decide here)

### 1. Cross-family cache sharing
`AiFocusWordSet.find_for` keys on scrubbed prompt + locale + core-words flag only (`app/models/ai_focus_word_set.rb` `hash_for` / `find_for`). `seed_user_global_id` / org id are audit metadata on `record_generation!`, not part of the lookup. Board gen + focus words were reclassified **Non-personal** 2026-07-09 (`docs/legal/AI_DATA_FLOW_CLASSIFICATION.md` §4.2) because the vendor payload is a scrubbed topic string. Separate finding from the consent bypass; this PR does not change cache keying.

### 2. Main-directed hotfix
Fix lands on `staging`; prod runs `main`. Latent / empty client DB → expectation is no hotfix. Your call.

## Test plan
- [x] Mutation-test: revert controller gate → red; restore → green
- [x] `DB_USER=melis bundle exec rspec spec/controllers/api/integrations_controller_spec.rb -e 'focus_generate_words'`
- [ ] Confirm no flag enablement of `article_50_disclosure` in this PR
- [ ] Scot: cross-family cache finding
- [ ] Scot: hotfix-to-main call

## Author-Model: fable-5

Made with [Cursor](https://cursor.com)