### PR TITLE
fix(boards): Home/Back/Exit Speak on classic board load errors

### DIFF
--- a/app/frontend/.eslint-todo
+++ b/app/frontend/.eslint-todo
@@ -1,7 +1,7 @@
 # ESLint baseline (grandfathered findings). Do not hand-edit.
 # Regenerate: npm run lint:js:todo
 # Format: file|ruleId|line|column|severity|messageHash
-# Generated: 2026-08-11T00:46:57.977Z
+# Generated: 2026-08-11T17:43:30.146Z
 app/app.js|ember/no-runloop|102|5|2|0843889163d3
 app/app.js|ember/no-runloop|168|7|2|0843889163d3
 app/app.js|ember/no-runloop|193|7|2|0843889163d3
@@ -361,17 +361,17 @@ app/controllers/board-details.js|ember/require-computed-property-dependencies|22
 app/controllers/board-details.js|ember/require-computed-property-dependencies|25|24|1|9d99d94c5a54
 app/controllers/board-preview.js|ember/require-computed-property-dependencies|43|17|1|e681e8485663
 app/controllers/board/history.js|ember/require-computed-property-dependencies|38|15|1|93a9c7f6575d
-app/controllers/board/index.js|ember/no-runloop|103|9|2|513c0395fe72
-app/controllers/board/index.js|ember/no-runloop|148|7|2|5addc2170315
-app/controllers/board/index.js|ember/no-runloop|166|11|2|5addc2170315
-app/controllers/board/index.js|ember/no-runloop|540|9|2|5addc2170315
-app/controllers/board/index.js|ember/no-runloop|555|13|2|5addc2170315
-app/controllers/board/index.js|ember/no-runloop|569|7|2|5addc2170315
-app/controllers/board/index.js|ember/no-runloop|80|44|2|5addc2170315
-app/controllers/board/index.js|ember/require-computed-property-dependencies|1192|18|1|75ca9c17a39f
-app/controllers/board/index.js|ember/require-computed-property-dependencies|1312|21|1|eddb3403101d
-app/controllers/board/index.js|ember/require-computed-property-dependencies|318|20|1|9af052ea8e71
-app/controllers/board/index.js|ember/require-computed-property-dependencies|983|21|1|29f0b403fef0
+app/controllers/board/index.js|ember/no-runloop|106|44|2|5addc2170315
+app/controllers/board/index.js|ember/no-runloop|129|9|2|513c0395fe72
+app/controllers/board/index.js|ember/no-runloop|174|7|2|5addc2170315
+app/controllers/board/index.js|ember/no-runloop|192|11|2|5addc2170315
+app/controllers/board/index.js|ember/no-runloop|566|9|2|5addc2170315
+app/controllers/board/index.js|ember/no-runloop|581|13|2|5addc2170315
+app/controllers/board/index.js|ember/no-runloop|595|7|2|5addc2170315
+app/controllers/board/index.js|ember/require-computed-property-dependencies|1009|21|1|29f0b403fef0
+app/controllers/board/index.js|ember/require-computed-property-dependencies|1218|18|1|75ca9c17a39f
+app/controllers/board/index.js|ember/require-computed-property-dependencies|1338|21|1|eddb3403101d
+app/controllers/board/index.js|ember/require-computed-property-dependencies|344|20|1|9af052ea8e71
 app/controllers/bulk_purchase.js|ember/no-runloop|46|5|2|5addc2170315
 app/controllers/bulk_purchase.js|ember/no-runloop|56|9|2|5addc2170315
 app/controllers/button-set.js|ember/no-runloop|60|11|2|5addc2170315

