### PR TITLE
DIAGNOSTIC (do not merge): identify why persistence test 1473 fails in CI

### DIFF
--- a/app/frontend/.eslint-todo
+++ b/app/frontend/.eslint-todo
@@ -1,7 +1,7 @@
 # ESLint baseline (grandfathered findings). Do not hand-edit.
 # Regenerate: npm run lint:js:todo
 # Format: file|ruleId|line|column|severity|messageHash
-# Generated: 2026-08-11T17:43:30.146Z
+# Generated: 2026-08-12T12:47:57.694Z
 app/app.js|ember/no-runloop|102|5|2|0843889163d3
 app/app.js|ember/no-runloop|168|7|2|0843889163d3
 app/app.js|ember/no-runloop|193|7|2|0843889163d3
@@ -1392,17 +1392,6 @@ tests/utils/persistence-sync-test.js|no-undef|4436|14|2|a67768f2a969
 tests/utils/persistence-sync-test.js|no-undef|4646|14|2|a67768f2a969
 tests/utils/persistence-sync-test.js|no-undef|4861|14|2|a67768f2a969
 tests/utils/persistence-test.js|ember/no-runloop|149|9|2|513c0395fe72
-tests/utils/persistence-test.js|ember/no-runloop|1546|13|2|b7a9757b024f
-tests/utils/persistence-test.js|ember/no-runloop|1583|13|2|b7a9757b024f
-tests/utils/persistence-test.js|ember/no-runloop|1632|13|2|b7a9757b024f
-tests/utils/persistence-test.js|ember/no-runloop|1683|13|2|b7a9757b024f
-tests/utils/persistence-test.js|ember/no-runloop|1695|13|2|513c0395fe72
-tests/utils/persistence-test.js|ember/no-runloop|1746|13|2|b7a9757b024f
-tests/utils/persistence-test.js|ember/no-runloop|1809|13|2|b7a9757b024f
-tests/utils/persistence-test.js|ember/no-runloop|1909|13|2|b7a9757b024f
-tests/utils/persistence-test.js|ember/no-runloop|1934|13|2|b7a9757b024f
-tests/utils/persistence-test.js|ember/no-runloop|1943|13|2|b7a9757b024f
-tests/utils/persistence-test.js|ember/no-runloop|366|11|2|b7a9757b024f
 tests/utils/scanner-test.js|ember/no-runloop|1170|28|2|5addc2170315
 tests/utils/scanner-test.js|ember/no-runloop|1342|9|2|513c0395fe72
 tests/utils/scanner-test.js|ember/no-runloop|1406|9|2|513c0395fe72

