### PR TITLE
docs(legal): drop the status token from the dated naming rule

### DIFF
--- a/.claude/skills/re-attest-record/SKILL.md
+++ b/.claude/skills/re-attest-record/SKILL.md
@@ -84,9 +84,17 @@ Use this for any planned change to an attested file under `docs/legal/**`.
 
 2. **Create the successor file** under `docs/legal/` with the dated naming convention from
    `docs/legal/README.md`:
-   `<YYYY-MM-DD>_<kebab-slug>_<status>.<ext>`
-   (ISO date, controlled status token, no `v2` / `final` / initials). Copy forward only what should
+   `<YYYY-MM-DD>_<kebab-slug>.<ext>`
+   (ISO date, no status token, no `v2` / `final` / initials). Copy forward only what should
    remain true; fix stale claims in the **new** file.
+
+   **The filename carries NO status token** (rule changed 2026-08-10; this step previously said
+   `<YYYY-MM-DD>_<kebab-slug>_<status>.<ext>`). Status is a mutable property of the register row,
+   and rule 3 freezes an attested file's name permanently, so a status in the name would either go
+   false at the first status change or force a rename that rule 3 forbids. A record must **never**
+   be attested at a `_draft` path. If you are superseding one of the four grandfathered dated
+   `_draft` records, rename it to the statusless path while it is still mutable and repair its
+   inbound references in that record's own cycle, before any attestation.
 
 3. **Add a new register row** in `audit-reports/DOCUMENT-REGISTER.json` for the successor:
    - Leave `id` and `contentHash` empty for git rows (render fills them).

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -2852,7 +2852,7 @@
       "lastReviewed": "2026-07-22",
       "nextReviewDue": "2027-07-22",
       "attestation": {},
-      "contentHash": "8f813636f42784c3909a2026a867de0d31cfd4d968a5d251574bac1dcfcfb771",
+      "contentHash": "fadcce65c39ae5c11902096733dd01af27880936ca18359e0606d8bff6e3e4cd",
       "bundles": [],
       "mirrors": [],
       "notes": "Written for IA report sec 9.2 (folder READMEs so agents stop filing things in the wrong place).",

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -95,7 +95,7 @@
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | published |  | Scot Wahlquist | 2026-06-21 | 2027-06-21 | no | `c8e466f878b5` |  |
-| docs/legal README (folder charter) | git | `docs/legal/README.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `8f813636f427` |  |
+| docs/legal README (folder charter) | git | `docs/legal/README.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `fadcce65c39a` |  |
 | Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | approved | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-07-28 | 2027-07-28 | 2026-07-28 | `0ee1b92ec130` | soc2-evidence, school-dpa-package, security-review, baa |
 | Incident Response and Breach Runbook (branded) | Drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | published | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Notion - Compliance Engineering Onboarding/Handoff | Notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | published |  | Scot Wahlquist | 2026-06-19 | 2026-12-19 | no | (supplied) |  |

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -57,11 +57,27 @@ Also acceptable here: executed instruments that have no better home and are smal
 
 ## Naming
 
-`<YYYY-MM-DD>_<kebab-slug>_<status>.<ext>` for new dated records, ISO dates only so lexical sort
-equals chronological sort. Status is a controlled token from the register's `statusEnum`. No `v2`,
-no `final`, no initials: the date plus the status carries everything a version number was doing and
-cannot lie. Existing `SCREAMING_SNAKE.md` filenames are grandfathered and are not being renamed,
+`<YYYY-MM-DD>_<kebab-slug>.<ext>` for new dated records, ISO dates only so lexical sort equals
+chronological sort. **The filename carries no status token.** Status is a mutable property of the
+register row (`statusEnum`), and rule 3 above freezes an attested file's name permanently, so a
+status encoded in the name would either become false at the first status change or force a rename
+that rule 3 forbids. The register is the single source of truth for status. No `v2`, no `final`, no
+initials, no status: the date plus the register row carries everything a version number was doing
+and cannot lie. Existing `SCREAMING_SNAKE.md` filenames are grandfathered and are not being renamed,
 because renaming breaks every inbound reference for no compliance benefit.
+
+Four dated records created before this rule are **also grandfathered in place** and are not renamed
+here, for the same reason: `2026-08-09_compliance-posture-report_draft.md`,
+`2026-08-09_compliance-program_draft.md`, `2026-08-09_compliance-program-overview_draft.md`, and
+`2026-08-09_data-retention_draft.md`. None is attested, so rule 3's freeze has not engaged on any of
+them.
+
+**Transition rule for those four.** A grandfathered dated `_draft` record may remain at its current
+path **while it is unattested**. Before any such record is attested it must first be renamed, while
+still mutable, to the statusless dated path above, with its inbound references repaired in that
+record's own cycle. **A record must never be attested at a `_draft` path**, because rule 3 would then
+freeze a filename asserting a status the register alone is entitled to carry, and the name could
+never be corrected.
 
 ## Retention
 

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -8413,6 +8413,18 @@ only for non-`docs/legal/**` git rows or explicit Scot-directed recovery after a
 in-place amend. Skill: `.claude/skills/re-attest-record/SKILL.md`. Example chain:
 `DOC-9f6a2412ad` → `DOC-ae3f9d06ef`.
 
