### PR TITLE
fix(button-settings): persist Speak text and avoid destroyed-object upload alert

### DIFF
--- a/app/frontend/.eslint-todo
+++ b/app/frontend/.eslint-todo
@@ -1,7 +1,7 @@
 # ESLint baseline (grandfathered findings). Do not hand-edit.
 # Regenerate: npm run lint:js:todo
 # Format: file|ruleId|line|column|severity|messageHash
-# Generated: 2026-08-12T23:13:56.037Z
+# Generated: 2026-08-13T21:08:41.848Z
 app/app.js|ember/no-runloop|102|5|2|0843889163d3
 app/app.js|ember/no-runloop|168|7|2|0843889163d3
 app/app.js|ember/no-runloop|193|7|2|0843889163d3
@@ -91,11 +91,11 @@ app/components/button-listener.js|ember/require-super-in-lifecycle-hooks|51|3|1|
 app/components/button-preview.js|ember/require-super-in-lifecycle-hooks|14|3|1|04fd54f45db7
 app/components/button-set.js|ember/no-runloop|226|9|2|5addc2170315
 app/components/button-set.js|ember/require-computed-property-dependencies|306|19|1|f4e704a7bafe
-app/components/button-settings.js|ember/no-runloop|1157|7|2|5addc2170315
-app/components/button-settings.js|ember/no-runloop|1259|11|2|5addc2170315
-app/components/button-settings.js|ember/no-runloop|1642|9|2|5addc2170315
+app/components/button-settings.js|ember/no-runloop|1167|7|2|5addc2170315
+app/components/button-settings.js|ember/no-runloop|1269|11|2|5addc2170315
+app/components/button-settings.js|ember/no-runloop|1657|9|2|5addc2170315
 app/components/button-settings.js|ember/no-runloop|230|9|2|5addc2170315
-app/components/button-settings.js|ember/no-runloop|757|5|2|5addc2170315
+app/components/button-settings.js|ember/no-runloop|767|5|2|5addc2170315
 app/components/button-tracker.js|ember/require-super-in-lifecycle-hooks|9|3|1|04fd54f45db7
 app/components/chart-sankey-parts-of-speech.js|ember/require-super-in-lifecycle-hooks|87|3|1|04fd54f45db7
 app/components/chart-sankey-parts-of-speech.js|ember/require-super-in-lifecycle-hooks|91|3|1|04fd54f45db7
@@ -376,10 +376,10 @@ app/controllers/bulk_purchase.js|ember/no-runloop|46|5|2|5addc2170315
 app/controllers/bulk_purchase.js|ember/no-runloop|56|9|2|5addc2170315
 app/controllers/button-set.js|ember/no-runloop|60|11|2|5addc2170315
 app/controllers/button-set.js|ember/require-computed-property-dependencies|103|19|1|99b85e93bc77
-app/controllers/button-settings.js|ember/no-runloop|1106|9|2|5addc2170315
+app/controllers/button-settings.js|ember/no-runloop|1118|9|2|5addc2170315
 app/controllers/button-settings.js|ember/no-runloop|130|9|2|5addc2170315
-app/controllers/button-settings.js|ember/no-runloop|563|5|2|5addc2170315
-app/controllers/button-settings.js|ember/no-runloop|820|9|2|5addc2170315
+app/controllers/button-settings.js|ember/no-runloop|569|5|2|5addc2170315
+app/controllers/button-settings.js|ember/no-runloop|826|9|2|5addc2170315
 app/controllers/caseload.js|ember/no-runloop|280|9|2|513c0395fe72
 app/controllers/confirm-delete-board.js|ember/no-runloop|120|13|2|5addc2170315
 app/controllers/confirm-delete-board.js|ember/no-runloop|134|23|2|5addc2170315
@@ -722,13 +722,13 @@ app/services/app-state.js|ember/require-computed-property-dependencies|3404|31|1
 app/services/app-state.js|ember/require-computed-property-dependencies|3407|40|1|c9d22bf53d58
 app/services/beta-welcome-mode.js|ember/no-runloop|39|22|2|b7a9757b024f
 app/services/beta-welcome-mode.js|ember/no-runloop|43|7|2|513c0395fe72
