### PR TITLE
fix(ci): pin the traffic shift, drop the fake staleness guard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,11 @@ Delete any section that does not apply.
 
 The migration checklist is NOT optional on a PR targeting `main`. Once the
 automatic pipeline is live on `main`, merging there creates a production
-deployment that builds, migrates the production database, and rolls out, gated
-only by an environment approval click. There is no other human step, and no
-opportunity to review the migration after the merge. See
-.github/workflows/deploy-cloudrun.yml.
+deployment request. It proceeds when a reviewer approves it in the `production`
+environment; it can also be superseded if a later merge queues behind it. The
+approval is a pause, not a review step: nobody re-reads the migration at that
+point, and there is no gate after it. Review the migration BEFORE you merge.
+See .github/workflows/deploy-cloudrun.yml.
 -->
 
 ## What
@@ -57,10 +58,12 @@ someone watching, or schedule a maintenance window.
       gcloud run services update-traffic lingolinq-web \
         --region us-central1 --to-revisions <prev>=100
 
-      Two caveats. It is only safe when the migration in this release is
-      backward compatible, since rolling code back does not roll the schema
-      back. And it PINS the service to that revision, clearing
-      `latestRevision`, so every later deploy will create a revision that takes
-      no traffic until someone runs `--to-latest`. The deploy workflow does that
-      un-pinning for you on its next successful run.
-      Neither command touches the worker pool; roll that back separately.
+      Three things to know. It is only safe when the migration in this release
+      is backward compatible, since rolling code back does not roll the schema
+      back. The service is always pinned by revision name (the deploy workflow
+      pins to the revision it verified, and does not use `--to-latest`), so this
+      command replaces one pin with another rather than fighting the workflow.
+      And the NEXT successful deploy will move traffic to its own newly verified
+      revision, which undoes this rollback -- so if you rolled back because a
+      commit is bad, revert or fix the commit, do not just re-run the deploy.
+      Nothing here touches the worker pool; roll that back separately.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,15 @@ Delete any section that does not apply.
 The migration checklist is NOT optional on a PR targeting `main`. Once the
 automatic pipeline is live on `main`, merging there creates a production
 deployment request. It proceeds when a reviewer approves it in the `production`
-environment; it can also be superseded if a later merge queues behind it. The
-approval is a pause, not a review step: nobody re-reads the migration at that
-point, and there is no gate after it. Review the migration BEFORE you merge.
+environment. Note that an unapproved run counts as in progress and BLOCKS every
+later merge from deploying until it is approved or rejected; it is not
+superseded by them.
+
+The approval is a pause, not a review step: nobody re-reads the migration at
+that point, and no later gate looks at it either. The automated gates that do
+run after approval (secret presence, the candidate health probe, the traffic
+read-back) check that the app boots and serves. None of them can tell whether
+your migration was safe. Review the migration BEFORE you merge.
 See .github/workflows/deploy-cloudrun.yml.
 -->
 
@@ -60,9 +66,13 @@ someone watching, or schedule a maintenance window.
 
       Three things to know. It is only safe when the migration in this release
       is backward compatible, since rolling code back does not roll the schema
-      back. The service is always pinned by revision name (the deploy workflow
-      pins to the revision it verified, and does not use `--to-latest`), so this
-      command replaces one pin with another rather than fighting the workflow.
+      back. After any successful run of the deploy workflow the service is
+      pinned by revision name (it pins to the revision it verified and never
+      uses `--to-latest`), so this command usually replaces one pin with
+      another; check first with `gcloud run services describe lingolinq-web
+      --region us-central1 --format='value(spec.traffic)'`, because if the
+      service is still on `latestRevision` this command CREATES a pin, and the
+      next manual deploy will then serve 0%.
       And the NEXT successful deploy will move traffic to its own newly verified
       revision, which undoes this rollback -- so if you rolled back because a
       commit is bad, revert or fix the commit, do not just re-run the deploy.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -59,10 +59,17 @@ someone watching, or schedule a maintenance window.
 - [ ] No new environment variable or secret is required. (Otherwise: seed it in
       GCP Secret Manager and add it to the relevant set in
       `deploy-cloudrun.yml` FIRST, or the deploy fails at boot.)
-- [ ] Rollback is understood. Traffic rollback is:
+- [ ] Rollback is understood. Find the revision to go back to, then pin it:
+
+      gcloud run revisions list --service lingolinq-web --region us-central1 \
+        --sort-by=~metadata.creationTimestamp
 
       gcloud run services update-traffic lingolinq-web \
-        --region us-central1 --to-revisions <prev>=100
+        --region us-central1 --to-revisions REVISION_NAME=100
+
+      (Substitute the real revision name. Do not paste a `<placeholder>`: the
+      angle brackets are shell redirection and bash will fail with a confusing
+      "No such file or directory" instead of running gcloud.)
 
       Three things to know. It is only safe when the migration in this release
       is backward compatible, since rolling code back does not roll the schema

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -8,30 +8,33 @@ name: Deploy to Cloud Run
 # and replaces the worker pool. `workflow_dispatch` is retained for manual redeploys and
 # rollforwards, but only on `main` (see the ref guard on the deploy job).
 #
-# Do not read "every push deploys" too literally. Two documented cases break it: a queued run
-# can be cancelled while pending (see CONCURRENCY below), and a run whose approval arrives
-# after `main` has moved on refuses to deploy stale code (see the staleness guard).
+# Do not read "every push deploys" too literally. A queued run can be cancelled while pending
+# (see CONCURRENCY below), so a merge can be superseded before it ever deploys. And a run that
+# sits unapproved does not deploy at all until someone acts on it.
 #
 # DO NOT assume `main` only receives vetted, staging-tested code. It does not. Release PRs from
 # `staging` are the common case, but hotfix branches merge DIRECTLY into `main` and that is the
 # intended workflow for urgent fixes (e.g. #734 scot/fix/bedrock-runtime-main-hotfix and #726
 # scot/fix/empty-button-sets-prod-hotfix, both 2026-08-02/03). Nothing restricts the source
 # branch of a PR into `main`. What makes automatic deploy acceptable is therefore NOT
-# provenance, it is the three gates below, and removing any of them removes the safety:
+# provenance, it is the four gates below, and removing any of them removes the safety:
 #   1. Required status checks on `main` (rspec, build-and-test, audit-artifacts-integrity,
 #      codex-review-tests, security-scan, secret-detection) with enforce_admins on, so no PR
 #      merges red against the base it was tested against, whatever branch it came from.
 #      Note `strict` is FALSE, deliberately: requiring every PR to be up to date with `main`
 #      before merging would block a hotfix behind a merge-back. The residual risk is real --
 #      a PR green against base X can merge after `main` has advanced to Y, so `main` can be