--- a/app/frontend/tests/utils/persistence-test.js
+++ b/app/frontend/tests/utils/persistence-test.js
@@ -1534,6 +1534,37 @@ describe("persistence", function() {
           var final_record = null;
           var final_error = null;
 
+          // TEMPORARY DIAGNOSTIC (test 1473, tracked separately). This test fails
+          // deterministically in CI and cannot be reproduced locally, so capture the
+          // rejection reason and the persistence-root state into the assertion value
+          // where the TAP reporter will print it. Revert once the cause is known.
+          var ser = function(err) {
+            try { return JSON.stringify(err, Object.getOwnPropertyNames(err || {})); }
+            catch(e) { return String(err); }
+          };
+          var diag = function(label, extra) {
+            var win = window.persistence;
+            var km_mod = (persistence.known_missing && persistence.known_missing.board) || {};
+            var km_win = (win && win.known_missing && win.known_missing.board) || {};
+            var rec_id = null;
+            try { rec_id = record && record.get && record.get('id'); } catch(e) { rec_id = 'ERR'; }
+            return [
+              label,
+              'mod_online=' + ser(persistence.get('online')),
+              'win_present=' + ser(!!win),
+              'win_is_mod=' + ser(win === persistence),
+              'win_online=' + ser(win && win.get && win.get('online')),
+              'win_destroyed=' + ser(!!(win && (win.isDestroyed || win.isDestroying))),
+              'rec_id=' + ser(rec_id),
+              'km_mod_hit=' + ser(!!(rec_id && km_mod[rec_id])),
+              'km_win_hit=' + ser(!!(rec_id && km_win[rec_id])),
+              'km_mod_n=' + ser(Object.keys(km_mod).length),
+              'km_win_n=' + ser(Object.keys(km_win).length),
+              'extras_ready=' + ser(!!(window.lingoLinqExtras && window.lingoLinqExtras.get && window.lingoLinqExtras.get('ready'))),
+              'detail=' + extra
+            ].join(' | ');
+          };
+
           var board = LingoLinq.store.createRecord('board', {key: 'ok/cool', name: "My Awesome Board"});
           board.save().then(function(res) {
             record = res;
@@ -1547,15 +1578,16 @@ describe("persistence", function() {
             setTimeout(function() {
               record.set('name', 'My Gnarly Board');
               record.save().then(function(res) {
+                if(!res) { final_error = diag('SAVE_RESOLVED_NULL', 'none'); return; }
                 expect(res.id).toEqual(record.id);
                 setTimeout(function() {
                   persistence.find('board', record.id).then(function(res) {
                     final_record = res;
                   }, function(err) {
-                    final_error = err || new Error('persistence.find rejected');
+                    final_error = diag('FIND_REJECTED', ser(err));
                   });
                 }, 50);
-              }, function() { dbg(); });
+              }, function(err) { final_error = diag('SAVE_REJECTED', ser(err)); dbg(); });
             }, 50);
           });
           waitsFor(function() { return final_record || final_error; });


### PR DESCRIPTION
**Do not merge. Diagnostic only.** This exists to make one CI failure legible; it will be reverted.

## Why

`persistence DSAdapter updateRecord - should update a locally-created record that hasn't been persisted yet` (test 1473) fails on every recent run of `staging` and on all three runs of the release PR #793.

It is **not** a regression from #791, #788, or #789. The same test failed on `staging` before any of them merged:

| Tree | Result |
| --- | --- |
| `f65bfd515` 20:08:12 | pass (last green) |
| `89b33370d` 20:08:30 | fail |
| `07ab1b24e` (#788 merge) | fail |
| `1991380d6` (#791 merge) | fail |
| `5d6ec6042` (#789 merge) | fail |
| #793 x3 | fail |

Seven consecutive failures. First appearance was `3a7ab8350` (#781) after 13 consecutive passes.

## Why instrumentation rather than a fix

The failure cannot be reproduced locally: 8/8 passes in isolation, 6/6 across the whole `persistence` module, 4/4 alongside `board-detail-cache`. The full suite will not run locally (Acceptance and `app_state` tests hang under a bare puppeteer harness), so CI is the only place it exists.

The failure is a **rejection, not a run-loop hang** — `expect(final_error).toEqual(null)` receives an object, with `TypeError: Cannot read properties of null (reading 'id')` in the browser log. `persistence.find` has seven rejection paths and the assertion currently prints only `[object Object]`.

## What this captures

Into the assertion value, so the TAP reporter prints it:

- which path fired: `SAVE_RESOLVED_NULL` / `SAVE_REJECTED` / `FIND_REJECTED`, plus the serialized error
- module-vs-`window` persistence divergence, which decides the branch at `persistence.js:4511`
- `known_missing` on both roots, the first check `find` performs
- `extras_ready`, covering the "extras not ready" branch

Existing assertions are untouched, so a pass is still a genuine pass.

## Note on .eslint-todo

Regenerated because the lint gate runs before the Ember test step; a stale baseline fails the build and the tests never run. The regenerate **removes 11 stale `persistence-test.js` entries and adds none** — leftovers from #791 replacing `later(` with `setTimeout(`. Nothing new is grandfathered; gate reports `new=0`.

## Fix status
| Item | Status | Evidence |
| --- | --- | --- |
| Root cause of test 1473 | Not fixed (diagnostic only) | this PR adds no fix |
| `_mineListBusy` leak (separate) | Not fixed | `app/controllers/user/index.js:1062-1067` |

## Not covered by this PR
- Any fix. This is instrumentation only and must be reverted.
- The `_mineListBusy` stranding bug found while investigating (`user/index.js:1062-1067`): the success path early-returns without clearing and the failure path clears only on `list_id` match, so a superseded Mine fetch can strand the flag `true` permanently, making `_wait_while_mine_list_busy` poll for its full 120s cap. Reported separately; not confirmed as the cause of this test failure.

## Author-Model: opus-5