-app/services/content-grabbers.js|ember/no-runloop|1357|21|2|5addc2170315
-app/services/content-grabbers.js|ember/no-runloop|1362|11|2|513c0395fe72
-app/services/content-grabbers.js|ember/no-runloop|1369|11|2|513c0395fe72
-app/services/content-grabbers.js|ember/no-runloop|1595|7|2|9ccbb762d93a
-app/services/content-grabbers.js|ember/no-runloop|2251|7|2|5addc2170315
-app/services/content-grabbers.js|ember/no-runloop|2340|7|2|5addc2170315
-app/services/content-grabbers.js|ember/no-runloop|2606|9|2|5addc2170315
+app/services/content-grabbers.js|ember/no-runloop|1361|21|2|5addc2170315
+app/services/content-grabbers.js|ember/no-runloop|1366|11|2|513c0395fe72
+app/services/content-grabbers.js|ember/no-runloop|1373|11|2|513c0395fe72
+app/services/content-grabbers.js|ember/no-runloop|1599|7|2|9ccbb762d93a
+app/services/content-grabbers.js|ember/no-runloop|2255|7|2|5addc2170315
+app/services/content-grabbers.js|ember/no-runloop|2344|7|2|5addc2170315
+app/services/content-grabbers.js|ember/no-runloop|2610|9|2|5addc2170315
 app/services/content-grabbers.js|ember/no-runloop|385|5|2|5addc2170315
 app/services/content-grabbers.js|ember/no-runloop|567|9|2|513c0395fe72
 app/services/content-grabbers.js|ember/no-runloop|655|5|2|5addc2170315

--- a/app/frontend/app/components/button-settings.js
+++ b/app/frontend/app/components/button-settings.js
@@ -316,6 +316,16 @@ export default Component.extend({
       label: this.get('model.label')
     });
   }),
+  // Sound tab "Speak" binds with set-field to model.vocalization only. Without this
+  // sync, board.buttons never gets the new speak text (same class of bug as urlChanged),
+  // so closing/saving the board keeps the old vocalization even though the modal preview
+  // showed the edit.
+  vocalizationChanged: observer('model.vocalization', function() {
+    if(!this.get('handle_updates') || !this.get('model.id')) { return; }
+    editManager.change_button(this.get('model.id'), {
+      vocalization: this.get('model.vocalization')
+    });
+  }),
   // The URL field is bound with a plain `set-field model.url`, which updates ONLY the
   // in-modal Button model — it never reached board.buttons the way labelChanged does.
   // board-detail speak mode rebuilds its display buttons from board.buttons (via