-#      red while every individual merge was green. The health gate below is the backstop.
+#      red while every individual merge was green. The health gate below catches only the
+#      subset of that which stops the app booting or answering; it is a boot smoke test, not a
+#      backstop for behavioural regressions, authorization bugs, or anything a test would find.
 #   2. The `production` environment on the deploy job: `main`-only branch policy plus required
 #      reviewers. A pause, an audit record, and a kill switch. NOT a two-person control; see
 #      the note on the `environment:` key below for what actually enforces that.
 #   3. The ref guard + the WIF provider's `assertion.ref` condition, so no other ref can
 #      deploy or even mint a deploy token.
 #   4. The candidate rollout: the new revision takes NO user traffic until it has answered
-#      two consecutive health probes on its own tagged URL.
+#      two consecutive health probes on its own tagged URL, and traffic is then pinned to
+#      that exact verified revision by name.
 #
 # MIGRATIONS MUST BE EXPAND-CONTRACT. This is a hard rule for anything that reaches `main`,
 # and it is a consequence of the step order below, which no amount of care in this file can
@@ -80,8 +83,9 @@ name: Deploy to Cloud Run
 #   - A run AWAITING ENVIRONMENT APPROVAL counts as in-progress and holds this group for as
 #     long as the approval sits unactioned, which can be days. Every merge behind it queues,
 #     and each new one cancels the previously pending one. Approve or reject promptly; an
-#     ignored approval quietly stops all production deploys. The staleness guard is what stops
-#     a late approval from shipping the stale commit it was created for.
+#     ignored approval quietly stops all production deploys. Nothing in this workflow stops a
+#     late approval from shipping the commit it was created for, even if `main` has moved on:
+#     see the note where the staleness guard used to be. Reject stale approvals by hand.
 # `cancel-in-progress: false` is still right: cancelling a run partway through the migration
 # Job is the one thing guaranteed to hurt.
 #
@@ -261,32 +265,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # Staleness guard. The environment approval can sit for days, and the job resumes with
-      # the ORIGINAL github.sha. Approving a forgotten deployment would then ship stale code,
-      # and its migrations, onto a schema that has since moved -- a worse version of the drift
-      # this workflow exists to prevent. A push-triggered run must still be the tip of `main`
-      # by the time a human approves it; if it is not, a newer run already covers this commit.
-      # workflow_dispatch is exempt: redeploying an older ref by hand is a legitimate rollforward.
-      - name: Assert this run is still the tip of main
-        if: github.event_name == 'push'
-        env:
-          RUN_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          TIP="$(git rev-parse origin/main 2>/dev/null || echo "")"
-          if [ -z "$TIP" ]; then
-            git fetch --quiet origin main
-            TIP="$(git rev-parse FETCH_HEAD)"
-          fi
-          echo "run sha: $RUN_SHA"
-          echo "main tip: $TIP"
-          if [ "$RUN_SHA" != "$TIP" ]; then
-            echo "::error::This run is for $RUN_SHA but main is now at $TIP."
-            echo "::error::Refusing to deploy stale code after a delayed approval. A newer run"
-            echo "::error::already covers this commit; approve that one instead."
-            exit 1
-          fi
-
+      # NO STALENESS GUARD HERE, DELIBERATELY. An earlier version of this workflow had one, and
+      # it could not work: `actions/checkout` fetches refspec `+<github.sha>:refs/remotes/origin/main`
+      # on a push event, so after checkout `origin/main` IS this run's own SHA. Any comparison
+      # against the checkout-local ref is a tautology that passes on every input, including a
+      # genuinely stale one, while printing two matching SHAs and a green check. A control that
+      # cannot fail is worse than a documented gap, because people trust it.
+      #
+      # THE GAP, stated plainly: an environment approval can sit for days, and the job then
+      # resumes with the ORIGINAL github.sha. Approving a forgotten deployment ships that
+      # commit, and its migrations, onto a schema that may have moved. Nothing here stops it.
+      # Mitigation is procedural: approve or reject promptly (the concurrency note above
+      # explains why a pending approval also blocks every later deploy), and if an approval is
+      # older than the current tip of `main`, reject it and let the newer run deploy.
+      #
+      # If this is re-introduced, it MUST resolve the tip from the API rather than the local
+      # ref -- `gh api repos/${{ github.repository }}/git/ref/heads/main --jq .object.sha` --
+      # and it MUST be tested against a deliberately stale SHA before anyone relies on it.
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         uses: google-github-actions/auth@v3
         with:
@@ -444,6 +439,17 @@ jobs:
             --set-secrets "$BOOT_SECRETS,$NON_BOOT_SECRETS" \
             --allow-unauthenticated
 
+      # COUPLING WITH THE PLANNED INGRESS LOCKDOWN -- READ BEFORE RUNNING phase5-frontend-lb.sh.
+      # This probe runs from a GitHub-hosted runner on the public internet and reaches the
+      # revision through its candidate---* tag URL. Cloud Run ingress restrictions apply to tag
+      # URLs as well as the main service URL. The moment `scripts/gcp/phase5-frontend-lb.sh`
+      # sets `--ingress=internal-and-cloud-load-balancing`, this probe starts failing on every
+      # attempt, and because the gate is fail-closed the outcome is: migration applied, traffic
+      # pinned to the OLD revision, worker pool never updated, deploy red. Every deploy, until
+      # someone notices. Before that lockdown lands, this probe must move behind the LB (a
+      # tag-targeted serverless NEG) or run from inside the VPC. Do not flip ingress and this
+      # workflow in the same change without deciding which one moves first.
+      #
       # Probe the CANDIDATE revision by its own tagged URL, before it takes any user traffic.
       # Probing the main service URL would be worthless here and actively dangerous: it would
       # answer from the CURRENT revision and pass regardless of whether the new one works.
@@ -460,13 +466,22 @@ jobs:
       - name: Verify candidate revision health
         run: |
           set -euo pipefail
-          TAG_URL="$(gcloud run services describe lingolinq-web \
+          CAND_JSON="$(gcloud run services describe lingolinq-web \
             --region "${{ vars.GCP_REGION }}" --format=json \
-            | jq -r '[.status.traffic[] | select(.tag == "candidate") | .url][0] // empty')"
-          if [ -z "$TAG_URL" ]; then
-            echo "::error::No candidate-tagged URL on lingolinq-web. The --tag candidate deploy did not take."
+            | jq -c '[.status.traffic[] | select(.tag == "candidate")][0] // empty')"
+          TAG_URL="$(printf '%s' "$CAND_JSON" | jq -r '.url // empty')"
+          CANDIDATE_REV="$(printf '%s' "$CAND_JSON" | jq -r '.revisionName // empty')"
+          if [ -z "$TAG_URL" ] || [ -z "$CANDIDATE_REV" ]; then
+            echo "::error::No candidate-tagged revision on lingolinq-web. The --tag candidate deploy did not take."
             exit 1
           fi