+> **SUPERSESSION NOTE, 2026-08-10.** The filename pattern in the Fix recipe above is superseded. The
+> original wording is preserved as written, because this is a historical log rather than a live spec.
+> The successor path is now `docs/legal/<YYYY-MM-DD>_<kebab-slug>.<ext>` with **no status token**:
+> status is a mutable register-row property, and `docs/legal/README.md` rule 3 freezes an attested
+> file's name permanently, so a status encoded in the name either goes false at the first status
+> change or forces a rename that rule 3 forbids. **A record must never be attested at a `_draft`
+> path.** Four dated `_draft` records predating the rule are grandfathered in place while unattested,
+> and each must be renamed to the statusless path, with its references repaired, before it is
+> attested. Everything else in this entry (Path A versus Path B, supersession pointers, bundle
+> retargeting by location) still stands. Authority: `docs/legal/README.md` Naming section, approved
+> by Scot 2026-08-10.
+
 **Also retarget live bundles by location, not title.** `meta.bundleDefinitions.*.requiredDocs`
 bind by `canonicalLocation`; moving live membership to the successor without updating those
 locations fails `--check` as a missing required member. Frozen dated binders can stay on the


### PR DESCRIPTION
## The contradiction

An attested `docs/legal` record could not satisfy its own naming rule.

| Source | Rule |
|---|---|
| `README.md` Naming | `<YYYY-MM-DD>_<kebab-slug>_<status>.<ext>`, status token from `statusEnum`, because date plus status "cannot lie" |
| `README.md` rule 3 | "Once Scot attests a document, its **bytes, filename, and location** are immutable" |
| `README.md` rule 5 | Only Scot moves a row to `approved` |

Created `_draft`, it can never be renamed to `_approved` after attestation. Created `_approved` before attestation, the filename asserts a status only Scot may confer while the row is still `draft`.

**sha256 does not resolve this.** It covers bytes only; rule 3 governs filename and location as separate properties. A rename is forbidden regardless of hash stability.

## The fix

The status token is the defect: it encodes a **mutable** property into an **immutable** name. Status now lives solely in the register row, where it is designed to change and where rule 5 already governs who changes it.

New rule: `docs/legal/<YYYY-MM-DD>_<kebab-slug>.<ext>`, no status token.

## Grandfathering, and the transition rule

Four dated records predate this rule and are **grandfathered in place**, not renamed here. They carry 11 inbound references between them, which is the same rationale that already grandfathers the `SCREAMING_SNAKE` filenames.

| File | Row | Status | Attested |
|---|---|---|---|
| `2026-08-09_compliance-posture-report_draft.md` | `DOC-4fc1647b7e` | draft | no |
| `2026-08-09_compliance-program_draft.md` | `DOC-73a80fc88d` | draft | no |
| `2026-08-09_compliance-program-overview_draft.md` | `DOC-90632edc44` | draft | no |
| `2026-08-09_data-retention_draft.md` | `DOC-e62caf7fb9` | draft | no |

None is attested, so rule 3's freeze has not engaged on any of them.

**Transition rule:** such a record may remain at its `_draft` path **while unattested**, but before it is attested it must be renamed to the statusless path while still mutable, with its references repaired in that record's own cycle. **A record must never be attested at a `_draft` path**, because rule 3 would then permanently freeze a filename asserting a status the register alone is entitled to carry.

## Why the skill is in this PR

`.claude/skills/re-attest-record/SKILL.md` is tracked and still instructed agents to create `_<status>` successors. Left stale, the very next Path A supersession cycle would have produced exactly the filename this rule forbids. Same rule, second location.

`docs/task-management/LEARNINGS.md` repeats it. Its historical wording is **preserved verbatim** with a dated supersession note appended, rather than rewriting the log.

## Fix status

| Item | Status | Evidence |
| --- | --- | --- |
| Naming rule drops the status token | Fixed | `docs/legal/README.md` Naming section |
| Four pre-existing dated records grandfathered explicitly | Fixed | same section |
| Transition rule bars attesting at a `_draft` path | Fixed | same section |
| Path A skill guidance repinned | Fixed | `.claude/skills/re-attest-record/SKILL.md` step 2 |
| Historical log superseded without rewriting | Fixed | `LEARNINGS.md`, note dated 2026-08-10 |

## Attestation impact

**None.** `docs/legal/README.md` is `DOC-6e34e8251a`, status `published`, `attestedBy: null`. Its contentHash refresh is ordinary bookkeeping. The register diff was grepped to confirm **no `attestedContentHash`, `attestedDate`, `attestedBy`, or `priorAttestations` field changed on any row**.

## Verification

- `scripts/regenerate-register.sh` green on all six checks: citation-check 111 PASS / 0 FAIL / 14 SKIP, calendar render, Notion page, document register (75 docs), publication status, capability ledger
- `attestation-hash-guard-test.sh`: OK, all guards fired
- `git diff --check` clean
- `codex-review-guard.sh`: PASS, no data-bearing paths
- Independent `codex review`: no findings

## Not covered by this PR

- No file renamed and no inbound reference redirected. Each grandfathered record is handled in its own cycle.
- **No mechanical enforcement.** `document-register-render.rb` performs no filename validation, so this rule is prose-only today. Register-aware enforcement is scoped as a separate task, to run after the pending AWS BAA supersession cycle. Per direction, it must validate the **register-row relationship** (an attested row must not sit at a status-token path, and the grandfather exemption must expire automatically on attestation), not merely match a filename pattern.

## Author-Model: opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193AngsyhgGGu1jjDv8PoGz