@@ -1589,8 +1599,13 @@ export default Component.extend({
       if(borderEl && borderEl.value) {
         this.set('model.border_color', borderEl.value);
       }
+      // Flush speak text + colors onto board.buttons before pending image work / destroy.
+      // vocalizationChanged covers live edits; this covers close-time sound_id clears and
+      // any path that mutated model.vocalization without firing the observer yet.
       if(this.get('model.id')) {
         editManager.change_button(this.get('model.id'), {
+          vocalization: this.get('model.vocalization'),
+          sound_id: this.get('model.sound_id'),
           background_color: this.get('model.background_color'),
           border_color: this.get('model.border_color')
         });

--- a/app/frontend/app/controllers/button-settings.js
+++ b/app/frontend/app/controllers/button-settings.js
@@ -205,6 +205,12 @@ export default modal.ModalController.extend({
       label: this.get('model.label')
     });
   }),
+  vocalizationChanged: observer('model.vocalization', function() {
+    if(!this.get('handle_updates') || !this.get('model.id')) { return; }
+    editManager.change_button(this.get('model.id'), {
+      vocalization: this.get('model.vocalization')
+    });
+  }),
   update_hidden: observer(
     'model',
     'model.id',
@@ -1058,6 +1064,12 @@ export default modal.ModalController.extend({
         this.send('clear_sound');
         this.send('clear_sound_work');
         this.set('model.sound_id', null);
+      }
+      if(this.get('model.id')) {
+        editManager.change_button(this.get('model.id'), {
+          vocalization: this.get('model.vocalization'),
+          sound_id: this.get('model.sound_id')
+        });
       }
       this.get('contentGrabbers').save_pending().then(function() {
         modal.close();

--- a/app/frontend/app/services/content-grabbers.js
+++ b/app/frontend/app/services/content-grabbers.js
@@ -858,8 +858,10 @@ var pictureGrabber = EmberObject.extend({
   },
   clear: function() {
     this.clear_image_preview();
-    this.controller.set('image_search', null);
-    var stream = this.controller.get('webcam.stream');
+    var controller = this.controller;
+    if(!controller || controller.isDestroyed || controller.isDestroying) { return; }
+    controller.set('image_search', null);
+    var stream = controller.get('webcam.stream');
     if(stream && stream.stop) {
       stream.stop();
     } else if(stream && stream.getTracks) {
@@ -869,15 +871,17 @@ var pictureGrabber = EmberObject.extend({
         }
       });
     }
-    this.controller.set('webcam', null);
-    this.controller.set('webcam', null);
+    controller.set('webcam', null);
+    controller.set('webcam', null);
     var vid = document.getElementById('webcam_video');
     if(vid) { vid.srcObject = null; vid.removeAttribute('src'); }
     var upload = document.getElementById('image_upload');
     if(upload) { upload.value = ''; }
   },
   clear_image_preview: function() {
-    this.controller.set('image_preview', null);
+    var controller = this.controller;
+    if(!controller || controller.isDestroyed || controller.isDestroying) { return; }
+    controller.set('image_preview', null);
   },
   normalize_preview_license: function(preview) {
     var license = preview && preview.license;

--- a/docs/task-management/LEARNINGS.md
+++ b/docs/task-management/LEARNINGS.md
@@ -23,6 +23,7 @@ file (see [README.md](README.md)).
 - [Gotcha: contentHash drift — ATTESTED means stop; unattested means regenerate-register](#gotcha-contenthash-drift--attested-means-stop-unattested-means-regenerate-register)
 - [Gotcha: Rails reserves `params['action']` — consent APIs must use `decision` or member approve/deny routes](#gotcha-rails-reserves-paramsaction--consent-apis-must-use-decision-or-member-approvedeny-routes)
 - [Gotcha: `pending_supervisor_requests` was never serialized — fetch the relationships index instead](#gotcha-pending_supervisor_requests-was-never-serialized--fetch-the-relationships-index-instead)
+- [Gotcha: button-settings Speak must sync vocalization via change_button — set-field alone does not persist](#gotcha-button-settings-speak-must-sync-vocalization-via-change_button--set-field-alone-does-not-persist)
 - [Gotcha: Capacitor offline AAC needs SQLite + Filesystem shims — IndexedDB-only is not speak-ready](#gotcha-capacitor-offline-aac-needs-sqlite--filesystem-shims--indexeddb-only-is-not-speak-ready)
 - [Gotcha: `capabilities.storage.status()` resolve shape is a contract — do not add diagnostic keys](#gotcha-capabilitiesstoragestatus-resolve-shape-is-a-contract--do-not-add-diagnostic-keys)
 - [Speak vs edit: Default symbols still showed OpenSymbols in speak mode](#speak-vs-edit-default-symbols-still-showed-opensymbols-in-speak-mode)
@@ -9514,3 +9515,9 @@ drift from `feature_flags.rb` only needed regenerate after the ledger JSON line 
 **Surface:** Ember `user.pending_supervisor_requests` attr + `PendingConsentRequests`.
 
 The User model exposes `pending_supervisor_requests`, but `lib/json_api/user.rb` never populates it. Enabling `supervisor_consent_flow` alone shows an empty pending list. Load pending rows from `GET /api/v1/supervisor_relationships?role=communicator&status=pending` and map into the UI shape (`id`, `requester_name`, `requester_avatar_url`, `permission_level`).
+
+## Gotcha: button-settings Speak must sync vocalization via change_button — set-field alone does not persist
+
+**Surface:** `button-settings` Sound → Speak (`model.vocalization`).
+
+`set-field` updates only the in-modal Button. Board save serializes `board.buttons`, so Speak edits disappear unless synced with `editManager.change_button` (same class of bug as `urlChanged` / `labelChanged`). Closing can also hit `pictureGrabber.clear_image_preview` during teardown; unguarded `controller.set('image_preview', null)` throws “calling set on destroyed object”, which the image-save error path surfaces as a misleading **upload failed** alert. Guard destroyed controllers in clear, and flush vocalization on close. Task log: `2026-08-13-button-settings-vocalization-save.md`.


### PR DESCRIPTION
## Summary
- Sync Sound → Speak (`vocalization`) to `board.buttons` via `editManager.change_button` (same pattern as label/url), including a flush on modal close
- Guard `pictureGrabber.clear` / `clear_image_preview` when the button-settings component is already destroyed, so teardown no longer surfaces as a misleading **upload failed** alert
- Distill the gotcha into `docs/task-management/LEARNINGS.md`

## Fix status
| Item | Status | Evidence |
|---|---|---|
| Speak text lost on close/save | Fixed | `button-settings.js` `vocalizationChanged` + close flush |
| `upload failed: calling set on destroyed object … image_preview` | Fixed | `content-grabbers.js` destroyed-controller guards |
| Classic controller parity | Fixed | `controllers/button-settings.js` same observer + close flush |

## Not covered by this PR
- Broader image-upload failure UX (still uses alert for real upload errors)
- Converting Speak field from single-line input to textarea for long vocalizations

## Test plan
- [ ] Open button-settings → Sound → edit Speak text → Close
- [ ] Confirm no “upload failed” / destroyed-object alert
- [ ] Save the board, reopen the button → Speak text persists
- [ ] Confirm label/picture/link edits still save as before
- [ ] Optional: open Picture tab then Close without selecting → no upload alert

## Author-Model: grok-x


Made with [Cursor](https://cursor.com)