+          # Pin the IMMUTABLE revision name now. The traffic shift must target this exact
+          # revision, not "whatever is latest at shift time": a concurrent manual
+          # `gcloud run deploy` between this probe and the shift would otherwise put 100% of
+          # production traffic on a revision nobody probed. GitHub concurrency does not
+          # serialize humans running gcloud.
+          echo "CANDIDATE_REV=$CANDIDATE_REV" >> "$GITHUB_ENV"
+          echo "Candidate revision: $CANDIDATE_REV"
           echo "Probing candidate at $TAG_URL/api/v1/health"
           OK=0
           for i in $(seq 1 12); do
@@ -483,28 +498,67 @@ jobs:
             fi
             sleep 15
           done
-          echo "::error::Candidate revision never returned two consecutive 200s from /api/v1/health."
-          echo "::error::NO user traffic was shifted. Production is untouched and still serving ${PREV_REVISION:-the previous revision}."
-          echo "::error::The worker pool was NOT replaced."
-          echo "::error::The database migration for this release HAS already been applied. If it is not"
-          echo "::error::backward compatible, the currently-serving revision may now be broken too --"
-          echo "::error::check before assuming production is fine."
+          # Strip the public tag off the FAILING revision before giving up. Without this it stays
+          # reachable at a stable unauthenticated candidate---* URL indefinitely.
+          gcloud run services update-traffic lingolinq-web \
+            --region "${{ vars.GCP_REGION }}" --remove-tags candidate || \
+            echo "::warning::Failed to remove the candidate tag; do it by hand."
+          echo "::error::Candidate revision $CANDIDATE_REV never returned two consecutive 200s from /api/v1/health."
+          echo "::error::"
+          echo "::error::STATE OF PRODUCTION RIGHT NOW, read this before touching anything:"
+          echo "::error::  * No user traffic was shifted. Users are on ${PREV_REVISION:-the previous revision}."
+          echo "::error::  * The worker pool was NOT replaced."
+          echo "::error::  * Traffic is now PINNED to that revision by name. \`latestRevision\` is CLEARED,"
+          echo "::error::    because --no-traffic converts the allocation to a named target. A manual"
+          echo "::error::    \`gcloud run deploy\` will therefore create a revision serving 0% and report"
+          echo "::error::    success. Restore with --to-latest, or pin deliberately, before redeploying."
+          echo "::error::  * The database migration for this release HAS already been applied. If it is"
+          echo "::error::    not backward compatible, the revision users are on may now be broken too."
           exit 1
 
-      # Traffic shift is its own step, gated on the probe above. --to-latest (not
-      # --to-revisions) is deliberate: it restores `latestRevision: true`, so a service left
-      # pinned by an earlier manual rollback is un-pinned here rather than silently keeping
-      # users on an old revision while every subsequent deploy reports success.
+      # Traffic shift, gated on the probe above. Pin to the EXACT revision that was probed, by
+      # immutable name. Do NOT use --to-latest here, for two reasons found in review:
+      #   1. Cloud Run resolves LATEST to the newest READY revision at the moment the command
+      #      runs, which is not necessarily the revision that just passed the probe. A
+      #      concurrent manual deploy would send all production traffic to an unprobed image.
+      #   2. --to-latest silently REVERSES a human incident rollback. After someone pins to a
+      #      known-good revision, a redeploy of the same bad SHA would pass this probe (it is a
+      #      boot smoke test and cannot see a functional bug) and restore the bad revision.
+      # Consequence to know: the service is deliberately left PINNED by name after every
+      # deploy, so `latestRevision` stays cleared. That is intended. Each deploy re-pins to its
+      # own verified revision. A manual `gcloud run deploy` outside this workflow will create a
+      # revision that serves 0% until someone shifts traffic to it on purpose.
+      # The candidate tag is removed in the same call, so no unauthenticated candidate---* URL
+      # outlives the release.
       - name: Shift traffic to the verified revision
         run: |
           set -euo pipefail
+          if [ -z "${CANDIDATE_REV:-}" ]; then
+            echo "::error::CANDIDATE_REV is unset; refusing to shift traffic."
+            exit 1
+          fi
           gcloud run services update-traffic lingolinq-web \
             --region "${{ vars.GCP_REGION }}" \
-            --to-latest
+            --to-revisions "$CANDIDATE_REV=100" \
+            --remove-tags candidate
           SERVING="$(gcloud run services describe lingolinq-web \
             --region "${{ vars.GCP_REGION }}" --format=json \
             | jq -r '[.status.traffic[] | select(.percent == 100) | .revisionName][0] // empty')"
+          if [ "$SERVING" != "$CANDIDATE_REV" ]; then
+            echo "::error::Traffic shift did not land where expected."
+            echo "::error::  probed and intended: $CANDIDATE_REV"
+            echo "::error::  actually serving:    ${SERVING:-<none / split>}"
+            echo "::error::Production may be serving an unverified revision. Investigate before proceeding."
+            exit 1
+          fi
           echo "Now serving: $SERVING (was: ${PREV_REVISION:-<unknown>})"
+          REMAINING_TAG="$(gcloud run services describe lingolinq-web \
+            --region "${{ vars.GCP_REGION }}" --format=json \
+            | jq -r '[.status.traffic[] | select(.tag == "candidate")] | length')"
+          if [ "$REMAINING_TAG" != "0" ]; then
+            echo "::warning::A candidate tag is still present on lingolinq-web. Remove it by hand:"
+            echo "::warning::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --remove-tags candidate"
+          fi
 
       - name: Deploy worker pool
         run: |

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -520,10 +520,25 @@ jobs:
           echo "::error::probe exists to catch revisions that start but do not work. --to-latest would put"
           echo "::error::100% of live traffic on it."
           echo "::error::"
