### PR TITLE
feat(render): enable isolated Bedrock runtime config in dev and staging

### DIFF
--- a/.github/workflows/sync-render-secrets.yml
+++ b/.github/workflows/sync-render-secrets.yml
@@ -50,10 +50,12 @@ jobs:
         run: |
           VAULTS=$(op vault list --format=json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "Accessible vaults: $VAULTS"
-          if ! echo "$VAULTS" | grep -q "LingoLinq Admin"; then
-            echo "::error::render-sync token cannot access LingoLinq Admin vault"
-            exit 1
-          fi
+          for vault in 'LingoLinq Admin' 'LingoLinq Shared Dev' 'LingoLinq Staging' 'LingoLinq Prod'; do
+            if ! echo "$VAULTS" | grep -Fq "$vault"; then
+              echo "::error::render-sync token cannot access required vault: $vault"
+              exit 1
+            fi
+          done
 
       - name: Run sync (dry-run)
         id: dryrun

--- a/scripts/sync-render-env.js
+++ b/scripts/sync-render-env.js
@@ -76,10 +76,13 @@ const VAULTS = {
 };
 
 // Keys that should be synced to Render services.
-// Format: { renderEnvName: { vault, item, field, perEnv|shared, defaultValue } }
+// Format: { renderEnvName: { vault, item, field, perEnv|shared, defaultValue,
+//                            renderEnvironments } }
 // `shared`: same value across all envs (read from vault[vault])
-// `perEnv`: different value per env (read from vault[env])
+// `perEnv`: different value per configured Render environment (read from vault[env])
 // `defaultValue`: hardcoded, no 1Password lookup
+// `renderEnvironments`: optional allowlist. Use this when a key belongs on only
+// a subset of Render services. Omitted means all Render services.
 const KEY_MANIFEST = {
   // -- Rails app secrets (per-environment, in env-specific vault) --
   SECRET_KEY_BASE:       { vault: null, item: 'Rails Secrets', field: 'SECRET_KEY_BASE', perEnv: true },
@@ -91,6 +94,43 @@ const KEY_MANIFEST = {
   // -- AWS (admin vault, shared across all envs) --
   AWS_KEY:               { vault: 'admin', item: 'AWS Credentials', field: 'AWS_KEY', shared: true },
   AWS_SECRET:            { vault: 'admin', item: 'AWS Credentials', field: 'AWS_SECRET', shared: true },
+
+  // -- Bedrock runtime AI (Render dev + staging only) --
+  // These are dedicated environment-specific Bedrock principals, not the
+  // legacy AWS_KEY/AWS_SECRET pair above. AiClient ignores that legacy pair,
+  // but does accept AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY. This synchronizer
+  // never writes those standard names; do not assume their presence would
+  // leave Bedrock dark if the dedicated pair were absent.
+  //
+  // Render production is deliberately EXCLUDED. Runtime production is Cloud
+  // Run and mounts this pair from Secret Manager in deploy-cloudrun.yml; the
+  // hourly Render sync must never duplicate that production credential there.
+  BEDROCK_AWS_KEY: {
+    item: 'BEDROCK_RUNTIME_AI',
+    field: 'BEDROCK_AWS_KEY',
+    perEnv: true,
+    required: true,
+    renderEnvironments: ['dev', 'staging'],
+  },
+  BEDROCK_AWS_SECRET: {
+    item: 'BEDROCK_RUNTIME_AI',
+    field: 'BEDROCK_AWS_SECRET',
+    perEnv: true,
+    required: true,
+    renderEnvironments: ['dev', 'staging'],
+  },
+  // Explicit rather than falling back to a legacy Render AWS_REGION setting.
+  // This region hosts the approved classic-plane Haiku inference profile.
+  BEDROCK_AWS_REGION: {
+    defaultValue: 'us-west-2',
+    renderEnvironments: ['dev', 'staging'],
+  },
+  // Non-secret control configuration. A present but malformed value fails AI
+  // closed, while an absent value would skip the account assertion entirely.
+  BEDROCK_EXPECTED_AWS_ACCOUNT: {
+    defaultValue: '239044785114',
+    renderEnvironments: ['dev', 'staging'],
+  },
 
   // -- Email (shared vault) --
   DEFAULT_EMAIL_FROM:    { vault: 'shared', item: 'Email Config', field: 'DEFAULT_EMAIL_FROM', shared: true },
@@ -128,6 +168,23 @@ const KEY_MANIFEST = {
   // REDIS_URL:     set by Render
   // LEADER_POSTGRES_URL:  set manually on prod for Octopus sharding
 };
+
+function renderEnvironmentsFor(config) {
+  const environments = config.renderEnvironments || Object.keys(RENDER_SERVICES);
+  if (!Array.isArray(environments) || environments.length === 0) {
+    throw new Error('Manifest renderEnvironments must be a non-empty array');
+  }
+  for (const environment of environments) {
+    if (!Object.prototype.hasOwnProperty.call(RENDER_SERVICES, environment)) {
+      throw new Error(`Manifest names unknown Render environment: ${environment}`);
+    }
+  }
+  return environments;
+}
+
+function valuesForRenderEnvironments(config, value) {
+  return Object.fromEntries(renderEnvironmentsFor(config).map(environment => [environment, value]));
+}
 
 const ENV_FILE_PATH = path.join(os.homedir(), 'ai-company-brain', 'config', '.env');
 const RENDER_API_BASE = 'https://api.render.com/v1';
@@ -284,8 +341,9 @@ function maskValue(val) {
   return val.slice(0, 4) + '...' + val.slice(-4);
 }
 
-// Services that failed to sync: current env vars unreadable, read as
-// suspiciously empty in apply mode, or the update PUT itself failed.
+// Services or required manifest values that failed to sync: current env vars
+// unreadable, read as suspiciously empty in apply mode, missing required
+// values, or the update PUT itself failed.
 // Non-empty at exit -> exit code 1, so the GitHub Actions workflow (and any
 // wrapper) sees the failure instead of a clean "Done."
 const syncFailures = [];
@@ -296,6 +354,11 @@ function reportEnvReadFailure(serviceName, reason) {
   console.error('  an apply would replace the ENTIRE env-var list with only the managed');
   console.error('  keys and wipe everything unmanaged (UPLOADS_S3_*, etc.).');
   syncFailures.push(serviceName);
+}
+
+function reportRequiredManifestValueFailure(key, environment, reason) {
+  console.error(`  ERROR: Required ${key} for ${environment} is unavailable: ${reason}`);
+  syncFailures.push(`${environment}:${key}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -373,14 +436,16 @@ async function audit(services) {
   }
 }
 
-async function sync(services, source, apply) {
+async function sync(services, source, apply, dependencies = {}) {
+  const isSignedIn = dependencies.isSignedIn || opIsSignedIn;
+  const readSecret = dependencies.readSecret || opRead;
   console.log(`\n=== Sync Render Env Vars (source: ${source}, mode: ${apply ? 'APPLY' : 'DRY-RUN'}) ===\n`);
 
   // Load desired values
   let desiredValues = {};
 
   if (source === 'op') {
-    if (!opIsSignedIn()) {
+    if (!isSignedIn()) {
       console.error('Error: 1Password CLI not signed in. Run: op signin');
       process.exit(1);
     }
@@ -388,32 +453,38 @@ async function sync(services, source, apply) {
     for (const [key, config] of Object.entries(KEY_MANIFEST)) {
       // Handle keys with static default values (no 1Password needed)
       if (config.defaultValue) {
-        desiredValues[key] = { dev: config.defaultValue, staging: config.defaultValue, prod: config.defaultValue };
+        desiredValues[key] = valuesForRenderEnvironments(config, config.defaultValue);
         continue;
       }
       if (config.shared) {
-        // Read once from the shared vault, use for all envs
+        // Read once from the configured vault, then distribute only to the
+        // manifest's allowed Render environments.
         const vaultName = VAULTS[config.vault];
         if (!vaultName) {
           console.warn(`  Warning: ${key} has invalid vault key: ${config.vault}`);
           continue;
         }
-        const val = opRead(vaultName, config.item, config.field);
+        const val = readSecret(vaultName, config.item, config.field);
         if (val) {
-          desiredValues[key] = { dev: val, staging: val, prod: val };
+          desiredValues[key] = valuesForRenderEnvironments(config, val);
         } else {
           console.warn(`  Warning: Could not read ${vaultName}/${config.item}/${config.field}`);
         }
       } else if (config.perEnv) {
-        // Read once per env from that env's vault
+        // Read once per allowed environment from that environment's vault.
         desiredValues[key] = {};
-        for (const env of ['dev', 'staging', 'prod']) {
+        for (const env of renderEnvironmentsFor(config)) {
           const vaultName = VAULTS[env];
-          const val = opRead(vaultName, config.item, config.field);
+          const val = readSecret(vaultName, config.item, config.field);
           if (val) {
             desiredValues[key][env] = val;
           } else {
-            console.warn(`  Warning: Could not read ${vaultName}/${config.item}/${config.field}`);
+            const location = `${vaultName}/${config.item}/${config.field}`;
+            if (config.required) {
+              reportRequiredManifestValueFailure(key, env, `Could not read ${location}`);
+            } else {
+              console.warn(`  Warning: Could not read ${location}`);
+            }
           }
         }
       }
@@ -424,11 +495,19 @@ async function sync(services, source, apply) {
     const envVars = loadEnvFile(ENV_FILE_PATH);
     for (const [key, config] of Object.entries(KEY_MANIFEST)) {
       if (config.defaultValue) {
-        desiredValues[key] = { dev: config.defaultValue, staging: config.defaultValue, prod: config.defaultValue };
+        desiredValues[key] = valuesForRenderEnvironments(config, config.defaultValue);
       } else if (envVars[key]) {
-        desiredValues[key] = { dev: envVars[key], staging: envVars[key], prod: envVars[key] };
+        desiredValues[key] = valuesForRenderEnvironments(config, envVars[key]);
       }
     }
+  }
+
+  // Do not write a partial configuration. In particular, the static Bedrock
+  // region/account settings must not land without both credential fields.
+  if (syncFailures.length > 0) {
+    console.error('\nRequired manifest values are unavailable; no Render environment will be changed.');
+    console.log('\nDone.\n');
+    return;
   }
 
   // Track changes across all environments for end-of-run notification
@@ -685,7 +764,7 @@ async function main() {
   } else {
     await sync(services, source, apply);
     if (syncFailures.length > 0) {
-      console.error(`\nSync INCOMPLETE -- ${syncFailures.length} service(s) skipped or failed: ${[...new Set(syncFailures)].join(', ')}`);
+      console.error(`\nSync INCOMPLETE -- ${syncFailures.length} required item(s) or service(s) skipped or failed: ${[...new Set(syncFailures)].join(', ')}`);
       process.exit(1);
     }
   }
@@ -700,4 +779,11 @@ if (require.main === module) {
 
 // Exported for tests (scripts/sync-render-env.test.js); CLI behavior is
 // unchanged because main() only runs when invoked directly.
-module.exports = { getRenderEnvVars, sync, syncFailures };
+module.exports = {
+  getRenderEnvVars,
+  sync,
+  syncFailures,
+  KEY_MANIFEST,
+  renderEnvironmentsFor,
+  valuesForRenderEnvironments,
+};

--- a/scripts/sync-render-env.test.js
+++ b/scripts/sync-render-env.test.js
@@ -18,6 +18,20 @@
 
 const https = require('https');
 const { EventEmitter } = require('events');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// The synchronizer normally reads the operator's brain .env file. Tests must
+// never load it: even masked output can disclose secret prefixes in CI logs.
+const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sre-home-'));
+const testConfigDir = path.join(testHome, 'ai-company-brain', 'config');
+fs.mkdirSync(testConfigDir, { recursive: true });
+fs.writeFileSync(path.join(testConfigDir, '.env'), [
+  'BEDROCK_AWS_KEY=test-bedrock-key',
+  'BEDROCK_AWS_SECRET=test-bedrock-secret',
+].join('\n'));
+os.homedir = () => testHome;
 
 // --- https mock (patch before exercising the module under test) ------------
 
@@ -47,7 +61,13 @@ process.env.RENDER_API_KEY = 'test-key-never-used-for-real-calls';
 // Keep notifyKeyRotation on its deterministic "skipping" path.
 delete process.env.GOOGLE_CHAT_WEBHOOK_KEY_ROTATION;
 
-const { getRenderEnvVars, sync, syncFailures } = require('./sync-render-env.js');
+const {
+  getRenderEnvVars,
+  sync,
+  syncFailures,
+  KEY_MANIFEST,
+  valuesForRenderEnvironments,
+} = require('./sync-render-env.js');
 
 // --- tiny harness -----------------------------------------------------------
 
@@ -77,6 +97,25 @@ function envVarPage(pairs, withCursor) {
     envVar: { key, value },
     ...(withCursor ? { cursor: `cur-${key}-${i}` } : {}),
   })));
+}
+
+function testBedrockTargetsOnlyDevAndStaging() {
+  const expected = { dev: 'test-value', staging: 'test-value' };
+  for (const key of [
+    'BEDROCK_AWS_KEY',
+    'BEDROCK_AWS_SECRET',
+    'BEDROCK_AWS_REGION',
+    'BEDROCK_EXPECTED_AWS_ACCOUNT',
+  ]) {
+    const values = valuesForRenderEnvironments(KEY_MANIFEST[key], 'test-value');
+    check(`Bedrock Render scope: ${key} targets dev and staging only`,
+      JSON.stringify(values) === JSON.stringify(expected), JSON.stringify(values));
+  }
+  check('Bedrock credential source is environment-specific',
+    KEY_MANIFEST.BEDROCK_AWS_KEY.perEnv === true &&
+      KEY_MANIFEST.BEDROCK_AWS_SECRET.perEnv === true &&
+      !KEY_MANIFEST.BEDROCK_AWS_KEY.vault &&
+      KEY_MANIFEST.BEDROCK_AWS_KEY.item === 'BEDROCK_RUNTIME_AI');
 }
 
 // --- tests ------------------------------------------------------------------
@@ -152,6 +191,52 @@ async function testRepeatedCursorThrows() {
 }
 
 const TEST_SERVICE = { prod: { id: 'srv-test-prod', name: 'test-prod', branch: 'main' } };
+const RENDER_SCOPE_SERVICES = {
+  dev: { id: 'srv-test-dev', name: 'test-dev', branch: 'develop' },
+  staging: { id: 'srv-test-staging', name: 'test-staging', branch: 'staging' },
+  prod: { id: 'srv-test-prod', name: 'test-prod', branch: 'main' },
+};
+
+async function testBedrockSyncNeverTargetsRenderProd() {
+  resetState();
+  const defaults = [
+    ['LD_PRELOAD', '/usr/lib/x86_64-linux-gnu/libjemalloc.so.2'],
+    ['MALLOC_CONF', 'background_thread:true,narenas:2,dirty_decay_ms:1000'],
+    ['RAILS_SERVE_STATIC_FILES', 'enabled'],
+    ['UNMANAGED', 'preserve-me'],
+  ];
+  routeHandler = (options) => {
+    if (options.method === 'GET') return { statusCode: 200, body: envVarPage(defaults, true) };
+    return { statusCode: 200, body: '[]' };
+  };
+  await sync(RENDER_SCOPE_SERVICES, 'env', true);
+  const puts = putRequests();
+  const putServices = puts.map(request => request.path.match(/^\/v1\/services\/([^/]+)/)[1]).sort();
+  check('Bedrock sync: applies only to Render dev and staging',
+    JSON.stringify(putServices) === JSON.stringify(['srv-test-dev', 'srv-test-staging']));
+  for (const request of puts) {
+    const keys = new Set(JSON.parse(request.body).map(item => item.key));
+    check(`Bedrock sync: ${request.path} carries all four required settings`,
+      ['BEDROCK_AWS_KEY', 'BEDROCK_AWS_SECRET', 'BEDROCK_AWS_REGION', 'BEDROCK_EXPECTED_AWS_ACCOUNT']
+        .every(key => keys.has(key)));
+  }
+}
+
+async function testMissingRequiredBedrockCredentialsAbortBeforeAnyPut() {
+  resetState();
+  routeHandler = (options) => {
+    if (options.method === 'GET') return { statusCode: 200, body: envVarPage([['UNMANAGED', 'preserve-me']], true) };
+    return { statusCode: 200, body: '[]' };
+  };
+  await sync(RENDER_SCOPE_SERVICES, 'op', true, {
+    isSignedIn: () => true,
+    readSecret: () => null,
+  });
+  check('Bedrock sync: missing required credentials fail the sync',
+    ['dev:BEDROCK_AWS_KEY', 'dev:BEDROCK_AWS_SECRET', 'staging:BEDROCK_AWS_KEY', 'staging:BEDROCK_AWS_SECRET']
+      .every(failure => syncFailures.includes(failure)), JSON.stringify(syncFailures));
+  check('Bedrock sync: missing credentials issue NO partial static-config PUT', putRequests().length === 0);
+}
 
 async function testApplySkipsOnReadFailure() {
   resetState();
@@ -240,9 +325,6 @@ function testMainExitsNonZeroOnReadFailure() {
   // preloaded via --require so no real network is touched, and assert the
   // process-level exit-1 contract the GitHub Actions workflow depends on.
   const { execFileSync } = require('child_process');
-  const fs = require('fs');
-  const os = require('os');
-  const path = require('path');
   const mockPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'sre-test-')), 'https-401-mock.js');
   fs.writeFileSync(mockPath, `
     const https = require('https');
@@ -264,7 +346,11 @@ function testMainExitsNonZeroOnReadFailure() {
     output = execFileSync(
       process.execPath,
       ['--require', mockPath, path.join(__dirname, 'sync-render-env.js'), '--source', 'env'],
-      { encoding: 'utf8', env: { ...process.env, RENDER_API_KEY: 'test-key' }, stdio: 'pipe' }
+      {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: testHome, RENDER_API_KEY: 'test-key' },
+        stdio: 'pipe',
+      }
     );
   } catch (err) {
     exitCode = err.status;
@@ -288,12 +374,15 @@ async function testDryRunNeverPuts() {
 // --- run --------------------------------------------------------------------
 
 (async () => {
+  testBedrockTargetsOnlyDevAndStaging();
   await testReadFailureThrows();
   await testNonArrayResponseThrows();
   await testEmptyOkReadReturnsEmpty();
   await testPaginationFollowsCursor();
   await testShortPageStopsPagination();
   await testRepeatedCursorThrows();
+  await testBedrockSyncNeverTargetsRenderProd();
+  await testMissingRequiredBedrockCredentialsAbortBeforeAnyPut();
   await testApplySkipsOnReadFailure();
   await testApplyRefusesEmptyCurrentList();
   await testApplyPreservesUnmanagedVars();


### PR DESCRIPTION
## Summary

- provisions distinct least-privilege Bedrock IAM principals for Render dev and staging
- synchronizes the dedicated credential pair, Bedrock region, and expected AWS account to those two Render services only
- excludes legacy Render production, which is not the Cloud Run production path
- requires the scheduled sync token to access both Admin and Prod 1Password vaults

## Why

`AiClient` only accepts `BEDROCK_AWS_KEY` and `BEDROCK_AWS_SECRET`; the Render synchronizer did not manage them, leaving dev and staging in the intentional "AI is not configured" state. The new credentials are environment-specific so a production runtime key is not distributed to non-production services.

## Validation

- `node --check scripts/sync-render-env.js`
- `node --check scripts/sync-render-env.test.js`
- `node scripts/sync-render-env.test.js` (33 passed)
- both new credentials authenticate with STS to AWS account `239044785114`, without printing values

## Rollout

After merge, run the Render-sync workflow in dry-run mode first. Confirm it proposes the four Bedrock settings only for dev and staging, then apply and test board generation with a non-student test account. Do not enable the Article 50 disclosure flag through this PR.
