### PR TITLE
feat(ai): enable word prediction on staging

### DIFF
--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -62,7 +62,7 @@ module FeatureFlags
               'find_multiple_buttons', 'new_speak_menu', 'swipe_pages', 'inflections_overlay',
               'ios_head_tracking', 'emergency_boards', 'evaluations',
               'vertical_ios_head_tracking', 'remote_modeling', 'auto_inflections', 'focus_word_highlighting',
-              'skin_tones', 'lessons', 'profiles', 'other_menu', 'ai_board_generation',
+              'skin_tones', 'lessons', 'profiles', 'other_menu', 'ai_board_generation', 'ai_word_prediction',
               'google_sso', 'quick_screen_eval', 'multi_user_board_import',
               'customize_menu', # TEMPORARY: forced ON for everyone during testing. Before production go-live, gate for staged rollout — return to AVAILABLE-only (beta opt-in per user) instead of blanket-ON (see the rollout policy above AVAILABLE_FRONTEND_FEATURES).
               'home_tour', # TEMPORARY (spike — 2026-05-27): ON for everyone so Traci can validate the Shepherd.js home-page tour in the browser. REMOVE from this list before merging the spike out of traci/styling/styling-updates — the canonical state is AVAILABLE-only (beta opt-in per user).


### PR DESCRIPTION
## Summary

Enable the already-implemented and configured `ai_word_prediction` feature on staging.

- The Bedrock runtime, account assertion, API backstops, and Render credentials are already present on staging.
- This changes only the staging `ENABLED_FRONTEND_FEATURES` list.
- Board generation remains enabled as before.
- The change is intentionally targeted at `staging` so main receives it through the normal staging-to-main release PR.

## Verification

- `ruby -c lib/feature_flags.rb` passed
- `git diff --check` passed

After merge, redeploy staging and smoke-test both board generation and word prediction with a synthetic test account. Do not enable `article_50_disclosure` as part of this change; its server-enforcement and jurisdiction gates remain a separate compliance release gate.