-          echo "::error::To re-assert the known-good revision explicitly:"
-          echo "::error::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --to-revisions ${PREV_REVISION:-<prev>}=100"
-          echo "::error::To inspect the failed revision, re-tag it (this does NOT give it traffic):"
-          echo "::error::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --set-tags candidate=$CANDIDATE_REV"
+          if [ -n "${PREV_REVISION:-}" ]; then
+            echo "::error::To re-assert the known-good revision explicitly:"
+            echo "::error::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --to-revisions $PREV_REVISION=100"
+          else
+            # No single 100% predecessor was recorded (split traffic, or the describe failed).
+            # Do NOT print a placeholder command: `<prev>` is shell redirection, not a visible
+            # blank, so a copy-paste yields "bash: prev: No such file or directory" and gcloud
+            # never runs. Send the operator to look the revision up instead.
+            echo "::error::No single known-good predecessor was recorded before this deploy."
+            echo "::error::Find the revision to pin to, then pin it deliberately:"
+            echo "::error::  gcloud run revisions list --service lingolinq-web --region ${{ vars.GCP_REGION }} --sort-by=~metadata.creationTimestamp"
+            echo "::error::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --to-revisions <that-revision>=100"
+          fi
+          echo "::error::To diagnose the failed revision WITHOUT exposing it publicly:"
+          echo "::error::  gcloud run revisions describe $CANDIDATE_REV --region ${{ vars.GCP_REGION }}"
+          echo "::error::  gcloud logging read 'resource.labels.revision_name=\"$CANDIDATE_REV\"' --freshness=1h --limit=100"
+          echo "::error::Do NOT re-tag it to reach it over HTTP. A tag is a stable public"
+          echo "::error::unauthenticated URL onto the production database, outside the load balancer"
+          echo "::error::and Cloud Armor. Removing it is why this step stripped the tag above."
           echo "::error::To roll FORWARD, push a fixed commit and let this workflow verify it."
           exit 1
 
@@ -552,27 +567,53 @@ jobs:
             --region "${{ vars.GCP_REGION }}" \
             --to-revisions "$CANDIDATE_REV=100" \
             --remove-tags candidate
-          SERVING="$(gcloud run services describe lingolinq-web \
-            --region "${{ vars.GCP_REGION }}" --format=json \
-            | jq -r '[.status.traffic[] | select(.percent == 100) | .revisionName][0] // empty')"
+          # Read back who is serving. This read is LOAD-BEARING (it is the assert), so it is
+          # guarded rather than left to `set -e`: a bare assignment failure would abort the step
+          # between the completed traffic shift and the un-run worker deploy, stranding new web
+          # code against old workers, and none of the diagnostics below would print. Distinguish
+          # "could not read" from "read fine, wrong revision" -- they need different responses.
+          SERVING=""
+          DESCRIBE_OK=1
+          for attempt in 1 2 3; do
+            if SERVING="$(gcloud run services describe lingolinq-web \
+                 --region "${{ vars.GCP_REGION }}" --format=json 2>/dev/null \
+                 | jq -r '[.status.traffic[] | select(.percent == 100) | .revisionName][0] // empty')"; then
+              DESCRIBE_OK=0
+              break
+            fi
+            DESCRIBE_OK=1
+            sleep 5
+          done
+          if [ "$DESCRIBE_OK" != "0" ]; then
+            echo "::error::Could not read back the traffic allocation after the shift (3 attempts)."
+            echo "::error::The shift command itself SUCCEEDED, so traffic is most likely on $CANDIDATE_REV,"
+            echo "::error::but that is unverified. The worker pool has NOT been replaced. Confirm with:"
+            echo "::error::  gcloud run services describe lingolinq-web --region ${{ vars.GCP_REGION }} --format='value(status.traffic)'"
+            exit 1
+          fi
           if [ "$SERVING" != "$CANDIDATE_REV" ]; then
             echo "::error::Traffic shift did not land where expected."
             echo "::error::  probed and intended: $CANDIDATE_REV"
-            echo "::error::  actually serving:    ${SERVING:-<none / split>}"
+            echo "::error::  actually serving:    ${SERVING:-<none, or a split with no 100% target>}"
             echo "::error::Production may be serving an unverified revision. Investigate before proceeding."
             exit 1
           fi
           echo "Now serving: $SERVING (was: ${PREV_REVISION:-<unknown>})"
-          # Belt-and-braces only. --remove-tags above already succeeded (set -e would have
-          # killed the step otherwise), so this should never fire; it exists to catch a human
-          # racing the runner or a lagging read. Defaulted to 0 on ANY failure so a transient
-          # describe error cannot fail the run HERE -- traffic has already shifted at this
-          # point and the worker pool has not been replaced, so aborting between those two
-          # would strand the exact new-web/old-worker split the header warns about.
-          REMAINING_TAG="$(gcloud run services describe lingolinq-web \
-            --region "${{ vars.GCP_REGION }}" --format=json 2>/dev/null \
-            | jq -r '[.status.traffic[] | select(.tag == "candidate")] | length' 2>/dev/null || echo 0)"
-          if [ "${REMAINING_TAG:-0}" != "0" ]; then
+          # Belt-and-braces only, never a gate. --remove-tags above already succeeded (set -e
+          # would have killed the step otherwise), so this should not fire; it catches a human
+          # racing the runner or a lagging read. Non-blocking on purpose, BUT a failed read is
+          # reported as a failed read rather than silently collapsing to "no tag" -- otherwise
+          # the one case this exists to report is the one case it cannot report.
+          REMAINING_TAG=""
+          if ! REMAINING_TAG="$(gcloud run services describe lingolinq-web \
+               --region "${{ vars.GCP_REGION }}" --format=json 2>/dev/null \
+               | jq -r '[.status.traffic[] | select(.tag == "candidate")] | length')"; then
+            REMAINING_TAG=""
+          fi
+          if [ -z "$REMAINING_TAG" ]; then
+            echo "::warning::Could not verify that the candidate tag was removed. Check by hand:"
+            echo "::warning::  gcloud run services describe lingolinq-web --region ${{ vars.GCP_REGION }} --format='value(status.traffic)'"
+          elif [ "$REMAINING_TAG" != "0" ]; then
             echo "::warning::A candidate tag is still present on lingolinq-web. Remove it by hand:"
             echo "::warning::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --remove-tags candidate"
           fi

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -511,9 +511,20 @@ jobs:
           echo "::error::  * Traffic is now PINNED to that revision by name. \`latestRevision\` is CLEARED,"
           echo "::error::    because --no-traffic converts the allocation to a named target. A manual"
           echo "::error::    \`gcloud run deploy\` will therefore create a revision serving 0% and report"
-          echo "::error::    success. Restore with --to-latest, or pin deliberately, before redeploying."
+          echo "::error::    success. Shift traffic explicitly after any manual deploy."
           echo "::error::  * The database migration for this release HAS already been applied. If it is"
           echo "::error::    not backward compatible, the revision users are on may now be broken too."