--- a/app/frontend/app/controllers/board.js
+++ b/app/frontend/app/controllers/board.js
@@ -1,8 +1,39 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
 
 export default Controller.extend({
   session: service('session'),
+  appState: service('app-state'),
+  app_state: alias('appState'),
+  stashes: service('stashes'),
+  /* Parent board shell error UI (invalid id / unsynced). Mirrors
+     board/index recovery so board-alt + legacy board aren't Try-Again-only. */
+  error_show_home: computed(
+    'appState.referenced_user.preferences.home_board.key',
+    'appState.currentUser.preferences.home_board.key',
+    'stashes.root_board_state.key',
+    'stashes.temporary_root_board_state.key',
+    function() {
+      if(this.get('appState.referenced_user.preferences.home_board.key')) { return true; }
+      if(this.get('appState.currentUser.preferences.home_board.key')) { return true; }
+      if(this.get('stashes.temporary_root_board_state.key')) { return true; }
+      return !!this.get('stashes.root_board_state.key');
+    }
+  ),
+  error_show_back: computed('appState.empty_board_history', function() {
+    return !this.get('appState.empty_board_history');
+  }),
+  error_show_exit_speak: computed(
+    'appState.speak_mode',
+    'appState.currentUser.supporter_role',
+    'appState.modeling',
+    function() {
+      if(!this.get('appState.speak_mode')) { return false; }
+      return !!(this.get('appState.currentUser.supporter_role') || this.get('appState.modeling'));
+    }
+  ),
   init() {
     this._super(...arguments);
     var self = this;
@@ -18,5 +49,21 @@ export default Controller.extend({
         self.send.apply(self, [actionName].concat(args));
       };
     };
+  },
+  actions: {
+    error_go_home: function() {
+      this.get('appState').jump_to_root_board({index_as_fallback: true});
+    },
+    error_go_back: function() {
+      this.get('appState').back_one_board();
+    },
+    error_exit_speak_mode: function() {
+      var appState = this.get('appState');
+      var ready = appState.open_speak_mode_exit_pin('none');
+      ready.then(function(res) {
+        if(!res || !res.correct_pin) { return; }
+        appState.toggle_speak_mode('off');
+      }, function() { });
+    },
   }
 });

