### PR TITLE
docs(legal): require Path A for grandfathered _draft transition

### DIFF
--- a/.claude/skills/re-attest-record/SKILL.md
+++ b/.claude/skills/re-attest-record/SKILL.md
@@ -92,9 +92,12 @@ Use this for any planned change to an attested file under `docs/legal/**`.
    `<YYYY-MM-DD>_<kebab-slug>_<status>.<ext>`). Status is a mutable property of the register row,
    and rule 3 freezes an attested file's name permanently, so a status in the name would either go
    false at the first status change or force a rename that rule 3 forbids. A record must **never**
-   be attested at a `_draft` path. If you are superseding one of the four grandfathered dated
-   `_draft` records, rename it to the statusless path while it is still mutable and repair its
-   inbound references in that record's own cycle, before any attestation.
+   be attested at a `_draft` path. If the live record is one of the four grandfathered dated
+   `_draft` files, do **not** rename that path in place (DOC-ids hash `canonicalLocation`; an
+   in-place rename changes identity and breaks Notion sync). Create this statusless successor as a
+   **new** file + new register row that `supersedes` the `_draft` row, mark the `_draft` row
+   superseded, retarget live bundles, then attest only the successor
+   (`docs/legal/README.md` Naming → Transition rule).
 
 3. **Add a new register row** in `audit-reports/DOCUMENT-REGISTER.json` for the successor:
    - Leave `id` and `contentHash` empty for git rows (render fills them).

--- a/audit-reports/DOCUMENT-REGISTER.json
+++ b/audit-reports/DOCUMENT-REGISTER.json
@@ -2852,7 +2852,7 @@
       "lastReviewed": "2026-07-22",
       "nextReviewDue": "2027-07-22",
       "attestation": {},
-      "contentHash": "fadcce65c39ae5c11902096733dd01af27880936ca18359e0606d8bff6e3e4cd",
+      "contentHash": "d154d1747c5a61ed347ab697073d8084aeafdd6f656818b31eb96bf3276938f1",
       "bundles": [],
       "mirrors": [],
       "notes": "Written for IA report sec 9.2 (folder READMEs so agents stop filing things in the wrong place).",

--- a/audit-reports/DOCUMENT-REGISTER.md
+++ b/audit-reports/DOCUMENT-REGISTER.md
@@ -95,7 +95,7 @@
 | Title | System | Canonical location | Status | Frameworks | Owner | Last reviewed | Next due | Attested | Hash | Bundles |
 |---|---|---|---|---|---|---|---|---|---|---|
 | Compliance Docs Guide (runbook) | git | `docs/legal/COMPLIANCE_DOCS_GUIDE.md` | published |  | Scot Wahlquist | 2026-06-21 | 2027-06-21 | no | `c8e466f878b5` |  |