+          echo "::error::"
+          echo "::error::DO NOT RUN \`--to-latest\`. The latest READY revision right now is"
+          echo "::error::$CANDIDATE_REV, the one that just failed this gate. Ready is not healthy: this"
+          echo "::error::probe exists to catch revisions that start but do not work. --to-latest would put"
+          echo "::error::100% of live traffic on it."
+          echo "::error::"
+          echo "::error::To re-assert the known-good revision explicitly:"
+          echo "::error::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --to-revisions ${PREV_REVISION:-<prev>}=100"
+          echo "::error::To inspect the failed revision, re-tag it (this does NOT give it traffic):"
+          echo "::error::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --set-tags candidate=$CANDIDATE_REV"
+          echo "::error::To roll FORWARD, push a fixed commit and let this workflow verify it."
           exit 1
 
       # Traffic shift, gated on the probe above. Pin to the EXACT revision that was probed, by
@@ -552,10 +563,16 @@ jobs:
             exit 1
           fi
           echo "Now serving: $SERVING (was: ${PREV_REVISION:-<unknown>})"
+          # Belt-and-braces only. --remove-tags above already succeeded (set -e would have
+          # killed the step otherwise), so this should never fire; it exists to catch a human
+          # racing the runner or a lagging read. Defaulted to 0 on ANY failure so a transient
+          # describe error cannot fail the run HERE -- traffic has already shifted at this
+          # point and the worker pool has not been replaced, so aborting between those two
+          # would strand the exact new-web/old-worker split the header warns about.
           REMAINING_TAG="$(gcloud run services describe lingolinq-web \
-            --region "${{ vars.GCP_REGION }}" --format=json \
-            | jq -r '[.status.traffic[] | select(.tag == "candidate")] | length')"
-          if [ "$REMAINING_TAG" != "0" ]; then
+            --region "${{ vars.GCP_REGION }}" --format=json 2>/dev/null \
+            | jq -r '[.status.traffic[] | select(.tag == "candidate")] | length' 2>/dev/null || echo 0)"
+          if [ "${REMAINING_TAG:-0}" != "0" ]; then
             echo "::warning::A candidate tag is still present on lingolinq-web. Remove it by hand:"
             echo "::warning::  gcloud run services update-traffic lingolinq-web --region ${{ vars.GCP_REGION }} --remove-tags candidate"
           fi

--- a/scripts/gcp/PHASE5-CLEAN-DB-REHEARSAL.md
+++ b/scripts/gcp/PHASE5-CLEAN-DB-REHEARSAL.md
@@ -228,8 +228,16 @@ gcloud run jobs execute lingolinq-migrate-cleandb --region "$REGION" --wait
 ## Step 4 - Stack health + five-path smoke test (0b + smoke). GATE: money (services up)
 
 Deploy the web service + worker pool against the seeded DB (same `gcloud run deploy` /
-`gcloud beta run worker-pools deploy` as `deploy-cloudrun.yml` lines 150-181) and hit the
-`run.app` URL directly - still **no DNS**.
+`gcloud beta run worker-pools deploy` as the deploy + worker steps in `deploy-cloudrun.yml`) and
+hit the `run.app` URL directly.
+
+> **A manual `gcloud run deploy` on `lingolinq-web` may serve 0% of traffic.** The deploy
+> workflow pins traffic to the specific revision it health-checked, which clears
+> `latestRevision`. Once any workflow run has done that, a hand deploy creates a revision that
+> takes no traffic and still exits 0. Check with
+> `gcloud run services describe lingolinq-web --region us-central1 --format='value(spec.traffic)'`,
+> and shift deliberately with
+> `gcloud run services update-traffic lingolinq-web --region us-central1 --to-revisions <new>=100`.
 
 - **0b worker health:** worker-pool instance `RUNNABLE`, connected to Memorystore over `rediss://`
   and Cloud SQL, draining `priority`/`default`/`slow` (enqueue a synthetic job, confirm it

--- a/scripts/gcp/PHASE5-CLEAN-DB-REHEARSAL.md
+++ b/scripts/gcp/PHASE5-CLEAN-DB-REHEARSAL.md
@@ -7,6 +7,18 @@ GCP stack up on a **fresh seeded Cloud SQL DB** and validates it on a `run.app` 
 DNS change**. It covers clean-DB steps 1-4; steps 5-6 (LB, DNS, soak, decommission) are
 unchanged from the main runbook and run only after this rehearsal is green.
 
+> **SUPERSEDED FOR RE-RUNS AS WRITTEN. Read before executing any step.** This runsheet was
+> written for a pre-DNS rehearsal and describes itself below as "non-destructive and
+> re-runnable". That was true then. It is not true now: DNS was cut on 2026-07-22, so
+> `app.lingolinq.com` resolves to the LB in front of `lingolinq-web`, and step 3a's
+> `db:schema:load` DROPS ALL TABLES on the database that the DNS-fronted service is using.
+> Re-running this end to end today wipes the live prod database and takes the public hostname
+> down. It does not currently destroy real user data (prod has no real users yet, Scot
+> 2026-08-09), which is the only reason this is an outage rather than an incident. That will
+> stop being true the moment a district is onboarded. Treat every "re-runnable" claim below as
+> scoped to the pre-DNS window it was written in, and do not run step 3a against
+> `lingolinq-prod-pg` again without a deliberate decision.
+>
 > **Status: DRAFT. Nothing here runs before Scot's explicit go.** The seed/secret reads and the
 > Cloud SQL / Cloud Run spin-up are real, cost money, and are HIPAA-relevant infra actions. Every
 > step has a dry/verify mode that touches nothing; run those first. Re-verify live state (Render

--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -15,12 +15,17 @@ preservation).
 > hits the DB and returns 200), worker pool Ready. The external HTTPS LB + Cloud Armor front end
 > **is built and provisioned in preview** (step 8): LB IP `136.68.41.122`, policy `lingolinq-armor`
 > with WAF rules 1001-1004 (`deny 403`) + rate-limit 2000 all in `preview=true` (log-only, not
-> enforcing), verified live 2026-07-15. **What is still gated and has NOT run:** pointing real DNS
-> traffic at that LB / the ingress lockdown (only after the LB path is validated against live DNS),
-> the DNS cut (step 9), the WAF **enforce** flip (9c), and the Render decommission (9b). Those are
-> the HIPAA-relevant, hard-to-reverse actions; nothing in that set runs before sign-off, and the
-> hard constraints (no DNS, no Cloud Armor enforce, no ingress lockdown, no Render/SES changes)
-> stay in force until explicitly lifted.
+> enforcing), verified live 2026-07-15. **THE DNS CUT HAS HAPPENED (step 9).** As of 2026-08-09
+> `app.lingolinq.com` resolves to `136.68.41.122` and `/api/v1/health` returns 200 through the LB.
+> Real district traffic is on GCP. This is no longer a rehearsal environment, and any instruction
+> below written in the future tense about "when we cut over" should be read as already done.
+> **What is still gated and has NOT run:** the ingress lockdown (the web service is still
+> `--ingress=all`, so the `run.app` URL bypasses the LB and Cloud Armor entirely), the WAF
+> **enforce** flip (9c), and the Render decommission (9b). Those remain the HIPAA-relevant,
+> hard-to-reverse actions; nothing in that set runs before sign-off, and those constraints (no
+> Cloud Armor enforce, no ingress lockdown, no Render/SES changes) stay in force until explicitly
+> lifted. Before the ingress lockdown specifically, read the coupling note at the LOCKDOWN GATE in
+> `scripts/gcp/phase5-frontend-lb.sh`: it breaks the deploy pipeline's health probe.
 
 > **Finding references in this runbook.** `audit-reports/FINDINGS.json` is the single source of
 > truth for the status of any `LL-*` finding. Notes below are dated, historical, and may cite a