--- a/app/frontend/app/controllers/board/index.js
+++ b/app/frontend/app/controllers/board/index.js
@@ -42,6 +42,32 @@ export default Controller.extend(prefClasses, {
   board_view_style: computed('appState.currentUser.preferences.board_view_style', function() {
     return this.get('appState.currentUser.preferences.board_view_style') === 'classic' ? 'classic' : 'modern';
   }),
+  /* Broken/unsynced board recovery (classic speak shell). Same roles as
+     board-detail: Home/Back for everyone; Exit Speak for supervisors. */
+  error_show_home: computed(
+    'appState.referenced_user.preferences.home_board.key',
+    'appState.currentUser.preferences.home_board.key',
+    'stashes.root_board_state.key',
+    'stashes.temporary_root_board_state.key',
+    function() {
+      if(this.get('appState.referenced_user.preferences.home_board.key')) { return true; }
+      if(this.get('appState.currentUser.preferences.home_board.key')) { return true; }
+      if(this.get('stashes.temporary_root_board_state.key')) { return true; }
+      return !!this.get('stashes.root_board_state.key');
+    }
+  ),
+  error_show_back: computed('appState.empty_board_history', function() {
+    return !this.get('appState.empty_board_history');
+  }),
+  error_show_exit_speak: computed(
+    'appState.speak_mode',
+    'appState.currentUser.supporter_role',
+    'appState.modeling',
+    function() {
+      if(!this.get('appState.speak_mode')) { return false; }
+      return !!(this.get('appState.currentUser.supporter_role') || this.get('appState.modeling'));
+    }
+  ),
   title: computed('model.name', function() {
     var name = this.get('model.name');
     var title = "Board";
@@ -1408,6 +1434,20 @@ export default Controller.extend(prefClasses, {
 
 
   actions: {
+    error_go_home: function() {
+      this.get('appState').jump_to_root_board({index_as_fallback: true});
+    },
+    error_go_back: function() {
+      this.get('appState').back_one_board();
+    },
+    error_exit_speak_mode: function() {
+      var appState = this.get('appState');
+      var ready = appState.open_speak_mode_exit_pin('none');
+      ready.then(function(res) {
+        if(!res || !res.correct_pin) { return; }
+        appState.toggle_speak_mode('off');
+      }, function() { });
+    },
     // Persist the user's preferred board UI shell. 'classic' = this
     // board-alt grid, 'modern' = board-detail. Saves only — navigation
     // is the separate go_to_modern_edit action so flipping the

--- a/app/frontend/app/styles/app.scss
+++ b/app/frontend/app/styles/app.scss
@@ -1214,6 +1214,77 @@ body.md-home-focused #content > .ember-view:empty {
   .board_status {
     color: #ccc;
   }
+  .board-load-error__message {
+    color: rgba(255, 255, 255, 0.92);
+  }
+  .board-load-error__retrying {
+    color: rgba(255, 255, 255, 0.65);
+  }
+  .board-load-error__retry-link {
+    color: rgba(255, 255, 255, 0.7);
+  }
+  .board-load-error__retry-link:hover,
+  .board-load-error__retry-link:focus-visible {
+    color: rgba(255, 255, 255, 0.95);
+  }
+}
+
+/* Classic / board-alt load failure: escape hatches (Home / Back / Exit Speak).
+   Mirrors board-detail's error recovery so Try Again is not the only exit. */
+.board-load-error,
+.board_status {
+  .board-load-error__actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    margin: 16px 0 8px;
+    max-width: 640px;
+  }
+  .board-load-error__action {
+    font-size: 1.05rem;
+    min-height: 48px;
+    padding: 12px 22px;
+    border-radius: 10px;
+  }
+  .board-load-error__retry-link {
+    appearance: none;
+    background: none;
+    border: none;
+    display: inline-block;
+    margin-top: 8px;
+    padding: 10px 16px;
+    min-height: 44px;
+    font-size: 1rem;
+    color: rgba(0, 0, 0, 0.55);
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .board-load-error__retry-link:hover,
+  .board-load-error__retry-link:focus-visible {
+    color: rgba(0, 0, 0, 0.9);
+  }
+}
+.board-load-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 240px;
+  padding: 48px 24px;
+  text-align: center;
+}
+.board-load-error__message {
+  font-size: 1.15rem;
+  margin: 0;
+  max-width: 520px;
+}
+.board-load-error__retrying {
+  font-size: 1rem;
+  margin: 0;
+  font-style: italic;
 }
 
 /* ==========================================================================

--- a/app/frontend/app/templates/board.hbs
+++ b/app/frontend/app/templates/board.hbs
@@ -24,9 +24,28 @@
       </div>
     {{else}}
       {{#if this.model.retrying}}
-        {{t "Trying again..." key="trying_again"}}
+        <p class="board-load-error__retrying">{{t "Trying again..." key="trying_again"}}</p>
       {{else}}
-        <a href="#" {{on "click" (this.ctrlAction "re_transition")}}>{{t "Try Again" key="try_again"}}</a>
+        <div class="board-load-error__actions">
+          {{#if this.error_show_home}}
+            <button type="button" class="btn btn-primary btn-lg board-load-error__action" {{on "click" (this.ctrlAction "error_go_home")}}>
+              {{t "Go to Home Board" key="error_go_to_home_board"}}
+            </button>
+          {{/if}}
+          {{#if this.error_show_back}}
+            <button type="button" class="btn btn-default btn-lg board-load-error__action" {{on "click" (this.ctrlAction "error_go_back")}}>
+              {{t "Go Back" key="error_go_back"}}
+            </button>
+          {{/if}}
+          {{#if this.error_show_exit_speak}}
+            <button type="button" class="btn btn-default btn-lg board-load-error__action" {{on "click" (this.ctrlAction "error_exit_speak_mode")}}>
+              {{t "Exit Speak Mode" key="exit_speak_mode"}}
+            </button>
+          {{/if}}
+        </div>
+        <button type="button" class="board-load-error__retry-link" {{on "click" (this.ctrlAction "re_transition")}}>
+          {{t "Try Again" key="try_again"}}
+        </button>
       {{/if}}
     {{/unless}}
   </div>

--- a/app/frontend/app/templates/board/index.hbs
+++ b/app/frontend/app/templates/board/index.hbs
@@ -185,11 +185,34 @@
   </div>
   {{/let}}
 {{else}}
-  <p>{{this.error_message}}</p>
-  {{#if this.model.retrying}}
-    {{t "Trying again..." key="trying_again"}}
-  {{else}}
-    <a href="#" {{on "click" (this.ctrlAction "re_transition")}}>{{t "Try Again" key="try_again"}}</a>
-  {{/if}}
+  <div class="board-load-error" role="alert">
+    <p class="board-load-error__message">{{this.error_message}}</p>
+    {{#if this.model.retrying}}
+      <p class="board-load-error__retrying">{{t "Trying again..." key="trying_again"}}</p>
+    {{else}}
+      {{!-- Same escape hatches as board-detail: Home/Back for everyone;
+           Exit Speak for supervisors. Try Again alone traps offline users. --}}
+      <div class="board-load-error__actions">
+        {{#if this.error_show_home}}
+          <button type="button" class="btn btn-primary btn-lg board-load-error__action" {{on "click" (this.ctrlAction "error_go_home")}}>
+            {{t "Go to Home Board" key="error_go_to_home_board"}}
+          </button>
+        {{/if}}
+        {{#if this.error_show_back}}
+          <button type="button" class="btn btn-default btn-lg board-load-error__action" {{on "click" (this.ctrlAction "error_go_back")}}>
+            {{t "Go Back" key="error_go_back"}}
+          </button>
+        {{/if}}
+        {{#if this.error_show_exit_speak}}
+          <button type="button" class="btn btn-default btn-lg board-load-error__action" {{on "click" (this.ctrlAction "error_exit_speak_mode")}}>
+            {{t "Exit Speak Mode" key="exit_speak_mode"}}
+          </button>
+        {{/if}}
+      </div>
+      <button type="button" class="board-load-error__retry-link" {{on "click" (this.ctrlAction "re_transition")}}>
+        {{t "Try Again" key="try_again"}}
+      </button>
+    {{/if}}
+  </div>
 {{/if}}
 </ButtonListener>

--- a/app/frontend/app/templates/user/board-alt/index.hbs
+++ b/app/frontend/app/templates/user/board-alt/index.hbs
@@ -175,11 +175,32 @@
   </div>
   {{/let}}
 {{else}}
-  <p>{{this.error_message}}</p>
-  {{#if this.model.retrying}}
-    {{t "Trying again..." key="trying_again"}}
-  {{else}}
-    <a href="#" {{on "click" (this.ctrlAction "re_transition")}}>{{t "Try Again" key="try_again"}}</a>
-  {{/if}}
+  <div class="board-load-error" role="alert">
+    <p class="board-load-error__message">{{this.error_message}}</p>
+    {{#if this.model.retrying}}
+      <p class="board-load-error__retrying">{{t "Trying again..." key="trying_again"}}</p>
+    {{else}}
+      <div class="board-load-error__actions">
+        {{#if this.error_show_home}}
+          <button type="button" class="btn btn-primary btn-lg board-load-error__action" {{on "click" (this.ctrlAction "error_go_home")}}>
+            {{t "Go to Home Board" key="error_go_to_home_board"}}
+          </button>
+        {{/if}}
+        {{#if this.error_show_back}}
+          <button type="button" class="btn btn-default btn-lg board-load-error__action" {{on "click" (this.ctrlAction "error_go_back")}}>
+            {{t "Go Back" key="error_go_back"}}
+          </button>
+        {{/if}}
+        {{#if this.error_show_exit_speak}}
+          <button type="button" class="btn btn-default btn-lg board-load-error__action" {{on "click" (this.ctrlAction "error_exit_speak_mode")}}>
+            {{t "Exit Speak Mode" key="exit_speak_mode"}}
+          </button>
+        {{/if}}
+      </div>
+      <button type="button" class="board-load-error__retry-link" {{on "click" (this.ctrlAction "re_transition")}}>
+        {{t "Try Again" key="try_again"}}
+      </button>
+    {{/if}}
+  </div>
 {{/if}}
 </ButtonListener>

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -39,6 +39,7 @@ file (see [README.md](README.md)).
 - [Pattern: board-detail `/tree` blocks paint on the full descendant payload](#pattern-board-detail-tree-blocks-paint-on-the-full-descendant-payload)
 - [Pattern: board-preview latency is cold-cache, not the loading gate — warm on intent](#pattern-board-preview-latency-is-cold-cache-not-the-loading-gate--warm-on-intent)
 - [Pattern: boards-page Mine list — cache-first paint, atomic background refresh](#pattern-boards-page-mine-list--cache-first-paint-atomic-background-refresh)
+- [Gotcha: Android “classic board” error may be stale packaged board-detail](#gotcha-android-classic-board-error-may-be-stale-packaged-board-detail)
 - [Gotcha: every route transition closes all modals (global_transition) — don't keep a modal "open behind" a routed page](#gotcha-every-route-transition-closes-all-modals-global_transition--dont-keep-a-modal-open-behind-a-routed-page)
 - [Gotcha: sync double `modal.open` — the *second* template wins; do not invent write-loss on the winner](#gotcha-sync-double-modalopen--the-second-template-wins-do-not-invent-write-loss-on-the-winner)
 - [Gotcha: Shepherd modal overlay is VISUAL-ONLY; canClickTarget:false makes the target click "fall through"](#gotcha-shepherd-modal-overlay-is-visual-only-canclicktargetfalse-makes-the-target-click-fall-through)
@@ -352,6 +353,14 @@ Board-detail has `_auto_rename_board`, which POSTs `/rename` when `board.name` c
 **Gotcha (list summary + locale):** Omitting button/content blobs must not skip `localized_name` / `localized_locale`. Index already eager-loads `board_content`; when `args[:locale]` is present, still load translations for `board_name` matching, but do not rewrite per-button labels (list payloads have no `buttons`). Gating the whole locale block behind `!list_summary` broke `Api::BoardsController index should return a localized board name`.
 
 **First seen in:** [2026-08-03-boards-page-cache-first.md](./2026-08-03-boards-page-cache-first.md); load-perf follow-up [2026-08-10-boards-page-load-perf.md](./2026-08-10-boards-page-load-perf.md)
+
+## Gotcha: Android “classic board” error may be stale packaged board-detail
+
+**Surface:** Capacitor app loads packaged `lingolinq_mobile/www/` (usually `PACKAGE_SOURCE=prod`), not Ember `:8184`. Speak/home routing uses `transitionToBoardForCurrentUiStyle` — default `modern` → `user.board-detail`; `classic` preference → `user.board-alt` (reuses `board/index`); only `obf/` / `integrations/` / odd keys hit legacy `board`.
+
+**Gotcha:** A Try-Again-only offline screen on Android often looks like “classic” but is **board-detail’s old error UI** from a www snapshot built before the Home/Back escape-hatch PR. Confirm with UI chrome (`md-board-detail-error` + Bootstrap button vs plain `<a>`) and whether the APK was re-packaged after the fix. Still keep escape hatches on classic `board` / `board-alt` error templates — real classic sessions and legacy keys still hit them.
+
+**First seen in:** [2026-08-11-classic-board-error-escape.md](./2026-08-11-classic-board-error-escape.md)
 
 ## Pattern: supervisor caseload session prefetch reuses board_detail_cache, not offline sync
 


### PR DESCRIPTION
## Summary
- Classic speak / `board-alt` / legacy `board` error screens only offered **Try Again**, which traps offline or unsynced users with no escape.
- Add the same recovery as board-detail: **Go to Home Board** + **Go Back** for everyone; **Exit Speak Mode** for supervisors; demote Try Again to a secondary link.
- Document that Android “classic” Try-Again-only screens are often a **stale packaged board-detail** snapshot, not a forced classic route.

## Fix status
| Item | Status | Evidence |
|------|--------|----------|
| Classic `board/index` error escapes | Fixed | `templates/board/index.hbs`, `controllers/board/index.js` |
| `board-alt` duplicate template | Fixed | `templates/user/board-alt/index.hbs` |
| Parent `board.hbs` invalid-id / unsynced | Fixed | `templates/board.hbs`, `controllers/board.js` |
| Styling (incl. dark `color_black`) | Fixed | `app.scss` `.board-load-error*` |

## Not covered by this PR
- Re-packaging Capacitor `www/` (done separately after merge / from staging assets)
- Changing default `board_view_style` or mobile routing

## Test plan
- [ ] Open an unsynced/missing board in classic speak (`board_view_style=classic`) — Home / Back visible; Try Again secondary
- [ ] Supervisor in speak mode — Exit Speak Mode also shown; PIN still required when configured
- [ ] Communicator — no Exit Speak; Home uses `jump_to_root_board` with index fallback
- [ ] Back only when browse history is non-empty
- [ ] Modern board-detail error UI unchanged (already shipped in #781)

## Author-Model: grok-4.5


Made with [Cursor](https://cursor.com)