-| docs/legal README (folder charter) | git | `docs/legal/README.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `fadcce65c39a` |  |
+| docs/legal README (folder charter) | git | `docs/legal/README.md` | published |  | Scot Wahlquist | 2026-07-22 | 2027-07-22 | no | `d154d1747c5a` |  |
 | Incident Response and Breach Runbook | git | `docs/legal/BREACH_RUNBOOK.md` | approved | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-07-28 | 2027-07-28 | 2026-07-28 | `0ee1b92ec130` | soc2-evidence, school-dpa-package, security-review, baa |
 | Incident Response and Breach Runbook (branded) | Drive | [open](https://docs.google.com/document/d/1aaJ9sXq4Y-SpX2d2rzOY2qUKN5NYXhOVgI3uZdMM2po/edit) | published | HIPAA, GDPR, FERPA | Scot Wahlquist | 2026-06-19 | 2027-06-19 | 2026-06-19 | (supplied) | compliance-records-set-2026-06, soc2-evidence |
 | Notion - Compliance Engineering Onboarding/Handoff | Notion | [open](https://www.notion.so/3845fe8215c28139aa9ec40eda1431c6) | published |  | Scot Wahlquist | 2026-06-19 | 2026-12-19 | no | (supplied) |  |

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -73,11 +73,18 @@ here, for the same reason: `2026-08-09_compliance-posture-report_draft.md`,
 them.
 
 **Transition rule for those four.** A grandfathered dated `_draft` record may remain at its current
-path **while it is unattested**. Before any such record is attested it must first be renamed, while
-still mutable, to the statusless dated path above, with its inbound references repaired in that
-record's own cycle. **A record must never be attested at a `_draft` path**, because rule 3 would then
-freeze a filename asserting a status the register alone is entitled to carry, and the name could
-never be corrected.
+path **while it is unattested**. Before any such record is attested, leave that path via **Path A
+supersession** (see `/re-attest-record`), not an in-place rename: create a new statusless dated file
+`<YYYY-MM-DD>_<kebab-slug>.<ext>`, add a new register row that `supersedes` the `_draft` row, mark
+the `_draft` row `superseded` with reciprocal `supersededBy`, retarget live bundle
+`requiredDocs.location` entries, repair prose references, then attest **only the successor**.
+**Do not rename the existing registered path in place.** Document IDs are
+`DOC-` + `sha256(canonicalLocation)[0,10]` (`meta.idAlgorithm`;
+`scripts/document-register-render.rb` `expected_id` / render overwrite), so an in-place rename
+changes the DOC-id, breaks the register's permanent-ID promise, and makes the Notion sync treat the
+result as a new row while orphaning or pruning the old one. **A record must never be attested at a
+`_draft` path**, because rule 3 would then freeze a filename asserting a status the register alone
+is entitled to carry, and the name could never be corrected.
 
 ## Retention
 

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -122,6 +122,7 @@ file (see [README.md](README.md)).
 - [Gotcha: `Worker.process_queues` destroys RemoteActions — assert RA rows after one wave, not two](#gotcha-workerprocess_queues-destroys-remoteactions--assert-ra-rows-after-one-wave-not-two)
 - [Gotcha: a single-quoted `i18n.t` default silently DELETES the key on the next generator run](#gotcha-a-single-quoted-i18nt-default-silently-deletes-the-key-on-the-next-generator-run)
 - [Gotcha: fail-closed Sentry filters must not collapse lookup failures to nil](#gotcha-fail-closed-sentry-filters-must-not-collapse-lookup-failures-to-nil)
+- [Gotcha: git DOC-ids hash `canonicalLocation` — never rename a registered path in place](#gotcha-git-doc-ids-hash-canonicallocation--never-rename-a-registered-path-in-place)
 - [Gotcha: dual-key tag reads — check each key independently, never `a || b` before coercion](#gotcha-dual-key-tag-reads--check-each-key-independently-never-a--b-before-coercion)
 - [Gotcha: Flusher `transfer_user_content` is not a checklist for `flush_user_content`](#gotcha-flusher-transfer_user_content-is-not-a-checklist-for-flush_user_content)
 - [Gotcha: set-field on nested model fields needs nested observer deps (videoChanged pattern)](#gotcha-set-field-on-nested-model-fields-needs-nested-observer-deps-videochanged-pattern)
@@ -8484,6 +8485,15 @@ in-place amend. Skill: `.claude/skills/re-attest-record/SKILL.md`. Example chain
 > retargeting by location) still stands. Authority: `docs/legal/README.md` Naming section, approved
 > by Scot 2026-08-10.
 
+> **SUPERSESSION NOTE, 2026-08-11.** The 2026-08-10 note's "rename … before it is attested" clause
+> is itself superseded. In-place rename of an already-registered git path changes the DOC-id
+> (`expected_id` hashes `canonicalLocation`; render overwrites `id`), which breaks the register's
+> permanent-ID promise and makes Notion sync create a new row while orphaning/pruning the old one.
+> The four grandfathered `_draft` records stay at their paths while unattested; before attestation,
+> leave via **Path A supersession** to a **new** statusless dated file + new register row (attest
+> only the successor). Do not rename the registered `_draft` path in place. Authority:
+> `docs/legal/README.md` Naming → Transition rule; Codex P2 on PR #784.
+
 **Also retarget live bundles by location, not title.** `meta.bundleDefinitions.*.requiredDocs`
 bind by `canonicalLocation`; moving live membership to the successor without updating those
 locations fails `--check` as a missing required member. Frozen dated binders can stay on the
@@ -8492,6 +8502,22 @@ DOC-03cb9fe91f → DOC-90632edc44; see
 [2026-08-09-pr721-path-a-supersession.md](./2026-08-09-pr721-path-a-supersession.md). When the
 same PR moves `lib/flusher.rb` definitions, re-pin `CAPABILITY-LEDGER.json` `currentEvidence.line`
 before the register gate (otherwise capability-check stays masked behind the attested-hash fail).
+
+## Gotcha: git DOC-ids hash `canonicalLocation` — never rename a registered path in place
+
+**Symptom:** A policy says "rename the file, repair inbound references, then attest." After rename +
+render, the row's `id` changes; Notion sync creates a new Doc ID page; `supersedes` /
+`supersededBy` / notes that cited the old DOC-id go stale.
+
+**Root cause:** `expected_id` is `DOC-` + `sha256(canonicalLocation)[0,10]`, and render always
+overwrites `doc['id']` (`scripts/document-register-render.rb`; `meta.idAlgorithm`). For git rows,
+path *is* identity. Drive rows use `driveFileId` precisely because Drive IDs survive renames; git
+has no equivalent.
+
+**Fix recipe:** Path A — new statusless dated file + new register row that `supersedes` the old
+path; mark the old row `superseded`; retarget live bundles by location; attest only the successor.
+Do not `git mv` an already-registered `docs/legal/**` path and pretend the DOC-id survived.
+Authority: `docs/legal/README.md` Naming → Transition rule (PR #784 Codex P2).
 
 ## Gotcha: fail-closed Sentry filters must not collapse lookup failures to nil
 


### PR DESCRIPTION
## Summary
- Follow-up to #784 Codex P2: in-place rename of an already-registered git path changes its DOC-id (`expected_id` hashes `canonicalLocation`), so the four grandfathered `_draft` records must leave via **Path A supersession**, not rename-in-place.
- Keeps “never attest at a `_draft` path”; updates `docs/legal/README.md`, `/re-attest-record`, and LEARNINGS; refreshes README register `contentHash`.

## Fix status
| Item | Status | Evidence |
|---|---|---|
| Transition rule requires Path A (not in-place rename) | Fixed | `docs/legal/README.md` Naming → Transition rule |
| `/re-attest-record` Path A step 2 aligned | Fixed | `.claude/skills/re-attest-record/SKILL.md` |
| LEARNINGS supersession note + durable gotcha | Fixed | `docs/task-management/LEARNINGS.md` |
| Register hash for README | Fixed | `audit-reports/DOCUMENT-REGISTER.json` (`contentHash` only; no attestation change) |

## Not covered by this PR
- No identity-preserving rename mechanism in `document-register-render.rb` (still out of scope)
- No actual Path A migration of the four `_draft` files (docs/policy only)

## Test plan
- [x] `ruby scripts/document-register-render.rb --check` green locally
- [ ] Confirm CI `audit-artifacts-integrity` passes
- [ ] Skim README transition rule + skill wording for consistency

## Author-Model: grok-4.5

Made with [Cursor](https://cursor.com)