--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -21,20 +21,35 @@ preservation).
 > record" instructions below are historical, not to-do. The body at line ~634 records the cutover
 > itself as 2026-07-22; 2026-08-09 is only the date this was re-verified.
 >
-> **UNRESOLVED, and it changes how you should treat this whole file: whether prod has REAL USERS.**
-> DNS resolving and a 200 from `/api/v1/health` prove the LB path serves. They do NOT prove real
-> district users are on it. Several places below still assert prod has no real users, only
-> internal test accounts, and one of them uses "no real user data" as the justification for
-> leaving `lingolinq_admin` on a deliberately simple password. Those cannot both be true. Do not
-> plan the ingress lockdown, the Render decommission, or any automated production deploy against
-> a guess. Settle it in writing, with evidence, and reconcile the password justification in the
-> same pass. Until then treat prod as if it holds real student data, because that is the safe
-> direction to be wrong in.
+> **PROD HAS NO REAL USERS YET (Scot, 2026-08-09).** DNS being cut does not mean launched. The
+> LB path serves and `app.lingolinq.com` is live, but the only accounts on it are internal and
+> test. The other statements throughout this file that prod holds no real user data are CORRECT;
+> an earlier version of this block said "real district traffic is on GCP", which was inferred
+> from DNS resolving plus a 200 health check and was wrong. Prod is the environment that WILL
+> hold real districts; it does not yet, and it will not while migration issues are being worked.
 >
-> Note also that the pre-cutover checklist near the end of this file still has unchecked `- [ ]`
-> boxes (DNS TTL lowered, operator quiet window, external writers enumerated and pause-tested,
-> client 503 re-queue confirmed). The checklist boxes are authoritative: the cut having happened
-> does NOT mean those were all satisfied first.
+> **What that buys, and what it does not.** It means the residual risks below are operational,
+> not FERPA/HIPAA incidents, and it makes this the cheapest possible window to exercise anything
+> risky, including the first run of the automated deploy pipeline. It does NOT make any of them
+> permanently acceptable. Everything in the next block is a hard gate on onboarding the first
+> real district, not a nice-to-have:
+>
+> - [ ] Rotate `lingolinq_admin` off the deliberately simple password. Its stated justification
+>       ("no real user data") expires the moment a real district exists, and the account will
+>       outlive the justification unless this is done deliberately.
+> - [ ] Ingress lockdown (`--ingress=internal-and-cloud-load-balancing`). Until then the
+>       `run.app` URL and any revision tag bypass the LB and Cloud Armor entirely. Read the
+>       coupling note in `scripts/gcp/phase5-frontend-lb.sh` first: it breaks the deploy
+>       pipeline's health probe.
+> - [ ] WAF enforce flip (9c). Rules 1001-1004 and 2000 are still `preview=true` / log-only.
+> - [ ] Cloud SQL `deletionProtection` on, and a pre-migration backup step in the deploy path.
+> - [ ] The unchecked `- [ ]` boxes in the pre-cutover checklist near the end of this file
+>       (DNS TTL lowered, operator quiet window, external writers enumerated and pause-tested,
+>       client 503 re-queue confirmed). The cut having happened does NOT mean those were all
+>       satisfied first; the checklist boxes remain authoritative.
+>
+> Treat that list as the launch gate. Once a real district is onboarded, every item on it turns
+> from an operational nicety into a Tier 1 compliance obligation.
 >
 > **What is still gated and has NOT run:** the ingress lockdown (the web service is still
 > `--ingress=all`, so the `run.app` URL bypasses the LB and Cloud Armor entirely), the WAF
@@ -563,9 +578,9 @@ live 2026-07-15). **DNS IS CUT OVER.** Verified 2026-08-09: `app.lingolinq.com` 
 `136.68.41.122` (the `lingolinq-https-fr` forwarding rule) and `/api/v1/health` returns 200
 through the LB. An earlier version of this paragraph said "no real DNS traffic points at the LB
 yet", which was true when written and is now false. Note what this does and does not establish:
-the LB path serves. Whether REAL district users are on it is unresolved and contradicted
-elsewhere in this file; see the Status block at the top before acting on either answer. What
-genuinely remains gated: the ingress lockdown (the web service is still `--ingress=all`, so the
+the LB path serves. It does NOT mean prod is launched. Prod has no real users yet (Scot,
+2026-08-09); see the Status block at the top for the gate list that must close before the first
+real district is onboarded. What genuinely remains gated: the ingress lockdown (the web service is still `--ingress=all`, so the
 `run.app` URL bypasses the LB and Cloud Armor entirely) and the WAF enforce flip (rules 1001-1004
 and 2000 are still `preview=true` / log-only). See the ingress lockdown and the enforce flip in
 step 9c.

--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -15,10 +15,27 @@ preservation).
 > hits the DB and returns 200), worker pool Ready. The external HTTPS LB + Cloud Armor front end
 > **is built and provisioned in preview** (step 8): LB IP `136.68.41.122`, policy `lingolinq-armor`
 > with WAF rules 1001-1004 (`deny 403`) + rate-limit 2000 all in `preview=true` (log-only, not
-> enforcing), verified live 2026-07-15. **THE DNS CUT HAS HAPPENED (step 9).** As of 2026-08-09
-> `app.lingolinq.com` resolves to `136.68.41.122` and `/api/v1/health` returns 200 through the LB.
-> Real district traffic is on GCP. This is no longer a rehearsal environment, and any instruction
-> below written in the future tense about "when we cut over" should be read as already done.
+> enforcing), verified live 2026-07-15. **THE DNS CUT HAS HAPPENED (step 9 is DONE).** Verified
+> 2026-08-09: `app.lingolinq.com` resolves to `136.68.41.122` (the `lingolinq-https-fr` forwarding
+> rule) and `/api/v1/health` returns 200 through the LB. Step 9 and the "NXDOMAIN / create the
+> record" instructions below are historical, not to-do. The body at line ~634 records the cutover
+> itself as 2026-07-22; 2026-08-09 is only the date this was re-verified.
+>
+> **UNRESOLVED, and it changes how you should treat this whole file: whether prod has REAL USERS.**
+> DNS resolving and a 200 from `/api/v1/health` prove the LB path serves. They do NOT prove real
+> district users are on it. Several places below still assert prod has no real users, only
+> internal test accounts, and one of them uses "no real user data" as the justification for
+> leaving `lingolinq_admin` on a deliberately simple password. Those cannot both be true. Do not
+> plan the ingress lockdown, the Render decommission, or any automated production deploy against
+> a guess. Settle it in writing, with evidence, and reconcile the password justification in the
+> same pass. Until then treat prod as if it holds real student data, because that is the safe
+> direction to be wrong in.
+>
+> Note also that the pre-cutover checklist near the end of this file still has unchecked `- [ ]`
+> boxes (DNS TTL lowered, operator quiet window, external writers enumerated and pause-tested,
+> client 503 re-queue confirmed). The checklist boxes are authoritative: the cut having happened
+> does NOT mean those were all satisfied first.
+>
 > **What is still gated and has NOT run:** the ingress lockdown (the web service is still
 > `--ingress=all`, so the `run.app` URL bypasses the LB and Cloud Armor entirely), the WAF
 > **enforce** flip (9c), and the Render decommission (9b). Those remain the HIPAA-relevant,
