### PR TITLE
compliance(register): close LL-1b0d78dbe6, Bedrock BAA account assertion

### DIFF
--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -1314,7 +1314,7 @@
       "lastReviewed": "2026-06-19",
       "nextReviewDue": "2026-09-19",
       "attestation": {},
-      "contentHash": "3a8340cce6e41530a55ccce8315009232ef2247b32272bc80b4d5126b0eecee3",
+      "contentHash": "92f616fa373b82df0a4d4861e6a7a187c79567b34e0ecbe03300a7aa8292e630",
       "bundles": [],
       "mirrors": [
         {

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -83,7 +83,7 @@
 | Compliance Status Snapshot (2026-08-09) | git | `docs/legal/COMPLIANCE_STATUS_2026-08-09.md` | draft |  | Scot Wahlquist | 2026-08-09 |  | no | `5d24b9f01831` |  |
 | Data & Compliance Pipeline - Build Inventory (dated) | Drive | [open](https://docs.google.com/document/d/1xxLsESUXKm6rDWuqr_Z-Ob5kWzUZUbFD3gTKZWfLMnY/edit) | approved |  | Scot Wahlquist | 2026-06-22 | 2026-09-22 | no | (supplied) |  |
 | Document Register (this file) | git | `audit-reports/DOCUMENT-REGISTER.json` | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (self) |  |
-| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `3a8340cce6e4` |  |
+| Findings Register (FINDINGS.json) | git | `audit-reports/FINDINGS.json` | published | FERPA, COPPA, HIPAA, GDPR, WCAG, SOC2 | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | `92f616fa373b` |  |
 | LingoLinq Capability Ledger (rendered) | git | `docs/legal/CAPABILITY_LEDGER.md` | published |  | Scot Wahlquist | 2026-07-12 | 2027-01-12 | no | `9f0c91ef2fc4` |  |
 | Notion - Compliance & Audits hub | Notion | [open](https://www.notion.so/3655fe8215c2815a949ec8ed971d5580) | published |  | Scot Wahlquist | 2026-06-19 | 2026-09-19 | no | (supplied) |  |
 | Notion - Compliance Documents board (LL) | Notion | [open](https://www.notion.so/3865fe8215c28174aef3ce32239ced5c) | published |  | Scot Wahlquist | 2026-06-21 | 2026-09-21 | no | (supplied) |  |

--- a/audit-reports/FINDINGS.json
+++ b/audit-reports/FINDINGS.json
@@ -4267,7 +4267,7 @@
       "frameworks": [
         "HIPAA"
       ],
-      "status": "open",
+      "status": "verified-closed",
       "evidence": {
         "type": "code",
         "file": "lib/ai_client.rb",
@@ -4283,15 +4283,15 @@
         "timeframe": "before Bedrock is marked operational"
       },
       "closureEvidence": {
-        "sha": "",
-        "verifierNote": "",
-        "attestation": ""
+        "sha": "9470ffbd7b15980c90c53b300148a8fdd6b8a2e3",
+        "verifierNote": "Control built and merged via PR #768 (merge commit 9470ffbd7b15980c90c53b300148a8fdd6b8a2e3 into staging on 2026-08-10; ancestor-verified). AiClient now calls sts:GetCallerIdentity under the exact credential pair it will sign Bedrock with, against an endpoint pinned to https://sts.<region>.amazonaws.com, and refuses to return a client unless the returned Account equals BEDROCK_EXPECTED_AWS_ACCOUNT (lib/ai_client.rb:508 account_verified?, :570 verify_account, :450 sts_endpoint). It fails closed on mismatch, on any probe error, on a malformed expected-account value, and on a region string that is not a well-formed commercial AWS region: the region is interpolated into the STS hostname, so an unvalidated region would defeat the endpoint pin. The result is memoized per credential+region+expected fingerprint under a mutex with a 60s retry floor on failure and a monotonic clock, and the Puma warm-up at config/puma.rb:37 runs it after fork so a wrong credential surfaces at boot rather than at first inference. All four runtime AI seams gate on AiClient.available? and take a client via AiClient.build!, which raises NotAvailableError rather than returning nil (lib/ai_word_predictor.rb:59,201; lib/ai_board_generator.rb:555,568; lib/ai_prediction_generator.rb:118,238; lib/eval_narrator.rb:251,345). The account id stays in configuration rather than hardcoded, so an account migration is a config change; because an absent env var skips the assertion, the deploy pins it as a plaintext literal (.github/workflows/deploy-cloudrun.yml:273) and reads it back after deploy on both lingolinq-web and the lingolinq-worker worker pool, pinned to the value ^239044785114$ rather than to a 12-digit shape (:716-724, via scripts/gcp/assert-runtime-secrets.sh --required-literal). Covered by 69 examples in spec/lib/ai_client_spec.rb plus a new spec/lib/ai_prediction_generator_spec.rb for the seam that had no spec file at all. Confirmed independently out of band on 2026-08-10: a live sts:GetCallerIdentity under the production Bedrock credential returned account 239044785114, principal user/lingolinq-bedrock-runtime, which is the account docs/legal/AWS_BAA_ACCEPTED.md is scoped to. Three adversarial review rounds preceded merge and two returned BLOCK; the defects they caught were a redirectable STS endpoint, a readback that pinned shape instead of value, an unvalidated region, and a scheduled drift job that could never have authenticated (dropped, filed as issue #769). SCOPE NOTE: production runs main, so the assertion has not yet executed in a production process. Its first production execution emits the log line '[AiClient] Bedrock credential verified against AWS account 239044785114' and lands on the next staging-to-main release, which auto-deploys under #758.",
+        "attestation": "Scot Wahlquist 2026-08-11: attested verified-closed. The automated account assertion this finding asked for is built, test-covered, and merged to staging in #768, and the production Bedrock credential was independently confirmed to resolve to the BAA'd account 239044785114. What remains is deployment, not construction; the production log line is being watched as deploy confirmation, not as evidence the control exists."
       },
       "disposition": {
-        "state": "untriaged",
-        "decidedBy": "",
-        "decidedDate": "",
-        "rationale": ""
+        "state": "fixed",
+        "decidedBy": "Scot Wahlquist",
+        "decidedDate": "2026-08-11",
+        "rationale": "Closed on the control's existence and test coverage rather than on its first production execution, because the finding is that no check asserts the account and that is no longer true at staging head. Reaching production is tracked as a release watch item on the next staging-to-main merge, not as an open finding."
       },
       "source": {
         "kind": "pr-review",

--- a/audit-reports/FINDINGS.md
+++ b/audit-reports/FINDINGS.md
@@ -5,11 +5,11 @@
 
 **Audited:** `scot/compliance/audit-refresh-2026-07-07` @ `20953ab3d5a80c3a9cbb249f37a79357b7f1baf1` on 2026-07-08  
 **Seed:** audit-reports/unified-audit-2026-04-09.md  
-**Headline (open + remediated-unverified):** 0 Critical / 12 High
+**Headline (open + remediated-unverified):** 0 Critical / 11 High
 
 Statuses are verified against live code at the audited SHA, not copied from the dated report prose. Only Scot closes a finding, downgrades severity, accepts risk, or sets a disposition. Disposition (triage) is orthogonal to status: a finding can be `open` yet `dismissed-false-positive`/`wontfix`/`accepted`; blank reads as `untriaged`.
 
-## Open (63)
+## Open (62)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -19,7 +19,6 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-a9d6d5a46b |  | high | WCAG | untriaged | manual | AI disclosure full-notice link uses the low-contrast verdigris token for text on the near-white modal surface | `app/frontend/app/styles/app.scss`:38150 |
 | LL-104bfa61dc |  | high | WCAG | untriaged | audit-run | Terms-agree modal is unreachable by switch scanning (no .modal_targets / .btn, opened without scannable) | `app/frontend/app/components/terms-agree.hbs`:27 |
 | LL-53cb93fab1 |  | high | GDPR, FERPA | untriaged | audit-run | Terms-agree modal can be silently replaced by intro before the user agrees | `app/frontend/app/routes/index.js`:132 |
-| LL-1b0d78dbe6 |  | high | HIPAA | untriaged | pr-review | No check asserts the Bedrock credential resolves to the BAA'd AWS account, so the AWS BAA's operative condition is an untested assumption | `lib/ai_client.rb`:89 |
 | LL-16ef84ad9a |  | high | FERPA, HIPAA, GDPR | untriaged | pr-review | Word-prediction cache holds the raw pre-scrubber user utterance in a process-global structure outside the PiiScrubber boundary, and is not tenant-scoped | `lib/ai_word_predictor.rb`:47 |
 | LL-522c1a6d13 |  | high | FERPA, HIPAA | untriaged | pr-review | Masquerade produces no AuditEvent; the site-admin branch impersonates any user with no disclosure record | `app/controllers/application_controller.rb`:181 |
 | LL-7314b5a8ea |  | medium | HIPAA | untriaged | audit-run | Render Key Value instance is plaintext and shared by prod-fallback, staging, dev, and PR previews | `render.yaml`:107 |
@@ -87,7 +86,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-5954bcbbe6 |  | medium | SOC2 | untriaged | audit-run | Pre-existing Resque background-job failures: ImageMagick identify missing in Cloud Run image, stale job_stash lookups, and a call to a removed Board method | (attestation) |
 | LL-a167848115 |  | medium | GDPR, COPPA, FERPA | **fixed** | pr-review | Text-to-speech posts raw user text to subprocessors absent from the register (Abair has no DPA; Google TTS flow unrowed) (GDPR Art. 28/44) | `lib/tts.rb`:30 |
 
-## Verified closed (50)
+## Verified closed (51)
 
 | ID | Legacy | Severity | Frameworks | Disposition | Source | Title | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -110,6 +109,7 @@ Statuses are verified against live code at the audited SHA, not copied from the 
 | LL-9a09771121 |  | high | SOC2 | **fixed** | audit-run | Render production (branch main) still hand-signs S3 POST policies with SigV2; every upload to the SSE-KMS uploads bucket fails and silently degrades to DB-stored data URIs | `lib/uploader.rb`:291 |
 | LL-47117a3443 |  | high | COPPA, GDPR, FERPA | untriaged | audit-run | COPPA verifiable parental consent is granted with no immutable AuditEvent | `app/controllers/parental_consents_controller.rb`:14 |
 | LL-85038c0a7b |  | high |  | untriaged | audit-run | buttonsets#generate debug_sync=1 path returns raw exception message and full Ruby backtrace as JSON error body | `app/controllers/api/button_sets_controller.rb`:83 |
+| LL-1b0d78dbe6 |  | high | HIPAA | **fixed** | pr-review | No check asserts the Bedrock credential resolves to the BAA'd AWS account, so the AWS BAA's operative condition is an untested assumption | `lib/ai_client.rb`:89 |
 | LL-efef111d59 | Dep-nokogiri-1194 | high | SOC2 | untriaged | audit-run | nokogiri 1.19.3 vulnerable to six published advisories (fixed in 1.19.4) | `Gemfile.lock`:281 |
 | LL-6619cc1811 | Infra-P1-1 | high | HIPAA | **fixed** | audit-run | Redis connections without TLS; shared across environments | `config/initializers/resque.rb`:23 |
 | LL-1085e59d29 | Infra-P1-2 | high | FERPA, HIPAA | **fixed** | audit-run | Webhook callback URL validation accepts plaintext http:// | `app/models/webhook.rb`:42 |

--- a/audit-reports/notion/compliance-audit-page.md
+++ b/audit-reports/notion/compliance-audit-page.md
@@ -11,13 +11,13 @@
 **Audited commit:** `20953ab3d5a80c3a9cbb249f37a79357b7f1baf1`  
 **Audited ref:** `scot/compliance/audit-refresh-2026-07-07`  
 **Run date:** 2026-07-08  
-**Page generated:** 2026-08-10T16:09:48Z
+**Page generated:** 2026-08-11T16:42:49Z
 
 ## Headline - open findings
 
 | Critical | High | Medium | Low |
 |---|---|---|---|
-| **0** | **12** | 31 | 25 |
+| **0** | **11** | 31 | 25 |
 
 _Headline is the count of `open` + `remediated-unverified` findings by severity (plan decision 5.9.2: counts, not a synthetic score). Only Scot closes a finding, downgrades severity, or accepts risk._
 
@@ -27,7 +27,6 @@ _Headline is the count of `open` + `remediated-unverified` findings by severity 
 |---|---|---|---|---|---|
 | LL-104bfa61dc |  | high | WCAG | Terms-agree modal is unreachable by switch scanning (no .modal_targets / .btn, opened without scannable) | `app/frontend/app/components/terms-agree.hbs`:27 |
 | LL-16ef84ad9a |  | high | FERPA, HIPAA, GDPR | Word-prediction cache holds the raw pre-scrubber user utterance in a process-global structure outside the PiiScrubber boundary, and is not tenant-scoped | `lib/ai_word_predictor.rb`:47 |
-| LL-1b0d78dbe6 |  | high | HIPAA | No check asserts the Bedrock credential resolves to the BAA'd AWS account, so the AWS BAA's operative condition is an untested assumption | `lib/ai_client.rb`:89 |
 | LL-522c1a6d13 |  | high | FERPA, HIPAA | Masquerade produces no AuditEvent; the site-admin branch impersonates any user with no disclosure record | `app/controllers/application_controller.rb`:181 |
 | LL-53cb93fab1 |  | high | GDPR, FERPA | Terms-agree modal can be silently replaced by intro before the user agrees | `app/frontend/app/routes/index.js`:132 |
 | LL-705b10bcd7 |  | high | SOC2 | BoardDownstreamButtonSet S3 writes fail against KMS-encrypted bucket: 'Requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4' | (attestation) |


### PR DESCRIPTION
Register-only change. Closes finding `LL-1b0d78dbe6` (high, HIPAA): *"No check asserts the Bedrock credential resolves to the BAA'd AWS account, so the AWS BAA's operative condition is an untested assumption."*

The control it asked for shipped in #768, merged to `staging` as `9470ffbd7` on 2026-08-10. This PR records that in the register.

## What the finding asked for, and what exists at HEAD

The finding's remediation text asked for four things. Each is verified at this branch's HEAD, not against the plan or a prior session:

| Asked for | At HEAD |
|---|---|
| `sts:GetCallerIdentity` under the exact credential `AiClient` will use | `lib/ai_client.rb:570` `verify_account`, called from `:508` `account_verified?` |
| Compare `Account` against the BAA'd account id | same, exact string equality after digit-stripping; fails closed on mismatch, probe error, malformed expected value, or malformed region |
| Deploy-time assertion so a wrong credential fails the deploy | `.github/workflows/deploy-cloudrun.yml:716-724`, readback pinned to `^239044785114$` on both `lingolinq-web` and the `lingolinq-worker` worker pool |
| Account id in configuration, not hardcoded | `BEDROCK_EXPECTED_AWS_ACCOUNT`, `lib/ai_client.rb:90`; set at `deploy-cloudrun.yml:273` |

A boot-time assertion was listed as an acceptable addition; `config/puma.rb:37` warms it after fork.

All four runtime AI seams gate on `AiClient.available?` and take a client through `AiClient.build!`, which raises rather than returning nil: `lib/ai_word_predictor.rb:59,201`; `lib/ai_board_generator.rb:555,568`; `lib/ai_prediction_generator.rb:118,238`; `lib/eval_narrator.rb:251,345`.

Independent confirmation, 2026-08-10: a live `sts:GetCallerIdentity` under the production Bedrock credential returned account `239044785114`, principal `user/lingolinq-bedrock-runtime`, which is the account `docs/legal/AWS_BAA_ACCEPTED.md` is scoped to.

## Fix status

| Item | Status | Evidence |
|---|---|---|
| `LL-1b0d78dbe6` status `open` -> `verified-closed` | Fixed | `audit-reports/FINDINGS.json` |
| Disposition `untriaged` -> `fixed`, decided by Scot Wahlquist 2026-08-11 | Fixed | same |
| `closureEvidence` populated with sha, verifier note, attestation | Fixed | same |
| Derived artifacts regenerated | Fixed | `scripts/regenerate-register.sh`; `FINDINGS.md`, `DOCUMENT-REGISTER.{json,md}`, `notion/compliance-audit-page.md` |
| Headline 12 High -> 11 High | Fixed | `FINDINGS.md:8`, `notion/compliance-audit-page.md:20` |

## Not covered by this PR

- **The assertion has never executed in a production process.** Production runs `main`; the last release to `main` was #770 on 2026-08-09, which predates #768. The control reaches production on the next `staging` -> `main` release, which auto-deploys under #758. This is stated explicitly in `closureEvidence.verifierNote` rather than left implicit, so the register does not imply a production-verified control.
- The confirming production log line is `[AiClient] Bedrock credential verified against AWS account 239044785114`. If `REFUSING` appears instead, unsetting `BEDROCK_EXPECTED_AWS_ACCOUNT` restores prior behavior with no code change.
- No severity re-rating. The finding stays `high`; closing does not require re-rating it.
- The stale `ai-features-anthropic` capability-ledger prose (says credentials withdrawn; revision `00017-n65` mounts them) is untouched and still needs correcting.
- Issue #769 (drift detection outside CI, which cannot authenticate from a scheduled workflow) stays open.

## Preflight

All green on this branch:

```
compliance-notion-publish --check      OK
document-register-render --check       OK (75 docs)
compliance-calendar-render --check     OK
compliance-publication-status --check  OK
capability-check --check               OK (19 capabilities at HEAD)
citation-check                         PASS 111 / FAIL 0 / SKIP 14
git diff --check                       clean
```

The `DOCUMENT-REGISTER` row for `FINDINGS.json` carries `"attestation": {}`, so no attested-byte pin is broken by the content hash moving and no re-attestation is owed for it.

## Author-Model: opus-5