@@ -542,14 +559,16 @@ Then, BEFORE any DNS change:
 The web service currently serves on its `--allow-unauthenticated` `run.app` URL. The Option B LB +
 Cloud Armor path below **is already built and provisioned** (LB IP `136.68.41.122`, policy
 `lingolinq-armor`, WAF rules 1001-1004 + rate-limit 2000 all in `preview=true` / log-only, verified
-live 2026-07-15). **DNS IS CUT OVER.** As of 2026-08-09, `app.lingolinq.com` resolves to
+live 2026-07-15). **DNS IS CUT OVER.** Verified 2026-08-09: `app.lingolinq.com` resolves to
 `136.68.41.122` (the `lingolinq-https-fr` forwarding rule) and `/api/v1/health` returns 200
-through the LB. Real district traffic is on this path; this is not a rehearsal environment. An
-earlier version of this paragraph said "no real DNS traffic points at the LB yet", which was
-true when written and is now false. What genuinely remains gated: the ingress lockdown (the web
-service is still `--ingress=all`, so the `run.app` URL bypasses the LB and Cloud Armor entirely)
-and the WAF enforce flip (rules 1001-1004 and 2000 are still `preview=true` / log-only). See the
-ingress lockdown and the enforce flip in step 9c.
+through the LB. An earlier version of this paragraph said "no real DNS traffic points at the LB
+yet", which was true when written and is now false. Note what this does and does not establish:
+the LB path serves. Whether REAL district users are on it is unresolved and contradicted
+elsewhere in this file; see the Status block at the top before acting on either answer. What
+genuinely remains gated: the ingress lockdown (the web service is still `--ingress=all`, so the
+`run.app` URL bypasses the LB and Cloud Armor entirely) and the WAF enforce flip (rules 1001-1004
+and 2000 are still `preview=true` / log-only). See the ingress lockdown and the enforce flip in
+step 9c.
 
 Before running the ingress lockdown, read the coupling note added at the LOCKDOWN GATE in
 `scripts/gcp/phase5-frontend-lb.sh`: it breaks the deploy pipeline's health probe.

--- a/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
+++ b/scripts/gcp/PHASE5-CUTOVER-RUNBOOK.md
@@ -537,9 +537,17 @@ Then, BEFORE any DNS change:
 The web service currently serves on its `--allow-unauthenticated` `run.app` URL. The Option B LB +
 Cloud Armor path below **is already built and provisioned** (LB IP `136.68.41.122`, policy
 `lingolinq-armor`, WAF rules 1001-1004 + rate-limit 2000 all in `preview=true` / log-only, verified
-live 2026-07-15). What has NOT happened: no real DNS traffic points at the LB yet, ingress is not
-locked down, and the WAF is not enforcing - those remain gated (see the DNS cut in step 9, the
-ingress lockdown, and the enforce flip in step 9c).
+live 2026-07-15). **DNS IS CUT OVER.** As of 2026-08-09, `app.lingolinq.com` resolves to
+`136.68.41.122` (the `lingolinq-https-fr` forwarding rule) and `/api/v1/health` returns 200
+through the LB. Real district traffic is on this path; this is not a rehearsal environment. An
+earlier version of this paragraph said "no real DNS traffic points at the LB yet", which was
+true when written and is now false. What genuinely remains gated: the ingress lockdown (the web
+service is still `--ingress=all`, so the `run.app` URL bypasses the LB and Cloud Armor entirely)
+and the WAF enforce flip (rules 1001-1004 and 2000 are still `preview=true` / log-only). See the
+ingress lockdown and the enforce flip in step 9c.
+
+Before running the ingress lockdown, read the coupling note added at the LOCKDOWN GATE in
+`scripts/gcp/phase5-frontend-lb.sh`: it breaks the deploy pipeline's health probe.
 
 **DECISION (Scot, 2026-06-23): Option B - external HTTPS Load Balancer + Cloud Armor in front of
 Cloud Run, gated on building and smoke-testing the full LB + Cloud Armor path in the dress

--- a/scripts/gcp/assert-runtime-secrets.sh
+++ b/scripts/gcp/assert-runtime-secrets.sh
@@ -35,7 +35,14 @@
 #   running `gcloud run deploy` directly, which never touches this workflow. Guarding
 #   that requires either restricting Cloud Run update permission to the deploy service
 #   account, or running this script on a schedule. Both are deliberately out of scope
-#   here. Run it standalone any time to reconcile live state:
+#   here.
+# * NOTE for anyone deploying lingolinq-web by hand: the deploy workflow pins traffic to
+#   the revision it health-checked, which clears `latestRevision`. After any workflow run
+#   has done that, your manual `gcloud run deploy` creates a revision serving 0% and still
+#   exits 0 -- so this script can report a revision "clean" that nobody is using. Check
+#   `gcloud run services describe lingolinq-web --region us-central1 --format='value(spec.traffic)'`
+#   and shift traffic deliberately with `update-traffic --to-revisions <new>=100`.
+#   Run it standalone any time to reconcile live state:
 #
 #     bash scripts/gcp/assert-runtime-secrets.sh \
 #       --project lingolinq-prod --region us-central1 \

--- a/scripts/gcp/phase5-frontend-lb.sh
+++ b/scripts/gcp/phase5-frontend-lb.sh
@@ -461,6 +461,17 @@ fi
 # ---------------------------------------------------------------------------------------
 # 3. [LOCKDOWN GATE] flip the web service to LB-only ingress. RUN LAST, after LB validated.
 # ---------------------------------------------------------------------------------------
+#
+# COUPLING WITH THE DEPLOY PIPELINE -- READ BEFORE RUNNING THIS STEP.
+# `.github/workflows/deploy-cloudrun.yml` health-gates every production deploy by probing the
+# new revision through its `candidate---*` TAG URL, from a GitHub-hosted runner on the public
+# internet. Cloud Run ingress restrictions apply to tag URLs, not just the main service URL.
+# So the moment this lockdown lands, that probe fails on every attempt, and the gate is
+# fail-closed: each deploy will apply its migration, leave traffic PINNED to the old revision,
+# never update the worker pool, and go red. Every deploy, until someone connects the two.
+# Before running this step, either move the probe behind the LB (a tag-targeted serverless NEG)
+# or run it from inside the VPC, and update the comment above the probe step in that workflow.
+# Do not treat a red deploy after lockdown as a deploy-pipeline bug; it is this line.
 if [ "$CONFIRM_INGRESS_LOCKDOWN" = "1" ]; then
   # Refuse to lock down ingress in the SAME run that builds the LB: lockdown must come only AFTER
   # the LB path is validated in the rehearsal, otherwise the service goes LB-only while the managed


### PR DESCRIPTION
Follow-up to #758. Round-3 dual review (Codex senior-dev + Claude adversary, in parallel) returned **request-changes** from both, with five Highs, two cross-confirmed. This applies the agreed direction. Findings: `outputs/docs/2026-08-09-pr758-dual-review-round3.md`.

**Do not promote `staging` to `main` until this lands.**

## 1. The staleness guard is removed, not fixed

It could never fail. `actions/checkout` fetches `+<github.sha>:refs/remotes/origin/main` on a push event, so after checkout `origin/main` **is** the run's own SHA. The comparison was a tautology that passed on every input, including a genuinely stale one, while printing two matching SHAs and a green check. The adversary reproduced it:

```
run sha  = fb5787ad...   (the commit being deployed)
true tip = fb390fb7...   (what main actually points at)
git rev-parse origin/main -> fb5787ad...
GUARD PASSES -> DEPLOYS STALE CODE
```

A control that cannot fail is worse than a documented gap, because people trust it. The gap is now stated explicitly where the step was, together with what a real implementation would need: resolve the tip from the API, and test it against a deliberately stale SHA before anyone relies on it.

This also removes the `workflow_dispatch` exemption, which existed only as the `if:` on that step. The exemption was unjustified regardless: the ref guard already rejects every ref except `main`, so there was no "deploy a specific ref" case for it to preserve.

## 2. The traffic shift is pinned to the exact probed revision

`--to-latest` resolves to the newest READY revision at the moment it runs, not the one that passed the probe. Two consequences, both found in review:

- A concurrent manual `gcloud run deploy` between probe and shift would put 100% of production traffic on an unprobed image. GitHub concurrency does not serialize humans running gcloud.
- It silently reversed incident rollbacks. After someone pinned to a known-good revision, a redeploy of the same bad SHA would pass the boot probe (which is `SELECT 1` plus a Redis ping and cannot see a functional bug) and restore the bad revision.

The candidate's immutable `revisionName` is now captured alongside its tag URL, used for `--to-revisions "$CANDIDATE_REV=100"`, and the step asserts the service is actually serving that revision afterwards.

**Behaviour change worth knowing:** the service is now deliberately left pinned by name after every deploy, so `latestRevision` stays cleared. Each deploy re-pins to its own verified revision. A manual `gcloud run deploy` outside this workflow will create a revision serving 0% until someone shifts traffic on purpose.

## 3. The candidate tag is removed on both paths

`--to-latest` preserved tag targets and nothing removed them, so every deploy left a permanent unauthenticated `candidate---*` URL on the production service. It serves the full bearer-token API outside `app.lingolinq.com`, bypassing the GCLB and the `lingolinq-armor` policy, and appears in no ingress inventory. On a probe failure it left the **failing** revision publicly reachable.

Success path removes it in the same `update-traffic` call; failure path removes it before exiting; success path warns if one survives anyway.

## 4. The ingress-lockdown coupling is documented in both files

`phase5-frontend-lb.sh`'s `--ingress=internal-and-cloud-load-balancing` applies to tag URLs, not just the main service URL. Once it lands, this probe fails from a public GitHub runner on every attempt, and because the gate is fail-closed each deploy would apply its migration, leave traffic pinned to the old revision, skip the worker pool, and go red. Every deploy, until someone connects the two.

Noted at the LOCKDOWN GATE in that script and above the probe step here. Not solved in this PR, by decision.

## Claims corrected

- The probe-failure message said "Production is untouched." False in the way that matters at 2am: `--no-traffic` has already cleared `latestRevision` and pinned the service, so a responder's instinctive `gcloud run deploy` creates a revision serving 0% and reports success. It now states the pinned state, that the migration is already applied, and that the serving revision may itself be broken if that migration was not backward compatible.
- Header said "the three gates below" and listed four.
- Header called the health gate a backstop for a stale-CI merge. It is a boot smoke test.
- PR template said merging leaves "no opportunity to review the migration", ignoring the approval pause, and sold the un-pinning as a convenience.
- `PHASE5-CUTOVER-RUNBOOK.md` still said "no real DNS traffic points at the LB yet". **Verified false:** `app.lingolinq.com` resolves to `136.68.41.122` and `/api/v1/health` returns 200 through the LB. Real district traffic is on that path. A reader would have concluded GCP prod was still a rehearsal environment.

## Known open, unchanged here

No advisory lock on the migration, no `queue: max`, no pre-migration backup, Cloud SQL `deletionProtection` false, `GCP_*` still repo-scoped Actions Variables, mutable action tags, the stale `COMPLIANCE.md` pre-deploy-scanning line, `assert-runtime-secrets` still running after the traffic shift while its comment claims it prevents shipping a degraded revision, and `timeout-minutes` not provably exceeding a cold build plus a full 3600s migration.

## Note on first execution

This deploy job has still never run anywhere. Per the agreed plan, the first execution is the `staging` to `main` promotion, watched. That promotion carries no migrations: `git diff origin/main...origin/staging -- db/migrate/ db/schema.rb` is empty.
